### PR TITLE
[Fix] Revise wording in the Job Application and Career History Portal

### DIFF
--- a/one_fm/templates/pages/career_history.js
+++ b/one_fm/templates/pages/career_history.js
@@ -143,7 +143,7 @@ career_history = Class.extend({
         <input type="text" class="form-control company_${company_no}_name" placeholder="Enter the ${stringifyNumber(company_no)} Company Name"/>
       </div>
       <div class="my-5 col-lg-6 col-md-6">
-        <label class="form-label">Where is it Located? </label> <br>
+        <label class="form-label">Select Country of Employment</label> <br>
         <select class="form-control country_of_company_${company_no}">
           <option>Select Country</option>
           {% for country in country_list %}

--- a/one_fm/templates/pages/job_application.html
+++ b/one_fm/templates/pages/job_application.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block header %}
-  <h5 id="job_opening" data="{{ job_opening.name }}">Dear Applicant, May I know who is applying for the postion of {{ job_opening.designation }} ?</h5>
+  <h5 id="job_opening" data="{{ job_opening.name }}">Dear Applicant for the postion of {{ job_opening.designation }}, Enter your Full Name in English.</h5>
 {% endblock %}
 
 {% block page_content %}

--- a/one_fm/templates/pages/job_application.js
+++ b/one_fm/templates/pages/job_application.js
@@ -63,13 +63,13 @@ job_application = Class.extend({
   show_country: function(applicant_name) {
     if(applicant_name){
       $(".applicant_country").empty();
-      $(".applicant_country").append(`<h5>Hey ${applicant_name} !, From where you are coming.</h5>`)
+      $(".applicant_country").append(`<h5>Hey ${applicant_name} !, Select your Country.</h5>`)
       $(".country_list").removeClass('hide');
     }
   },
   show_applicant_contact_details: function() {
     $(".applicant_contact").empty();
-    $(".applicant_contact").append(`<h5>May I know your mobile number and the email ID to connect you.</h5>`)
+    $(".applicant_contact").append(`<h5>Enter your mobile number and the email ID to connect you.</h5>`)
     $(".contact_number").removeClass('hide');
     $(".contact_email").removeClass('hide');
   },


### PR DESCRIPTION
## Feature description
- Revise wording in the Job Application and Career History Portal

## Areas affected and ensured
- `one_fm/templates/pages/job_application.js`
- `one_fm/templates/pages/job_application.html`
- `one_fm/templates/pages/career_history.js`

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome