### PR TITLE
chore: Add UOM to the Contracts DocType (Could be Hour, Day, Month)

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -434,7 +434,8 @@
    "fieldname": "billing_type",
    "fieldtype": "Select",
    "label": "Billing Type",
-   "options": "\nActual Hours\nShift Hours"
+   "options": "\nHourly\nDaily\nMonthly",
+   "reqd": 1
   },
   {
    "fieldname": "amended_from",
@@ -453,7 +454,7 @@
   }
  ],
  "links": [],
- "modified": "2022-01-12 16:21:11.836393",
+ "modified": "2022-01-19 13:57:03.242593",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",


### PR DESCRIPTION
…rts #180958844]

## Feature description
Clearly and concisely describe the feature.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Add UOM to the Contracts DocType (Could be Hour, Day, Month).
The type of billing (Hourly, Daily, Monthly) is set on a contract level which will apply to all manpower items inside the Contract.

## Output screenshots (optional)
![image](https://user-images.githubusercontent.com/10146518/150117420-213ce55d-f4f6-47a5-a22b-a928f81d4d90.png)


