### PR TITLE
hotfix: import collision - runtime error, no object bound to db

### DIFF
--- a/one_fm/accommodation/utils.py
+++ b/one_fm/accommodation/utils.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils.print_format import download_pdf, print_by_server
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 @frappe.whitelist()
 def accommodation_qr_code_live_details(docname):

--- a/one_fm/api/mobile/authentication.py
+++ b/one_fm/api/mobile/authentication.py
@@ -11,7 +11,7 @@ import requests, json
 from one_fm.api.mobile.roster import get_current_user_details
 from frappe.utils.password import update_password as _update_password
 from twilio.rest import Client 
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 @frappe.whitelist(allow_guest=True)
 def login(client_id, grant_type, employee_id, password):

--- a/one_fm/api/v1/authentication.py
+++ b/one_fm/api/v1/authentication.py
@@ -11,7 +11,7 @@ import requests, json
 from frappe.utils.password import update_password as _update_password
 from twilio.rest import Client as TwilioClient
 from one_fm.api.v1.utils import response
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 @frappe.whitelist(allow_guest=True)

--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.py
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.py
@@ -12,7 +12,7 @@ from frappe.utils import today, add_days, get_url, date_diff, getdate
 from frappe.model.document import Document
 from one_fm.grd.doctype.medical_insurance import medical_insurance
 from frappe.utils import get_datetime, add_to_date, getdate, get_link_to_form, now_datetime, nowdate, cstr
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 class FingerprintAppointment(Document):

--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.py
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.py
@@ -12,7 +12,7 @@ from frappe.core.doctype.communication.email import make
 from frappe.utils import now_datetime
 from one_fm.grd.doctype.residency_payment_request import residency_payment_request
 from one_fm.grd.doctype.moi_residency_jawazat import moi_residency_jawazat
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class MedicalInsurance(Document):
     

--- a/one_fm/grd/doctype/paci/paci.py
+++ b/one_fm/grd/doctype/paci/paci.py
@@ -10,7 +10,7 @@ from one_fm.api.notification import create_notification_log
 from frappe.utils import today, add_days, get_url, date_diff
 from frappe.utils import get_datetime, add_to_date, getdate, get_link_to_form, now_datetime, nowdate, cstr
 from frappe.core.doctype.communication.email import make
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class PACI(Document):
     def validate(self):

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -25,7 +25,7 @@ from one_fm.grd.doctype.residency_payment_request import residency_payment_reque
 from one_fm.grd.doctype.moi_residency_jawazat import moi_residency_jawazat
 from one_fm.grd.doctype.paci import paci
 from one_fm.grd.doctype.fingerprint_appointment import fingerprint_appointment
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class Preparation(Document):
     def validate(self):

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -18,7 +18,7 @@ from email import policy
 from one_fm.grd.doctype.fingerprint_appointment import fingerprint_appointment
 from one_fm.grd.doctype.medical_insurance import medical_insurance
 from frappe.core.doctype.communication.email import make
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 # from PyPDF2 import PdfFileReader
 

--- a/one_fm/grd/utils.py
+++ b/one_fm/grd/utils.py
@@ -11,7 +11,7 @@ from datetime import date
 from frappe.model.mapper import get_mapped_doc
 from dateutil.relativedelta import relativedelta
 from one_fm.api.notification import create_notification_log
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 def sendmail_reminder_to_book_appointment_for_pifss(): #before 1 week of the new month

--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.py
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.py
@@ -12,7 +12,7 @@ from one_fm.hiring.doctype.work_contract.work_contract import employee_details_f
 from one_fm.hiring.utils import make_employee_from_job_offer
 from frappe.utils import now, today, getdate
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 class OnboardEmployee(Document):

--- a/one_fm/hiring/doctype/work_contract/work_contract.py
+++ b/one_fm/hiring/doctype/work_contract/work_contract.py
@@ -8,7 +8,7 @@ from frappe.model.document import Document
 from one_fm.hiring.utils import update_onboarding_doc, update_onboarding_doc_workflow_sate
 from frappe.utils import today
 from frappe import _
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 class WorkContract(Document):

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -2,13 +2,16 @@
 # encoding: utf-8
 from __future__ import unicode_literals
 import frappe, json
-from frappe.utils import get_url, fmt_money, month_diff, add_days, add_years, getdate
+from frappe.utils import (
+    get_url, fmt_money, month_diff, add_days, add_years, getdate
+)
 from frappe.model.mapper import get_mapped_doc
 from one_fm.api.notification import create_notification_log
 from frappe.modules import scrub
 from frappe import _
 from frappe.desk.form import assign_to
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
+
 
 @frappe.whitelist()
 def get_performance_profile_resource():

--- a/one_fm/legal/doctype/legal_investigation/legal_investigation.py
+++ b/one_fm/legal/doctype/legal_investigation/legal_investigation.py
@@ -8,7 +8,7 @@ from frappe.model.document import Document
 from frappe import _
 from frappe.utils import get_link_to_form, nowdate, getdate, now_datetime, cstr,add_to_date
 from frappe.desk.form.assign_to import add as assign_to
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class LegalInvestigation(Document):
 	def after_insert(self):

--- a/one_fm/legal/doctype/penalty/penalty.py
+++ b/one_fm/legal/doctype/penalty/penalty.py
@@ -10,7 +10,7 @@ import base64
 from frappe import _
 import pickle, face_recognition
 from one_fm.api.notification import create_notification_log
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 from frappe.utils import cint, getdate, add_to_date, get_link_to_form, now_datetime
 from one_fm.one_fm.page.face_recognition.face_recognition import recognize_face
 

--- a/one_fm/legal/doctype/penalty_issuance/penalty_issuance.py
+++ b/one_fm/legal/doctype/penalty_issuance/penalty_issuance.py
@@ -9,7 +9,7 @@ from frappe.utils import cstr, cint, get_datetime, getdate, add_to_date,get_link
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.desk.form.assign_to import add as assign_to
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class PenaltyIssuance(Document):
 	def after_insert(self):

--- a/one_fm/one_fm/doctype/employee_paid_holiday_timesheet/employee_paid_holiday_timesheet.py
+++ b/one_fm/one_fm/doctype/employee_paid_holiday_timesheet/employee_paid_holiday_timesheet.py
@@ -7,7 +7,7 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 from frappe.utils import now_datetime, add_to_date
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class EmployeePaidHolidayTimesheet(Document):
 	def on_update(self):

--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -11,7 +11,7 @@ from frappe.utils.user import get_user_fullname
 from frappe import _
 from one_fm.one_fm.calendar_event.meetFunc import CalendarEvent
 from one_fm.api.notification import create_notification_log
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class ERF(Document):
 	def onload(self):

--- a/one_fm/one_fm/doctype/gp_letter_request/gp_letter_request.py
+++ b/one_fm/one_fm/doctype/gp_letter_request/gp_letter_request.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import get_url
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 class GPLetterRequest(Document):

--- a/one_fm/one_fm/doctype/magic_link/magic_link.py
+++ b/one_fm/one_fm/doctype/magic_link/magic_link.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils.password import decrypt, encrypt
 from frappe.utils import get_url
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class MagicLink(Document):
 	pass

--- a/one_fm/one_fm/doctype/request_employee_assignment/request_employee_assignment.py
+++ b/one_fm/one_fm/doctype/request_employee_assignment/request_employee_assignment.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 from frappe.utils import nowdate, add_to_date, cstr, cint, getdate, get_link_to_form
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class RequestEmployeeAssignment(Document):
 

--- a/one_fm/one_fm/doctype/request_employee_schedule/request_employee_schedule.py
+++ b/one_fm/one_fm/doctype/request_employee_schedule/request_employee_schedule.py
@@ -6,7 +6,7 @@ from frappe.utils import nowdate, add_to_date, cstr, cint, getdate, get_link_to_
 from frappe import _
 import frappe
 import pandas as pd
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class RequestEmployeeSchedule(Document):
 	def autoname(self):

--- a/one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py
+++ b/one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py
@@ -10,7 +10,7 @@ from frappe.utils import get_url, cint
 from frappe.core.doctype.communication.email import make
 from erpnext.accounts.party import get_party_account_currency, get_party_details
 from six import string_types
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 class RequestforSupplierQuotation(Document):

--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import nowdate, add_to_date, cstr, cint, getdate, get_link_to_form
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class RosterEmployeeActions(Document):
 	def autoname(self):

--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import nowdate, add_to_date, cstr, cint, getdate, get_link_to_form
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 class RosterPostActions(Document):

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -1,0 +1,24 @@
+import frappe
+
+@frappe.whitelist()
+def sendemail(recipients, subject, header=None, message=None,
+        content=None, reference_name=None, reference_doctype=None,
+        sender=None, cc=None , attachments=None, delay=None):
+    logo = "https://one-fm.com/files/ONEFM_Identity.png"
+
+    frappe.sendmail(template = "default_email",
+                    recipients=recipients,
+                    sender= sender,
+                    cc=cc,
+                    reference_name= reference_name,
+                    reference_doctype = reference_doctype,
+                    subject=subject,
+                    args=dict(
+                        header=header[0],
+                        subject=subject,
+                        message=message,
+                        content=content,
+                        logo=logo
+                    ),
+                    attachments = attachments,
+                    delayed=delay)

--- a/one_fm/purchase/doctype/request_for_material/request_for_material.py
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.py
@@ -13,7 +13,7 @@ from frappe.permissions import has_permission
 from erpnext.controllers.buying_controller import BuyingController
 from one_fm.purchase.doctype.item_reservation.item_reservation import get_item_balance
 from one_fm.utils import fetch_employee_signature
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class RequestforMaterial(BuyingController):
 	def on_submit(self):

--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
@@ -9,7 +9,7 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import nowdate, getdate, get_url
 from one_fm.utils import fetch_employee_signature
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class RequestforPurchase(Document):
 	def onload(self):

--- a/one_fm/templates/emails/default_email.html
+++ b/one_fm/templates/emails/default_email.html
@@ -42,7 +42,7 @@
                             9th Floor, Humoud Tower, Qibla, Kuwait City, Kuwait</a> 
                     </h4>
                 </div>
-                <div style="display:flex;padding-left: 1vh 15vw;">
+                <div style="display:flex;padding: 1vh 15vw;">
                     <a href="https://www.facebook.com/ONEFacilitiesManagementCompany/" ><img class="facebook_logo" src="https://one-fm.com/files/facebook.png"/></a>
                     <a href="https://twitter.com/facilitiesone" ><img class="twitter_logo" src="https://one-fm.com/files/twitter.png"/></a>
                     <a href="https://kw.linkedin.com/company/one-facilities-management-kuwait" ><img class="linkedin_logo" src="https://one-fm.com/files/linkedin.png"/></a>

--- a/one_fm/templates/pages/gp_letter_attachment.py
+++ b/one_fm/templates/pages/gp_letter_attachment.py
@@ -9,7 +9,7 @@ import requests
 import json
 from frappe.utils.file_manager import save_file
 import hashlib
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 
 def get_context(context):

--- a/one_fm/templates/pages/gp_letter_request.py
+++ b/one_fm/templates/pages/gp_letter_request.py
@@ -10,7 +10,7 @@ import json
 from frappe.utils.file_manager import save_file
 import hashlib
 from frappe.utils import cint, cstr, flt, nowdate, comma_and, date_diff, getdate, formatdate ,get_url, get_datetime
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 def get_context(context):
     if frappe.local.request.method == "GET" and "pid" not in frappe.form_dict:

--- a/one_fm/templates/pages/homepage.py
+++ b/one_fm/templates/pages/homepage.py
@@ -8,7 +8,7 @@ from frappe.utils.data import flt, nowdate, getdate, cint
 from frappe.utils import cint, cstr, flt, nowdate, comma_and, date_diff, getdate , add_days
 import frappe, json
 from frappe.utils.file_manager import save_file
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 no_cache = 1
 no_sitemap = 1

--- a/one_fm/templates/pages/job_application.py
+++ b/one_fm/templates/pages/job_application.py
@@ -3,7 +3,7 @@ import frappe, json
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import get_url
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 def get_context(context):
     context.parents = [{'route': 'jobs', 'title': _('All Jobs') }]

--- a/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py
+++ b/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py
@@ -9,7 +9,7 @@ from frappe.utils import today, month_diff, add_days, getdate
 from frappe import _
 from erpnext.stock.get_item_details import get_item_details
 from frappe.model.mapper import get_mapped_doc
-from one_fm.utils import sendemail
+from one_fm.processor import sendemail
 
 class EmployeeUniform(Document):
 	def before_insert(self):

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -4,28 +4,36 @@ from __future__ import unicode_literals
 import itertools
 from one_fm.api.notification import create_notification_log
 from frappe import _
-import frappe, os, erpnext
-import json
-import math
+import frappe, os, erpnext, json, math
 from frappe.model.document import Document
 from frappe.utils import get_site_base_path
 from erpnext.hr.doctype.employee.employee import get_holiday_list_for_employee
 from frappe.utils.data import flt, nowdate, getdate, cint
 from frappe.utils.csvutils import read_csv_content
-from frappe.utils import cint, cstr, flt, rounded,  nowdate, comma_and, date_diff, getdate, formatdate ,get_url, get_datetime, add_to_date, time_diff, get_time, time_diff_in_hours
+from frappe.utils import (
+    cint, cstr, flt, rounded,  nowdate, comma_and, date_diff, getdate,
+    formatdate ,get_url, get_datetime, add_to_date, time_diff, get_time,
+    time_diff_in_hours
+)
 from datetime import tzinfo, timedelta, datetime
 from dateutil import parser
 from datetime import date
 from frappe.model.naming import set_name_by_naming_series
-from erpnext.hr.doctype.leave_ledger_entry.leave_ledger_entry import expire_allocation, create_leave_ledger_entry
+from erpnext.hr.doctype.leave_ledger_entry.leave_ledger_entry import (
+    expire_allocation, create_leave_ledger_entry
+)
 from dateutil.relativedelta import relativedelta
-from frappe.utils import cint, cstr, date_diff, flt, formatdate, getdate, get_link_to_form, \
-    comma_or, get_fullname, add_years, add_months, add_days, nowdate,get_first_day,get_last_day, today
+from frappe.utils import (
+    cint, cstr, date_diff, flt, formatdate, getdate, get_link_to_form,
+    comma_or, get_fullname, add_years, add_months, add_days,
+    nowdate,get_first_day,get_last_day, today
+)
 import datetime
 from datetime import datetime, time
 from frappe import utils
 import pandas as pd
 from erpnext.hr.utils import get_holidays_for_employee
+from one_fm.processor import sendemail
 
 def check_upload_original_visa_submission_reminder2():
     pam_visas = frappe.db.sql_list("select name from `tabPAM Visa` where upload_original_visa_submitted=0 and upload_original_visa_reminder2_done=1")
@@ -2264,7 +2272,7 @@ def send_verification_code(doctype, document_name):
         verification_code = generate_code()
         employee_user_email = frappe.session.user
         subject = _("Verification code for {doctype}.".format(doctype=doctype))
-        
+
         message = """Dear user,<br><br>
             An attempt was made to use your signature in {doctype}: {document}.<br><br>
             To use your signature, use the verification code: <b>{verification_code}</b>.<br><br>
@@ -2327,24 +2335,3 @@ def generate_code():
 @frappe.whitelist()
 def fetch_employee_signature(user_id):
     return frappe.get_value("Employee", {"user_id":user_id},["employee_signature"])
-
-@frappe.whitelist()
-def sendemail(recipients, subject, header=None, message=None, content=None, reference_name=None, reference_doctype=None , sender=None, cc=None , attachments=None, delay=None):
-    logo = "https://one-fm.com/files/ONEFM_Identity.png"
-    
-    frappe.sendmail(template = "default_email",
-                    recipients=recipients,
-                    sender= sender,
-                    cc=cc,
-                    reference_name= reference_name,
-                    reference_doctype = reference_doctype,
-                    subject=subject,
-                    args=dict(
-                        header=header[0],
-                        subject=subject,
-                        message=message,
-                        content=content,
-                        logo=logo
-                    ),
-                    attachments = attachments,
-                    delayed=delay)


### PR DESCRIPTION
## Feature description
This PR fixes 'Weukzueg - raise RuntimeError("no object bound to %s" % self.__name__)'
This error was cause by an import collision by one_fm.__init__py on line 14. 

## Solution description
Modifying __init__.py will have a considerable effect on the app, the solution was to create a processor.py, move the sendmail to it.

Note: functions/methods that will be cross imported in __init__py and any other file should not be stored in processor.py 
