### PR TITLE
Indicate roster day off OT

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2863,6 +2863,7 @@ function schedule_change_post(page) {
 			{ 'label': 'Project End Date', 'fieldname': 'project_end_date', 'fieldtype': 'Check' },
 			{ 'label': 'Keep Days Off', 'fieldname': 'keep_days_off', 'fieldtype': 'Check' },
 			{ 'label': 'Request Employee Schedule', 'fieldname': 'request_employee_schedule', 'fieldtype': 'Check' },
+			{ 'label': 'Day Off OT', 'fieldname': 'day_off_ot', 'fieldtype': 'Check' },
 			{ 'fieldname': 'cb1', 'fieldtype': 'Column Break' },
 			{
 				'label': 'Till Date', 'fieldname': 'end_date', 'fieldtype': 'Date', 'depends_on': 'eval:doc.project_end_date==0', onchange: function () {
@@ -2879,7 +2880,7 @@ function schedule_change_post(page) {
 		],
 		primary_action: function () {
 
-			let { shift, site, post_type, project, start_date, project_end_date, keep_days_off, end_date, request_employee_schedule } = d.get_values();
+			let { shift, site, post_type, project, start_date, project_end_date, keep_days_off, day_off_ot, end_date, request_employee_schedule } = d.get_values();
 			$('#cover-spin').show(0);
 			let element = get_wrapper_element();
 			if (element == ".rosterOtMonth") {
@@ -2888,7 +2889,7 @@ function schedule_change_post(page) {
 				otRoster = false;
 			}
 			frappe.xcall('one_fm.one_fm.page.roster.roster.schedule_staff',
-				{ employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, request_employee_schedule, end_date })
+				{ employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, day_off_ot, request_employee_schedule, end_date })
 				.then(res => {
 					d.hide();
 					$('#cover-spin').hide();

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1151,7 +1151,8 @@ function render_roster(res, page, isOt) {
 				'Sick Leave': 'purplebox',
 				'Emergency Leave': 'purplebox',
 				'Annual Leave': 'purplebox',
-				'ASA': 'pinkboxcolor'
+				'ASA': 'pinkboxcolor',
+				'Day Off OT': 'orangeboxcolor'
 			};
 			let leavemap = {
 				'Day Off': 'DO',
@@ -1173,15 +1174,22 @@ function render_roster(res, page, isOt) {
 				'Half Day': 'HD',
 				'On Leave': 'OL'
 			};
-			let { employee, employee_name, date, post_type, post_abbrv, employee_availability, shift, roster_type, attendance, asa } = employees_data[employee_key][i];
+			let { employee, employee_name, date, post_type, post_abbrv, employee_availability, shift, roster_type, attendance, asa, day_off_ot } = employees_data[employee_key][i];
 			//OT schedule view
 			if (isOt) {
-				if (post_abbrv && roster_type == 'Over-Time') {
+				if (post_abbrv && roster_type == 'Over-Time' && day_off_ot==0) {
 					j++;
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so"
-							data-selectid="${employee + "|" + date + "|" + post_type + "|" + shift + "|" + employee_availability}">${post_abbrv}</div>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center so customtooltip"
+							data-selectid="${employee + "|" + date + "|" + post_type + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
+					</td>`;
+				}else if(post_abbrv && roster_type == 'Over-Time' && day_off_ot==1){
+					j++;
+					sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['Day Off OT']} d-flex justify-content-center align-items-center so customtooltip"
+							data-selectid="${employee + "|" + date + "|" + post_type + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 					</td>`;
 				}else if (employee_availability && !post_abbrv) {
 					sch = `
@@ -2888,8 +2896,19 @@ function schedule_change_post(page) {
 			} else if (element == ".rosterMonth") {
 				otRoster = false;
 			}
+
+			// Validate day off ot while scheduling
+			if (otRoster == false && parseInt(day_off_ot) == 1){
+				$('#cover-spin').hide();
+				frappe.msgprint(
+					msg='Please select OT Roster tab to roster employees in Day Off OT.',
+					title='Error',
+					raise_exception=1
+				)
+				frappe.throw()
+			}
 			frappe.xcall('one_fm.one_fm.page.roster.roster.schedule_staff',
-				{ employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, day_off_ot, request_employee_schedule, end_date })
+				{ employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, request_employee_schedule, day_off_ot, end_date })
 				.then(res => {
 					d.hide();
 					$('#cover-spin').hide();

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -359,9 +359,9 @@ def schedule_staff(employees, shift, post_type, otRoster, start_date, project_en
 			frappe.throw(_(e))
 
 def create_request_employee_schedule(employee, from_shift, from_post_type, to_shift, to_post_type, otRoster, start_date, end_date):
-	if otRoster == 'false':
+	if not bool(otRoster):
 		roster_type = 'Basic'
-	elif otRoster == 'true':
+	elif bool(otRoster):
 		roster_type = 'Over-Time'
 	req_es_doc = frappe.new_doc("Request Employee Schedule")
 	req_es_doc.employee = employee

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -359,9 +359,9 @@ def schedule_staff(employees, shift, post_type, otRoster, start_date, project_en
 			frappe.throw(_(e))
 
 def create_request_employee_schedule(employee, from_shift, from_post_type, to_shift, to_post_type, otRoster, start_date, end_date):
-	if not bool(otRoster):
+	if otRoster == 'false':
 		roster_type = 'Basic'
-	elif bool(otRoster):
+	elif otRoster == 'true':
 		roster_type = 'Over-Time'
 	req_es_doc = frappe.new_doc("Request Employee Schedule")
 	req_es_doc.employee = employee

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -405,7 +405,7 @@ def schedule(employee, shift, post_type, otRoster, start_date, end_date, keep_da
 				roster_doc.employee_availability = "Working"
 				roster_doc.post_type = post_type
 				roster_doc.roster_type = roster_type
-				roster_doc.day_off_ot = day_off_ot
+				roster_doc.day_off_ot = cint(day_off_ot)
 				roster_doc.save(ignore_permissions=True)
 		else:
 			if frappe.db.exists("Employee Schedule", {"employee": employee, "date": cstr(date.date()), "roster_type" : roster_type, 'employee_availability': 'Working'}):
@@ -905,7 +905,7 @@ def update_existing_schedule(roster, shift, site, shift_type, project, post_abbr
 	frappe.db.set_value("Employee Schedule", roster, "employee_availability", val=employee_availability)
 	frappe.db.set_value("Employee Schedule", roster, "post_type", val=post_type)
 	frappe.db.set_value("Employee Schedule", roster, "roster_type", val=roster_type)
-	frappe.db.set_value("Employee Schedule", roster, "day_off_ot", val=day_off_ot)
+	frappe.db.set_value("Employee Schedule", roster, "day_off_ot", val=cint(day_off_ot))
 
 
 @frappe.whitelist(allow_guest=True)

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -287,7 +287,7 @@ def get_current_user_details():
 
 	
 @frappe.whitelist()
-def schedule_staff(employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, request_employee_schedule, end_date=None):
+def schedule_staff(employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, day_off_ot, request_employee_schedule, end_date=None):
 
 	validation_logs = []
 	
@@ -334,7 +334,7 @@ def schedule_staff(employees, shift, post_type, otRoster, start_date, project_en
 			start = time.time()
 			for employee in json.loads(employees):
 				if not cint(request_employee_schedule):
-					frappe.enqueue(schedule, employee=employee, start_date=start_date, end_date=end_date, shift=shift, post_type=post_type, otRoster=otRoster, keep_days_off=keep_days_off, is_async=True, queue='long')
+					frappe.enqueue(schedule, employee=employee, start_date=start_date, end_date=end_date, shift=shift, post_type=post_type, otRoster=otRoster, keep_days_off=keep_days_off, day_off_ot=day_off_ot, is_async=True, queue='long')
 				else:
 					from_schedule = frappe.db.sql("""select shift, post_type from `tabEmployee Schedule` where shift!= %(shift)s and date >= %(start_date)s and date <= %(end_date)s and employee = %(employee)s""",{
 						'shift' : shift,
@@ -380,7 +380,7 @@ def create_request_employee_schedule(employee, from_shift, from_post_type, to_sh
 def update_roster(key):
 	frappe.publish_realtime(key, "Success")
 
-def schedule(employee, shift, post_type, otRoster, start_date, end_date, keep_days_off):
+def schedule(employee, shift, post_type, otRoster, start_date, end_date, keep_days_off, day_off_ot):
 	start = time.time()
 
 	if otRoster == 'false':
@@ -396,7 +396,7 @@ def schedule(employee, shift, post_type, otRoster, start_date, end_date, keep_da
 				site, project, shift_type= frappe.get_value("Operations Shift", shift, ["site", "project", "shift_type"])
 				post_abbrv = frappe.get_value("Post Type", post_type, "post_abbrv")
 				roster = frappe.get_value("Employee Schedule", {"employee": employee, "date": cstr(date.date()), "roster_type" : roster_type })
-				update_existing_schedule(roster, shift, site, shift_type, project, post_abbrv, cstr(date.date()), "Working", post_type, roster_type)
+				update_existing_schedule(roster, shift, site, shift_type, project, post_abbrv, cstr(date.date()), "Working", post_type, roster_type, day_off_ot)
 			else:
 				roster_doc = frappe.new_doc("Employee Schedule")
 				roster_doc.employee = employee
@@ -405,13 +405,14 @@ def schedule(employee, shift, post_type, otRoster, start_date, end_date, keep_da
 				roster_doc.employee_availability = "Working"
 				roster_doc.post_type = post_type
 				roster_doc.roster_type = roster_type
+				roster_doc.day_off_ot = day_off_ot
 				roster_doc.save(ignore_permissions=True)
 		else:
 			if frappe.db.exists("Employee Schedule", {"employee": employee, "date": cstr(date.date()), "roster_type" : roster_type, 'employee_availability': 'Working'}):
 				site, project, shift_type= frappe.get_value("Operations Shift", shift, ["site", "project", "shift_type"])
 				post_abbrv = frappe.get_value("Post Type", post_type, "post_abbrv")
 				roster = frappe.get_value("Employee Schedule", {"employee": employee, "date": cstr(date.date()), "roster_type" : roster_type })
-				update_existing_schedule(roster, shift, site, shift_type, project, post_abbrv, cstr(date.date()), "Working", post_type, roster_type)
+				update_existing_schedule(roster, shift, site, shift_type, project, post_abbrv, cstr(date.date()), "Working", post_type, roster_type, day_off_ot)
 			elif not frappe.db.exists("Employee Schedule", {"employee": employee, "date": cstr(date.date()), "roster_type" : roster_type}):
 				roster_doc = frappe.new_doc("Employee Schedule")
 				roster_doc.employee = employee
@@ -420,6 +421,7 @@ def schedule(employee, shift, post_type, otRoster, start_date, end_date, keep_da
 				roster_doc.employee_availability = "Working"
 				roster_doc.post_type = post_type
 				roster_doc.roster_type = roster_type
+				roster_doc.day_off_ot = day_off_ot
 				roster_doc.save(ignore_permissions=True)
 
 	"""Update employee assignment"""
@@ -893,7 +895,7 @@ def assign_job(employee, shift, site, project):
 	print("------------------[TIME TAKEN]===================", end-start)
 
 @frappe.whitelist(allow_guest=True)
-def update_existing_schedule(roster, shift, site, shift_type, project, post_abbrv, date, employee_availability, post_type, roster_type):
+def update_existing_schedule(roster, shift, site, shift_type, project, post_abbrv, date, employee_availability, post_type, roster_type, day_off_ot):
 	frappe.db.set_value("Employee Schedule", roster, "shift", val=shift)
 	frappe.db.set_value("Employee Schedule", roster, "site", val=site)
 	frappe.db.set_value("Employee Schedule", roster, "shift_type", val=shift_type)
@@ -903,6 +905,7 @@ def update_existing_schedule(roster, shift, site, shift_type, project, post_abbr
 	frappe.db.set_value("Employee Schedule", roster, "employee_availability", val=employee_availability)
 	frappe.db.set_value("Employee Schedule", roster, "post_type", val=post_type)
 	frappe.db.set_value("Employee Schedule", roster, "roster_type", val=roster_type)
+	frappe.db.set_value("Employee Schedule", roster, "day_off_ot", val=day_off_ot)
 
 
 @frappe.whitelist(allow_guest=True)

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -158,7 +158,7 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
 		filters.update({'date': ['between', (start_date, end_date)], 'employee': key[0]})
 		if isOt:
 			filters.update({'roster_type' : 'Over-Time'})	
-		schedules = frappe.db.get_list("Employee Schedule",filters, ["employee", "employee_name", "date", "post_type", "post_abbrv",  "shift", "roster_type", "employee_availability"], order_by="date asc, employee_name asc", ignore_permissions=True)
+		schedules = frappe.db.get_list("Employee Schedule",filters, ["employee", "employee_name", "date", "post_type", "post_abbrv",  "shift", "roster_type", "employee_availability", "day_off_ot"], order_by="date asc, employee_name asc", ignore_permissions=True)
 		if isOt:
 			filters.pop("roster_type", None)
 
@@ -287,7 +287,7 @@ def get_current_user_details():
 
 	
 @frappe.whitelist()
-def schedule_staff(employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, day_off_ot, request_employee_schedule, end_date=None):
+def schedule_staff(employees, shift, post_type, otRoster, start_date, project_end_date, keep_days_off, request_employee_schedule, day_off_ot=None, end_date=None):
 
 	validation_logs = []
 	

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.json
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "format:{date}/{employee}/{roster_type}",
  "creation": "2020-05-12 15:44:18.133872",
  "doctype": "DocType",
@@ -21,7 +22,8 @@
   "project",
   "attendance_status_section",
   "attended_status",
-  "roster_type"
+  "roster_type",
+  "day_off_ot"
  ],
  "fields": [
   {
@@ -138,10 +140,17 @@
    "fieldtype": "Select",
    "label": "Roster Type",
    "options": "Basic\nOver-Time"
+  },
+  {
+   "default": "0",
+   "fieldname": "day_off_ot",
+   "fieldtype": "Check",
+   "label": "Day Off OT"
   }
  ],
- "modified": "2021-05-26 08:59:21.055668",
- "modified_by": "m.ahmed@armor-services.com",
+ "links": [],
+ "modified": "2021-12-22 16:35:42.508708",
+ "modified_by": "Administrator",
  "module": "Operations",
  "name": "Employee Schedule",
  "owner": "Administrator",


### PR DESCRIPTION
## Feature description
As a Roster Operator, I want to indicate when an employee is working on his Day off, so that the employee receives an OT pay for that day

## Solution description
Added a checkbox in Employee Schedule to set if employee is working on a day off or not.
Similar checkbox added in the Schedule/Change Post dialog to make a day off OT entry.
Note: Day off OT can only be scheduled from the OT Roster tab.

## Output screenshots
Schedule/Change Post dialog OT Roster tab:
<img width="571" alt="Screen Shot 2021-12-23 at 9 49 54 AM" src="https://user-images.githubusercontent.com/45887110/147200374-da7dd6af-7f0a-47ed-89f3-9a7b3dd28c56.png">

Day Off OT indicator in OT roster tab:
<img width="1114" alt="Screen Shot 2021-12-23 at 9 50 39 AM" src="https://user-images.githubusercontent.com/45887110/147200475-c0622bea-719d-4264-9ae8-63ecf37694f3.png">


## Areas affected and ensured
Nothing affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
