### PR TITLE
[Fix] Add Quotation Attachments to the PO

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -154,7 +154,9 @@ doc_events = {
 	"Purchase Order": {
 		"on_submit": "one_fm.purchase.doctype.request_for_material.request_for_material.update_completed_purchase_qty",
 		"on_cancel": "one_fm.purchase.doctype.request_for_material.request_for_material.update_completed_purchase_qty",
-		"on_update_after_submit": "one_fm.purchase.utils.check_for_signature_for_purchase_order"
+		"on_update_after_submit": "one_fm.purchase.utils.check_for_signature_for_purchase_order",
+		"after_insert": "one_fm.purchase.utils.set_quotation_attachment_in_po"
+
 	},
 	"Leave Application": {
 		"on_submit": "one_fm.utils.leave_appillication_on_submit",

--- a/one_fm/purchase/doctype/request_for_material/request_for_material.js
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.js
@@ -19,6 +19,7 @@ frappe.ui.form.on('Request for Material', {
 			var df = frappe.meta.get_docfield("Request for Material Item","reject_item", cur_frm.doc.name);
             df.hidden = 0;
 		}
+		set_item_field_property(frm);
 	},
 	onload: function(frm) {
 		erpnext.utils.add_item(frm);
@@ -33,7 +34,6 @@ frappe.ui.form.on('Request for Material', {
 				filters: {'company': doc.company}
 			};
 		};
-
 	},
 	onload_post_render: function(frm) {
 		frm.get_field("items").grid.set_multiple_add("item_code", "qty");

--- a/one_fm/purchase/doctype/request_for_material/request_for_material.py
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.py
@@ -218,7 +218,7 @@ class RequestforMaterial(BuyingController):
 
 	def check_for_signature(self):
 		if self.status == "Approved" and not self.authority_signature:
-			frappe.throw(__('Please Sign the form to Accept the Request'))
+			frappe.throw(_('Please Sign the form to Accept the Request'))
 
 	def update_status(self, status):
 		self.check_modified_date()

--- a/one_fm/purchase/utils.py
+++ b/one_fm/purchase/utils.py
@@ -151,3 +151,25 @@ def get_supplier_list(doctype, txt, searchfield, start, page_len, filters):
                 'txt': "%%%s%%" % txt
             }
         )
+
+def set_quotation_attachment_in_po(doc, method):
+    if doc.one_fm_request_for_purchase:
+        quotations = frappe.get_list('Quotation From Supplier', {'request_for_purchase': doc.one_fm_request_for_purchase})
+        if len(quotations) > 0:
+            set_attachments_to_doctype('Quotation From Supplier', quotations, doc.doctype, doc.name)
+
+def set_attachments_to_doctype(source_dt, list_of_source, target_dt, target_name):
+    for source in list_of_source:
+        """Copy attachments"""
+        from frappe.desk.form.load import get_attachments
+        #loop through attachments
+        for attach_item in get_attachments(source_dt, source.name):
+            #save attachments to new doc
+            _file = frappe.get_doc({
+            "doctype": "File",
+            "file_url": attach_item.file_url,
+            "file_name": attach_item.file_name,
+            "attached_to_name": target_name,
+            "attached_to_doctype": target_dt,
+            "folder": "Home/Attachments"})
+            _file.save()


### PR DESCRIPTION
## Feature description
 - Add Quotation Attachments to the PO
 - Fixes in RFM


## Solution description
 - Get attachments from the Quotation and Update those attachments to the PO in after insert method
 - Created a method `set_attachments_to_doctype` for fetch attachments from source and set to the target doc

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
