### PR TITLE
Post Type Actions [Enhancement and bug fixes]

### DIFF
--- a/one_fm/one_fm/doctype/post_types_not_filled/post_types_not_filled.json
+++ b/one_fm/one_fm/doctype/post_types_not_filled/post_types_not_filled.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2021-11-07 10:47:12.278579",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "post_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "post_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Post Type",
+   "options": "Post Type",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2021-11-07 10:47:12.278579",
+ "modified_by": "Administrator",
+ "module": "one_fm",
+ "name": "Post Types Not Filled",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/one_fm/one_fm/doctype/post_types_not_filled/post_types_not_filled.py
+++ b/one_fm/one_fm/doctype/post_types_not_filled/post_types_not_filled.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, omar jaber and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class PostTypesNotFilled(Document):
+	pass

--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.json
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.json
@@ -1,28 +1,25 @@
 {
  "actions": [],
- "autoname": "format:{#####}-{date}-{post_type}-{action_type}",
  "creation": "2021-10-13 12:21:16.765478",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "date",
+  "start_date",
+  "col_br_1",
+  "end_date",
+  "actions_section",
   "status",
-  "supervisor",
   "action_type",
-  "post_type"
+  "supervisor",
+  "supervisor_name",
+  "post_types_not_filled"
  ],
  "fields": [
   {
-   "fieldname": "date",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Date",
-   "reqd": 1
-  },
-  {
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
    "options": "Pending\nCompleted\nOverdue\nCancelled"
   },
@@ -31,7 +28,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Supervisor",
-   "options": "Employee"
+   "options": "Employee",
+   "reqd": 1
   },
   {
    "fieldname": "action_type",
@@ -40,17 +38,46 @@
    "options": "Fill Post Type\nReview Post Type"
   },
   {
-   "fieldname": "post_type",
-   "fieldtype": "Link",
+   "fieldname": "start_date",
+   "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Post Type",
-   "options": "Post Type",
+   "label": "Start Date",
    "reqd": 1
+  },
+  {
+   "fieldname": "col_br_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "actions_section",
+   "fieldtype": "Section Break",
+   "label": "Actions"
+  },
+  {
+   "fieldname": "post_types_not_filled",
+   "fieldtype": "Table",
+   "label": "Post Types Not Filled",
+   "options": "Post Types Not Filled",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "supervisor.employee_name",
+   "fieldname": "supervisor_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Supervisor Name",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-10-13 14:58:49.498162",
+ "modified": "2021-11-07 11:08:24.652142",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Roster Post Actions",

--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
@@ -8,6 +8,10 @@ from frappe.utils import nowdate, add_to_date, cstr, cint, getdate, get_link_to_
 
 
 class RosterPostActions(Document):
+
+	def autoname(self):
+		self.name = self.start_date + "|" + self.end_date + "|" + self.action_type  + "|" + self.supervisor
+
 	def after_insert(self):
 		# send notification to supervisor
 		user_id = frappe.db.get_value("Employee", self.supervisor, ["user_id"])

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1654,7 +1654,7 @@ def update_onboarding_doc_for_bank_account(doc):
 def issue_roster_actions():
     # Queue roster actions functions to backgrounds jobs
     frappe.enqueue(create_roster_employee_actions, is_async=True, queue='long')
-    # frappe.enqueue(create_roster_post_actions, is_async=True, queue='long')
+    frappe.enqueue(create_roster_post_actions, is_async=True, queue='long')
 
 
 def create_roster_employee_actions():


### PR DESCRIPTION
## Feature description
A function that creates a Roster Post Actions document specifying the supervisor in charge, post types not filled under the same supervisor and the action to be taken, fetching post types not filled in a date range of 14 days (2 weeks).

## Analysis and design (optional)
For a span of two weeks, all post types that are not filled are fetched. The supervisors that are supervising the shifts that the post types are scheduled in are then grouped together with these post types.
The supervisors are then notified, issuing them actions to fill the post type in their shift.

## Solution description
First, the post types that are not filled are fetched by making comparisons in post schedules and employee schedules.
Then, the supervisors and the post types scheduled in their shifts are obtained.
Lastly, for each supervisor, issue a Roster Post action listing the post types to be filled.
The Roster Post Actions upon creation automatically sends an email notification to the supervisor, providing a link to the document.

## Output screenshots (optional)

## Areas affected and ensured
Nothing affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
