### PR TITLE
feat: Auto create Payment Request from Expense Claim

### DIFF
--- a/one_fm/api/doc_methods/expense_claim.py
+++ b/one_fm/api/doc_methods/expense_claim.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe import _
+
+
+
+def on_submit(doc, event):
+    """
+        Expense Cliam submit events
+    """
+    # create Payment Request
+    if(doc.approval_status=='Approved' and not doc.is_paid):
+        pr = frappe.get_doc(dict(
+            doctype='Payment Request',
+            payment_request_type='Outward',
+            party_type='Employee',
+            party=doc.employee,
+            reference_doctype='Expense Claim',
+            reference_name=doc.name,
+            mode_of_payment=doc.mode_of_payment,
+            grand_total=doc.grand_total,
+            message=doc.remark
+        )).insert()

--- a/one_fm/api/doc_methods/expense_claim.py
+++ b/one_fm/api/doc_methods/expense_claim.py
@@ -20,3 +20,4 @@ def on_submit(doc, event):
             grand_total=doc.grand_total,
             message=doc.remark
         )).insert()
+    # end 

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -266,6 +266,9 @@ doc_events = {
 	"Payroll Entry": {
 		"on_submit": "one_fm.api.doc_methods.payroll_entry.export_payroll",
 	},
+	"Expense Claim": {
+		"on_submit": "one_fm.api.doc_methods.expense_claim.on_submit",
+	},
 	# "Additional Salary" :{
 	# 	"on_submit": "one_fm.grd.utils.validate_date"
 	# }


### PR DESCRIPTION
## Feature description
As a Finance Officer, I want to log Expense Claims (reimbursements) as Payment Requests, so that my ledger accounts are up to date


## Solution description
Payment Request will be automatically created when Expense Claim is submitted with the following conditions:

1. Expense Claim must be approved
2. is_paid is false. So as not to have double payment.

## Output screenshots (optional)
![image](https://user-images.githubusercontent.com/10146518/150729381-8fcf60fb-cd87-4a66-bdb3-134c08167fcf.png)
![image](https://user-images.githubusercontent.com/10146518/150729557-336fd069-c833-4108-bb27-32b70ba7b7d2.png)

