### PR TITLE
Contracts Amendment

### DIFF
--- a/one_fm/one_fm/sales_invoice_custom.py
+++ b/one_fm/one_fm/sales_invoice_custom.py
@@ -209,7 +209,7 @@ def append_invoice_parent_details(sales_invoice, contracts):
 
 #Get contracts list
 def get_contracts_list(due_date, start_date, end_date,is_invoice_for_airport = 0):
-    filters = {'due_date': due_date, 'start_date': start_date, 'end_date': end_date}
+    filters = {'due_date': due_date, 'start_date': start_date, 'end_date': end_date, 'workflow_state': 'Active'}
     conditions = "due_date = %(due_date)s and start_date <= %(start_date)s and end_date >= %(end_date)s"
     if is_invoice_for_airport != 0:
         filters['is_invoice_for_airport'] = True

--- a/one_fm/operations/doctype/contracts/contracts.js
+++ b/one_fm/operations/doctype/contracts/contracts.js
@@ -7,9 +7,9 @@ function open_form(frm, doctype, child_doctype, parentfield) {
 	frappe.model.with_doctype(doctype, () => {
         let new_doc = frappe.model.get_new_doc(doctype);
         new_doc.type  = 'Contracts';
-		new_doc.customer = frm.doc.client;
+		new_doc.client = frm.doc.client;
 		new_doc.project = frm.doc.project;
-
+		new_doc.price_list = frm.doc.price_list;
 		frappe.ui.form.make_quick_entry(doctype, null, null, new_doc);
 	});
 
@@ -87,6 +87,11 @@ frappe.ui.form.on('Contracts', {
 		}
 	},
 	refresh:function(frm){
+		if (frm.doc.workflow_state == "Inactive"){
+			frm.add_custom_button(__("Ammend Contract"), function() {
+				open_form(frm, "Contracts", null, null)
+			});
+		}
 		var days,management_fee_percentage,management_fee;
 		frm.set_query("bank_account", function() {
 			return {

--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -437,13 +437,14 @@
   },
   {
    "fieldname": "amended_from",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Amended From",
+   "options": "Contracts",
    "read_only": 1
   }
  ],
  "links": [],
- "modified": "2022-01-13 03:38:44.429017",
+ "modified": "2022-01-13 16:59:31.405721",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",

--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "format:{client}-{project}-{start_date}",
  "creation": "2020-04-28 11:07:30.373279",
@@ -6,6 +7,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "amended_from",
   "client",
   "project",
   "monthly_working_days",
@@ -432,9 +434,16 @@
    "fieldtype": "Select",
    "label": "Billing Type",
    "options": "\nActual Hours\nShift Hours"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Data",
+   "label": "Amended From",
+   "read_only": 1
   }
  ],
- "modified": "2021-06-30 06:39:32.525621",
+ "links": [],
+ "modified": "2022-01-13 03:38:44.429017",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -24,6 +24,9 @@ class Contracts(Document):
 		if(years < 1 and months > 0):
 			self.duration = cstr(months) + ' month'
 
+	def on_cancel(self):
+		frappe.throw("Contracts cannot be cancelled. Please try to ammend the existing record.")
+
 @frappe.whitelist()
 def get_contracts_asset_items(contracts):
 	contracts_item_list = frappe.db.sql("""

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -80,3 +80,16 @@ def auto_renew_contracts():
 		contract_doc.end_date = add_years(contract_doc.end_date, 1)
 		contract_doc.save()
 		frappe.db.commit()
+
+@frappe.whitelist()
+def set_inactive(docname):
+	try:
+		doc = frappe.get_doc("Contracts", docname)
+		doc.workflow_state = "Inactive"
+		doc.save()
+		doc.submit()
+		frappe.db.commit()
+		return True
+	
+	except Exception as error:
+		frappe.throw(error)


### PR DESCRIPTION
## Feature description
As a Finance Officer, I want my contract amendments to be reflected in my Sales Invoices so that my invoices are always up to date.

## Analysis and design
- Legal documents such as Contracts must not have a 'Cancelled' state. Submitted documents must not be cancelled.
- Contracts now have a workflow state: Active, Inactive.
- When a contract is amended, the old one becomes inactive.
- When a contract is amended, new sales invoices will be issued on the amended contract.
- When a contract is amended, it is linked to the old contract.

## Solution description
- Added a 'Amended From' field in Contracts that links to the Contract it had been amended from.
- Added button to amend a contract that sets the current contract as 'Inactive' and directs the user to a new Contracts form which has the amend from linked to the previous contract. The base values are auto fetched.
- Throw error message when user tries to cancel a Contract.

## Areas affected and ensured
Nothing.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
