### PR TITLE
feat: Employee shift summary data API

### DIFF
--- a/one_fm/api/dashboard_utils.py
+++ b/one_fm/api/dashboard_utils.py
@@ -1,7 +1,10 @@
-import frappe
+from datetime import datetime, date
+import calendar
+import frappe, json
 from frappe import _
-import json
 from frappe.desk.notifications import get_filters_for
+from erpnext.hr.report.employee_leave_balance.employee_leave_balance import get_data as get_leave_balance
+from one_fm.api.utils import response
 
 @frappe.whitelist()
 def get_open_count(doctype, name, links):
@@ -48,3 +51,108 @@ def get_open_count(doctype, name, links):
 		out['timeline_data'] = module.get_timeline_data(doctype, name)
 	# print(out)
 	return out
+
+
+@frappe.whitelist()
+def get_employee_shift(employee_id, date_type='month'):
+	"""
+		Fetch employee information relating to
+		leave_balance, shift, penalties and attendance
+	"""
+
+	# prepare dates
+	today = datetime.today()
+	_start = today.replace(day=1).date()
+	_end = today.replace(day = calendar.monthrange(today.year, today.month)[1]).date()
+	if(date_type=='year'):
+		_start = date(today.year, 1, 31)
+		_end = date(today.year, 12, 31)
+
+	data = {
+		"leave_balance": "",
+		"penalties": "",
+		"days_worked": "",
+		"shift_time_from": "",
+		"shift_time_to": "",
+		"shift_location": "",
+		"shift_latitude_and_longitude": ""
+	}
+	try:
+		employee = frappe.get_doc('Employee', employee_id)
+		shift_assignment =  frappe.db.get_list('Shift Assignment',
+     		filters=[
+		         ['employee', '=', employee.name],
+		     ],
+		     fields=['name', 'employee', 'site', 'shift_type'],
+		     order_by='modified desc',
+		     limit=1,
+		 )
+		if(len(shift_assignment)):
+			shift_location = frappe.get_doc('Location', shift_assignment[0].site)
+			shift_type = frappe.get_doc('Shift Type', shift_assignment[0].shift_type)
+			days_worked = frappe.db.get_list('Attendance',
+		    filters=[
+	             ['employee', '=', employee.name],
+	             ['status', '=', 'Present'],
+	             ['attendance_date', 'BETWEEN', [_start, _end]],
+	        ],
+		    fields=['COUNT(*) as count', 'name', 'employee', 'status', 'attendance_date'],
+		    order_by='modified desc',
+		 	)[0].count
+			penalties = frappe.db.sql(f"""
+				SELECT COUNT(*) as count, pi.name, pie.employee_id
+				FROM `tabPenalty Issuance Employees` pie
+				JOIN `tabPenalty Issuance` pi ON pie.parent=pi.name
+				WHERE pie.employee_id="{employee.name}" AND pi.docstatus=1
+				AND pi.issuing_time BETWEEN "{_start} 00:00:00" AND "{_end} 23:59:59";
+			""", as_dict=1)[0].count
+			# get leav balance filters
+			filters=frappe._dict({'from_date':_start, 'to_date':_end, 'employee':employee.name})
+			leave_balance = sum([i.closing_balance for i in get_leave_balance(filters)])
+			response(
+				code=201, title='Result found!',
+				msg="Successful"
+			)
+			return {
+				'message': f"Employee shift record retrieved from {_start} to {_end}",
+				'data':{
+					'employee': employee.name,
+					'leave_balance':leave_balance,
+					'penalties': penalties,
+					'days_worked':days_worked,
+					'shift_time_from': shift_type.start_time,
+					'shift_time_to': shift_type.end_time,
+					'shift_location': shift_location.name,
+					'shift_latitude_and_longitude': {
+						'latitude': shift_location.latitude,
+						'longitude': shift_location.longitude,
+					}
+				},
+				'status': 201,
+				'succuess': True
+			}
+		else:
+			# return no shift found
+			response(
+				code=201, title='No shift found',
+				msg=f"No shift found for {employee.name}"
+			)
+			return {
+				'message':f"No shift found for {employee.name}",
+				'data':{},
+				'status': 201,
+				'succuess': False
+			}
+
+	except Exception as e:
+		# an error occured
+		response(
+			code=404, title='Employee Shift Summary',
+			msg=str(e)
+		)
+		return {
+			'message':str(e),
+			'data':{},
+			'status': 404,
+			'succuess': False
+		}

--- a/one_fm/api/dashboard_utils.py
+++ b/one_fm/api/dashboard_utils.py
@@ -109,10 +109,6 @@ def get_employee_shift(employee_id, date_type='month'):
 			# get leav balance filters
 			filters=frappe._dict({'from_date':_start, 'to_date':_end, 'employee':employee.name})
 			leave_balance = sum([i.closing_balance for i in get_leave_balance(filters)])
-			response(
-				code=201, title='Result found!',
-				msg="Successful"
-			)
 			return {
 				'message': f"Employee shift record retrieved from {_start} to {_end}",
 				'data':{
@@ -133,10 +129,6 @@ def get_employee_shift(employee_id, date_type='month'):
 			}
 		else:
 			# return no shift found
-			response(
-				code=201, title='No shift found',
-				msg=f"No shift found for {employee.name}"
-			)
 			return {
 				'message':f"No shift found for {employee.name}",
 				'data':{},
@@ -146,10 +138,6 @@ def get_employee_shift(employee_id, date_type='month'):
 
 	except Exception as e:
 		# an error occured
-		response(
-			code=404, title='Employee Shift Summary',
-			msg=str(e)
-		)
 		return {
 			'message':str(e),
 			'data':{},

--- a/one_fm/api/dashboard_utils.py
+++ b/one_fm/api/dashboard_utils.py
@@ -125,7 +125,7 @@ def get_employee_shift(employee_id, date_type='month'):
 					}
 				},
 				'status': 201,
-				'succuess': True
+				'success': True
 			}
 		else:
 			# return no shift found
@@ -133,7 +133,7 @@ def get_employee_shift(employee_id, date_type='month'):
 				'message':f"No shift found for {employee.name}",
 				'data':{},
 				'status': 201,
-				'succuess': False
+				'success': False
 			}
 
 	except Exception as e:
@@ -142,5 +142,5 @@ def get_employee_shift(employee_id, date_type='month'):
 			'message':str(e),
 			'data':{},
 			'status': 404,
-			'succuess': False
+			'success': False
 		}

--- a/one_fm/api/utils.py
+++ b/one_fm/api/utils.py
@@ -1,0 +1,9 @@
+import frappe
+
+def response(code, title, msg, data=None):
+    frappe.local.response['http_status_code'] = code
+    frappe.local.response['message'] = {
+        'title': title,
+        'msg': msg,
+        'data':data
+    }

--- a/one_fm/operations/doctype/operations_site/operations_site.js
+++ b/one_fm/operations/doctype/operations_site/operations_site.js
@@ -11,7 +11,7 @@ frappe.ui.form.on('Operations Site', {
 				]
 			}
 		});
-		
+
 		// Remove and change it
 		let {changes_log} = frm.doc;
 		let changes = ``;
@@ -44,8 +44,8 @@ frappe.ui.form.on('Operations Site', {
 						}
 					)
 				}
-			).addClass('btn-primary');		
-		}			
+			).addClass('btn-primary');
+		}
 	},
 })
 
@@ -57,9 +57,9 @@ function quick_entry_shifts_and_posts(frm){
 				let post_dialog = new frappe.ui.Dialog({
 					'fields': [
 						{
-							'label': 'Select Shifts', 
-							'fieldname': 'shifts', 
-							'fieldtype': 'Table', 
+							'label': 'Select Shifts',
+							'fieldname': 'shifts',
+							'fieldtype': 'Table',
 							'fields': [
 								{
 									fieldtype:'Link',
@@ -87,9 +87,9 @@ function quick_entry_shifts_and_posts(frm){
 						{'fieldname': 'cb2', 'fieldtype': 'Column Break'},
 						{'label': 'Number of Posts', 'fieldname': 'qty', 'fieldtype': 'Int'},
 						{
-							'label': 'Post Names', 
-							'fieldname': 'post_names', 
-							'fieldtype': 'Table', 
+							'label': 'Post Names',
+							'fieldname': 'post_names',
+							'fieldtype': 'Table',
 							'fields': [
 								{
 									fieldtype:'Data',
@@ -104,7 +104,7 @@ function quick_entry_shifts_and_posts(frm){
 								return this.data;
 							},
 							data: [],
-						},	
+						},
 						{'label': 'Post Type', 'fieldname': 'post_template', 'fieldtype': 'Link', 'options': 'Post Type', onchange: function(){
 							let post_type = this.value;
 							if(post_type !== undefined){
@@ -122,13 +122,13 @@ function quick_entry_shifts_and_posts(frm){
 											post_dialog.fields_dict["designations"].grid.remove_all();
 
 											skills.forEach((skill) => {
-												post_dialog.fields_dict["skills"].grid.df.data.push(skill);	
+												post_dialog.fields_dict["skills"].grid.df.data.push(skill);
 											});
 											post_dialog.fields_dict["skills"].grid.refresh();
 
 											designations.forEach((designation) => {
-												post_dialog.fields_dict["designations"].grid.df.data.push(designation);	
-											});										
+												post_dialog.fields_dict["designations"].grid.df.data.push(designation);
+											});
 											post_dialog.fields_dict["designations"].grid.refresh();
 
 										}
@@ -139,9 +139,9 @@ function quick_entry_shifts_and_posts(frm){
 						{'label': 'Sale Item', 'fieldname': 'sale_item', 'fieldtype': 'Link', 'options':'Item'},
 						{'fieldname': 'sb', 'fieldtype': 'Section Break'},
 						{
-							'label': 'Skills', 
-							'fieldname': 'skills', 
-							'fieldtype': 'Table', 
+							'label': 'Skills',
+							'fieldname': 'skills',
+							'fieldtype': 'Table',
 							'fields': [
 								{
 									fieldtype:'Link',
@@ -174,9 +174,9 @@ function quick_entry_shifts_and_posts(frm){
 							},
 						},
 						{
-							'label': 'Designations', 
-							'fieldname': 'designations', 
-							'fieldtype': 'Table', 
+							'label': 'Designations',
+							'fieldname': 'designations',
+							'fieldtype': 'Table',
 							'fields': [
 								{
 									fieldtype:'Link',
@@ -225,7 +225,7 @@ function quick_entry_shifts_and_posts(frm){
 							},
 							callback: function(r) {
 								if(!r.exc) {
-									post_dialog.hide();						
+									post_dialog.hide();
 								}
 							}
 						});
@@ -296,4 +296,3 @@ function set_contact(doc){
 	console.log(contact_details);
 	$('div[data-fieldname="contact_html"]').empty().append(`<div class="address-box">${contact_details}</div>`);
 }
-


### PR DESCRIPTION
**Employee shift summary data API**
  An API that retrieve Employee shift summary data and present the result format as below:
 
``{
    "message": "Employee shift record retrieved from 2022-01-31 to 2022-01-31",
    "data": {
        "leave_balance": 45,
        "penalties": 3,
        "days_worked": 13,
        "shift_time_from": "08:00:00",
        "shift_time_to": "15:00:00",
        "shift_location": "Austin",
        "shift_latitude_and_longitude": {
           "latitude":30.267153,
           "longitude": -97.7430608
        }
    },
    "success": true,
    'status': 201
}``

- highlight

   The following keys can be returned with the following values:

1.    status: 201, 404
2. success: true, false

- parameters: 
        - employee_id, date_type
        - date_type can be 'year' or 'month'. This will retrieve results based on month_start/month_end or 
          year_start/year_end

- Usage
   ** from backend ***
    ``
    from one_fm.api.dashboard_utils import get_employee_shift
    shift_detail = get_employee_shift('HR-EMP-78457854', date_type='year')
    ``
    ** AJAX API **
    ```url: "/api/method/one_fm.api.dashboard_utils.get_employee_shift"
    data/args: {employee_id:'HR-EMP-78457854', date_type:'year'}```

- Screenshot
![image](https://user-images.githubusercontent.com/10146518/147926545-9c705a45-1a82-44bc-8682-86c01ff9711f.png)





