### PR TITLE
#180327885

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -8,6 +8,8 @@ from one_fm.api.doc_methods.shift_request import shift_request_submit
 from one_fm.api.doc_methods.payroll_entry import validate_employee_attendance, get_count_holidays_of_employee, get_count_employee_attendance
 from one_fm.api.doc_methods.salary_slip import get_holidays_for_employee,get_leave_details
 from one_fm.api.doc_methods.item_price import validate,check_duplicates
+from erpnext.hr.doctype.leave_application.leave_application import LeaveApplication
+from one_fm.api.mobile.Leave_application import notify_leave_approver
 
 __version__ = '0.0.1'
 
@@ -20,3 +22,4 @@ SalarySlip.get_holidays_for_employee = get_holidays_for_employee
 SalarySlip.get_leave_details = get_leave_details
 ItemPrice.validate = validate
 ItemPrice.check_duplicates = check_duplicates
+LeaveApplication.notify_leave_approver = notify_leave_approver

--- a/one_fm/api/mobile/Leave_application.py
+++ b/one_fm/api/mobile/Leave_application.py
@@ -167,7 +167,7 @@ def notify_leave_approver(doc):
     This function is to notify the leave approver and request his action. 
     The Message sent through mail consist of 2 action: Approve and Reject.(It is sent only when the not sick leave.)
 
-    Param: doc -> Leave Application DocName (which needs approval)
+    Param: doc -> Leave Application Doc (which needs approval)
 
     It's a action that takes place on update of Leave Application.
     """

--- a/one_fm/api/mobile/Leave_application.py
+++ b/one_fm/api/mobile/Leave_application.py
@@ -167,6 +167,8 @@ def notify_leave_approver(doc):
     This function is to notify the leave approver and request his action. 
     The Message sent through mail consist of 2 action: Approve and Reject.(It is sent only when the not sick leave.)
 
+    Param: doc -> Leave Application DocName (which needs approval)
+
     It's a action that takes place on update of Leave Application.
     """
     #If Leave Approver Exist

--- a/one_fm/api/mobile/Leave_application.py
+++ b/one_fm/api/mobile/Leave_application.py
@@ -3,7 +3,6 @@ from frappe import _
 from erpnext.hr.doctype.leave_application.leave_application import get_leave_balance_on, get_leave_allocation_records, get_leave_details
 from datetime import date
 import datetime
-from one_fm.one_fm.doctype.leave_application.leave_application import get_leave_approver,get_employee_schedule, notifier_leave
 import collections
 from one_fm.api.tasks import get_action_user,get_notification_user
 
@@ -74,7 +73,7 @@ def leave_notify(docname,status):
     frappe.db.commit()
 
 #This function is the api to create a new leave notification.
-#bench execute --kwargs "{'employee':'HR-EMP-00002','from_date':'2021-11-02','to_date':'2021-11-02','leave_type':'Annual Leave','reason':'fever'}"  one_fm.api.mobile.Leave_application.create_new_leave_application
+#bench execute --kwargs "{'employee':'HR-EMP-00002','from_date':'2021-11-17','to_date':'2021-11-17','leave_type':'Annual Leave','reason':'fever'}"  one_fm.api.mobile.Leave_application.create_new_leave_application
 @frappe.whitelist()
 def create_new_leave_application(employee,from_date,to_date,leave_type,reason):
     """
@@ -135,3 +134,59 @@ def response(message, data, status_code):
      frappe.local.response["data_obj"] = data
      frappe.local.response["http_status_code"] = status_code
      return
+
+@frappe.whitelist()
+def get_leave_approver(employee):
+    """
+    This function fetches the leave approver for a given employee.
+    The leave approver is fetched  either Report_to or Leave Approver. 
+    But, if both don't exist, Operation manager is the Leave Approver.
+
+    Params: ERP Employee ID
+
+    Return: User ID of Leave Approver
+
+    """
+    approver = None
+    #check if employee has leave approver or report to assigned in the employee doctype
+    leave_approver, report_to = frappe.db.get_value("Employee", employee, ["leave_approver", "reports_to"])
+    if not leave_approver:
+        if report_to:
+            approver = frappe.db.get_value('Employee', {'name': report_to}, ['user_id'])
+        else:
+            #if not, return the 'Operational Manager' as the leave approver. But, check if employee himself is not a leave manager.
+            operation_manager = frappe.db.get_value('Employee', {'Designation': "Operation Manager"}, ['name','user_id'])
+            if operation_manager[0]!= employee:
+                approver = operation_manager[1]
+    else:
+        approver = leave_approver
+    return approver
+
+def notify_leave_approver(doc, method):
+    """
+    This function is to notify the leave approver and request his action. 
+    The Message sent through mail consist of 2 action: Approve and Reject.(It is sent only when the not sick leave.)
+
+    It's a docevent that takes place on update of Leave Application.
+    """
+    if doc.status == "Open" and doc.docstatus < 1:
+        # notify leave approver about creation
+        if frappe.db.get_single_value("HR Settings", "send_leave_notification"):
+            if doc.leave_approver:
+                parent_doc = frappe.get_doc('Leave Application', doc.name)
+                args = parent_doc.as_dict()
+
+                template = frappe.db.get_single_value('HR Settings', 'leave_approval_notification_template')
+                if not template:
+                    frappe.msgprint(_("Please set default template for Leave Approval Notification in HR Settings."))
+                    return
+                email_template = frappe.get_doc("Email Template", template)
+                message = frappe.render_template(email_template.response_html, args)
+
+                doc.notify({
+                    # for post in messages
+                    "message": message,
+                    "message_to": doc.leave_approver,
+                    # for email
+                    "subject": email_template.subject
+                })

--- a/one_fm/api/mobile/Leave_application.py
+++ b/one_fm/api/mobile/Leave_application.py
@@ -169,24 +169,24 @@ def notify_leave_approver(doc):
 
     It's a action that takes place on update of Leave Application.
     """
-    if doc.status == "Open" and doc.docstatus < 1:
-        # notify leave approver about creation
-        if frappe.db.get_single_value("HR Settings", "send_leave_notification"):
-            if doc.leave_approver:
-                parent_doc = frappe.get_doc('Leave Application', doc.name)
-                args = parent_doc.as_dict()
+    #If Leave Approver Exist
+    if doc.leave_approver:
+        parent_doc = frappe.get_doc('Leave Application', doc.name)
+        args = parent_doc.as_dict() #fetch fields from the doc.
 
-                template = frappe.db.get_single_value('HR Settings', 'leave_approval_notification_template')
-                if not template:
-                    frappe.msgprint(_("Please set default template for Leave Approval Notification in HR Settings."))
-                    return
-                email_template = frappe.get_doc("Email Template", template)
-                message = frappe.render_template(email_template.response_html, args)
+        #Fetch Email Template for Leave Approval. The email template is in HTML format.
+        template = frappe.db.get_single_value('HR Settings', 'leave_approval_notification_template')
+        if not template:
+            frappe.msgprint(_("Please set default template for Leave Approval Notification in HR Settings."))
+            return
+        email_template = frappe.get_doc("Email Template", template)
+        message = frappe.render_template(email_template.response_html, args)
 
-                doc.notify({
-                    # for post in messages
-                    "message": message,
-                    "message_to": doc.leave_approver,
-                    # for email
-                    "subject": email_template.subject
-                })
+        #send notification
+        doc.notify({
+            # for post in messages
+            "message": message,
+            "message_to": doc.leave_approver,
+            # for email
+            "subject": email_template.subject
+        })

--- a/one_fm/api/mobile/Leave_application.py
+++ b/one_fm/api/mobile/Leave_application.py
@@ -162,12 +162,12 @@ def get_leave_approver(employee):
         approver = leave_approver
     return approver
 
-def notify_leave_approver(doc, method):
+def notify_leave_approver(doc):
     """
     This function is to notify the leave approver and request his action. 
     The Message sent through mail consist of 2 action: Approve and Reject.(It is sent only when the not sick leave.)
 
-    It's a docevent that takes place on update of Leave Application.
+    It's a action that takes place on update of Leave Application.
     """
     if doc.status == "Open" and doc.docstatus < 1:
         # notify leave approver about creation

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -154,7 +154,6 @@ doc_events = {
 	},
 	"Leave Application": {
 		"on_submit": "one_fm.utils.leave_appillication_on_submit",
-		"on_update": "one_fm.api.mobile.Leave_application.notify_leave_approver",
 		"validate": "one_fm.utils.validate_hajj_leave",
 		"on_cancel": "one_fm.utils.leave_appillication_on_cancel"
 	},

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -154,6 +154,7 @@ doc_events = {
 	},
 	"Leave Application": {
 		"on_submit": "one_fm.utils.leave_appillication_on_submit",
+		"on_update": "one_fm.api.mobile.Leave_application.notify_leave_approver",
 		"validate": "one_fm.utils.validate_hajj_leave",
 		"on_cancel": "one_fm.utils.leave_appillication_on_cancel"
 	},


### PR DESCRIPTION
## Feature description
Fetching Leave Approver and Sending Leave Approval Notification in HTML format. This notification would consist of 2 actions: Accept or Reject.

## Solution description
Fetch the correct leave approver: either Report_to or Leave Approver. 
    But, if both don't exist, the Operation manager is the Leave Approver.
Once the form is submitted, an Approval Notification is sent through email. 

## Output screenshots (optional)
<img width="600" alt="Screen Shot 2021-11-17 at 12 44 40 PM" src="https://user-images.githubusercontent.com/29017559/142177582-01b4214d-a979-4bdf-b51f-fe458daa3cc3.png">

## Areas affected and ensured
Leave Application Notification:
- if Leave Type is Sick Leave, then text formate email is sent without Buttons.
- if Not, the doc status is open, and the HTML format is submitted, with Action Buttons.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
