### PR TITLE
Fix: priority level and empty designation

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -261,6 +261,8 @@ def schedule(employee, shift, post_type, otRoster, start_date, end_date):
 			post_abbrv = frappe.get_value("Post Type", post_type, "post_abbrv")
 			roster = frappe.get_value("Employee Schedule", {"employee": employee, "date": cstr(date.date()), "roster_type" : roster_type })
 			update_existing_schedule(roster, shift, site, shift_type, project, post_abbrv, cstr(date.date()), "Working", post_type, roster_type)
+			#Update employee assignment upon change in schedule as the roster fetches values from the employee doctype
+			update_employee_assignment(employee, project, shift, site)
 		else:
 			roster = frappe.new_doc("Employee Schedule")
 			roster.employee = employee
@@ -272,6 +274,12 @@ def schedule(employee, shift, post_type, otRoster, start_date, end_date):
 			roster.save(ignore_permissions=True)
 	end = time.time()
 	print("Scheduled employee : ", employee, end-start)
+
+def update_employee_assignment(employee, project, shift, site):
+	""" This function updates the employee project, site and shift in the employee doctype """
+	frappe.db.set_value("Employee", employee, "project", val=project)
+	frappe.db.set_value("Employee", employee, "site", val=site)
+	frappe.db.set_value("Employee", employee, "shift", val=shift)	
 
 @frappe.whitelist()
 def schedule_leave(employees, leave_type, start_date, end_date):

--- a/one_fm/operations/doctype/post_allocation_plan/post_allocation_plan.js
+++ b/one_fm/operations/doctype/post_allocation_plan/post_allocation_plan.js
@@ -54,8 +54,8 @@ function add_employees(frm){
 			
 			frm.set_value('assignments', '');
 
-			// Fill posts in decreasing priority level. e.g Level 5 first, Level 4 then......Level 1 at the end
-			for(let i=5; i>=1; i--){
+			// Fill posts in decreasing priority level. e.g Level 10 first, Level 9 then......Level 1 at the end
+			for(let i=10; i>=1; i--){
 				employees = (posts[i] && assign_post(frm, posts[i], employees)) || employees;
 			}
 
@@ -75,7 +75,6 @@ function add_employees(frm){
 function assign_post(frm, posts, employees){
 	posts.forEach(function(i,v){
 		let {designations} = posts[v];
-
 		// Select matching designations employees only and pass to get_best_employee_match
 		let matching_employees = employees.filter(emp => designations.includes(emp.designation))
 			

--- a/one_fm/operations/doctype/post_allocation_plan/post_allocation_plan.py
+++ b/one_fm/operations/doctype/post_allocation_plan/post_allocation_plan.py
@@ -75,8 +75,8 @@ def get_employee_data_map(employee, shift, date):
 	if frappe.db.exists("Employee Skill Map", employee.employee):
 		employee_skill = frappe.get_doc("Employee Skill Map", employee.employee).as_dict()
 		employee_skills.skills = [{'skill': skill.skill, 'proficiency': skill.proficiency } for skill in employee_skill.employee_skills]
-		employee_doc = frappe.get_doc("Employee", employee.employee).as_dict()
-		employee_skills.designation = employee_doc.designation
+		employee_skills.designation = frappe.db.get_value("Employee", employee.employee, "designation")
+		print(employee_skills.designation)
 	else:
 		frappe.throw(_("Employee Skill Map not found for {id}:{name}".format(id=employee.employee, name=employee.employee_name)))
 

--- a/one_fm/operations/doctype/post_allocation_plan/post_allocation_plan.py
+++ b/one_fm/operations/doctype/post_allocation_plan/post_allocation_plan.py
@@ -30,7 +30,6 @@ def filter_posts(doctype, txt, searchfield, start, page_len, filters):
 def get_table_data(operations_shift, date):
 	employees = frappe.get_all("Employee Schedule", {'date': date, 'shift': operations_shift, 'employee_availability': 'Working'}, ["employee", "employee_name"])
 	posts = get_posts(operations_shift, date)
-	
 	post_list = {}
 
 	for key, group in itertools.groupby(posts, key=lambda x: (x['priority_level'])):
@@ -76,7 +75,8 @@ def get_employee_data_map(employee, shift, date):
 	if frappe.db.exists("Employee Skill Map", employee.employee):
 		employee_skill = frappe.get_doc("Employee Skill Map", employee.employee).as_dict()
 		employee_skills.skills = [{'skill': skill.skill, 'proficiency': skill.proficiency } for skill in employee_skill.employee_skills]
-		employee_skills.designation = employee_skill.designation
+		employee_doc = frappe.get_doc("Employee", employee.employee).as_dict()
+		employee_skills.designation = employee_doc.designation
 	else:
 		frappe.throw(_("Employee Skill Map not found for {id}:{name}".format(id=employee.employee, name=employee.employee_name)))
 
@@ -123,7 +123,6 @@ def get_day_off_employees(operations_shift, date):
 		'shift': operations_shift,
 		'date': date
 	}, as_dict=1)
-	print(employees, len(employees))
 	return employees
 
 


### PR DESCRIPTION
- Changed priority level starting from 5 to starting from 10.
- Temporary fix for employee designation: Fetch designation directly from employee doctype instead of employee skill map.
- Update employee assignment in employee doctype upon change of shift.