### PR TITLE
[Feat] Assign SI to Collection Officer when Approved by Finance

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -252,7 +252,8 @@ doc_events = {
 	},
 	"Sales Invoice":{
 		"before_submit": "one_fm.one_fm.sales_invoice_custom.before_submit_sales_invoice",
-		"validate": "one_fm.one_fm.sales_invoice_custom.set_print_settings_from_contracts"
+		"validate": "one_fm.one_fm.sales_invoice_custom.set_print_settings_from_contracts",
+		"on_update_after_submit": "one_fm.one_fm.sales_invoice_custom.assign_collection_officer_to_sales_invoice_on_workflow_state"
 	},
 	"Salary Slip": {
 		#"before_submit": "one_fm.api.doc_methods.salary_slip.salary_slip_before_submit",

--- a/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.js
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.js
@@ -4,14 +4,37 @@
 frappe.ui.form.on('Accounts Additional Settings', {
 	onload: function(frm) {
 		set_options_for_assign_collection_officer_on_workflow_sate(frm);
+		show_create_role_button(frm);
+	},
+	assign_collection_officer_to_sales_invoice_on_workflow_state: function(frm) {
+		show_create_role_button(frm);
+	},
+	create_collection_officer_role: function(frm) {
+		frappe.call({
+			method: 'one_fm.one_fm.utils.create_role_if_not_exists',
+			args: {'role': 'Collection Officer'},
+			callback: function(r) {
+				if(!r.exc){
+					frm.reload_doc();
+				}
+			},
+			freeze: true,
+			freeze_message: __("Creating Collection Officer Role !!")
+		});
 	}
 });
+
+var show_create_role_button = function(frm) {
+	frm.set_df_property('create_collection_officer_role', 'hidden', true);
+	if(frm.doc.assign_collection_officer_to_sales_invoice_on_workflow_state && 'collection_officer_role_exists' in frm.doc.__onload){
+		frm.set_df_property('create_collection_officer_role', 'hidden', frm.doc.__onload['collection_officer_role_exists']?true:false);
+	}
+};
 
 var set_options_for_assign_collection_officer_on_workflow_sate = function(frm) {
 	frappe.call({
 		method: "one_fm.one_fm.doctype.accounts_additional_settings.accounts_additional_settings.get_options_for_assign_collection_officer_on_workflow_sate",
 		callback:function(r){
-			console.log(r);
 			if(r.message){
 				r.message.forEach((item, i) => {
 					frm.set_df_property('sales_invoice_workflow_sate_to_assign_collection_officer', "options", r.message);

--- a/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.js
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, omar jaber and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Accounts Additional Settings', {
+	onload: function(frm) {
+		set_options_for_assign_collection_officer_on_workflow_sate(frm);
+	}
+});
+
+var set_options_for_assign_collection_officer_on_workflow_sate = function(frm) {
+	frappe.call({
+		method: "one_fm.one_fm.doctype.accounts_additional_settings.accounts_additional_settings.get_options_for_assign_collection_officer_on_workflow_sate",
+		callback:function(r){
+			console.log(r);
+			if(r.message){
+				r.message.forEach((item, i) => {
+					frm.set_df_property('sales_invoice_workflow_sate_to_assign_collection_officer', "options", r.message);
+					frm.refresh_field("sales_invoice_workflow_sate_to_assign_collection_officer");
+				});
+			}
+		}
+	});
+};

--- a/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.json
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-02-13 18:56:42.837561",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "collection_settings_section",
+  "assign_collection_officer_to_sales_invoice_on_workflow_state",
+  "sales_invoice_workflow_sate_to_assign_collection_officer"
+ ],
+ "fields": [
+  {
+   "fieldname": "collection_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Collection Settings"
+  },
+  {
+   "default": "0",
+   "description": "Automatically Assign the Sales Invoice to the Collection Officer upon Workflow State Update",
+   "fieldname": "assign_collection_officer_to_sales_invoice_on_workflow_state",
+   "fieldtype": "Check",
+   "label": "Assign Collection Officer to Sales Invoice on Workflow State"
+  },
+  {
+   "depends_on": "assign_collection_officer_to_sales_invoice_on_workflow_state",
+   "fieldname": "sales_invoice_workflow_sate_to_assign_collection_officer",
+   "fieldtype": "Select",
+   "label": "Sales Invoice Workflow Sate to Assign Collection Officer",
+   "mandatory_depends_on": "assign_collection_officer_to_sales_invoice_on_workflow_state"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-02-18 09:40:57.107250",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Accounts Additional Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.json
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.json
@@ -8,7 +8,8 @@
  "field_order": [
   "collection_settings_section",
   "assign_collection_officer_to_sales_invoice_on_workflow_state",
-  "sales_invoice_workflow_sate_to_assign_collection_officer"
+  "sales_invoice_workflow_sate_to_assign_collection_officer",
+  "create_collection_officer_role"
  ],
  "fields": [
   {
@@ -29,12 +30,18 @@
    "fieldtype": "Select",
    "label": "Sales Invoice Workflow Sate to Assign Collection Officer",
    "mandatory_depends_on": "assign_collection_officer_to_sales_invoice_on_workflow_state"
+  },
+  {
+   "fieldname": "create_collection_officer_role",
+   "fieldtype": "Button",
+   "hidden": 1,
+   "label": "Create Collection Officer Role"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-02-18 09:40:57.107250",
+ "modified": "2022-02-18 13:01:57.246390",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Accounts Additional Settings",

--- a/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.py
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2022, omar jaber and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+class AccountsAdditionalSettings(Document):
+	pass
+
+@frappe.whitelist()
+def get_options_for_assign_collection_officer_on_workflow_sate():
+	from one_fm.one_fm.utils import get_workflow_sates
+	states = []
+	workflow_states = get_workflow_sates('Sales Invoice')
+	for state in workflow_states:
+		states.append(state.state)
+	return states

--- a/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.py
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.py
@@ -5,7 +5,8 @@ import frappe
 from frappe.model.document import Document
 
 class AccountsAdditionalSettings(Document):
-	pass
+	def onload(self):
+		self.set_onload('collection_officer_role_exists', frappe.db.exists("Role", {"role_name": 'Collection Officer'}))
 
 @frappe.whitelist()
 def get_options_for_assign_collection_officer_on_workflow_sate():

--- a/one_fm/one_fm/doctype/accounts_additional_settings/test_accounts_additional_settings.py
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/test_accounts_additional_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, omar jaber and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestAccountsAdditionalSettings(unittest.TestCase):
+	pass

--- a/one_fm/one_fm/sales_invoice_custom.py
+++ b/one_fm/one_fm/sales_invoice_custom.py
@@ -1027,8 +1027,6 @@ def assign_collection_officer_to_sales_invoice_on_workflow_state(doc, method):
                     'description': (_('The Sales Invoice {0} is ready for Delivery.\n Please attach the delivered invoice copy to the Sales Invoice').format(doc.name))
                 })
             else:
-                from one_fm.one_fm.utils import create_role_if_not_exists
-                create_role_if_not_exists('Collection Officer')
                 frappe.msgprint(_('Please Assing a User for Collection Officer Role!'))
         except DuplicateToDoError:
             frappe.message_log.pop()

--- a/one_fm/one_fm/sales_invoice_custom.py
+++ b/one_fm/one_fm/sales_invoice_custom.py
@@ -4,6 +4,8 @@ from dateutil.relativedelta import relativedelta
 from datetime import date,timedelta,datetime
 from frappe.utils import getdate,get_first_day,get_last_day,add_days,add_months,flt
 from one_fm.one_fm.timesheet_custom import timesheet_automation,calculate_hourly_rate,days_of_month
+from frappe.desk.form.assign_to import add as add_assignment, DuplicateToDoError
+from one_fm.one_fm.payroll_utils import get_user_list_by_role
 #from frappe import _
 
 def create_sales_invoice():
@@ -1003,3 +1005,27 @@ def set_print_settings_from_contracts(doc, method):
                 doc.format = contracts_print_settings[0].sales_invoice_print_format
             if contracts_print_settings[0].sales_invoice_letter_head:
                 doc.letter_head = contracts_print_settings[0].sales_invoice_letter_head
+
+def assign_collection_officer_to_sales_invoice_on_workflow_state(doc, method):
+    '''
+        This Method is used to notify the Collection Officer, such that the Sales Invoice is ready for delivery.
+        args:
+            doc: Object of Sales Invocie
+        Method will check if `workflow_state` is Equal to Workflow State configured in the `Accounts Additional Settings`,
+        if it is ture,
+        grab the Collection Office user to make an assignment to the Sales Invoice with that user.
+    '''
+    sales_invoice_workflow_sate_to_assign_collection_officer = frappe.db.get_single_value('Accounts Settings', 'sales_invoice_workflow_sate_to_assign_collection_officer')
+    if frappe.get_meta(doc.doctype).has_field("workflow_state") and doc.workflow_state == sales_invoice_workflow_sate_to_assign_collection_officer:
+        try:
+            collection_officer = get_user_list_by_role('Collection Officer')
+            if len(collection_officer) > 0 and collection_officer[0]:
+                add_assignment({
+                    'doctype': doc.doctype,
+                    'name': doc.name,
+                    'assign_to': collection_officer[0],
+                    'description': (_('The Sales Invoice {0} is ready for Delivery.\n Please attach the delivered invoice copy to the Sales Invoice').format(doc.name))
+                })
+        except DuplicateToDoError:
+            frappe.message_log.pop()
+            pass

--- a/one_fm/one_fm/sales_invoice_custom.py
+++ b/one_fm/one_fm/sales_invoice_custom.py
@@ -1015,8 +1015,8 @@ def assign_collection_officer_to_sales_invoice_on_workflow_state(doc, method):
         if it is ture,
         grab the Collection Office user to make an assignment to the Sales Invoice with that user.
     '''
-    sales_invoice_workflow_sate_to_assign_collection_officer = frappe.db.get_single_value('Accounts Settings', 'sales_invoice_workflow_sate_to_assign_collection_officer')
-    if frappe.get_meta(doc.doctype).has_field("workflow_state") and doc.workflow_state == sales_invoice_workflow_sate_to_assign_collection_officer:
+    assign_collection_officer = frappe.db.get_single_value('Accounts Additional Settings', 'assign_collection_officer_to_sales_invoice_on_workflow_state')
+    if assign_collection_officer and frappe.get_meta(doc.doctype).has_field("workflow_state") and doc.workflow_state == frappe.db.get_single_value('Accounts Additional Settings', 'sales_invoice_workflow_sate_to_assign_collection_officer'):
         try:
             collection_officer = get_user_list_by_role('Collection Officer')
             if len(collection_officer) > 0 and collection_officer[0]:
@@ -1026,6 +1026,10 @@ def assign_collection_officer_to_sales_invoice_on_workflow_state(doc, method):
                     'assign_to': collection_officer[0],
                     'description': (_('The Sales Invoice {0} is ready for Delivery.\n Please attach the delivered invoice copy to the Sales Invoice').format(doc.name))
                 })
+            else:
+                from one_fm.one_fm.utils import create_role_if_not_exists
+                create_role_if_not_exists('Collection Officer')
+                frappe.msgprint(_('Please Assing a User for Collection Officer Role!'))
         except DuplicateToDoError:
             frappe.message_log.pop()
             pass

--- a/one_fm/one_fm/sales_invoice_custom.py
+++ b/one_fm/one_fm/sales_invoice_custom.py
@@ -1,3 +1,4 @@
+from frappe import _
 import frappe,calendar
 import itertools
 from dateutil.relativedelta import relativedelta
@@ -6,7 +7,6 @@ from frappe.utils import getdate,get_first_day,get_last_day,add_days,add_months,
 from one_fm.one_fm.timesheet_custom import timesheet_automation,calculate_hourly_rate,days_of_month
 from frappe.desk.form.assign_to import add as add_assignment, DuplicateToDoError
 from one_fm.one_fm.payroll_utils import get_user_list_by_role
-#from frappe import _
 
 def create_sales_invoice():
     today = date.today()
@@ -1023,7 +1023,7 @@ def assign_collection_officer_to_sales_invoice_on_workflow_state(doc, method):
                 add_assignment({
                     'doctype': doc.doctype,
                     'name': doc.name,
-                    'assign_to': collection_officer[0],
+                    'assign_to': [collection_officer[0]],
                     'description': (_('The Sales Invoice {0} is ready for Delivery.\n Please attach the delivered invoice copy to the Sales Invoice').format(doc.name))
                 })
             else:

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -388,3 +388,12 @@ def cancel_compensatory_leave_request_from_attendance(attendance):
     })
     if exist_compensatory_leave_request:
         frappe.get_doc('Compensatory Leave Request', exist_compensatory_leave_request).cancel()
+
+def get_workflow_sates(doctype):
+    workflow_states = []
+    exists_workflow = frappe.db.exists('Workflow', {'is_active': True, 'document_type': doctype})
+    if exists_workflow:
+        workflow = frappe.get_doc('Workflow', exists_workflow)
+        for state in workflow.states:
+            workflow_states.append(state)
+    return workflow_states

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -390,6 +390,12 @@ def cancel_compensatory_leave_request_from_attendance(attendance):
         frappe.get_doc('Compensatory Leave Request', exist_compensatory_leave_request).cancel()
 
 def get_workflow_sates(doctype):
+    '''
+        Method used to Get active Workflow States of a Doctype
+        args:
+            doctype: Name of Doctype
+        return list of Workflow States object in Active Workflow
+    '''
     workflow_states = []
     exists_workflow = frappe.db.exists('Workflow', {'is_active': True, 'document_type': doctype})
     if exists_workflow:
@@ -397,3 +403,18 @@ def get_workflow_sates(doctype):
         for state in workflow.states:
             workflow_states.append(state)
     return workflow_states
+
+def create_role_if_not_exists(role, desk_access=True):
+    '''
+        Method is used to create Role.
+        args:
+            role: Name of the Role, Text
+            desk_access: Boolean for Desk Access
+    '''
+    if not frappe.db.exists("Role", {"role_name": role}):
+        doc = frappe.new_doc("Role")
+        doc.update({
+            "role_name": role,
+            "desk_access": desk_access
+        })
+        doc.insert(ignore_permissions=True)

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -389,6 +389,7 @@ def cancel_compensatory_leave_request_from_attendance(attendance):
     if exist_compensatory_leave_request:
         frappe.get_doc('Compensatory Leave Request', exist_compensatory_leave_request).cancel()
 
+@frappe.whitelist()
 def get_workflow_sates(doctype):
     '''
         Method used to Get active Workflow States of a Doctype
@@ -404,6 +405,7 @@ def get_workflow_sates(doctype):
             workflow_states.append(state)
     return workflow_states
 
+@frappe.whitelist()
 def create_role_if_not_exists(role, desk_access=True):
     '''
         Method is used to create Role.


### PR DESCRIPTION
## Feature description
Collection Officer, needs to be notified when a Sales Invoice is Approved by Finance, so that Collection Officer can attach the necessary documents

## Analysis and design (optional)
On Workflow state change of Sales Invoice, Collection Officer will assign to the Sales Invoice (On Assignment it will automatically Create a ToDo for the Collection Officer referenced with the Sales Invoice)

## Solution description
 - Created Configuration for Sales Invoice Assignment with the Collection Officer on Workflow state Update
![Screenshot 2022-02-18 at 3 58 53 PM](https://user-images.githubusercontent.com/20554466/154791237-3f7a0ed7-abfc-452a-9585-32a7d6dc03f1.png)
![Screenshot 2022-02-18 at 4 20 37 PM](https://user-images.githubusercontent.com/20554466/154791253-fcca6b9f-674a-4963-a1c8-df54d2189047.png)

https://user-images.githubusercontent.com/20554466/154791262-7498460f-f090-4a63-80ad-a04fb5e62c3e.mov

![Screenshot 2022-02-18 at 4 19 07 PM](https://user-images.githubusercontent.com/20554466/154791281-5878372f-b3c5-4829-a8dc-bec47dac833f.png)
![Screenshot 2022-02-18 at 4 25 00 PM](https://user-images.githubusercontent.com/20554466/154791319-b0964167-9c88-4ac3-8fab-fb96ad24b7d2.png)
 

 - On Workflow state change of Sales Invoice, Collection Officer will assign to the Sales Invoice (On Assignment it will automatically Create a ToDo for the Collection Officer referenced with the Sales Invoice)

https://user-images.githubusercontent.com/20554466/154791336-0c985266-ab11-4491-8267-1ad9d9f7680d.mov


https://user-images.githubusercontent.com/20554466/154791355-b7713ec3-bb47-4275-9079-e9999b17a015.mov


## Areas affected and ensured
- Sales Invoice Hook
-`sales_invoice_custom.py` and `utils.py`

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
