### PR TITLE
chore: Auto download facial recognition file before installation

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -14,7 +14,7 @@ from one_fm.api.mobile.Leave_application import notify_leave_approver
 from one_fm.hiring.utils import grant_leave_alloc_for_employee
 
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 
 ShiftRequest.on_submit = shift_request_submit

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -113,7 +113,7 @@ home_page = "landing_page"
 # Installation
 # ------------
 
-# before_install = "one_fm.install.before_install"
+before_install = "one_fm.install.before_install.execute"
 # after_install = "one_fm.install.after_install"
 
 # Desk Notifications
@@ -517,3 +517,6 @@ fixtures = [
 # 	"frappe.desk.doctype.event.event.get_events": "one_fm.event.get_events"
 # }
 ShiftType.process_auto_attendance = process_auto_attendance
+
+# Required apps before installation
+required_apps = ['frappe', 'erpnext']

--- a/one_fm/install/before_install.py
+++ b/one_fm/install/before_install.py
@@ -16,7 +16,7 @@ def install_face_predictor():
         print('Downloading Landmark facial recognition')
         r = requests.get(url, stream=True)
         if r.ok:
-            print("saving 'Landmark facial recogintion to' ", path)
+            print("saving 'Landmark facial recognition to' ", path)
             with open(f"{path}{filename}", 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024 * 8):
                     if chunk:

--- a/one_fm/install/before_install.py
+++ b/one_fm/install/before_install.py
@@ -16,7 +16,7 @@ def install_face_predictor():
         print('Downloading Landmark facial recognition')
         r = requests.get(url, stream=True)
         if r.ok:
-            print("saving to 'Landmark facial recogintion to' ", path)
+            print("saving 'Landmark facial recogintion to' ", path)
             with open(f"{path}{filename}", 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024 * 8):
                     if chunk:

--- a/one_fm/install/before_install.py
+++ b/one_fm/install/before_install.py
@@ -1,0 +1,27 @@
+import frappe, requests, os
+
+
+def execute():
+    install_face_predictor()
+
+def install_face_predictor():
+    # download facial predictor
+    path =  f"{frappe.utils.get_bench_path()}/sites{frappe.utils.get_site_path().replace('.', '')}/private/files/"
+    filename = "shape_predictor_68_face_landmarks.dat"
+    url = 'https://github.com/italojs/facial-landmarks-recognition/raw/master/shape_predictor_68_face_landmarks.dat'
+    print("Checking if Landmark facial recogintion exists...")
+    if(os.path.exists(path+filename)):
+        print("Facial recognition found!.")
+    else:
+        print('Downloading Landmark facial recognition')
+        r = requests.get(url, stream=True)
+        if r.ok:
+            print("saving to 'Landmark facial recogintion to' ", path)
+            with open(f"{path}{filename}", 'wb') as f:
+                for chunk in r.iter_content(chunk_size=1024 * 8):
+                    if chunk:
+                        f.write(chunk)
+                        f.flush()
+                        os.fsync(f.fileno())
+        else:  # HTTP status code 4XX/5XX
+            print("Download failed: status code {}\n{}".format(r.status_code, r.text))

--- a/one_fm/one_fm/workspace/grd/grd.json
+++ b/one_fm/one_fm/workspace/grd/grd.json
@@ -1,0 +1,210 @@
+{
+ "cards_label": "GRD Module",
+ "category": "Modules",
+ "charts": [],
+ "creation": "2021-08-25 12:46:35.406474",
+ "developer_mode_only": 0,
+ "disable_user_customization": 0,
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "extends_another_page": 0,
+ "hide_custom": 1,
+ "icon": "",
+ "idx": 0,
+ "is_default": 0,
+ "is_standard": 1,
+ "label": "GRD",
+ "links": [
+  {
+   "hidden": 0,
+   "icon": "fa fa-stamp",
+   "is_query_report": 0,
+   "label": "Public Institution for Social Security",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PIFSS Authorized Signatory List",
+   "link_to": "PIFSS Authorized Signatory",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PIFSS Form 103 List",
+   "link_to": "PIFSS Form 103",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PIFSS Form 55 List",
+   "link_to": "PIFSS Form 55",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PIFSS Monthly Deduction List",
+   "link_to": "PIFSS Monthly Deduction",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Manpower and Government Restructuring Program",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "MGRP",
+   "link_to": "MGRP",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Ministry Of Commerce And Industry",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "MOCI License List",
+   "link_to": "MOCI License",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Public Authority Of Manpower",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PAM File List",
+   "link_to": "PAM File",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PAM Authorized Signatory List",
+   "link_to": "PAM Authorized Signatory List",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PAM Designation List",
+   "link_to": "PAM Designation List",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Work Permit List",
+   "link_to": "Work Permit",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Medical Insurance",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Medical Insurance List",
+   "link_to": "Medical Insurance",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Ministry Of Interior ",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "MOI Residency Jawazat List",
+   "link_to": "MOI Residency Jawazat",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Fingerprint Appointment List",
+   "link_to": "Fingerprint Appointment",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Public Authority For Civil Information",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PACI List",
+   "link_to": "PACI",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  }
+ ],
+ "modified": "2022-01-10 11:51:10.141743",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "GRD",
+ "owner": "a.alshawa@armor-services.com",
+ "pin_to_bottom": 0,
+ "pin_to_top": 0,
+ "shortcuts": []
+}


### PR DESCRIPTION
## Auto download facial recognition file before installation
One FM app require facial recognition for processing images, a .dat file 'shape_predictor_68_face_landmarks.dat' for the processing images. Fresh installation of ONE-FM app fails because the file was not found.

This PR checks if the file exists before installation/app update, if exists, skips else it downloads and save the file in the private directory.

The file can be found in the following url:  [https://github.com/italojs/facial-landmarks-recognition/blob/master/shape_predictor_68_face_landmarks.dat](url)

An installation drive was executed and result can be seen in screenshot below.
![image](https://user-images.githubusercontent.com/10146518/148741117-e2315cc1-47b1-41f5-acb9-acf8c53c936e.png)

