### PR TITLE
Shift permission approve, reject, cancel api's

### DIFF
--- a/one_fm/api/mobile/shift_permission.py
+++ b/one_fm/api/mobile/shift_permission.py
@@ -118,7 +118,7 @@ def shift_permission_approved(supervisor_id, shift_permission_id):
                 notify_for_shift_permission_status(subject,message,user_id,shift_permission_record,1)
                 return response({'message':"Shift Permission Approved Successfully",'data':{shift_permission_record.workflow_state}},200)
             elif shift_permission_record.workflow_state == "Approved":
-                return response({'message':"Shift Permission is Already Approved",'data':{}},500)
+                return response({'message':"Shift Permission is Already Approved",'data':{}},400)
         elif shift_supervisor != supervisor_id:
             return response({'message':"Only Supervisor Has The Right to Approve",'data':{}},400)
     except Exception as e:
@@ -144,7 +144,7 @@ def shift_permission_rejected(supervisor_id, shift_permission_id):
                 notify_for_shift_permission_status(subject,message,user_id,shift_permission_record,1)
                 return response({'message':"Shift Permission Rejected Successfully",'data':{shift_permission_record.workflow_state}},200)
             elif shift_permission_record.workflow_state == "Rejected":
-                return response({'message':"Shift Permission is Already Rejected",'data':{}},500)
+                return response({'message':"Shift Permission is Already Rejected",'data':{}},400)
         elif shift_supervisor != supervisor_id:
             return response({'message':"Only Supervisor Has The Right to Reject",'data':{}},400)
     except Exception as e:
@@ -171,7 +171,7 @@ def shift_permission_cancelled(supervisor_id, shift_permission_id):
                 notify_for_shift_permission_status(subject,message,user_id,shift_permission_record,1)
                 return response({'message':"Shift Permission Cancelled Successfully",'data':{shift_permission_record.workflow_state}},200)
             elif shift_permission_record.workflow_state == "Cancelled":
-                return response({'message':"Shift Permission is Already Cancelled",'data':{}},500)
+                return response({'message':"Shift Permission is Already Cancelled",'data':{}},400)
         elif shift_supervisor != supervisor_id:
             return response({'message':"Only Supervisor Has The Right to Cancel",'data':{}},400)
     except Exception as e:

--- a/one_fm/api/notification.py
+++ b/one_fm/api/notification.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 
-def create_notification_log(subject, message, for_users, reference_doc):
+def create_notification_log(subject, message, for_users, reference_doc, mobile_notification=None):
 	for user in for_users:
 		doc = frappe.new_doc('Notification Log')
 		doc.subject = subject
@@ -10,6 +10,7 @@ def create_notification_log(subject, message, for_users, reference_doc):
 		doc.document_type = reference_doc.doctype
 		doc.document_name = reference_doc.name
 		doc.from_user = reference_doc.modified_by
+		doc.one_fm_mobile_app = mobile_notification
 		doc.save(ignore_permissions=True)
 		frappe.publish_realtime(event='eval_js', message="frappe.show_alert({message: '"+message+"', indicator: 'blue'})", user=user)
 	frappe.db.commit()

--- a/one_fm/operations/doctype/shift_permission/shift_permission.json
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.json
@@ -140,7 +140,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-27 10:22:12.585705",
+ "modified": "2021-11-06 16:56:05.624791",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Shift Permission",
@@ -156,6 +156,20 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Shift Supervisor",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -13,8 +13,6 @@ class ShiftPermission(Document):
 		self.check_permission_type()
 		self.check_shift_details_value()
 		self.validate_date()
-
-	def on_update(self):
 		self.validate_record()
 
 	def check_permission_type(self):

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -13,12 +13,14 @@ class ShiftPermission(Document):
 		self.check_permission_type()
 		self.check_shift_details_value()
 		self.validate_date()
+
+	def on_update(self):
 		self.validate_record()
-		
+
 	def check_permission_type(self):
 		if self.permission_type == "Arrive Late":
 			field_list = [{'Arrival Time':'arrival_time'}]
-			self.set_mendatory_fields(field_list)
+			self.set_mandatory_fields(field_list)
 		if self.permission_type == "Leave Early":
 			field_list = [{'Leaving Time':'leaving_time'}]
 			self.set_mandatory_fields(field_list)
@@ -36,7 +38,7 @@ class ShiftPermission(Document):
 	# This method validates any dublicate permission for the employee on same day
 	def validate_record(self):
 		date = getdate(self.date).strftime('%d-%m-%Y')
-		if self.docstatus==0 and frappe.db.exists("Shift Permission", {"employee": self.employee, "date":self.date, "assigned_shift": self.assigned_shift, "permission_type": self.permission_type}):
+		if self.docstatus==0 and frappe.db.exists("Shift Permission", {"employee": self.employee, "date":self.date, "assigned_shift": self.assigned_shift, "permission_type": self.permission_type, "workflow_state":"Pending"}):
 			frappe.throw(_("{employee} has already applied for permission to {type} on {date}.".format(employee=self.emp_name, type=self.permission_type.lower(), date=date)))
 
 	# This method will display the mandatory fields for the user


### PR DESCRIPTION
## Feature description
Approve, Reject, and Cancel shift permission API by the shift Supervisor.

## Solution description
Three API one for Approve shift, Reject the shift and Cancel shift permission API by the shift supervisor.

## Output screenshots (optional)
1- Approved shift permission:
<img width="1132" alt="approved permission" src="https://user-images.githubusercontent.com/80109720/140639182-fd3f1bd7-3cf9-40e2-bbd0-687215aad1f4.png">
2- Notify employee with the approved shift permission:
<img width="1092" alt="notify employee" src="https://user-images.githubusercontent.com/80109720/140639215-5be42a25-4b74-40f6-be07-6173de54a856.png">
3- Approve shift more than once by Supervisor:
<img width="1135" alt="approve document more than once" src="https://user-images.githubusercontent.com/80109720/140639234-4ef80464-c3b2-495c-ab08-6e3597430d00.png">
4- Reject the shift permission by Supervisor:
<img width="1116" alt="reject permission" src="https://user-images.githubusercontent.com/80109720/140639315-25ff7a89-a7e5-4d88-96fc-ef06c42072e0.png">
5- Notify employee with the rejected shift permission:
<img width="1186" alt="notify employee with the reject" src="https://user-images.githubusercontent.com/80109720/140639428-cc62078e-06cc-40b5-85f3-dd1517987021.png">
6- Cancel Approved shift permission by Supervisor:
<img width="1135" alt="cancel approved shift" src="https://user-images.githubusercontent.com/80109720/140639456-aaf15c80-5be9-4da9-ad32-0a24c4139035.png">
7- Notify employee with the cancelled shift permission:
<img width="1191" alt="cancel notification to employee" src="https://user-images.githubusercontent.com/80109720/140639486-e1ced6af-a8b8-4048-b92c-60d6ad4d793c.png">
8- Checking who is approving the shift permission :
<img width="1135" alt="Not supervisor approve" src="https://user-images.githubusercontent.com/80109720/140639551-d927986e-5d43-413b-92af-f076ba4b85f9.png">

## Areas affected and ensured
Customizing Create Notification log method by adding mobile notification parameter to it.
 

## Is there any existing behavior change of other features due to this code change?
Yes, we can add some notifications in the mobile notification list by updating create notification log.
 - fixing error in shift permission python file.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [ ] Safari
