### PR TITLE
Update: fix create multiple tp for same applicant

### DIFF
--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
@@ -19,12 +19,13 @@ var set_employee_details = function(frm){
                 filters: {
                 name: frm.doc.employee
                 },
-                fieldname:["one_fm_duration_of_work_permit","employee_name","one_fm_nationality","one_fm_civil_id","gender","date_of_birth","work_permit_salary","pam_file_number","employee_id","valid_upto"]
+                fieldname:["employee_name","one_fm_duration_of_work_permit","employee_name","one_fm_nationality","one_fm_civil_id","gender","date_of_birth","work_permit_salary","pam_file_number","employee_id","valid_upto"]
             }, 
             callback: function(r) { 
         
                 // set the returned value in a field
                 frm.set_value('civil_id', r.message.one_fm_civil_id);
+                frm.set_value('full_name', r.message.employee_name);
 				frm.set_value('first_name_arabic', r.message.one_fm_first_name_in_arabic);
                 frm.set_value('second_name_arabic', r.message.one_fm_second_name_in_arabic);
                 frm.set_value('third_name_arabic', r.message.one_fm_third_name_in_arabic);

--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.json
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.json
@@ -16,7 +16,7 @@
   "status",
   "section_break_9",
   "date_and_time_confirmation",
-  "attach_barcode",
+  "upload_appointment_form",
   "required_transportation",
   "section_break_13",
   "preparing_documents",
@@ -32,6 +32,7 @@
   "service_type",
   "section_break_12",
   "civil_id",
+  "full_name",
   "first_name_arabic",
   "second_name_arabic",
   "third_name_arabic",
@@ -39,11 +40,11 @@
   "moi_reference_number",
   "column_break_18",
   "employee_id",
+  "nationality",
   "first_name_english",
   "second_name_english",
   "third_name_english",
   "last_name_english",
-  "nationality",
   "section_break_24",
   "grd_operator_renewal",
   "grd_operator_transfer",
@@ -347,7 +348,7 @@
    "fieldname": "fingerprint_appointment_type",
    "fieldtype": "Select",
    "label": "Fingerprint Appointment Type",
-   "options": "\nRenewal Non-Kuwaiti\nLocal Transfer"
+   "options": "\nRenewal\nLocal Transfer"
   },
   {
    "fieldname": "date_of_application",
@@ -403,23 +404,30 @@
    "label": "Registration Details"
   },
   {
-   "allow_on_submit": 1,
-   "fieldname": "attach_barcode",
-   "fieldtype": "Attach",
-   "label": "Attach Barcode"
-  },
-  {
    "fieldname": "column_break_14",
    "fieldtype": "Column Break"
   },
   {
    "fieldname": "section_break_13",
    "fieldtype": "Section Break"
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "label": "Full Name",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "upload_appointment_form",
+   "fieldtype": "Attach",
+   "label": "Upload Appointment Form"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-09-13 08:02:31.629468",
+ "modified": "2021-09-14 18:20:02.361126",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Fingerprint Appointment",

--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.py
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.py
@@ -50,8 +50,8 @@ class FingerprintAppointment(Document):
                 self.reminded_grd_operator = 1
 
         if self.workflow_state == "Booked":
-            field_list = [{'Date and Time Confirmation':'date_and_time_confirmation'},{'Attach Barcode':'upload_appointment_form'},{'Required Transportation':'required_transportation'}]
-            message_detail = '<b style="color:red; text-align:center;">First, You Need Apply on <a href="{0}" target="_blank"> Fingerprint Website</a></b>'.format(self.website)
+            field_list = [{'Date and Time Confirmation':'date_and_time_confirmation'},{'Upload Appointment Form':'upload_appointment_form'},{'Required Transportation':'required_transportation'}]
+            message_detail = '<b style="color:red; text-align:center;">First, You Need to Apply on <a href="{0}" target="_blank"> Fingerprint Website</a></b>'.format(self.website)
             self.set_mendatory_fields(field_list,message_detail)
             self.notify_site_supervisor()
             self.notify_shift_supervisor()
@@ -127,7 +127,7 @@ class FingerprintAppointment(Document):
 
     def notify_transportation(self):
         """Notify transportation with the employee's appointment"""
-        user_email = "a.alshawa@armor-services.com"#"I.ANWARE@one-fm.com"
+        user_email = "I.ANWARE@one-fm.com"
         content="<h4>Dear "+ user_email +",</h4><p> This email to inform you that Fingerprint Appointment for employee Name: {0} - {1} Required Transportation at {2}.</p>".format(self.full_name,self.employee_id,self.date_and_time_confirmation)  
         frappe.sendmail(recipients=[user_email],
             sender=self.grd_supervisor,

--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.py
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.py
@@ -50,12 +50,13 @@ class FingerprintAppointment(Document):
                 self.reminded_grd_operator = 1
 
         if self.workflow_state == "Booked":
-            field_list = [{'Date and Time Confirmation':'date_and_time_confirmation'},{'Attach Barcode':'attach_barcode'},{'Required Transportation':'required_transportation'}]
+            field_list = [{'Date and Time Confirmation':'date_and_time_confirmation'},{'Attach Barcode':'upload_appointment_form'},{'Required Transportation':'required_transportation'}]
             message_detail = '<b style="color:red; text-align:center;">First, You Need Apply on <a href="{0}" target="_blank"> Fingerprint Website</a></b>'.format(self.website)
             self.set_mendatory_fields(field_list,message_detail)
             self.notify_site_supervisor()
             self.notify_shift_supervisor()
-            #inform transportation if required
+            if self.required_transportation == "Yes":
+                self.notify_transportation()
     
     def before_one_day_of_appointment_date(self):
         today = date.today()
@@ -64,7 +65,7 @@ class FingerprintAppointment(Document):
 
     def notify_operator_to_apply_for_fp(self):
         page_link = get_url("/desk#Form/Fingerprint Appointment/" + self.name)
-        if self.fingerprint_appointment_type == "Renewal Non-Kuwaiti" and self.workflow_state == "Awaiting for Appointment":
+        if self.fingerprint_appointment_type == "Renewal" and self.workflow_state == "Awaiting for Appointment":
             message = "<p>Please Apply for Fingerprint Appointment for Renewal to civil id: <a href='{0}'>{1}</a>.</p>".format(page_link, self.civil_id)
             subject = 'Apply for Fingerprint Appointment for Renewal to civil id:{0} '.format(self.civil_id)
             create_notification_log(subject, message, [self.grd_operator_renewal], self)
@@ -77,7 +78,7 @@ class FingerprintAppointment(Document):
 
     def notify_operator_to_prepare_for_fp(self):
         page_link = get_url("/desk#Form/Fingerprint Appointment/" + self.name)
-        if self.fingerprint_appointment_type == "Renewal Non-Kuwaiti" and self.workflow_state == "Booked":
+        if self.fingerprint_appointment_type == "Renewal" and self.workflow_state == "Booked":
             message = "<p>Please Prepare Fingerprint Appointment Documents for employee with civil id: <a href='{0}'>{1}</a>.</p>".format(page_link, self.civil_id)
             subject = 'Please Prepare Fingerprint Appointment Documents for employee with civil id:{0} '.format(self.civil_id)
             create_notification_log(subject, message, [self.grd_operator_renewal], self)
@@ -112,7 +113,7 @@ class FingerprintAppointment(Document):
         if site:
             site_doc = frappe.get_doc("Operations Site",site)
             if site_doc:
-                employee = frappe.get_doc("Employee", site_doc.account_supervisor)# will return employee
+                employee = frappe.get_doc("Employee", site_doc.account_supervisor)
                 send_email_notification(self, [employee.user_id])
             
     def notify_shift_supervisor(self):
@@ -121,8 +122,16 @@ class FingerprintAppointment(Document):
         if shift:
             shift_doc = frappe.get_doc("Operations Shift",shift)
             if shift_doc:
-                employee = frappe.get_doc("Employee", shift_doc.supervisor)# will return employee
+                employee = frappe.get_doc("Employee", shift_doc.supervisor)
                 send_email_notification(self, [employee.user_id])
+
+    def notify_transportation(self):
+        """Notify transportation with the employee's appointment"""
+        user_email = "a.alshawa@armor-services.com"#"I.ANWARE@one-fm.com"
+        content="<h4>Dear "+ user_email +",</h4><p> This email to inform you that Fingerprint Appointment for employee Name: {0} - {1} Required Transportation at {2}.</p>".format(self.full_name,self.employee_id,self.date_and_time_confirmation)  
+        frappe.sendmail(recipients=[user_email],
+            sender=self.grd_supervisor,
+            subject="Transportation Required For Fingerprint Appointment", content=content)
 
     def check_appointment_date(self):
         today = date.today()
@@ -154,7 +163,7 @@ def get_employee_list():
             
 def creat_fp(employee,type,preparation):
     if type == "Renewal":
-        fingerprint_appointment_type = "Renewal Non-Kuwaiti"
+        fingerprint_appointment_type = "Renewal"
     if type == "Local Transfer":
         fingerprint_appointment_type = "Local Transfer"
 
@@ -182,7 +191,7 @@ def send_email_notification(doc, recipients):
 	message = "<p>Please Review the Fingerprint Appointment for employee: {0} at {1}<a href='{2}'>{3}</a>.</p>".format(doc.employee_id,doc.date_and_time_confirmation,page_link, doc.name)
 	frappe.sendmail(
 		recipients= recipients,
-		subject='{0} Fingerprint Appointment for {1}'.format(doc.workflow_state, doc.employee_id),
+		subject='{0} Fingerprint Appointment for employee Name:{1} - {2}'.format(doc.workflow_state, doc.full_name,doc.employee_id),
 		message=message,
 		reference_doctype=doc.doctype,
 		reference_name=doc.name

--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.js
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.js
@@ -2,6 +2,22 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Medical Insurance', {
+    refresh(frm){
+        if(frm.doc.docstatus === 1 && frm.doc.insurance_status == "Local Transfer"){
+            		frm.add_custom_button(__('Go to MOI Residency Jawazat'),
+            			  function () {
+            			frappe.db.get_value('MOI Residency Jawazat', {'category':'Transfer','one_fm_civil_id':frm.doc.civil_id}, 'name', (r) => {
+            			if (r && r.name) {
+            				frappe.set_route("Form", "MOI Residency Jawazat", r.name);
+            			}
+            		});
+            	}
+            ).addClass('btn-primary');
+        }
+    },
+    onload: function(frm){
+        set_employee_details(frm);
+    },
     work_permit: function(frm){
         set_employee_details(frm);
         set_insurance_type(frm);
@@ -103,6 +119,7 @@ var set_employee_details = function(frm){
                 frm.set_value('nationality',r.message.nationality);
                 frm.set_value('no_of_years', r.message.duration_of_work_permit);
                 frm.set_value('passport_expiry_date',r.message.passport_expiry_date);
+                frm.set_value('pam_file_number',r.message.pam_file_number);
             }
         });
     }

--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.json
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.json
@@ -68,6 +68,7 @@
   {
    "fieldname": "insurance_status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Insurance Status",
    "options": "\nRenewal\nNew\nLocal Transfer"
   },
@@ -126,7 +127,6 @@
    "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Full Name",
    "read_only": 1
   },
@@ -264,7 +264,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-09-08 08:59:43.917407",
+ "modified": "2021-09-14 16:54:43.472141",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Medical Insurance",

--- a/one_fm/grd/doctype/moi_residency_jawazat/moi_residency_jawazat.js
+++ b/one_fm/grd/doctype/moi_residency_jawazat/moi_residency_jawazat.js
@@ -1,7 +1,22 @@
 // Copyright (c) 2020, omar jaber and contributors
 // For license information, please see license.txt
 frappe.ui.form.on('MOI Residency Jawazat', {
+	refresh(frm){
+			if(frm.doc.docstatus === 1 && frm.doc.category == "Transfer"){
+				frm.add_custom_button(__('Go to PACI'),
+					  function () {
+					frappe.db.get_value('PACI', {'category':frm.doc.category,'civil_id':frm.doc.one_fm_civil_id}, 'name', (r) => {
+					if (r && r.name) {
+						frappe.set_route("Form", "PACI", r.name);
+					}
+				});
+			}
+		).addClass('btn-primary');
+		}
+
+	},
 	onload: function(frm) {
+		set_employee_details(frm);
 		if(frm.doc.__islocal){
 			frappe.call({
 				method:"frappe.client.get_value",
@@ -14,7 +29,6 @@ frappe.ui.form.on('MOI Residency Jawazat', {
 				}, 
 				callback: function(r) { 
 			
-					// set the returned value in a field
 					frm.set_value('company_pam_file_number', r.message.pam_file_number);
 					frm.set_value('company_centralized_number', r.message.company_unified_number);
 					frm.set_value('governorate', r.message.pam_file_governorate_arabic);

--- a/one_fm/grd/doctype/paci/paci.js
+++ b/one_fm/grd/doctype/paci/paci.js
@@ -1,11 +1,9 @@
 // Copyright (c) 2021, omar jaber and contributors
 // For license information, please see license.txt
 frappe.ui.form.on('PACI', {
-	// refresh: function(frm) { //was causing NOT SAVED document
-	// 	if (!frm.is_new()){
-    //         set_employee_details(frm);
-    //     }
-    // },
+	onload: function(frm){
+        set_employee_details(frm);
+    },
     employee: function(frm){
         set_employee_details(frm);
     },

--- a/one_fm/grd/doctype/paci/paci.json
+++ b/one_fm/grd/doctype/paci/paci.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "naming_series:",
  "creation": "2021-04-21 11:04:12.147303",
  "doctype": "DocType",
@@ -32,6 +33,7 @@
   "residency_expiry_date",
   "section_break_19",
   "upload_civil_id_payment",
+  "upload_hawiyati",
   "upload_civil_id",
   "new_civil_id_expiry_date",
   "column_break_25",
@@ -40,7 +42,8 @@
   "completed_on",
   "amended_from",
   "grd_operator",
-  "grd_supervisor"
+  "grd_supervisor",
+  "grd_operator_transfer"
  ],
  "fields": [
   {
@@ -276,10 +279,21 @@
    "fieldtype": "Select",
    "label": "PACI Status",
    "options": "\nDraft\nUnder-Process\nCompleted"
+  },
+  {
+   "fieldname": "upload_hawiyati",
+   "fieldtype": "Attach",
+   "label": "Upload Hawiyati"
+  },
+  {
+   "fieldname": "grd_operator_transfer",
+   "fieldtype": "Data",
+   "label": "GRD Operator Transfer"
   }
  ],
  "is_submittable": 1,
- "modified": "2021-06-30 14:42:15.624154",
+ "links": [],
+ "modified": "2021-09-14 18:45:46.565949",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PACI",

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -93,10 +93,6 @@ class Preparation(Document):
             send_email(self, [self.grd_operator], message, subject)
             create_notification_log(subject, message, [self.grd_operator], self)
 
-def preparation_monthly_task():
-    frappe.enqueue(create_preparation, is_async=True, queue='long')
-    
-
 # Calculate the date of the next month (First & Last) (monthly cron in hooks)
 def create_preparation():
     doc = frappe.new_doc('Preparation')

--- a/one_fm/grd/doctype/work_permit/work_permit.js
+++ b/one_fm/grd/doctype/work_permit/work_permit.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Work Permit', {
+    onload: function(frm){
+        set_employee_details(frm); 
+    },
     work_permit_status: function(frm){
         if (frm.doc.work_permit_status == "Rejected"){
             frm.set_value("work_permit_status","read_only",1);
@@ -34,6 +37,7 @@ frappe.ui.form.on('Work Permit', {
         set_required_documents(frm);
     },
     refresh(frm) {
+        set_button_for_medical_insurance_transfer(frm);
         set_restart_application(frm);
         set_grd_supervisor(frm);
         set_mgrp(frm);
@@ -83,7 +87,19 @@ frappe.ui.form.on('Work Permit', {
 
     
 });
-
+var set_button_for_medical_insurance_transfer = function(frm){
+    if(frm.doc.docstatus === 1 && frm.doc.work_permit_type == "Local Transfer"){
+        frm.add_custom_button(__('Go to Medical Insurance'),
+          	function () {
+            frappe.db.get_value('Medical Insurance', {'work_permit':frm.doc.name}, 'name', (r) => {
+			if (r && r.name) {
+				frappe.set_route("Form", "Medical Insurance", r.name);
+			}
+		});
+    }
+).addClass('btn-primary');
+}
+};
 var set_restart_application = function(frm){
     if(frm.doc.docstatus == 1 && frm.doc.work_permit_status == "Rejected"){
         frm.add_custom_button(__('Restart Application'), function(){

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -33,6 +33,15 @@
   "previous_company_status",
   "column_break_20",
   "inform_previous_company_on",
+  "payment_details_section_section",
+  "attach_invoice",
+  "column_break_29",
+  "upload_payment_invoice_on",
+  "work_permit_information_section",
+  "upload_work_permit",
+  "new_work_permit_expiry_date",
+  "column_break_32",
+  "upload_work_permit_on",
   "pam_work_permit_registration_section",
   "reference_number_on_pam_registration",
   "work_permit_registration",
@@ -90,6 +99,7 @@
   "documents_required",
   "amended_from",
   "grd_section",
+  "grd_operator_transfer",
   "grd_operator",
   "grd_supervisor",
   "section_break_61",
@@ -98,14 +108,8 @@
   "reminded_grd_operator_approve_previous_company",
   "section_break_72",
   "work_permit_approved",
-  "upload_work_permit",
-  "attach_invoice",
-  "new_work_permit_expiry_date",
-  "column_break_32",
   "reminded_grd_operator_again",
   "reminded_grd_operator_approve_previous_company_again",
-  "upload_work_permit_on",
-  "upload_payment_invoice_on",
   "reason_for_rejection",
   "section_break_60",
   "notify_finance_user",
@@ -362,7 +366,6 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.work_permit_status == \"Pending by Operator\" || doc.work_permit_status == \"Completed\"",
    "fieldname": "attach_invoice",
    "fieldtype": "Attach",
    "label": "Upload Payment Invoice"
@@ -382,7 +385,6 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.work_permit_status == \"Pending by Operator\"",
    "fieldname": "upload_work_permit",
    "fieldtype": "Attach",
    "label": "Upload Work Permit"
@@ -427,7 +429,6 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.work_permit_status == \"Pending by Operator\" || doc.work_permit_status == \"Completed\"",
    "fieldname": "upload_work_permit_on",
    "fieldtype": "Data",
    "label": "Upload On",
@@ -435,7 +436,6 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.work_permit_status == \"Pending by Operator\"",
    "fieldname": "upload_payment_invoice_on",
    "fieldtype": "Data",
    "label": "Upload Payment Invoice On",
@@ -594,10 +594,8 @@
    "permlevel": 1
   },
   {
-   "depends_on": "eval: doc.ref_doctype == \"Transfer Paper\"",
    "fieldname": "transfer_paper",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "Transfer Paper",
    "options": "Transfer Paper"
   },
@@ -730,7 +728,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.work_permit_type == \"New Kuwaiti\" || doc.work_permit_type ==\"Local Transfer\" && doc.workflow_state != \"Draft\" ",
+   "depends_on": "eval:(doc.work_permit_type == \"New Kuwaiti\" || doc.work_permit_type ==\"Local Transfer\" || doc.work_permit_type ==\"Renewal Kuwaiti\" || doc.work_permit_type ==\"Renewal Non Kuwaiti\") && doc.workflow_state != \"Draft\" ",
    "fieldname": "pam_work_permit_registration_section",
    "fieldtype": "Section Break",
    "label": "PAM Work Permit Registration"
@@ -784,7 +782,7 @@
    "label": "Previous Company Status"
   },
   {
-   "depends_on": "eval: doc.work_permit_type == \"Local Transfer\" && (doc.workflow_state == \"Pending  For Payment\" || doc.workflow_state == \"Pending By Operator\" || doc.workflow_state == \"Completed\")",
+   "depends_on": "eval:doc.work_permit_type == \"Local Transfer\" && (doc.workflow_state == \"Pending  For Payment\" || doc.workflow_state == \"Pending By Operator\" || doc.workflow_state == \"Completed\")",
    "fieldname": "section_break_14",
    "fieldtype": "Section Break",
    "label": "Payment Details"
@@ -841,11 +839,33 @@
    "fieldtype": "Datetime",
    "label": "Attach On",
    "read_only": 1
+  },
+  {
+   "fieldname": "grd_operator_transfer",
+   "fieldtype": "Link",
+   "label": "GRD Operator Transfer",
+   "options": "User"
+  },
+  {
+   "depends_on": "eval:doc.work_permit_status == \"Pending by Supervisor\" || doc.work_permit_status == \"Pending by Operator\" || doc.work_permit_status == \"Completed\"",
+   "fieldname": "payment_details_section_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Details Section"
+  },
+  {
+   "depends_on": "eval: doc.work_permit_status == \"Pending by Operator\" || doc.work_permit_status == \"Completed\"",
+   "fieldname": "work_permit_information_section",
+   "fieldtype": "Section Break",
+   "label": "Work Permit Information"
+  },
+  {
+   "fieldname": "column_break_29",
+   "fieldtype": "Column Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-09-12 17:12:25.366679",
+ "modified": "2021-09-14 16:01:11.834578",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -21,63 +21,44 @@ from one_fm.grd.doctype.medical_insurance import medical_insurance
 
 # from pdfminer.pdfparser import PDFParser, PDFDocument  
 class WorkPermit(Document):
-
     def on_update(self):
+        # self.update_work_permit_details_in_tp() # <In progress>
         self.check_required_document_for_workflow()
 
     def validate(self):
         self.set_grd_values()
-        self.check_workflow_status()
-        # if self.work_permit_type == "Local Transfer":  //inform previous company - auto reject - fp record - inform transfer operator
-        #     self.check_inform_previous_company()
-        #     if self.work_permit_approved == "Yes":
-        #         self.recall_create_fingerprint_appointment_transfer()
-        #         self.notify_grd_transfer_fp_record()
-
+        
     def set_grd_values(self):
         if not self.grd_supervisor:
             self.grd_supervisor = frappe.db.get_single_value("GRD Settings", "default_grd_supervisor")
         if not self.grd_operator:
             self.grd_operator = frappe.db.get_single_value("GRD Settings", "default_grd_operator")
+        if not self.grd_operator_transfer:
+            self.grd_operator_transfer = frappe.db.get_single_value("GRD Settings", "default_grd_operator_transfer")
 
-    def check_workflow_status(self):
-        if self.work_permit_type != "Cancellation" or self.work_permit_type != "New Kuwaiti":
-            if self.work_permit_status == "Draft":
-                page_link = get_url("/desk#Form/Work Permit/" + self.name)
-                message = "<p>Apply Online for Work Permit<a href='{0}'>{1}</a>.</p>".format(page_link, self.name)
-                subject = '{0} Apply Online for Work Permit'.format(self.grd_operator)
-                self.notify_grd(page_link,message,subject,"GRD Operator")
-
-            if self.work_permit_status == "Pending by Supervisor":
-                page_link = get_url("/desk#Form/Work Permit/" + self.name)
-                message = "<p>Check Work Permit for Acceptance<a href='{0}'>{1}</a>.</p>".format(page_link, self.name)
-                subject = 'Check Work Permit for Acceptance for {0}'.format(self.first_name)
-                self.notify_grd(page_link,message,subject,"GRD Supervisor")
-
-            if self.work_permit_status == "Pending by Operator":
-                if not self.upload_work_permit and not self.attach_invoice and not self.new_work_permit_expiry_date:
-                    if not self.notify_to_upload:
-                        page_link = get_url("/desk#Form/Work Permit/" + self.name)
-                        message = "<p>Upload Required Documents for Work Permit<a href='{0}'>{1}</a>.</p>".format(page_link, self.name)
-                        subject = '{0} Upload Required Documents for Work Permit'.format(self.grd_operator)
-                        self.notify_grd(page_link,message,subject,"GRD Operator")
-                        self.notify_to_upload = 1
-
-# <b style="color:red; text-align:center;">First, You Need to Apply for {0} through <a href="{1}">PIFSS Website</a></b><br>
     def check_required_document_for_workflow(self):
+        if self.workflow_state == "Apply Online by PRO":
+            self.reload()
+
         if self.workflow_state == "Pending By Supervisor" and self.work_permit_type == "Cancellation":
             field_list = [{'PAM Reference Number':'reference_number_on_pam'}]
             message_detail = '<b style="color:red; text-align:center;">First, You Need to Apply for Work Permit Cancellation through <a href="{0}" target="_blank">PAM Website</a></b>'.format(self.pam_website)
             self.set_mendatory_fields(field_list,message_detail)
 
         if self.workflow_state == "Pending By Supervisor":
-            if self.work_permit_type == "New Kuwaiti" or self.work_permit_type == "Local Transfer":
+            if self.work_permit_type == "New Kuwaiti" or self.work_permit_type == "Local Transfer" or self.work_permit_type =="Renewal Kuwaiti" or self.work_permit_type =="Renewal Non Kuwaiti":
                 field_list = [{'PAM Reference Number':'reference_number_on_pam_registration'}]
                 message_detail = '<b style="color:red; text-align:center;">First, You Need to Apply for Work Permit Registration through <a href="{0}" target="_blank">PAM Website</a></b>'.format(self.pam_website)
                 self.set_mendatory_fields(field_list,message_detail)
             self.reload()
 
         if self.workflow_state == "Pending By PAM":
+            if self.work_permit_type == "Renewal Kuwaiti" or self.work_permit_type == "Renewal Non Kuwaiti" or self.work_permit_type == "New Kuwaiti":
+                field_list = [{'Upload Payment Invoice':'attach_invoice'}]
+                message_detail = '<b style="color:red; text-align:center;">First, You Need to Pay through <a href="{0}" target="_blank">PAM Website</a></b>'.format(self.pam_website)
+                self.set_mendatory_fields(field_list,message_detail)
+            self.reload()
+
             if self.work_permit_type == "Local Transfer":
                 field_list = [{'Previous Company Status':'previous_company_status'}]
                 message_detail = '<b style="color:red; text-align:center;">First, You Need to Inform Previous Company.<br>Second, Check Previous Company Response on <a href="{0}" target="_blank">PAM Website</a></b>'.format(self.pam_website)
@@ -93,6 +74,11 @@ class WorkPermit(Document):
 
 
         if self.workflow_state == "Completed":
+            if self.work_permit_type == "Renewal Non Kuwaiti" or self.work_permit_type == "Renewal Kuwaiti":
+                field_list = [{'Upload Work Permit':'upload_work_permit'},{'Updated Work Permit Expiry Date':'new_work_permit_expiry_date'}]
+                message_detail = '<b style="color:red; text-align:center;">First, You Need to Attch Work Permit taken from <a href="{0}" target="_blank">PAM Website</a></b>'.format(self.pam_website)
+                self.set_mendatory_fields(field_list,message_detail)
+
             if self.work_permit_type == "Cancellation":
                 field_list = [{'Work Permit Cancellation ':'work_permit_cancellation'}]
                 message_detail = '<b style="color:red; text-align:center;">First, You Need to Attach the Work Permit Cancellation taken from <a href="{0}" target="_blank">PAM Website</a></b>'.format(self.pam_website)
@@ -114,7 +100,7 @@ class WorkPermit(Document):
                 field_list = [{'Reason Of Rejection':'reason_of_rejection'},{'Details of Rejection':'details_of_rejection'}]
                 message_detail = '<b style="color:red; text-align:center;">First, You Need to set the reason of Rejection Mentioned in <a href="{0}" target="_blank">PAM Website</a></b>'.format(self.pam_website)
                 self.set_mendatory_fields(field_list,message_detail)
-                self.reload()
+            self.reload()
 
     
     def set_mendatory_fields(self,field_list,message_detail=None):
@@ -135,12 +121,44 @@ class WorkPermit(Document):
             message += '</ul>'
             frappe.throw(message)
 
-    def check_inform_previous_company(self):
-         # 3 days with in the applied days so 2
-        if date_diff(today(),self.date_of_application) == 2 and self.previous_company_status == "No":
-            self.work_permit_status = "Rejected"
-            self.save()
-
+    def update_work_permit_details_in_tp(self):
+        if self.work_permit_type == "Local Transfer" and self.transfer_paper:
+            tp = frappe.get_doc('Transfer Paper',self.transfer_paper)
+            if tp:
+                print("Child table", tp.work_permit_records)
+                print("wp name ", self.name)
+                if tp.work_permit_records != []:
+                    for wp in tp.work_permit_records:
+                        print("wp",wp)
+                        print("wp.work_permit_reference",wp.work_permit_reference)
+                        if wp.work_permit_reference  == self.name and self.work_permit_status != "Completed":
+                            # tp.append("work_permit_records", {
+                            #     "work_permit_reference": self.name,
+                            #     "status": self.work_permit_status,
+                            #     "reason_of_rejection": self.reason_of_rejection
+                            #     })
+                            # wp.status = self.work_permit_status
+                            # wp.reason_of_rejection = self.reason_of_rejection
+                            wp.save()
+                        if wp.work_permit_reference  == self.name and self.work_permit_status == "Completed":
+                            wp.status = self.work_permit_status
+                            wp.reason_of_rejection = self.reason_of_rejection
+                            wp.save()
+                            tp.workflow_state = "Completed"
+                        if wp.work_permit_reference  != self.name:
+                            tp.append("work_permit_records", {
+                            "work_permit_reference": self.name,
+                            "status": self.work_permit_status,
+                            "reason_of_rejection": self.reason_of_rejection
+                            })
+                elif tp.work_permit_records == []:
+                    tp.append("work_permit_records", {
+                    "work_permit_reference": self.name,
+                    "status": self.work_permit_status,
+                    "reason_of_rejection": self.reason_of_rejection
+                    })
+            tp.save()
+                    
     def on_submit(self):
         if self.work_permit_type != "Cancellation" and self.work_permit_type != "New Kuwaiti" and self.work_permit_type != "Local Transfer" and self.workflow_state != "Rejected":
             if "Completed" in self.workflow_state and self.upload_work_permit and self.attach_invoice and self.new_work_permit_expiry_date:
@@ -162,34 +180,17 @@ class WorkPermit(Document):
 
     def recall_create_medical_insurance_transfer(self):
         medical_insurance.creat_medical_insurance_for_transfer(self.employee)
-        print("done")
 
     def notify_grd_transfer_mi_record(self):
         transfer_operator = frappe.db.get_single_value("GRD Settings", "default_grd_operator_transfer")
-        print(transfer_operator)
         mi = frappe.db.get_value("Medical Insurance",{'employee':self.employee,'insurance_status':'Local Transfer'},['name'])#,
-        print(mi)#printing wp name
         if mi:
             mi_record = frappe.get_doc('Medical Insurance', mi)
             page_link = get_url("/desk#Form/Medical Insurance/" + mi_record.name)
             subject = ("Apply for Medical Insurance Online")
             message = "<p>Please Apply for Medical Insurance for employee:  <a href='{0}'></a>.</p>".format(mi_record.civil_id,page_link)
             create_notification_log(subject, message, [transfer_operator], mi_record)
-            print("recieve no")
-
-    # def recall_create_fingerprint_appointment_transfer(self):
-    #     fingerprint_appointment.create_fp_record_for_transfer(frappe.get_doc('Employee',self.employee))
-
-    # def notify_grd_transfer_fp_record(self):
-    #     fp = frappe.db.get_value("Fingerprint Appointment",{'employee':self.employee,'fingerprint_appointment_type':'Local Transfer'})
-    #     print(fp)#printing wp name
-    #     if fp:
-    #         fp_record = frappe.get_doc('Fingerprint Appointment', fp)
-    #         page_link = get_url("/desk#Form/Fingerprint Appointment/" + fp_record.name)
-    #         subject = ("Apply for Transfer Fingerprint Appointment Online")
-    #         message = "<p>Please Apply for Transfer Fingerprint Appointment Online for <a href='{0}'></a>.</p>".format(fp_record.employee)
-    #         create_notification_log(subject, message, [self.grd_operator], fp_record)
-            
+     
     def validate_mandatory_fields_for_grd_operator_again(self):
         users = frappe.utils.user.get_users_with_role('GRD Operator')
         filtered_users = []
@@ -222,8 +223,6 @@ class WorkPermit(Document):
     def set_work_permit_attachment_in_employee_doctype(self):
         today = date.today()
         employee = frappe.get_doc('Employee', self.employee)
-        filters= {"document_name":['=',"Work Permit"]}
-        employee_wp_document = frappe.db.get_list('Employee Document',filters, ['document_name','attach','issued_on','valid_till'])
         employee.append("one_fm_employee_documents", {
             "attach": self.upload_work_permit,
             "document_name": "Work Permit",

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -453,4 +453,6 @@ def create_new_work_permit(work_permit):
     if doc.work_permit_type == "Renewal Non Kuwaiti" or doc.work_permit_type == "Renewal Kuwaiti":
         wp.preparation = doc.preparation
     wp.save(ignore_permissions=True)
+    from one_fm.grd.doctype.work_permit import work_permit
+    work_permit.update_work_permit_details_in_tp(wp)
     return wp

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -261,24 +261,27 @@ def get_onboarding_details(parent, parenttype):
 @frappe.whitelist()
 def make_transfer_paper_from_job_offer(source_name, target_doc=None):
     offer_record = frappe.get_doc('Job Offer',source_name)
-    print(offer_record.job_applicant)
-    doc = get_mapped_doc("Job Applicant", offer_record.job_applicant, {
-        "Job Applicant": {
-            "doctype": "Transfer Paper",
-            "field_map": {
-                "one_fm_previous_company_trade_name_in_arabic": "previous_company_trade_name_arabic",
-                "one_fm__previous_company_authorized_signatory_name_arabic":"previous_company_authorized_signatory_name_arabic",
-                "one_fm_previous_company_contract_file_number":"previous_company_contract_file_number",
-                "one_fm_previous_company_issuer_number":"previous_company_issuer_number",
-                "one_fm_previous_company_pam_file_number":"previous_company_pam_file_number",
-                "one_fm_work_permit_salary":"previous_company_work_permit_salary",
-                "one_fm_work_permit_number":"work_permit_number",
-                "one_fm_last_working_date":"end_work_date",
-                "one_fm_duration_of_work_permit":"previous_company_duration_of_work_permit",
-                "name":"applicant"
+    if not frappe.db.exists("Transfer Paper", {'applicant': offer_record.job_applicant}):
+        print(offer_record.job_applicant)
+        doc = get_mapped_doc("Job Applicant", offer_record.job_applicant, {
+            "Job Applicant": {
+                "doctype": "Transfer Paper",
+                "field_map": {
+                    "one_fm_previous_company_trade_name_in_arabic": "previous_company_trade_name_arabic",
+                    "one_fm__previous_company_authorized_signatory_name_arabic":"previous_company_authorized_signatory_name_arabic",
+                    "one_fm_previous_company_contract_file_number":"previous_company_contract_file_number",
+                    "one_fm_previous_company_issuer_number":"previous_company_issuer_number",
+                    "one_fm_previous_company_pam_file_number":"previous_company_pam_file_number",
+                    "one_fm_work_permit_salary":"previous_company_work_permit_salary",
+                    "one_fm_work_permit_number":"work_permit_number",
+                    "one_fm_last_working_date":"end_work_date",
+                    "one_fm_duration_of_work_permit":"previous_company_duration_of_work_permit",
+                    "name":"applicant"
+                }
             }
-        }
-    }, target_doc)
+        }, target_doc)
+    else:
+        doc = frappe.msgprint(_("Transfer Paper is already exists for {0} Applicant").format(offer_record.applicant_name))
     return doc
 
 def update_onboarding_doc(doc, is_trash=False, cancel_oe=False):

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -236,8 +236,11 @@ doc_events = {
 		"on_submit": "one_fm.api.doc_events.update_training_event_data"
 	},
 	"Training Result" :{
-		"on_submit": "one_fm.api.doc_events.update_certification_data"
+		"on_submit": "one_fm.api.doc_events.update_certification_data" 
 	},
+	# "Additional Salary" :{
+	# 	"on_submit": "one_fm.grd.utils.validate_date"
+	# }
 }
 
 standard_portal_menu_items = [
@@ -310,8 +313,10 @@ scheduler_events = {
 	],
 
 	"cron": {
-		"0 8 1 * *": [# first day of the Month at 8 am
+		"0 8 15 * *": [
 			'one_fm.grd.doctype.preparation.preparation.create_preparation',
+		],
+		"0 8 1 * *": [# first day of the Month at 8 am
 			'one_fm.grd.doctype.pifss_monthly_deduction.pifss_monthly_deduction.auto_create_pifss_monthly_deduction_record',
 		],
 		"0/1 * * * *": [
@@ -350,6 +355,7 @@ scheduler_events = {
 			'one_fm.utils.send_gp_letter_attachment_reminder2',
 			'one_fm.utils.send_gp_letter_attachment_no_response',
 			'one_fm.grd.doctype.fingerprint_appointment.fingerprint_appointment.before_one_day_of_appointment_date',
+			'one_fm.grd.doctype.paci.paci.notify_to_upload_hawiyati',
 			# 'one_fm.grd.doctype.fingerprint_appointment.fingerprint_appointment.get_employee_list',
 			'one_fm.grd.doctype.fingerprint_appointment.fingerprint_appointment.notify_grd_operator_documents',
 			'one_fm.grd.doctype.pifss_form_103.pifss_form_103.notify_grd_to_check_status_on_pifss',

--- a/one_fm/public/js/doctype_js/job_offer.js
+++ b/one_fm/public/js/doctype_js/job_offer.js
@@ -11,7 +11,9 @@ frappe.ui.form.on('Job Offer', {
 				function () {
           frappe.model.open_mapped_doc({
             method: "one_fm.hiring.utils.make_transfer_paper_from_job_offer",
-            frm: frm
+            frm: frm,
+            freeze: true,
+            freeze_message: __("Creating Transfer Paper ...")
           });
 				}
 			);


### PR DESCRIPTION
-  stop creating transfer paper for existing records.
-  adding freeze message.
-  add buttons to link to the next grd transfer records.
-  update work permit workflow to handle GRD processes (Transfer-Extend-Renewal).
-  Add notification methods.
-  Update field name in Fingerprint Appointment.
-  Remove method.