### PR TITLE
Fix: name 'date' is not defined

### DIFF
--- a/one_fm/one_fm/doctype/indemnity_allocation/indemnity_allocation.py
+++ b/one_fm/one_fm/doctype/indemnity_allocation/indemnity_allocation.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from frappe.model.document import Document
 from frappe import _
 import frappe
+from datetime import date
 from frappe.utils import getdate, nowdate
 from frappe.model.document import Document
 from dateutil.relativedelta import relativedelta


### PR DESCRIPTION
## Feature description
HotFix: name 'date' is not defined

## Solution description
import 'date'. from datetime library

## Areas affected and ensured
- daily_indemnity_allocation_builder and create_indemnity_allocation where tested.

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
