### PR TITLE
Fix: Roster rework, fixed day-Off issue, OT count

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1080,31 +1080,57 @@ function render_roster(res, page, isOt){
 				'Annual Leave': 'AL',
 				'Emergency Leave': 'EL'
 			}
-			let {employee, employee_name, date, post_type, post_abbrv, employee_availability, shift} = employees_data[employee_key][i];
-			
-			if(post_abbrv){
-				j++;
-				sch = `
-				<td>
-					<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so"
-						data-selectid="${employee+"|"+date+"|"+post_type+"|"+shift+"|"+employee_availability}">${post_abbrv}</div>
-				</td>`;	
-			} else if(employee_availability && !post_abbrv){
-				sch = `
-				<td>
-					<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so"
-						data-selectid="${employee+"|"+date+"|"+employee_availability}">${leavemap[employee_availability]}</div>
-				</td>`;	
-			} else {
-				sch = `
-				<td>
-					<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
-						data-selectid="${employee+"|"+date}"></div>
-				</td>`;
-			}
-			i++;
-			start_date.add(1, 'days');
-			$rosterMonth.find(`#rowchildtable tbody tr[data-name="${employee_name}"]`).append(sch);
+			let {employee, employee_name, date, post_type, post_abbrv, employee_availability, shift, roster_type} = employees_data[employee_key][i];
+			if (isOt){
+				if(post_abbrv && roster_type == 'Over-Time'){
+					j++;
+					sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so"
+							data-selectid="${employee+"|"+date+"|"+post_type+"|"+shift+"|"+employee_availability}">${post_abbrv}</div>
+					</td>`;			
+				} else if(employee_availability && !post_abbrv){
+					sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so"
+							data-selectid="${employee+"|"+date+"|"+employee_availability}">${leavemap[employee_availability]}</div>
+					</td>`;	
+				 } else {
+					sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
+							data-selectid="${employee+"|"+date}"></div>
+					</td>`;
+				}
+				i++;
+				start_date.add(1, 'days');
+				$rosterMonth.find(`#rowchildtable tbody tr[data-name="${employee_name}"]`).append(sch);
+			}else{
+				if(post_abbrv && roster_type == 'Basic'){
+					j++;
+					sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so"
+							data-selectid="${employee+"|"+date+"|"+post_type+"|"+shift+"|"+employee_availability}">${post_abbrv}</div>
+					</td>`;			
+				} else if(employee_availability && !post_abbrv){
+					sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so"
+							data-selectid="${employee+"|"+date+"|"+employee_availability}">${leavemap[employee_availability]}</div>
+					</td>`;	
+				} else {
+					sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
+							data-selectid="${employee+"|"+date}"></div>
+					</td>`;
+				}
+				i++;
+				start_date.add(1, 'days');
+				$rosterMonth.find(`#rowchildtable tbody tr[data-name="${employee_name}"]`).append(sch);
+
+			}	
 		}
 		$rosterMonth.find(`#rowchildtable tbody tr[data-name="${employees_data[employee_key][i-1]['employee_name']}"]`).append(`<td>${j}</td>`);
 
@@ -2641,14 +2667,12 @@ function schedule_change_post(page){
 	let employees =  [];
 	let selected = [... new Set(classgrt)];
 	let otRoster = false;
-	if(selected.length > 1){
+	if(selected.length > 0){
 		selected.forEach(function(i){
 			let [employee, date] = i.split("|");
 			employees.push(employee);
 			employees = [... new Set(employees)];
 		})
-	}else{
-		
 	}
 	let d = new frappe.ui.Dialog({
 		'title': 'Schedule/Change Post',

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.json
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.json
@@ -1,5 +1,5 @@
 {
- "autoname": "format:{date}/{employee}",
+ "autoname": "format:{date}/{employee}/{roster_type}",
  "creation": "2020-05-12 15:44:18.133872",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -137,11 +137,11 @@
    "fieldname": "roster_type",
    "fieldtype": "Select",
    "label": "Roster Type",
-   "options": "Basic\nOver Time"
+   "options": "Basic\nOver-Time"
   }
  ],
- "modified": "2021-04-27 15:39:07.438622",
- "modified_by": "Administrator",
+ "modified": "2021-05-26 08:59:21.055668",
+ "modified_by": "m.ahmed@armor-services.com",
  "module": "Operations",
  "name": "Employee Schedule",
  "owner": "Administrator",

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.utils import cstr
 class EmployeeSchedule(Document):
 	def before_insert(self):
-		if frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": self.date}):
+		if frappe.db.exists("Employee Schedule", {"employee": self.employee, "date": self.date, "roster_type" : self.roster_type}):
 			frappe.throw(_("Employee Schedule already scheduled for {employee} on {date}.".format(employee=self.employee_name, date=cstr(self.date))))
 
 


### PR DESCRIPTION
- Fixed OT days count and OT schedule view in the roster.
- Fixed Day Off not shown in roster view.
- Changed naming format of employee schedule doctype to separate out basic and OT shifts.
- Upon scheduling Day Off for an employee, change 'roster_type' to default (Basic).