### PR TITLE
Add Firebase_admin Initialization inside a function

### DIFF
--- a/one_fm/api/api.py
+++ b/one_fm/api/api.py
@@ -10,8 +10,14 @@ import json
 from frappe.desk.page.user_profile.user_profile import get_energy_points_heatmap_data, get_user_rank
 from frappe.social.doctype.energy_point_log.energy_point_log import get_energy_points, get_user_energy_and_review_points
 
-cred = credentials.Certificate(frappe.utils.cstr(frappe.local.site)+"/private/files/one-fm-70641-firebase-adminsdk-nuf6h-667458c1a5.json")
-firebase_admin.initialize_app(cred)
+@frappe.whitelist()
+def initialize_firebase():
+    """
+        Initialize Firebase-Admin
+    """
+    #fetch credential file to initilize Firebase SDK
+    cred = credentials.Certificate(frappe.utils.cstr(frappe.local.site)+"/private/files/one-fm-70641-firebase-adminsdk-nuf6h-667458c1a5.json")
+    firebase_admin.initialize_app(cred)
 
 @frappe.whitelist()
 def _one_fm():
@@ -131,6 +137,7 @@ def push_notification_for_checkin(employee_id, title, body, checkin, arriveLate 
     
     It returns the response received.
     """ 
+    initialize_firebase()
     # Collect the registration token from employee doctype for the given list of employees
     registration_token = frappe.get_value("Employee", {"name": employee_id}, "fcm_token")
     


### PR DESCRIPTION
## Feature description
Create a function to initialize Firebase-Admin

## Solution description
The firebase admin was initialized independently, which was causing an issue. So, we created a new function that is been called only when necessary.

## Areas affected and ensured
Push Notifications for Checkin
initialize_firebase

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
