### PR TITLE
Create Notification log to Notify

### DIFF
--- a/one_fm/legal/doctype/penalty/penalty.py
+++ b/one_fm/legal/doctype/penalty/penalty.py
@@ -249,8 +249,8 @@ def notify_employee_autoreject(doc):
 	create_notification_log(subject, message, [doc.recipient_user], doc)
 
 def automatic_reject():
-	time = add_to_date(now_datetime(), hours=-1, as_datetime=True).strftime("%Y-%m-%d %H:%M")
-	time_range = add_to_date(now_datetime(), hours=-0, as_datetime=True).strftime("%Y-%m-%d %H:%M")
+	time = add_to_date(now_datetime(), hours=-48, as_datetime=True).strftime("%Y-%m-%d %H:%M")
+	time_range = add_to_date(now_datetime(), hours=-47, as_datetime=True).strftime("%Y-%m-%d %H:%M")
 	docs = frappe.get_all("Penalty", {"penalty_issuance_time": ["between", [time, time_range]], "workflow_state": "Penalty Issued"})
     #"2021-05-11 11:07:09"
 	for doc in docs:


### PR DESCRIPTION
## Feature description
[Fix: Penalty Rejection Email / Notification Issue](https://dev.one-fm.com/app/issue/ISS-2022-00003)

## Solution description
Create Notification Log and add reference Doc as a link.

## Output screenshots (optional)

<img width="1287" alt="Screen Shot 2022-01-17 at 2 59 43 PM" src="https://user-images.githubusercontent.com/29017559/149767053-8269c70c-9538-426f-a8c8-599fe4847014.png">

<img width="1038" alt="Screen Shot 2022-01-17 at 3 03 38 PM" src="https://user-images.githubusercontent.com/29017559/149766750-785a00b8-55e7-4462-bfc9-357608627765.png">


## Areas affected and ensured
- Create Notification Log.

## Is there any existing behavior change of other features due to this code change?
no

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
