### PR TITLE
#180324466 configure OT rates

### DIFF
--- a/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
+++ b/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
@@ -8,7 +8,12 @@
   "hr_settings_section",
   "holiday_compensatory_leave_type",
   "payroll_settings_section",
-  "holiday_additional_salary_component"
+  "holiday_additional_salary_component",
+  "overtime_additional_salary_component",
+  "col_br_1",
+  "working_day_overtime_rate",
+  "day_off_overtime_rate",
+  "public_holiday_overtime_rate"
  ],
  "fields": [
   {
@@ -36,12 +41,43 @@
    "label": "Holiday Additional Salary Component",
    "options": "Salary Component",
    "reqd": 1
+  },
+  {
+   "fieldname": "overtime_additional_salary_component",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Overtime Additional Salary Component",
+   "options": "Salary Component",
+   "reqd": 1
+  },
+  {
+   "fieldname": "col_br_1",
+   "fieldtype": "Column Break",
+   "label": "Overtime Amount = Basic Hourly Wage * Hours Worked * Overtime Rate"
+  },
+  {
+   "fieldname": "working_day_overtime_rate",
+   "fieldtype": "Float",
+   "label": "Working Day Overtime Rate",
+   "precision": "3"
+  },
+  {
+   "fieldname": "day_off_overtime_rate",
+   "fieldtype": "Float",
+   "label": "Day Off Overtime Rate",
+   "precision": "3"
+  },
+  {
+   "fieldname": "public_holiday_overtime_rate",
+   "fieldtype": "Float",
+   "label": "Public Holiday Overtime Rate",
+   "precision": "3"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-11-10 10:14:11.824807",
+ "modified": "2021-11-16 14:27:26.511718",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "HR and Payroll Additional Settings",


### PR DESCRIPTION
## Feature description
Added a provision to configure overtime rates for working day, day off and public holidays in HR and Payroll Additional Settings and calculated overtime allowance in additional salary as per configured rates.

## Solution description
Added fields to set overtime allowance component, working day overtime rate, day off overtime rate and public holiday overtime rate. To calculate the respective overtime rate for the employee, the following conditions are taken into consideration.

1. If the employee has an existing basic employee schedule on the same day as the overtime attendance with a status of working, working day overtime is taken and amount is calculated as `basic hourly wage * number of hours worked * working day overtime rate`.
2. Else if there is a holiday list assigned to the employee, holidays are fetched for the same date as the attendance date.
 - If the holiday date is of type weekly off, day off overtime rate is taken and amount is calculated as `basic hourly wage * number of hours worked * day off overtime rate`.
 - If the holiday is of type non weekly, which means it is a public/additional holiday and public holiday overtime rate is taken and amount is calculated as `basic hourly wage * number of hours worked * public holiday overtime rate`.

## Output screenshots
<img width="1427" alt="Screen Shot 2021-11-18 at 1 09 43 PM" src="https://user-images.githubusercontent.com/45887110/142395314-3e6f70bf-14c4-4096-b6e0-8b499e230ecc.png">
<img width="1430" alt="Screen Shot 2021-11-18 at 1 10 13 PM" src="https://user-images.githubusercontent.com/45887110/142395408-6ee38f77-7304-4efe-9127-2ce7da85c366.png">

## Areas affected and ensured
Nothing affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
