### PR TITLE
chore: Extend the APIIntegration DocType to handle extra fields

### DIFF
--- a/one_fm/api/doc_methods/issue.py
+++ b/one_fm/api/doc_methods/issue.py
@@ -20,7 +20,8 @@ def log_pivotal_tracker():
         headers={"X-TrackerToken":pivotal_tracker.get_password('api_token').replace(' ', ''),
             "Content-Type": "application/json"}
         project_id = pivotal_tracker.get_password('project_id').replace(' ', '')
-        url = f"https://www.pivotaltracker.com/services/v5/projects/{project_id}/stories"
+        url = f"{pivotal_tracker.url}/services/v5/projects/{project_id}/stories"
+        print(url)
         # escape HTML in description
         TAG_RE = re.compile(r'<[^>]+>')
         description = TAG_RE.sub('', doc.description)
@@ -35,7 +36,7 @@ def log_pivotal_tracker():
         )
         if(req.status_code==200):
             response_data = frappe._dict(req.json())
-            doc.db_set('pivotal_tracker', f"https://www.pivotaltracker.com/n/projects/{project_id}/stories/{response_data.id}")
+            doc.db_set('pivotal_tracker', f"{pivotal_tracker.url}/n/projects/{project_id}/stories/{response_data.id}")
             return {'status':'success'}
         else:
             frappe.throw(f"Pivotal Tracker story could not be created:\n {req.json()}")

--- a/one_fm/one_fm/doctype/api_integration/api_integration.json
+++ b/one_fm/one_fm/doctype/api_integration/api_integration.json
@@ -9,10 +9,11 @@
   "api_name",
   "api_key",
   "api_secret",
-  "column_break_3",
   "api_token",
   "url",
-  "project_id"
+  "project_id",
+  "column_break_3",
+  "api_parameter"
  ],
  "fields": [
   {
@@ -51,10 +52,16 @@
    "fieldname": "project_id",
    "fieldtype": "Password",
    "label": "Project ID"
+  },
+  {
+   "fieldname": "api_parameter",
+   "fieldtype": "Table",
+   "label": "API Parameter",
+   "options": "API Parameter"
   }
  ],
  "links": [],
- "modified": "2022-02-20 09:56:08.761115",
+ "modified": "2022-02-23 13:29:22.970891",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "API Integration",

--- a/one_fm/one_fm/doctype/api_parameter/api_parameter.json
+++ b/one_fm/one_fm/doctype/api_parameter/api_parameter.json
@@ -1,0 +1,49 @@
+{
+ "actions": [],
+ "creation": "2022-02-23 13:27:32.958869",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "parameter",
+  "value",
+  "header"
+ ],
+ "fields": [
+  {
+   "fieldname": "parameter",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Parameter",
+   "print_width": "150px",
+   "reqd": 1,
+   "width": "150px"
+  },
+  {
+   "fieldname": "value",
+   "fieldtype": "Password",
+   "in_list_view": 1,
+   "label": "Value",
+   "print_width": "150px",
+   "reqd": 1,
+   "width": "150px"
+  },
+  {
+   "default": "0",
+   "fieldname": "header",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Header"
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2022-02-23 13:27:32.958869",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "API Parameter",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/one_fm/one_fm/doctype/api_parameter/api_parameter.py
+++ b/one_fm/one_fm/doctype/api_parameter/api_parameter.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, omar jaber and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class APIParameter(Document):
+	pass

--- a/one_fm/one_fm/workspace/one_fm_settings/one_fm_settings.json
+++ b/one_fm/one_fm/workspace/one_fm_settings/one_fm_settings.json
@@ -1,0 +1,51 @@
+{
+ "category": "Modules",
+ "charts": [],
+ "creation": "2022-02-23 13:50:56.417220",
+ "developer_mode_only": 0,
+ "disable_user_customization": 0,
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "extends_another_page": 0,
+ "hide_custom": 0,
+ "idx": 0,
+ "is_default": 0,
+ "is_standard": 1,
+ "label": "ONE FM Settings",
+ "links": [
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "API Integration",
+   "link_to": "API Integration",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Default API Integration",
+   "link_to": "Default API Integration",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2022-02-23 13:52:17.052195",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "ONE FM Settings",
+ "owner": "Administrator",
+ "pin_to_bottom": 0,
+ "pin_to_top": 0,
+ "shortcuts": []
+}


### PR DESCRIPTION
## Feature description
This PR adds an extra child table field in API Integration doctype to handle more API configuration key-value pair. As well as a minor fix to Pivotal Tracker that replaced the hard-coded URL with the API url.
In addition, a workspace was added for easy navigation to settings related doctypes.


## Output screenshots (optional)
![image](https://user-images.githubusercontent.com/10146518/155304747-b15244a7-7c82-4b51-8687-5750ee528120.png)
![image](https://user-images.githubusercontent.com/10146518/155305578-c312e08e-8183-4c8d-be9d-2ce916643bc7.png)


