### PR TITLE
[Fix] Removing the core DocType references from the GSD Workspace

### DIFF
--- a/one_fm/one_fm/doctype/employee_incentive_item/employee_incentive_item.json
+++ b/one_fm/one_fm/doctype/employee_incentive_item/employee_incentive_item.json
@@ -1,0 +1,83 @@
+{
+ "actions": [],
+ "creation": "2021-11-15 05:44:59.579823",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "employee",
+  "employee_name",
+  "wage",
+  "wage_factor",
+  "incentive_amount",
+  "column_break_5",
+  "salary_component",
+  "payroll_date"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Employee Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "wage",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Wage"
+  },
+  {
+   "fieldname": "wage_factor",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Wage Factor"
+  },
+  {
+   "fieldname": "incentive_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Incentive Amount",
+   "options": "currency",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_5",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "salary_component",
+   "fieldtype": "Link",
+   "label": "Salary Component",
+   "options": "Salary Component",
+   "reqd": 1
+  },
+  {
+   "fieldname": "payroll_date",
+   "fieldtype": "Date",
+   "label": "Payroll Date",
+   "reqd": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2021-12-27 13:38:20.539976",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Employee Incentive Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "title_field": "employee_name"
+}

--- a/one_fm/one_fm/doctype/employee_incentive_item/employee_incentive_item.py
+++ b/one_fm/one_fm/doctype/employee_incentive_item/employee_incentive_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, omar jaber and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class EmployeeIncentiveItem(Document):
+	pass

--- a/one_fm/one_fm/workspace/gsd/gsd.json
+++ b/one_fm/one_fm/workspace/gsd/gsd.json
@@ -324,55 +324,10 @@
    "type": "Link"
   },
   {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Purchase Order",
-   "link_to": "Purchase Order",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Purchase Invoice",
-   "link_to": "Purchase Invoice",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
    "hidden": 0,
    "is_query_report": 0,
    "label": "Purchase Settings",
    "link_to": "Purchase Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Items",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Item",
-   "link_to": "Item",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Item Group",
-   "link_to": "Item Group",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -433,84 +388,6 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Supplier",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Supplier",
-   "link_to": "Supplier",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Supplier Group",
-   "link_to": "Supplier Group",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Contact",
-   "link_to": "Contact",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Address",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Stock Transactions",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Stock Entry",
-   "link_to": "Stock Entry",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Purchase Receipt",
-   "link_to": "Purchase Receipt",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Warehouse",
-   "link_to": "Warehouse",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Fleet Management",
    "link_type": "DocType",
    "onboard": 0,
@@ -535,7 +412,7 @@
    "type": "Link"
   }
  ],
- "modified": "2021-08-18 01:25:47.611787",
+ "modified": "2022-01-02 10:26:24.782670",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "GSD",


### PR DESCRIPTION
## Feature description
 - Removing the core DocType references from the GSD Workspace

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
