### PR TITLE
chore: Remove overtime acceptance workflow from operations employees

### DIFF
--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.js
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.js
@@ -2,13 +2,27 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Overtime Request', {
-	
+	refresh: (frm)=>{
+		// disable Request Type
+		frm.toggle_enable('request_type', 0);
+		frm.trigger('set_employee_query');
+	},
 	request_type: function(frm) {
 		set_naming_series(frm);
 	},
 	employee: function(frm) {
 		set_naming_series(frm);
 	},
+	set_employee_query: (frm)=>{
+		// filter employee based on request_type
+		frm.set_query('employee', () => {
+		    return {
+		        filters: {
+		            department: ['!=', 'Operations - ONEFM'] 
+		        }
+		    }
+		})
+	}, // end filter employee
 });
 
 // Updating the `naming_series` upon request type (eg: request type: Head Office - naming: OT-HO-HR-EMP-00004)

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.json
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.json
@@ -88,10 +88,11 @@
    "reqd": 1
   },
   {
+   "default": "Head Office",
    "fieldname": "request_type",
    "fieldtype": "Select",
    "label": "Request Type",
-   "options": "\nOperations\nHead Office",
+   "options": "Head Office\nOperations",
    "reqd": 1
   },
   {
@@ -127,7 +128,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-12 12:40:34.775950",
+ "modified": "2022-01-04 11:01:44.694748",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Overtime Request",

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.py
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.py
@@ -135,6 +135,11 @@ class OvertimeRequest(Document):
 				mandatory_fields.append('Post Type')
 			self.set_mendatory_fields(mandatory_fields)
 
+		# FILTER OUT OPERATIONS REQUEST TYPE
+		if(self.request_type=='Operations'):
+			frappe.throw("""Request type <b>Operations</b> not allowed.
+				Only <b>Head Office</b> is permitted.""")
+
 	# This Method throw the mandatory fields message to the user
 	def set_mendatory_fields(self, mandatory_fields):
 		if len(mandatory_fields) > 0:


### PR DESCRIPTION
## Remove overtime acceptance workflow from operations employees
Overtime Request should only be applied to head office, filter out operations employee.

![image](https://user-images.githubusercontent.com/10146518/148028095-f4cfb1ab-73c3-4ea7-a959-c83cce109e83.png)

