### PR TITLE
OT Request

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -210,7 +210,8 @@ doc_events = {
 	},
 	"Employee Checkin": {
 		"validate": "one_fm.api.doc_events.employee_checkin_validate",
-		"after_insert": "one_fm.api.doc_events.checkin_after_insert"
+		"after_insert": "one_fm.api.doc_events.checkin_after_insert",
+		"on_update": "one_fm.utils.create_additional_salary_for_overtime_request_for_head_office" 
 	},
 	"Purchase Receipt": {
 		"before_submit": "one_fm.purchase.utils.before_submit_purchase_receipt",

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.js
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.js
@@ -3,19 +3,19 @@
 
 frappe.ui.form.on('Overtime Request', {
 	
-	// Updating the `naming_series` upon request type (eg: request type: Head Office - naming: OT-HO-HR-EMP-00004)
 	request_type: function(frm) {
-		if (frm.doc.request_type == "Operations"){
-			frm.set_value("naming_series", "OT-OP-.{employee}.-");
-		}else if (frm.doc.request_type == "Head Office"){
-			frm.set_value("naming_series", "OT-HO-.{employee}.-");
-		}
+		set_naming_series(frm);
 	},
 	employee: function(frm) {
-		if (frm.doc.request_type == "Operations"){
-			frm.set_value("naming_series", "OT-OP-.{employee}.-");
-		}else if (frm.doc.request_type == "Head Office"){
-			frm.set_value("naming_series", "OT-HO-.{employee}.-");
-		}
-	},
+		set_naming_series(frm);
+	}
 });
+
+// Updating the `naming_series` upon request type (eg: request type: Head Office - naming: OT-HO-HR-EMP-00004)
+var set_naming_series = function(frm){
+	if (frm.doc.request_type == "Operations"){
+		frm.set_value("naming_series", "OT-OP-.{employee}.-");
+	}else if (frm.doc.request_type == "Head Office"){
+		frm.set_value("naming_series", "OT-HO-.{employee}.-");
+	}
+},

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.js
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021, omar jaber and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Overtime Request', {
+	
+	// Updating the `naming_series` upon request type (eg: request type: Head Office - naming: OT-HO-HR-EMP-00004)
+	request_type: function(frm) {
+		if (frm.doc.request_type == "Operations"){
+			frm.set_value("naming_series", "OT-OP-.{employee}.-");
+		}else if (frm.doc.request_type == "Head Office"){
+			frm.set_value("naming_series", "OT-HO-.{employee}.-");
+		}
+	},
+	employee: function(frm) {
+		if (frm.doc.request_type == "Operations"){
+			frm.set_value("naming_series", "OT-OP-.{employee}.-");
+		}else if (frm.doc.request_type == "Head Office"){
+			frm.set_value("naming_series", "OT-HO-.{employee}.-");
+		}
+	},
+});

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.json
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.json
@@ -16,7 +16,7 @@
   "status",
   "date",
   "overtime_hours",
-  "operations_ot_section",
+  "shift_details_section",
   "shift",
   "column_break_12",
   "post_type",
@@ -105,12 +105,6 @@
    "options": "Post Type"
   },
   {
-   "depends_on": "eval: doc.request_type == \"Operations\"",
-   "fieldname": "operations_ot_section",
-   "fieldtype": "Section Break",
-   "label": "Operations OT"
-  },
-  {
    "fieldname": "shift",
    "fieldtype": "Link",
    "label": "Shift",
@@ -122,12 +116,18 @@
    "fieldtype": "Data",
    "label": "Full Name",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.request_type == \"Operations\"",
+   "fieldname": "shift_details_section",
+   "fieldtype": "Section Break",
+   "label": "Shift Details"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-11 10:00:23.943003",
+ "modified": "2021-11-12 12:40:34.775950",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Overtime Request",
@@ -143,6 +143,33 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects Manager",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.json
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.json
@@ -1,0 +1,152 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2021-11-09 12:11:55.534255",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "request_type",
+  "employee",
+  "full_name",
+  "start_time",
+  "end_time",
+  "column_break_2",
+  "status",
+  "date",
+  "overtime_hours",
+  "operations_ot_section",
+  "shift",
+  "column_break_12",
+  "post_type",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Overtime Request",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date"
+  },
+  {
+   "depends_on": "eval: doc.request_type == \"Head Office\"",
+   "fieldname": "overtime_hours",
+   "fieldtype": "Data",
+   "label": "Overtime Hours",
+   "precision": "1",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.request_type == \"Head Office\"",
+   "fieldname": "start_time",
+   "fieldtype": "Time",
+   "label": "Start Time"
+  },
+  {
+   "depends_on": "eval: doc.request_type == \"Head Office\"",
+   "fieldname": "end_time",
+   "fieldtype": "Time",
+   "label": "End Time"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "\nDraft\nPending\nAccepted\nRejected"
+  },
+  {
+   "fieldname": "column_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "OT-OP-.{employee}.-",
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Series",
+   "options": "\nOT-OP-.{employee}.-\nOT-HO-.{employee}.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "request_type",
+   "fieldtype": "Select",
+   "label": "Request Type",
+   "options": "\nOperations\nHead Office",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_12",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "post_type",
+   "fieldtype": "Link",
+   "label": "Post Type",
+   "options": "Post Type"
+  },
+  {
+   "depends_on": "eval: doc.request_type == \"Operations\"",
+   "fieldname": "operations_ot_section",
+   "fieldtype": "Section Break",
+   "label": "Operations OT"
+  },
+  {
+   "fieldname": "shift",
+   "fieldtype": "Link",
+   "label": "Shift",
+   "options": "Operations Shift"
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "label": "Full Name",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2021-11-11 10:00:23.943003",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Overtime Request",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.py
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2021, omar jaber and contributors
+# For license information, please see license.txt
+
+import frappe, erpnext
+from frappe.model.document import Document
+from frappe.utils import time_diff_in_hours, getdate, cstr
+from one_fm.api.notification import create_notification_log, get_employee_user_id
+from frappe import _
+from frappe.utils import rounded
+
+class OvertimeRequest(Document):
+	
+	def on_update(self):
+		self.calculate_overtime_hours()
+		self.workflow_notification()
+		self.validate_mandatory()
+
+	def calculate_overtime_hours(self):
+		"""This method sets the `overtime_hours` for Head Office employee"""
+		if self.request_type == "Head Office":
+			if self.start_time and self.end_time:
+				hours=time_diff_in_hours(self.end_time,self.start_time)
+				self.db_set('overtime_hours',rounded(hours,1))
+
+	def workflow_notification(self):
+		"""
+		Explicit Explanation:
+		---------------------
+		The method is checking `workflow_state` and notifying the requested employee upon `request_type`:
+		For `Head Office`: `report_to` is the one needed to be notified upon employee response (Accept or Reject) 
+		For `Operations`: Shift Supervisor `supervisor_name` is the one needed to be notified upon employee response (Accept or Reject) 
+
+		On Acceptance of OT request for `Operations` employee, Employee Schedule record will be created with the shift details mentioned in the OT request
+		"""
+		date = getdate(self.date).strftime('%d-%m-%Y')
+		if self.workflow_state == "Pending":
+			if self.request_type == "Head Office":
+				reports_to = frappe.db.get_value("Employee",{'name':self.employee},['reports_to'])
+				supervisor_name = self.get_employee_name(reports_to)
+				employee_user_id = get_employee_user_id(self.employee)
+				subject = _("{employee} has Requested for {hours} Hours Overtime on {date}.".format(employee=supervisor_name, hours=rounded(self.overtime_hours,1), date=date))
+				message = _("{employee} has Requested for {hours} Hours Overtime on {date}.".format(employee=supervisor_name, hours=rounded(self.overtime_hours,1), date=date))
+				create_notification_log(subject, message, [employee_user_id], self)
+
+			if self.request_type == "Operations":
+				shift_name = frappe.db.get_value("Employee",{'name':self.employee},['shift'])
+				supervisor_name = frappe.db.get_value("Operations Shift",{'name':shift_name},['supervisor_name'])
+				employee_user_id = get_employee_user_id(self.employee)
+				subject = _("{employee} has Requested for Overtime Shift on {date}.".format(employee=supervisor_name, date=date))
+				message = _("{employee} has Requested for Overtime Shift on {date}.".format(employee=supervisor_name, date=date))
+				create_notification_log(subject, message, [employee_user_id], self)
+
+		if self.workflow_state == "Request Accepted":
+			if self.request_type == "Head Office":
+				reports_to, employee_name = frappe.db.get_value("Employee",{'name':self.employee},['reports_to', 'employee_name'])
+				supervisor_user_id = get_employee_user_id(reports_to)
+				subject = _("{employee} has Accepted The Overtime Request for {hours} Hours on {date}.".format(employee=employee_name, hours=rounded(self.overtime_hours,1), date=date))
+				message = _("{employee} has Accepted The Overtime Request for {hours} Hours on {date}.".format(employee=employee_name, hours=rounded(self.overtime_hours,1), date=date))
+				create_notification_log(subject, message, [supervisor_user_id], self)
+
+			if self.request_type == "Operations":
+				shift_name, employee_name = frappe.db.get_value("Employee",{'name':self.employee},['shift', 'employee_name'])
+				supervisor= frappe.db.get_value("Operations Shift",{'name':shift_name},['supervisor'])
+				supervisor_user_id = get_employee_user_id(supervisor)
+				subject = _("{employee} has Accepted The Overtime Request on {date}.".format(employee=employee_name, date=date))
+				message = _("{employee} has Accepted The Overtime Request on {date}.".format(employee=employee_name, date=date))
+				create_notification_log(subject, message, [supervisor_user_id], self)
+				self.create_employee_schedule()
+
+		if self.workflow_state == "Request Rejected":
+			if self.request_type == "Head Office":
+				reports_to, employee_name = frappe.db.get_value("Employee",{'name':self.employee},['reports_to', 'employee_name'])
+				supervisor_user_id = get_employee_user_id(reports_to)
+				supervisor_user_id = get_employee_user_id(reports_to)
+				subject = _("{employee} has Rejected The Overtime Request for {hours} Hours on {date}.".format(employee=employee_name, hours=rounded(self.overtime_hours,1), date=date))
+				message = _("{employee} has Rejected The Overtime Request for {hours} Hours on {date}.".format(employee=employee_name, hours=rounded(self.overtime_hours,1), date=date))
+				create_notification_log(subject, message, [supervisor_user_id], self)
+
+			if self.request_type == "Operations":
+				shift_name, employee_name = frappe.db.get_value("Employee",{'name':self.employee},['shift', 'employee_name'])
+				supervisor= frappe.db.get_value("Operations Shift",{'name':shift_name},['supervisor'])
+				supervisor_user_id = get_employee_user_id(supervisor)
+				subject = _("{employee} has Rejected The Overtime Request on {date}.".format(employee=employee_name, date=date))
+				message = _("{employee} has Rejected The Overtime Request on {date}.".format(employee=employee_name, date=date))
+				create_notification_log(subject, message, [supervisor_user_id], self)
+
+	# Method returns employee full name 
+	def get_employee_name(self, employee_code):
+		"""
+		Param: `employee_code` (eg: HR-EMP-00004)
+		Return: `employee_name` (eg: Amna Hatem Alshawa)
+		"""
+		return frappe.db.get_value("Employee", employee_code, "employee_name")
+
+	# Method creating employee Schedula on The Acceptance of OT Request for Operations Employee
+	def create_employee_schedule(self):
+		"""
+		setting data << employee, shift, post type, date, employee_availability, Roster Type >>
+		"""
+		if not frappe.db.exists("Employee Schedule",{'employee':self.employee, 'date':self.date, 'shift':self.operation_shift, 'post_type':self.post_type, 'roster_type':"Over-Time"}):
+			employee_schedule = frappe.new_doc("Employee Schedule")
+			employee_schedule.employee = self.employee
+			employee_schedule.date = cstr(self.date)
+			employee_schedule.employee_availability = "Working"
+			employee_schedule.post_type = self.post_type
+			employee_schedule.shift = self.shift
+			employee_schedule.roster_type = "Over-Time"
+		employee_schedule.save(ignore_permissions=True)
+
+	# This method checks mandatory fields per Request Type
+	def validate_mandatory(self):
+		if self.workflow_state == "Pending":
+			if self.request_type == "Head Office":
+				field_list = [{'Start Time':'start_time'},{'End Time':'end_time'}]
+				self.set_mendatory_fields(field_list)
+
+			if self.request_type == "Operations":
+				field_list = [{'Shift':'shift'},{'Post Type':'post_type'}]
+				self.set_mendatory_fields(field_list)
+
+	# This Method throw the mandatory fields message to the user
+	def set_mendatory_fields(self, field_list):
+		mandatory_fields = []
+		for fields in field_list:
+			for field in fields:
+				if not self.get(fields[field]):
+					mandatory_fields.append(field)
+        
+		if len(mandatory_fields) > 0:
+			message= 'Mandatory Fields required For Overtime Request Form<br><br><ul>'
+			for mandatory_field in mandatory_fields:
+				message += '<li>' + mandatory_field +'</li>'
+			message += '</ul>'
+			frappe.throw(message)
+
+

--- a/one_fm/one_fm/doctype/overtime_request/test_overtime_request.py
+++ b/one_fm/one_fm/doctype/overtime_request/test_overtime_request.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, omar jaber and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestOvertimeRequest(unittest.TestCase):
+	pass

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1966,7 +1966,7 @@ def create_additional_salary_for_overtime_request_for_head_office(doc,method):
             if checkin_datetime:
                 if is_checkin_record_available(check_out_date, check_out_time, checkin_datetime, overtime_doc.start_time, overtime_doc.end_time):
                     if basic_salary:
-                        if overtime_doc.overtime_hours and not frappe.db.exists("Additional Salary",{'employee':doc.employee, 'payroll_date':getdate(), 'salary_component':"Overtime Allowance"}):
+                        if overtime_doc.overtime_hours and not frappe.db.exists("Additional Salary",{'employee':doc.employee, 'payroll_date':getdate(), 'notes':"Overtime Earning"}):
                             overtime_amount = rounded(flt(overtime_doc.overtime_hours)*1.5*flt(basic_salary),3) # Overtime = `overtime_hours` * 1.5 * basic hourly wage
                             create_additional_salary(doc.employee,overtime_amount)
                             update_employee_schedule(frappe.get_doc("Employee Schedule",{'employee':doc.employee, 'date':check_out_date, 'employee_availability':"Day Off"}))
@@ -1977,7 +1977,7 @@ def create_additional_salary_for_overtime_request_for_head_office(doc,method):
             if cstr(check_out_time) >= cstr(overtime_doc.end_time):# Check-out time is equal to or after the requested time.
                 
                 if basic_salary:
-                    if overtime_doc.overtime_hours and not frappe.db.exists("Additional Salary",{'employee':doc.employee, 'payroll_date':getdate(), 'salary_component':"Overtime Allowance"}):
+                    if overtime_doc.overtime_hours and not frappe.db.exists("Additional Salary",{'employee':doc.employee, 'payroll_date':getdate(), 'notes':"Overtime Earning"}):
                         overtime_amount = rounded(flt(overtime_doc.overtime_hours)*1.5*flt(basic_salary),3) # Overtime = `overtime_hours` * 1.5 * basic hourly wage
                         create_additional_salary(doc.employee,overtime_amount)
                 if not basic_salary:

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3,16 +3,15 @@
 from __future__ import unicode_literals
 import itertools
 from one_fm.api.notification import create_notification_log
-import frappe
 from frappe import _
-import frappe, os
+import frappe, os, erpnext
 import json
 from frappe.model.document import Document
 from frappe.utils import get_site_base_path
 from erpnext.hr.doctype.employee.employee import get_holiday_list_for_employee
 from frappe.utils.data import flt, nowdate, getdate, cint
 from frappe.utils.csvutils import read_csv_content
-from frappe.utils import cint, cstr, flt, nowdate, comma_and, date_diff, getdate, formatdate ,get_url, get_datetime, add_to_date
+from frappe.utils import cint, cstr, flt, rounded,  nowdate, comma_and, date_diff, getdate, formatdate ,get_url, get_datetime, add_to_date, time_diff, get_time, time_diff_in_hours
 from datetime import tzinfo, timedelta, datetime
 from dateutil import parser
 from datetime import date
@@ -1933,3 +1932,108 @@ def get_annual_leave_employees(date):
 def get_emergency_leave_employees(date):
     """ returns list of employees who's employee availability status is emergency leave for a given date """
     return frappe.db.get_list("Employee Schedule", {'date': date, 'employee_availability': 'Emergency Leave'})
+
+
+@frappe.whitelist()
+def create_additional_salary_for_overtime_request_for_head_office(doc,method):
+    """
+    Method called in `Hook.py` Employee Checkin
+
+    Param: 
+    -------
+    checkout record
+    method: `on_update`
+
+    Returns:
+    --------
+    create Addiitonal Salary for Overtime request (OT request)
+
+    Explicit Explanation:
+    ----------------------
+    Method is covering two cases:
+    case1: Employee has OT request within a working day. The system will check the check-out time and accepted the OT request to create an additional salary.
+    case2: Employee has OT request within a day off. The system will check both check-in and checkout and accepted OT request to create additional salary and update employee schedule record.
+    """
+    
+    if doc.log_type == "OUT" and frappe.db.exists("Overtime Request",{'employee':doc.employee, 'request_type':"Head Office", 'date':getdate(doc.time), 'status':"Accepted"}):
+        check_out_time = get_time(doc.time)
+        check_out_date = getdate(doc.time) 
+        overtime_doc = frappe.get_doc("Overtime Request",{'employee':doc.employee, 'request_type':"Head Office", 'date':check_out_date, 'status':"Accepted"})
+        basic_salary = frappe.db.get_value("Employee",{'name':doc.employee},['one_fm_basic_salary'])
+        
+        if frappe.db.exists("Employee Schedule",{'employee':doc.employee, 'date':check_out_date, 'employee_availability':"Day Off"}):
+            checkin_datetime = frappe.db.get_value("Employee Checkin",{'employee':doc.employee, 'log_type':"IN"}, ['time'])
+            if checkin_datetime:
+                if is_checkin_record_available(check_out_date, check_out_time, checkin_datetime, overtime_doc.start_time, overtime_doc.end_time):
+                    if basic_salary:
+                        if overtime_doc.overtime_hours and not frappe.db.exists("Additional Salary",{'employee':doc.employee, 'payroll_date':getdate(), 'salary_component':"Overtime Allowance"}):
+                            overtime_amount = rounded(flt(overtime_doc.overtime_hours)*1.5*flt(basic_salary),3) # Overtime = `overtime_hours` * 1.5 * basic hourly wage
+                            create_additional_salary(doc.employee,overtime_amount)
+                            update_employee_schedule(frappe.get_doc("Employee Schedule",{'employee':doc.employee, 'date':check_out_date, 'employee_availability':"Day Off"}))
+                    if not basic_salary:
+                        frappe.throw("Please Define The Basic Salary for {employee} to Create Overtime Allowance".format(employee=doc.employee))
+        
+        if frappe.db.exists("Employee Schedule",{'employee':doc.employee, 'date':check_out_date, 'employee_availability':"Working"}):
+            if cstr(check_out_time) >= cstr(overtime_doc.end_time):# Check-out time is equal to or after the requested time.
+                
+                if basic_salary:
+                    if overtime_doc.overtime_hours and not frappe.db.exists("Additional Salary",{'employee':doc.employee, 'payroll_date':getdate(), 'salary_component':"Overtime Allowance"}):
+                        overtime_amount = rounded(flt(overtime_doc.overtime_hours)*1.5*flt(basic_salary),3) # Overtime = `overtime_hours` * 1.5 * basic hourly wage
+                        create_additional_salary(doc.employee,overtime_amount)
+                if not basic_salary:
+                    frappe.throw("Please Define The Basic Salary for {employee} to Create Overtime Allowance".format(employee=doc.employee))
+
+# The method checks the availability of check-in records for Head Office employees during their Day Off 
+# and verifies both the check-in and checkout time with the requested time in the Overtime request (OT request)      
+def is_checkin_record_available(check_out_date, check_out_time, checkin_datetime, start_time, end_time):
+    """
+    Param: 
+    -------
+    check_out_date (eg: 2021-11-11)
+    check_out_time (eg: 11:00:00)
+    checkin_datetime (eg: 2021-11-11 11:00:00)
+    start_time (eg: 10:00:00) - `start_time` mentioned in the overtime request
+    end_time (eg: 11:00:00) - `end_time` mentioned in the overtime request
+
+    Returns:
+    --------
+     boolean (True or False)
+
+    The method verifies the check-in and checkout time to be within the start and end time in the overtime request
+    """
+    checkin_date = getdate(checkin_datetime)
+    checkin_time = get_time(checkin_datetime)
+    if checkin_date == check_out_date:
+        if cstr(checkin_time) <= cstr(start_time) and cstr(check_out_time) >= cstr(end_time):
+            return True     
+    else:
+        return False
+
+# The Method is updating Employee Schedule data for `employee_availability` and `roster_type`
+def update_employee_schedule(employee_schedule_doc):
+    """
+    Param:
+    ------
+    Employee Schedule doctype
+    """
+    employee_schedule_doc.employee_availability = "Working"
+    employee_schedule_doc.roster_type = "Over-Time"
+    employee_schedule_doc.save(ignore_permissions=True)
+                    
+# Create Additional Salary For employee and set the overtime allowance for them amount
+def create_additional_salary(employee, amount):
+	"""
+    Param:
+    ------
+    Employee & overtime amount
+    """
+	additional_salary = frappe.new_doc("Additional Salary")
+	additional_salary.employee = employee
+	additional_salary.salary_component = "Overtime Allowance"
+	additional_salary.amount = amount
+	additional_salary.payroll_date = getdate()
+	additional_salary.company = erpnext.get_default_company()
+	additional_salary.overwrite_salary_structure_amount = 1
+	additional_salary.notes = "Overtime Earning"
+	additional_salary.insert()
+	additional_salary.submit()


### PR DESCRIPTION
## Feature description
- Create overtime requests for HO & Operations employees.
- Add workflow for the request.
- Workflow notification
- Modify the overtime request to handle Operations employees (in their case, a shift is defined in the overtime request instead of the time start and time end)
- Calculate and create an additional salary for HO employees checking two cases.

## Analysis and design (optional)


## Solution description
- For HO employees:
 **case1:** Employee has OT request within a working day. The system will check the check-out time and accept OT requests to create an additional salary.
 **case2:** Employee has OT request within a day off. The system will check both check-in and checkout and accept OT requests to create additional salary and update employee schedule record.

## Output screenshots (optional)

## Areas affected and ensured
In `hooks.py` file calling `create_additional_salary_for_overtime_request_for_head_office` on_update

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [ ] Safari
