### PR TITLE
#181199295 : Rearranging of the button.

### DIFF
--- a/one_fm/one_fm/doctype/interview/interview.json
+++ b/one_fm/one_fm/doctype/interview/interview.json
@@ -109,7 +109,7 @@
    "fieldname": "language",
    "fieldtype": "Link",
    "label": "Language",
-   "options": "Interview"
+   "options": "Language"
   },
   {
    "fieldname": "experience",
@@ -177,7 +177,7 @@
   }
  ],
  "links": [],
- "modified": "2020-11-02 12:49:49.058944",
+ "modified": "2022-02-10 16:57:32.848536",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Interview",

--- a/one_fm/public/js/doctype_js/job_applicant.js
+++ b/one_fm/public/js/doctype_js/job_applicant.js
@@ -11,19 +11,19 @@ frappe.ui.form.on('Job Applicant', {
 	},
 	refresh(frm) {
 		// Changes the buttons for `PAM File Number` and `PAM Desigantion` once operator wants to changethe data of any
-		// if(frm.doc.pam_number_button == 0 || frm.is_new()){
-		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#3789ff";
-		// }if(frm.doc.pam_designation_button == 0 || frm.is_new()){
-		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#3789ff";
-		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
-		// }if(frm.doc.pam_number_button == 1 || !frm.is_new()){
-		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#ec645e";
-		// }if(frm.doc.pam_designation_button == 1 || !frm.is_new()){
-		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#ec645e";
-		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
-		// }
-		// document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.margin ='1.6em';
-		// document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
+		if(frm.doc.pam_number_button == 0 || frm.is_new()){
+			document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#3789ff";
+		}if(frm.doc.pam_designation_button == 0 || frm.is_new()){
+			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#3789ff";
+			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
+		}if(frm.doc.pam_number_button == 1 || !frm.is_new()){
+			document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#ec645e";
+		}if(frm.doc.pam_designation_button == 1 || !frm.is_new()){
+			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#ec645e";
+			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
+		}
+		document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.margin ='1.6em';
+		document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
 		frm.set_df_property('status', 'label', 'Final Status');
 		frm.remove_custom_button("Job Offer");
 		set_country_field_empty_on_load(frm);
@@ -55,6 +55,8 @@ frappe.ui.form.on('Job Applicant', {
 				},'Action');
 			frm.add_custom_button(__(''), function() {
 				},'Action').css({"padding": "0.01rem", "background-color":"gray"});
+			
+			// view career history button only when career history exist.
 			if(frm.doc.one_fm_job_applicant_score.find(i => i.reference_dt == "Career History")){
 			frm.add_custom_button(__('View Career History'), function() {
 				view_career_history(frm);
@@ -66,6 +68,8 @@ frappe.ui.form.on('Job Applicant', {
 			}
 			frm.add_custom_button(__(''), function() {
 			},'Action').css({"padding": "0.01rem", "background-color":"gray"});
+
+			// view Interview button only when career history exist.
 			if(frm.doc.one_fm_job_applicant_score.find(i => i.reference_dt == "Interview Result")){
 				frm.add_custom_button(__('View Interview'), function() {
 					view_interview(frm);

--- a/one_fm/public/js/doctype_js/job_applicant.js
+++ b/one_fm/public/js/doctype_js/job_applicant.js
@@ -37,49 +37,67 @@ frappe.ui.form.on('Job Applicant', {
 
 
 		// if(frm.doc.one_fm_document_verification == 'Verified' || frm.doc.one_fm_document_verification == 'Verified - With Exception'){
-		// 	frm.set_df_property('one_fm_interview_schedules', 'hidden', false);
+			frm.set_df_property('one_fm_interview_schedules', 'hidden', false);
 		// }
 		// else{
-		frm.set_df_property('one_fm_interview_schedules_section', 'hidden', true);
-		frm.set_df_property('one_fm_interview_schedules', 'hidden', true);
+		//frm.set_df_property('one_fm_interview_schedules_section', 'hidden', true);
+		//frm.set_df_property('one_fm_interview_schedules', 'hidden', true);
 		// }
 		if(!frm.doc.__islocal){
+			frm.remove_custom_button("Create Interview")
 			frm.set_df_property('one_fm_erf', 'read_only', true);
-			frm.add_custom_button(__('Create'), function() {
-				create_career_history(frm);
-			}, __('Career History'));
-			frm.add_custom_button(__('Career History'), function() {
-				send_magic_link(frm, 'one_fm.templates.pages.career_history.send_career_history_magic_link');
-			}, __('Send Magic Link'));
-			frm.add_custom_button(__('Applicant More Details'), function() {
+			// add a standard menu item
+			frm.add_custom_button(__('Send Career History'), function() {
+					send_magic_link(frm, 'one_fm.templates.pages.career_history.send_career_history_magic_link');
+					},'Action');
+			frm.add_custom_button(__('Send Applicant Doc'), function() {
 				send_magic_link(frm, 'one_fm.templates.pages.applicant_docs.send_applicant_doc_magic_link');
-			}, __('Send Magic Link'));
-			frm.add_custom_button(__('View'), function() {
-        view_career_history(frm);
-      }, __('Career History'));
-			frm.add_custom_button(__('View'), function() {
-        view_interview(frm);
-      }, __('Interview'));
-			frm.add_custom_button(__('Create'), function() {
-				create_interview(frm);
-			}, __('Interview'));
+				},'Action');
+			frm.add_custom_button(__(''), function() {
+				},'Action').css({"padding": "0.01rem", "background-color":"gray"});
+			frm.add_custom_button(__('View Career History'), function() {
+				view_career_history(frm);
+				},'Action');
+			frm.add_custom_button(__('Create Career History'), function() {
+				create_career_history(frm);
+				},'Action');
+			frm.add_custom_button(__(''), function() {
+			},'Action').css({"padding": "0.01rem", "background-color":"gray"});
+			//if(frm.doc.one_fm_interview_schedules.length != 0){
+				frm.add_custom_button(__('View Interview'), function() {
+					view_interview(frm);
+				},'Action');
+			// }
+			// else{
+				frm.add_custom_button(__('Create An Interview'), function() {
+					view_interview(frm);
+				},'Action');
+			//}
+			frm.add_custom_button(__(''), function() {
+			},'Action').css({"padding": "0.01rem", "background-color":"gray"});
 			frm.add_custom_button(__('Best Reference'), function() {
-        view_best_reference(frm);
-      });
+				    view_best_reference(frm);
+				  },'Action');
+			frm.add_custom_button(__(''), function() {
+			},'Action').css({"padding": "0.01rem", "background-color":"gray"});
+		
 			if (frm.doc.__onload && frm.doc.__onload.job_offer) {
 				if(frm.doc.status != 'Accepted' && frm.doc.status != 'Rejected'){
 					frm.add_custom_button(__('Accept Offer'), function() {
 						update_job_offer_from_applicant(frm, 'Accepted');
-		      }).addClass('btn-primary');
+		      		},"Action").css("background-color", "red");
 					frm.add_custom_button(__('Reject Offer'), function() {
 						update_job_offer_from_applicant(frm, 'Rejected');
-		      }).addClass('btn-danger');
+		      		},"Action").addClass('btn-danger');
 				}
+				frm.add_custom_button(__(''), function() {
+				},'Action').css({"padding": "0.01rem", "background-color":"gray"});
 			}
+			
 			if(frm.doc.one_fm_applicant_status != 'Selected' && frm.doc.status != 'Rejected'){
 				frm.add_custom_button(__('Select Applicant'), function() {
 					change_applicant_status(frm, 'one_fm_applicant_status', 'Selected');
-				}).addClass('btn-primary');
+				},"Action");
 				frm.add_custom_button(__('Reject Applicant'), function() {
 					if (frm.doc.__onload && frm.doc.__onload.job_offer) {
 						update_job_offer_from_applicant(frm, 'Rejected');
@@ -87,17 +105,19 @@ frappe.ui.form.on('Job Applicant', {
 					else{
 						change_applicant_status(frm, 'status', 'Rejected');
 					}
-				}).addClass('btn-danger');
+				},'Action');
 			}
+			frm.add_custom_button(__(''), function() {
+			},'Action').css({"padding": "0.01rem", "background-color":"gray"});
 			if(frm.doc.one_fm_applicant_status != 'Selected' && frm.doc.status != 'Rejected'){
 				if (frappe.user.has_role("Hiring Manager")){
 					frm.add_custom_button(__('Change ERF'), function() {
 						change_applicant_erf(frm);
-					});
+					},"Action");
 				}
 			}
-    }
-		if ((!frm.doc.__islocal) && (frm.doc.status == 'Accepted')) {
+    // }
+		// if ((!frm.doc.__islocal) && (frm.doc.status == 'Accepted')) {
 // 			frappe.db.get_value("Employee", {"job_applicant": frm.doc.name}, "name", function(r) {
 // 				if(!r || !r.name){
 // 					frm.add_custom_button(__('Create Employee'),
@@ -110,8 +130,8 @@ frappe.ui.form.on('Job Applicant', {
 // 					);
 // 				}
 // 			});
-		}
-
+				}
+		
 	},
 	one_fm_change_pam_file_number: function(frm){
 		// on the change of pam desigantion change the button color and set the flag value
@@ -739,18 +759,19 @@ var validate_min_age = function(frm) {
 };
 
 var create_interview = function(frm) {
-  frappe.route_options = {"job_applicant": frm.doc.name};
-	frappe.new_doc("Interview Result");
+	frappe.new_doc("Interview Result", {"job_applicant": frm.doc.name});
 };
-
+var check_doc_exist = function(frm, docname){
+	doc = frappe.get_doc(docname,{"job_applicant":frm.doc.name})
+	console.log(doc)
+}
 var view_interview = function(frm) {
 	frappe.route_options = {"job_applicant": frm.doc.name};
 	frappe.set_route("List", "Interview Result");
 };
 
 var create_career_history = function(frm) {
-  frappe.route_options = {"job_applicant": frm.doc.name};
-	frappe.new_doc("Career History");
+	frappe.new_doc("Career History", {"job_applicant":frm.doc.name});
 };
 
 var send_magic_link = function(frm, method) {

--- a/one_fm/public/js/doctype_js/job_applicant.js
+++ b/one_fm/public/js/doctype_js/job_applicant.js
@@ -11,19 +11,19 @@ frappe.ui.form.on('Job Applicant', {
 	},
 	refresh(frm) {
 		// Changes the buttons for `PAM File Number` and `PAM Desigantion` once operator wants to changethe data of any
-		if(frm.doc.pam_number_button == 0 || frm.is_new()){
-			document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#3789ff";
-		}if(frm.doc.pam_designation_button == 0 || frm.is_new()){
-			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#3789ff";
-			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
-		}if(frm.doc.pam_number_button == 1 || !frm.is_new()){
-			document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#ec645e";
-		}if(frm.doc.pam_designation_button == 1 || !frm.is_new()){
-			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#ec645e";
-			document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
-		}
-		document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.margin ='1.6em';
-		document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
+		// if(frm.doc.pam_number_button == 0 || frm.is_new()){
+		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#3789ff";
+		// }if(frm.doc.pam_designation_button == 0 || frm.is_new()){
+		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#3789ff";
+		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
+		// }if(frm.doc.pam_number_button == 1 || !frm.is_new()){
+		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.backgroundColor ="#ec645e";
+		// }if(frm.doc.pam_designation_button == 1 || !frm.is_new()){
+		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.backgroundColor ="#ec645e";
+		// 	document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
+		// }
+		// document.querySelectorAll("[data-fieldname='one_fm_change_pam_file_number']")[1].style.margin ='1.6em';
+		// document.querySelectorAll("[data-fieldname='one_fm_change_pam_designation']")[1].style.marginLeft ='2em';
 		frm.set_df_property('status', 'label', 'Final Status');
 		frm.remove_custom_button("Job Offer");
 		set_country_field_empty_on_load(frm);
@@ -55,24 +55,26 @@ frappe.ui.form.on('Job Applicant', {
 				},'Action');
 			frm.add_custom_button(__(''), function() {
 				},'Action').css({"padding": "0.01rem", "background-color":"gray"});
+			if(frm.doc.one_fm_job_applicant_score.find(i => i.reference_dt == "Career History")){
 			frm.add_custom_button(__('View Career History'), function() {
 				view_career_history(frm);
 				},'Action');
+			} else {
 			frm.add_custom_button(__('Create Career History'), function() {
 				create_career_history(frm);
 				},'Action');
+			}
 			frm.add_custom_button(__(''), function() {
 			},'Action').css({"padding": "0.01rem", "background-color":"gray"});
-			//if(frm.doc.one_fm_interview_schedules.length != 0){
+			if(frm.doc.one_fm_job_applicant_score.find(i => i.reference_dt == "Interview Result")){
 				frm.add_custom_button(__('View Interview'), function() {
 					view_interview(frm);
 				},'Action');
-			// }
-			// else{
+			}
 				frm.add_custom_button(__('Create An Interview'), function() {
 					view_interview(frm);
 				},'Action');
-			//}
+			
 			frm.add_custom_button(__(''), function() {
 			},'Action').css({"padding": "0.01rem", "background-color":"gray"});
 			frm.add_custom_button(__('Best Reference'), function() {

--- a/one_fm/public/js/doctype_js/job_applicant.js
+++ b/one_fm/public/js/doctype_js/job_applicant.js
@@ -767,10 +767,7 @@ var validate_min_age = function(frm) {
 var create_interview = function(frm) {
 	frappe.new_doc("Interview Result", {"job_applicant": frm.doc.name});
 };
-var check_doc_exist = function(frm, docname){
-	doc = frappe.get_doc(docname,{"job_applicant":frm.doc.name})
-	console.log(doc)
-}
+
 var view_interview = function(frm) {
 	frappe.route_options = {"job_applicant": frm.doc.name};
 	frappe.set_route("List", "Interview Result");


### PR DESCRIPTION
## Feature description
Re-arrange Buttons in Job Applications.

## Solution description
- All the buttons are rearranged into one group. 
- Removing of creating Interview button by ERP since not being used.

## Output screenshots (optional)
<img width="1000" alt="Screen Shot 2022-02-15 at 12 07 24 PM" src="https://user-images.githubusercontent.com/29017559/154029139-6fb58ec3-f5a2-4da5-a350-2df8a909f432.png">


## Areas affected and ensured
Buttons are formed under one group.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
