### PR TITLE
chore: Combine Contract Items and Contract Assets into one

### DIFF
--- a/one_fm/operations/doctype/contract_item/contract_item.json
+++ b/one_fm/operations/doctype/contract_item/contract_item.json
@@ -1,11 +1,14 @@
 {
+ "actions": [],
  "creation": "2020-08-20 21:02:05.412966",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "item_code",
-  "head_count",
+  "item_group",
+  "subitem_group",
+  "count",
   "uom",
   "price_list_rate",
   "type",
@@ -21,7 +24,9 @@
   "shift_hours",
   "gender",
   "days_off",
-  "days"
+  "days",
+  "overtime_rate",
+  "site"
  ],
  "fields": [
   {
@@ -31,13 +36,6 @@
    "in_list_view": 1,
    "label": "Item Code",
    "options": "Item"
-  },
-  {
-   "columns": 2,
-   "fieldname": "head_count",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Head Count"
   },
   {
    "default": "0",
@@ -135,13 +133,15 @@
   },
   {
    "columns": 2,
-   "fetch_from": "item_price.uom",
+   "fetch_from": "item_code.stock_uom",
+   "fetch_if_empty": 1,
    "fieldname": "uom",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "UOM",
    "options": "UOM",
-   "read_only": 1
+   "read_only": 1,
+   "reqd": 1
   },
   {
    "fetch_from": "item_price.price_list_rate",
@@ -160,10 +160,49 @@
    "label": "Rate",
    "options": "currency",
    "read_only": 1
+  },
+  {
+   "fetch_from": "item_code.item_group",
+   "fetch_if_empty": 1,
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "label": "Item Group",
+   "options": "Item Group",
+   "read_only": 1
+  },
+  {
+   "depends_on": "item_code.item_group=='Service'",
+   "fieldname": "overtime_rate",
+   "fieldtype": "Currency",
+   "label": "Overtime Rate"
+  },
+  {
+   "fieldname": "site",
+   "fieldtype": "Link",
+   "label": "Site",
+   "options": "Operations Site"
+  },
+  {
+   "fetch_from": "item_code.subitem_group",
+   "fetch_if_empty": 1,
+   "fieldname": "subitem_group",
+   "fieldtype": "Link",
+   "label": "Subitem Group",
+   "options": "Item Group",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "count",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Count",
+   "reqd": 1
   }
  ],
  "istable": 1,
- "modified": "2021-06-22 23:40:21.818457",
+ "links": [],
+ "modified": "2022-01-26 15:37:06.714644",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contract Item",

--- a/one_fm/operations/doctype/contracts/contracts.js
+++ b/one_fm/operations/doctype/contracts/contracts.js
@@ -87,8 +87,14 @@ frappe.ui.form.on('Contracts', {
 			}
 		}
 	},
+	items_on_form_rendered: (frm)=>{
+		// set tiems properties
+		frm.doc.items.forEach((item, i) => {
+			change_items_table_properties(frm, item);
+		})
+	},
 	refresh:function(frm){
-		
+
 		if (frm.doc.workflow_state == "Inactive" && frappe.user_roles.includes("Finance Manager")){
 			frm.add_custom_button(__("Amend Contract"), function() {
 				open_form(frm, "Contracts", null, null);
@@ -469,6 +475,7 @@ frappe.ui.form.on('Contract Addendum', {
 let change_items_table_properties = (frm, row) => {
 	// change Items Table field properties
 	// set Site
+	console.log(row.idx);
 	let idx = $(`[data-idx=${row.idx}]`)[0];
 	if(row.subitem_group=='Service'){
 		idx.querySelector('[data-fieldname="site"]').hidden = true;

--- a/one_fm/operations/doctype/contracts/contracts.js
+++ b/one_fm/operations/doctype/contracts/contracts.js
@@ -88,6 +88,7 @@ frappe.ui.form.on('Contracts', {
 		}
 	},
 	refresh:function(frm){
+		
 		if (frm.doc.workflow_state == "Inactive" && frappe.user_roles.includes("Finance Manager")){
 			frm.add_custom_button(__("Amend Contract"), function() {
 				open_form(frm, "Contracts", null, null);
@@ -141,7 +142,7 @@ frappe.ui.form.on('Contracts', {
 		frm.fields_dict['items'].grid.get_field('item_code').get_query = function() {
             return {
                 filters:{
-					is_stock_item: 0,
+					// is_stock_item: 0,
 					is_sales_item: 1,
                     disabled: 0
                 }
@@ -287,6 +288,26 @@ function set_contact(doc){
 }
 
 frappe.ui.form.on('Contract Item', {
+	refresh: (frm, cdt, cdn)=>{
+		let row = locals[cdt][cdn];
+		change_items_table_properties(frm, row);
+	},
+	subitem_group: (frm, cdt, cdn)=> {
+		let row = locals[cdt][cdn];
+		// change properties for (site, )
+		change_items_table_properties(frm, row);
+		// end change properties
+	},
+	uom: (frm, cdt, cdn)=>{
+		// check uom agains Service item
+		let row = locals[cdt][cdn];
+		if(row.subitem_group=='Service' &&
+			!['Hourly', 'Daily', 'Monthly'].includes(row.uom)){
+				row.uom = null;
+				frm.refresh_field('items');
+				frappe.throw("Item of subgroup 'Service' UOM must be <b>Hourly, Daily or Month'</b>.");
+			}
+	},
 	item_code: function(frm, cdt, cdn) {
 		let d = locals[cdt][cdn];
 		if(d.item_code){
@@ -312,12 +333,14 @@ frappe.ui.form.on('Contract Item', {
 				}
 			});
 			frappe.model.set_value(d.doctype, d.name, "item_price", null);
-			frappe.model.set_value(d.doctype, d.name, "uom", null);
-			frappe.model.set_value(d.doctype, d.name, "gender", null);
-			frappe.model.set_value(d.doctype, d.name, "shift_hours", 0);
-			frappe.model.set_value(d.doctype, d.name, "days_off", 0);
+			// frappe.model.set_value(d.doctype, d.name, "uom", null);
 			frappe.model.set_value(d.doctype, d.name, "price_list_rate", 0);
 			frappe.model.set_value(d.doctype, d.name, "rate", 0);
+			if(d.subitem_group=="Service"){
+				frappe.model.set_value(d.doctype, d.name, "gender", null);
+				frappe.model.set_value(d.doctype, d.name, "shift_hours", 0);
+				frappe.model.set_value(d.doctype, d.name, "days_off", 0);
+			}
 		}
 
 	},
@@ -441,3 +464,27 @@ frappe.ui.form.on('Contract Addendum', {
 		}
 	}
 })
+
+
+let change_items_table_properties = (frm, row) => {
+	// change Items Table field properties
+	// set Site
+	let idx = $(`[data-idx=${row.idx}]`)[0];
+	if(row.subitem_group=='Service'){
+		idx.querySelector('[data-fieldname="site"]').hidden = true;
+		idx.querySelector('[data-fieldname="management_fee_percentage"]').hidden = false;
+		idx.querySelector('[data-fieldname="management_fee"]').hidden = false;
+		idx.querySelector('[data-fieldname="shift_hours"]').hidden = false;
+		idx.querySelector('[data-fieldname="gender"]').hidden = false;
+		idx.querySelector('[data-fieldname="days_off"]').hidden = false;
+		idx.querySelector('[data-fieldname="days"]').hidden = false;
+	} else {
+		idx.querySelector('[data-fieldname="site"]').hidden = false;
+		idx.querySelector('[data-fieldname="management_fee_percentage"]').hidden = true;
+		idx.querySelector('[data-fieldname="management_fee"]').hidden = true;
+		idx.querySelector('[data-fieldname="shift_hours"]').hidden = true;
+		idx.querySelector('[data-fieldname="gender"]').hidden = true;
+		idx.querySelector('[data-fieldname="days_off"]').hidden = true;
+		idx.querySelector('[data-fieldname="days"]').hidden = true;
+	}
+}

--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -51,7 +51,6 @@
   "items",
   "section_break_28",
   "frequency",
-  "assets",
   "section_break_30",
   "create_sales_invoice_as",
   "site_wise_option",
@@ -201,12 +200,6 @@
    "fieldname": "section_break_28",
    "fieldtype": "Section Break",
    "label": "Contract Assets"
-  },
-  {
-   "fieldname": "assets",
-   "fieldtype": "Table",
-   "label": "Assets",
-   "options": "Contract Asset"
   },
   {
    "fieldname": "section_break_30",
@@ -448,7 +441,7 @@
   }
  ],
  "links": [],
- "modified": "2022-01-24 13:48:14.181204",
+ "modified": "2022-01-26 15:39:59.100405",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",


### PR DESCRIPTION
## Feature description
This PR combines Item and Asset table in Contracts doctype as one table(Contract Item). 
Two extra fields were added/modified:

- Item Group
- Subitem Group
- UOM (required)


On changing **Item Code**, the corresponding **UOM** value must be **[Hourly, Daily or Monthly ]** if **Subitem Group** is '**Service**'

The table modify fields property based on **Subitem Group**.
If **subitem_group=='Service'** below fields properties will change:

- site.hidden = true
- management_fee_percentage.hidden = false
- management_fee.hidden = false
- shift_hours.hidden = false
- gender.hidden = false
- days_off.hidden = false
- days.hidden = false

If **subitem_group!='Service'** below fields properties will change:
- site.hidden = false
- management_fee_percentage.hidden = true
- management_fee.hidden = true
- shift_hours.hidden = true
- gender.hidden = true
- days_off.hidden = true
- days.hidden = true



## Output screenshots (optional)
![image](https://user-images.githubusercontent.com/10146518/151169944-24a92f2f-c25b-481f-88c5-6e988e6ab5a7.png)
![image](https://user-images.githubusercontent.com/10146518/151170308-89b783f7-d5e1-4457-97ca-aea138b61f05.png)
![image](https://user-images.githubusercontent.com/10146518/151172327-0ac601cc-2451-46c4-918a-f3a60054dc47.png)
![image](https://user-images.githubusercontent.com/10146518/151172594-d0ec9019-a771-41f7-afb7-560737453c15.png)




## Is there any existing behavior change of other features due to this code change?
Yes, the item_code in items table filters only service items but has now be modified to filter both service and consumable items.
