### PR TITLE
Civil ID OCR for Non-Kuwaiti

### DIFF
--- a/one_fm/templates/pages/applicant-docs.html
+++ b/one_fm/templates/pages/applicant-docs.html
@@ -153,9 +153,9 @@
                                         <input class="form-control input" type="text" id="PACI_No" name="paci_no" ></label><br>  <br>                          
                                     </div> 
 
-                                    <div class="form-group col-md-6" style="display: none;">
-                                        <label  for="Sponsor">Sponsor
-                                        <input class="form-control input" type="text" id="Sponsor" name="sponsor" ></label><br><br>
+                                    <div class="form-group col-md-6" >
+                                        <label  for="Sponsor_Name">Sponsor
+                                        <input class="form-control input" style="display: none;" type="text" id="Sponsor_Name" name="sponsor" ></label><br><br>
                                     </div>
                                       
                                 </div> 

--- a/one_fm/templates/pages/applicant-docs.js
+++ b/one_fm/templates/pages/applicant-docs.js
@@ -148,17 +148,18 @@ function fill_form(data, type){
       input_data(data,'front_text','Date_Of_Birth');
       input_data(data,'front_text','Expiry_Date');
       input_data(data,'back_text','PACI_No');
+      input_data(data,'front_text','Passport_Number');
       if(data['front_text']['Country_Code'] != undefined){
         fetchNationality(data['front_text']['Country_Code']);
       }
-      if(is_kuwaiti==1){
-        document.getElementById("Sponsor").style.display = "block"; 
+      if(is_kuwaiti==0){
+        document.getElementById("Sponsor_Name").style.display = "block"; 
+        input_data(data,'back_text','Sponsor_Name');
       }      
     }
     else if(type == "Passport"){
       input_data(data,'front_text','Passport_Date_of_Issue');
       input_data(data,'front_text','Passport_Date_of_Expiry');
-      input_data(data,'front_text','Passport_Number');
       input_data(data,'back_text','Passport_Place_of_Issue');
     }
   }

--- a/one_fm/templates/pages/applicant-docs.py
+++ b/one_fm/templates/pages/applicant-docs.py
@@ -90,11 +90,12 @@ def get_front_side_civil_id_text(image_path, client, is_kuwaiti):
     result = {}
     assemble = {}
     index = 0
+    print(texts[0].description)
 
     for index in range(1,len(texts)):
         assemble[index] = texts[index].description
     
-    if is_kuwaiti:
+    if is_kuwaiti == 1:
         result["Civil_ID_No"] = texts[find_index(assemble,"CARD")+1].description
         result["Country_Code"] = texts[find_index(assemble,"Nationality")+1].description
         result["Date_Of_Birth"] = datetime.datetime.strptime(texts[find_index(assemble,"Birth")+2].description, '%d/%m/%Y').strftime('%Y-%m-%d')
@@ -113,19 +114,21 @@ def get_front_side_civil_id_text(image_path, client, is_kuwaiti):
             result["Arabic_Name"] = result["Arabic_Name"] + texts[i].description + " "
 
     else:
-        result["Civil_ID_No"] = texts[find_index(assemble,"CARD")+1].description
+        result["Civil_ID_No"] = texts[find_index(assemble,"Civil")+3].description
         result["Country_Code"] = texts[find_index(assemble,"Nationality")+1].description
-        result["Date_Of_Birth"] = texts[find_index(assemble,"Birth")-7].description
+        result["Date_Of_Birth"] = datetime.datetime.strptime(texts[find_index(assemble,"لجن")+1].description, '%d/%m/%Y').strftime('%Y-%m-%d')
+        result["Expiry_Date"] = datetime.datetime.strptime(texts[find_index(assemble,"لجن")+2].description, '%d/%m/%Y').strftime('%Y-%m-%d')
+        result["Passport_Number"] = texts[find_index(assemble,"Nationality")+2].description
         result["Gender"] = ""
-        if texts[find_index(assemble,"Sex")-3].description == "M" or texts[find_index(assemble,"Sex")-3].description == "F":
-            result["Gender"] = texts[find_index(assemble,"Sex")-3].description
+        if texts[find_index(assemble,"Sex")+1].description == "M" or texts[find_index(assemble,"Sex")+1].description == "F":
+            result["Gender"] = texts[find_index(assemble,"Sex")+1].description
 
         result["Name"] = ""
-        for i in range(find_index(assemble,"Name")+1,find_index(assemble,"Passport")-1):
+        for i in range(find_index(assemble,"Name")+1,find_index(assemble,"Passport")):
             result["Name"] = result["Name"] + texts[i].description + " "
         
         result["Arabic_Name"]= ""
-        for i in range(find_index(assemble,"CARD")+2,find_index(assemble,"Civil")):
+        for i in range(find_index(assemble,"الرقه")+1,find_index(assemble,"Name")):
             result["Arabic_Name"] = result["Arabic_Name"] + texts[i].description + " "
             
         result["Arabic_Name"] = result["Arabic_Name"][::-1]
@@ -160,8 +163,7 @@ def get_back_side_civil_id_text(image_path, client, is_kuwaiti):
     
     for index in range(1,len(texts)):
         assemble[index] = texts[index].description
-    print(texts[0].description)
-    if is_kuwaiti:
+    if is_kuwaiti == 1:
         if find_index(assemble,"all"):
             result["PACI_No"] = texts[find_index(assemble,"all")-1].description
         else:
@@ -172,12 +174,12 @@ def get_back_side_civil_id_text(image_path, client, is_kuwaiti):
         if find_index(assemble,"YI"):
             result["PACI_No"] = texts[find_index(assemble,"YI")-1].description
         
-        result["Sponsor Name"]= ""
+        result["Sponsor_Name"]= ""
         if find_index(assemble, "(") and find_index(assemble, ")"):
             for i in range(find_index(assemble,")")+1,find_index(assemble,"العنوان:")):
-                result["Sponsor Name"] = result["Sponsor Name"] + texts[i].description + " "
+                result["Sponsor_Name"] = result["Sponsor_Name"] + texts[i].description + " "
                 
-            result["Sponsor Name"] = result["Sponsor Name"][::-1]
+            result["Sponsor_Name"] = result["Sponsor_Name"][::-1]
     
     return result
 


### PR DESCRIPTION
## Feature description
Portal to upload civil ID and fetch the text using Google Vision API for Non-Kuwaiti.  

## Solution description
Create a frontend to input civil ID in form of an image(Front and Back).  Run that two images through Vision API and fetch the text. Users could opt to not upload any civil ID Image and fill out the form manually.

## Output screenshots (optional)
<img width="512" alt="Screen Shot 2021-12-14 at 10 46 20 AM" src="https://user-images.githubusercontent.com/29017559/145955120-a96da362-509d-4e82-a044-f7d3c7d90aa4.png">


## Areas affected and ensured
New Field added and displayed only is non-Kuwaiti

## Is there any existing behavior change of other features due to this code change?
yes,
- Added Extra Fields
- Optimize the OCR 

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [] Safari
