### PR TITLE
Fix: return only when shift exists

### DIFF
--- a/one_fm/api/mobile/roster.py
+++ b/one_fm/api/mobile/roster.py
@@ -586,10 +586,6 @@ def get_current_shift(employee):
 				else:
 					if start_time <= time <= end_time:
 						return shift
-		elif len(shifts)==0:
-			return shifts		
-		else:
-			return shifts[0].shift
 	except Exception as e:
 		print(frappe.get_traceback())
 		return frappe.utils.response.report_error(e.http_status_code)


### PR DESCRIPTION
## Feature description
Return Shift in "get_current_shift" only if it exists/ greater than 0. This avoided fetching of an empty list.

## Solution description
- Return only when the length of the shift is greater than 0.

## Areas affected and ensured
- Fetch of the current shift of the employee.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
