### PR TITLE
Returning the Retries Left if face recognition Fails.

### DIFF
--- a/one_fm/api/mobile/legal.py
+++ b/one_fm/api/mobile/legal.py
@@ -176,9 +176,9 @@ def accept_penalty(file, retries, docname):
 
 			frappe.db.commit()
 
-			return response("Face Recognition Successfull.", True ,{},200)
+			return response("Face Recognition Successfull.", {}, True ,200)
 		else:
-			return response("Face Recognition Failed. You have "+str(retries_left)+" retries left.", False ,{"retries_left":retries_left},401)
+			return response("Face Recognition Failed. You have "+str(retries_left)+" retries left." ,{"retries_left":retries_left},False,401)
 			penalty.db_set("retries", retries_left)
 			frappe.throw(_("Face could not be recognized. You have {0} retries left.").format(frappe.bold(retries_left)), title='Validation Error')
 
@@ -203,14 +203,9 @@ def reject_penalty(rejection_reason, docname):
 			penalty.workflow_state = "Penalty Rejected"
 			penalty.save(ignore_permissions=True)
 			frappe.db.commit()
-			return {
-					'message': 'success'
-				}
+			return response("Penalty Rejected", {}, True, 200)
 		else:
-			return {
-					'message': f'No penalty {docname} found'
-				}
+			return response("No penalty {docname} found." , {}, False, 401)
 	except Exception as exc:
-		print(frappe.get_traceback())
 		frappe.log_error(frappe.get_traceback())
-		return frappe.utils.response.report_error(exc)
+		return response(exc,False,[], 500)

--- a/one_fm/api/mobile/legal.py
+++ b/one_fm/api/mobile/legal.py
@@ -149,7 +149,6 @@ def accept_penalty(file, retries, docname):
 		'success' message upon verification || updated retries and 'error' message || Exception. 
 	"""
 	try:
-		print(retries)
 		retries_left = cint(retries) - 1
 		OUTPUT_IMAGE_PATH = frappe.utils.cstr(frappe.local.site)+"/private/files/"+frappe.session.user+".png"
 		penalty = frappe.get_doc("Penalty", docname)
@@ -172,7 +171,6 @@ def accept_penalty(file, retries, docname):
 				"folder": "Home/Attachments",
 				"is_private": 1
 			})
-			print(file_doc.as_dict())
 			file_doc.flags.ignore_permissions = True
 			file_doc.insert()
 

--- a/one_fm/api/mobile/legal.py
+++ b/one_fm/api/mobile/legal.py
@@ -184,7 +184,7 @@ def accept_penalty(file, retries, docname):
 
 	except Exception as exc:
 		frappe.log_error(frappe.get_traceback())
-		return response(exc,False,[], 500)
+		return response(exc,{},False, 500)
 
 @frappe.whitelist()
 def reject_penalty(rejection_reason, docname):
@@ -208,4 +208,4 @@ def reject_penalty(rejection_reason, docname):
 			return response("No penalty {docname} found." , {}, False, 401)
 	except Exception as exc:
 		frappe.log_error(frappe.get_traceback())
-		return response(exc,False,[], 500)
+		return response(exc,{},False, 500)

--- a/one_fm/api/mobile/legal.py
+++ b/one_fm/api/mobile/legal.py
@@ -6,6 +6,7 @@ from one_fm.one_fm.page.face_recognition.face_recognition import recognize_face
 from frappe import _
 import pickle, face_recognition
 import json
+from one_fm.utils import response
 
 @frappe.whitelist()
 def get_employee_list(shift, penalty_occurence_time):
@@ -134,6 +135,11 @@ def get_penalty_details(penalty_name):
 @frappe.whitelist()
 def accept_penalty(file, retries, docname):
 	"""
+	This is an API to accept penalty. To Accept Penalty, one needs to pass the face recognition test.
+	Image file in base64 format is passed through face regonition test. And, employee is given 3 tries.
+	If face recognition is true, the penalty gets excepted. 
+	If Face recognition fails even after 3 tries, the image is sent to legal mangager for investigation. 
+
 	Params:
 	File: Base64 url of captured image.
 	Retries: number of tries left out of three
@@ -148,13 +154,13 @@ def accept_penalty(file, retries, docname):
 		OUTPUT_IMAGE_PATH = frappe.utils.cstr(frappe.local.site)+"/private/files/"+frappe.session.user+".png"
 		penalty = frappe.get_doc("Penalty", docname)
 		image = upload_image(file, OUTPUT_IMAGE_PATH)
-		if recognize_face(file) or retries_left == 0:
+		if recognize_face(image) or retries_left == 0:
 			if retries_left == 0:
 				penalty.verified = 0
 				send_email_to_legal(penalty)
 			else:
 				penalty.verified = 1		
-			penalty.workflow_state = "Penalty Accepted"
+				penalty.workflow_state = "Penalty Accepted"
 			penalty.save(ignore_permissions=True)
 			
 			file_doc = frappe.get_doc({
@@ -172,17 +178,15 @@ def accept_penalty(file, retries, docname):
 
 			frappe.db.commit()
 
-			return {
-				'message': 'success'
-			}
+			return response("Face Recognition Successfull.", True ,{},200)
 		else:
+			return response("Face Recognition Failed. You have "+str(retries_left)+" retries left.", False ,{"retries_left":retries_left},401)
 			penalty.db_set("retries", retries_left)
 			frappe.throw(_("Face could not be recognized. You have {0} retries left.").format(frappe.bold(retries_left)), title='Validation Error')
 
 	except Exception as exc:
-		print(frappe.get_traceback())
 		frappe.log_error(frappe.get_traceback())
-		return frappe.utils.response.report_error(exc)
+		return response(exc,False,[], 500)
 
 @frappe.whitelist()
 def reject_penalty(rejection_reason, docname):

--- a/one_fm/api/mobile/legal.py
+++ b/one_fm/api/mobile/legal.py
@@ -137,7 +137,7 @@ def accept_penalty(file, retries, docname):
 	"""
 	This is an API to accept penalty. To Accept Penalty, one needs to pass the face recognition test.
 	Image file in base64 format is passed through face regonition test. And, employee is given 3 tries.
-	If face recognition is true, the penalty gets excepted. 
+	If face recognition is true, the penalty gets accepted. 
 	If Face recognition fails even after 3 tries, the image is sent to legal mangager for investigation. 
 
 	Params:

--- a/one_fm/legal/doctype/penalty/penalty.py
+++ b/one_fm/legal/doctype/penalty/penalty.py
@@ -79,6 +79,20 @@ class Penalty(Document):
 
 @frappe.whitelist()
 def accept_penalty(file, retries, docname):
+	"""
+	This is an API to accept penalty. To Accept Penalty, one needs to pass the face recognition test.
+	Image file in base64 format is passed through face regonition test. And, employee is given 3 tries.
+	If face recognition is true, the penalty gets excepted. 
+	If Face recognition fails even after 3 tries, the image is sent to legal mangager for investigation. 
+
+	Params:
+	File: Base64 url of captured image.
+	Retries: number of tries left out of three
+	Docname: Name of the penalty doctype
+
+	Returns: 
+		'success' message upon verification || updated retries and 'error' message || Exception. 
+	"""
 	retries_left = cint(retries) - 1
 	OUTPUT_IMAGE_PATH = frappe.utils.cstr(frappe.local.site)+"/private/files/"+frappe.session.user+".png"
 	penalty = frappe.get_doc("Penalty", docname)

--- a/one_fm/legal/doctype/penalty/penalty.py
+++ b/one_fm/legal/doctype/penalty/penalty.py
@@ -115,7 +115,6 @@ def accept_penalty(file, retries, docname):
 			"folder": "Home/Attachments",
 			"is_private": 1
 		})
-		print(file_doc.as_dict())
 		file_doc.flags.ignore_permissions = True
 		file_doc.insert()
 

--- a/one_fm/legal/doctype/penalty/penalty.py
+++ b/one_fm/legal/doctype/penalty/penalty.py
@@ -82,7 +82,7 @@ def accept_penalty(file, retries, docname):
 	"""
 	This is an API to accept penalty. To Accept Penalty, one needs to pass the face recognition test.
 	Image file in base64 format is passed through face regonition test. And, employee is given 3 tries.
-	If face recognition is true, the penalty gets excepted. 
+	If face recognition is true, the penalty gets accepted. 
 	If Face recognition fails even after 3 tries, the image is sent to legal mangager for investigation. 
 
 	Params:

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2038,8 +2038,8 @@ def create_additional_salary(employee, amount):
 	additional_salary.insert()
 	additional_salary.submit()
 
-def response(message, success, data, status_code):
-     # Function to create response to the API. It generates json with message, success data object and the status code.
+def response(message, data, success, status_code):
+     # Function to create response to the API. It generates json with message, success, data object and the status code.
      frappe.local.response["message"] = message
      frappe.local.response["success"] = success
      frappe.local.response["data_obj"] = data

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2037,3 +2037,11 @@ def create_additional_salary(employee, amount):
 	additional_salary.notes = "Overtime Earning"
 	additional_salary.insert()
 	additional_salary.submit()
+
+def response(message, success, data, status_code):
+     # Function to create response to the API. It generates json with message, success data object and the status code.
+     frappe.local.response["message"] = message
+     frappe.local.response["success"] = success
+     frappe.local.response["data_obj"] = data
+     frappe.local.response["http_status_code"] = status_code
+     return


### PR DESCRIPTION
## Feature description
This is an API to accept penalties. To Accept a Penalty, one needs to pass the face recognition test. Image file in base64 format is passed through the face recognition test. And, the employee is given 3 tries. If face recognition is true, the penalty gets excepted. If Face recognition fails even after 3 tries, the image is sent to the legal manager for investigation. 

## Solution description
Send response using Response API. 
If Success = True, Status would be 200.
If Face recognition fails, return back the Retries left in data_obj.

## Output screenshots (optional)
On success:
<img width="300" alt="Screen Shot 2021-11-16 at 7 44 32 PM" src="https://user-images.githubusercontent.com/29017559/142171468-f1a9eb1b-acf2-4d1a-a611-67f906ee6d95.png">

On Fail:
<img width="300" alt="Screen Shot 2021-11-16 at 7 50 56 PM" src="https://user-images.githubusercontent.com/29017559/142171478-692d5e16-33ec-4198-a804-f3c385a35035.png">

## Areas affected and ensured
Accept Penalty API Response structure is Changed.

## Is there any existing behavior change of other features due to this code change?
yes, Response for Accept_Penalty.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
