### PR TITLE
#180747567 - Remove WH filters for type "Individual"

### DIFF
--- a/one_fm/purchase/doctype/request_for_material/request_for_material.js
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.js
@@ -530,7 +530,7 @@ var set_item_field_property = function(frm) {
 
 var set_warehouse_filters = function(frm) {
 	var wh_filters = {'is_group': 0};
-	if(frm.doc.type == 'Individual' || frm.doc.type == 'Department'){
+	if(frm.doc.type == 'Department'){
 		wh_filters = {'is_group': 0, 'department': frm.doc.department};
 	}
 	if(frm.doc.type == 'Project'){


### PR DESCRIPTION
## Feature description
RFM: When Type is chosen as "individual" , Warehouse is mandatory, but its Not reflecting in the Warehouse selection.

## Solution description
Removed check for type == "Individual".

## Areas affected and ensured
Nothing.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
