### PR TITLE
Change signature field from signature to Attach

### DIFF
--- a/one_fm/grd/doctype/pam_authorized_signatory_table/pam_authorized_signatory_table.json
+++ b/one_fm/grd/doctype/pam_authorized_signatory_table/pam_authorized_signatory_table.json
@@ -74,13 +74,13 @@
   },
   {
    "fieldname": "signature",
-   "fieldtype": "Signature",
+   "fieldtype": "Attach",
    "label": "Signature"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-12-19 10:55:41.467589",
+ "modified": "2021-12-22 12:08:01.945761",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PAM Authorized Signatory Table",


### PR DESCRIPTION
## Feature description
Fix: Change signature field from signature to Attach

## Solution description
Change the Fieldtype of Signature in PAM Authorized Signatory Table.

## Output screenshots (optional)
<img width="300" alt="Screen Shot 2021-12-22 at 12 10 02 PM" src="https://user-images.githubusercontent.com/29017559/147067278-c267a755-afbe-4104-b33e-3b9f6b55e571.png">

## Areas affected and ensured
-  Fieldtype of Signature in PAM Authorized Signatory Table.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
