### PR TITLE
Pushing Body Parameter according to the OS of the device.

### DIFF
--- a/one_fm/api/api.py
+++ b/one_fm/api/api.py
@@ -105,8 +105,6 @@ def store_fcm_token(employee_id ,fcm_token,device_os):
     Params: Employee ID (Single employee ID), FCM Token and Device OS comes from the client side.
     
     It returns true or false based on the execution.
-    
-    eg:bench execute --kwargs "{'employee_id':'HR-EMP-00002','fcm_token':'f0_1sEWK7kksiegwCZ7dUm:APA91bHCFXcmXdI7AnI_37dbfjTz5uKf46_kvwIXgmtSoxGCbApo4zFETfbaWaEj8FpKXzJlwUS6CTTCfSX8WStuiFx1oPR4gtH3I46-jNbQkbhfvXI_lR3mKDl6e2ek2nB_5OFTfH9c', 'device_os':'ios'}" one_fm.api.api.store_fcm_token 
     """
     Employee = frappe.get_doc("Employee",{"name":employee_id})
     try:
@@ -123,7 +121,7 @@ def store_fcm_token(employee_id ,fcm_token,device_os):
 
 
 @frappe.whitelist()
-def push_notification(employee_id, title, body, checkin, arriveLate ,checkout):
+def push_notification_for_checkin(employee_id, title, body, checkin, arriveLate ,checkout):
     """
     This Function send push notification to group of devices. here, we use 'firebase admin' library to send the message.
     
@@ -161,21 +159,20 @@ def push_notification(employee_id, title, body, checkin, arriveLate ,checkout):
     return response
 
 @frappe.whitelist()
-def push_notification_rest_api(employee_id, title, body, checkin, arriveLate ,checkout ):
+def push_notification_rest_api_for_checkin(employee_id, title, body, checkin, arriveLate ,checkout ):
     """ 
     This function is used to send notification through Firebase CLoud Message. 
     It is a rest API that sends request to "https://fcm.googleapis.com/fcm/send"
     
     Params: employee_id e.g. HR_EMP_00001, , title:"Title of your message", body:"Body of your message"
-    test Execution: bench execute --kwargs "{'employee_id':'HR-EMP-00001','title':'Hello','body':'Testing','checkin':'True','arriveLate':'True','checkout':'False'}" one_fm.api.api.push_notification_rest_api
 
     serverToken is fetched from firebase -> project settings -> Cloud Messaging -> Project credentials
     Device Token and Device OS is store in employee doctype using 'store_fcm_token' on device end.
     """
     serverToken = frappe.get_value("Firebase Cloud Message",filters=None, fieldname=['server_token'])
-    token = frappe.get_list("Employee", {"name": employee_id}, "fcm_token, device_os")
-    deviceToken = token[0].fcm_token
-    device_os = token[0].device_os
+    token, os = frappe.db.get_value("Employee", {"name": employee_id}, ["fcm_token", "device_os"])
+    deviceToken = token
+    device_os = os
 
     headers = {
             'Content-Type': 'application/json',

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -12,7 +12,7 @@ from erpnext.payroll.doctype.payroll_entry.payroll_entry import get_end_date
 from one_fm.api.doc_methods.payroll_entry import create_payroll_entry
 from erpnext.hr.doctype.attendance.attendance import mark_attendance
 from one_fm.api.mobile.roster import get_current_shift
-from one_fm.api.api import push_notification
+from one_fm.api.api import push_notification, push_notification_rest_api
 
 class DeltaTemplate(Template):
 	delimiter = "%"
@@ -148,11 +148,11 @@ def notify(recipients,log_type):
 		if log_type=="IN":
 			#arrive late button is true only if the employee has the user role "Head Office Employee".
 			if "Head Office Employee" in user_roles:
-				push_notification(employee_id, Notification_title, Notification_body, checkin="True",arriveLate="True",checkout="False")
+				push_notification_rest_api(employee_id, Notification_title, Notification_body, checkin=True,arriveLate=True,checkout=False)
 			else:
-				push_notification(employee_id, Notification_title, Notification_body, checkin="True",arriveLate="False",checkout="False")
+				push_notification_rest_api(employee_id, Notification_title, Notification_body, checkin=True,arriveLate=False,checkout=False)
 		if log_type=="OUT":
-			push_notification(employee_id, Notification_title, Notification_body, checkin="False",arriveLate="False",checkout="True")
+			push_notification_rest_api(employee_id, Notification_title, Notification_body, checkin=False,arriveLate=False,checkout=True)
 	
 	# send notification mail to list of employee using user_id
 	send_notification(checkin_subject, checkin_message, user_id)

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -12,7 +12,7 @@ from erpnext.payroll.doctype.payroll_entry.payroll_entry import get_end_date
 from one_fm.api.doc_methods.payroll_entry import create_payroll_entry
 from erpnext.hr.doctype.attendance.attendance import mark_attendance
 from one_fm.api.mobile.roster import get_current_shift
-from one_fm.api.api import push_notification, push_notification_rest_api
+from one_fm.api.api import push_notification_for_checkin, push_notification_rest_api_for_checkin
 
 class DeltaTemplate(Template):
 	delimiter = "%"
@@ -148,11 +148,11 @@ def notify(recipients,log_type):
 		if log_type=="IN":
 			#arrive late button is true only if the employee has the user role "Head Office Employee".
 			if "Head Office Employee" in user_roles:
-				push_notification_rest_api(employee_id, Notification_title, Notification_body, checkin=True,arriveLate=True,checkout=False)
+				push_notification_rest_api_for_checkin(employee_id, Notification_title, Notification_body, checkin=True,arriveLate=True,checkout=False)
 			else:
-				push_notification_rest_api(employee_id, Notification_title, Notification_body, checkin=True,arriveLate=False,checkout=False)
+				push_notification_rest_api_for_checkin(employee_id, Notification_title, Notification_body, checkin=True,arriveLate=False,checkout=False)
 		if log_type=="OUT":
-			push_notification_rest_api(employee_id, Notification_title, Notification_body, checkin=False,arriveLate=False,checkout=True)
+			push_notification_rest_api_for_checkin(employee_id, Notification_title, Notification_body, checkin=False,arriveLate=False,checkout=True)
 	
 	# send notification mail to list of employee using user_id
 	send_notification(checkin_subject, checkin_message, user_id)


### PR DESCRIPTION
## Feature description
Pushing Body Parameter according to the OS of the device. Two device OS: Android and iOS require different parameters for the body. 

## Solution description
The Response is sent using a Rest API. The device OS is stored in Employee doctype along with the device Token. The Body is designed based on the device OS.

## Output screenshots (optional)
<img width="250" alt="Screen Shot 2021-11-14 at 2 46 29 PM" src="https://user-images.githubusercontent.com/29017559/141745916-d68c9120-6500-44f7-99e8-d32cc889a20e.jpg">

## Areas affected and ensured
- Final Reminder 
- Push Notification

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
