### PR TITLE
Optimize Report

### DIFF
--- a/one_fm/hiring/report/head_hunt_count/head_hunt_count.py
+++ b/one_fm/hiring/report/head_hunt_count/head_hunt_count.py
@@ -11,6 +11,7 @@ def execute(filters=None):
 
 def get_columns():
     return [
+		_("Head Hunt Doc") + ":Link/Head Hunt:150",
 		_("Source") + ":Data:150",
 		_("Creation Date") + ":Date:150",
 		_("Total Count") + ":Data:150",
@@ -30,9 +31,12 @@ def get_data(filters):
 	data=[]
 	conditions = get_conditions(filters)
 
-	head_hunt = frappe.db.sql("""SELECT * from `tabHead Hunt` where 1=1 {0} """.format(conditions),as_dict=1)
+    #Fetch 
+	head_hunt = frappe.db.sql("""SELECT * , 
+			(select COUNT(*) from `tabHead Hunt Item` I WHERE parenttype="Head Hunt" AND parent=H.name) as count
+			from `tabHead Hunt` H where 1=1 {0} """.format(conditions),as_dict=1)
+
 	for h in head_hunt:
-		doc = frappe.db.sql("""SELECT count(*) as count from `tabHead Hunt Item` WHERE parenttype="Head Hunt" AND parent=%s""",(h.name), as_dict=1)
-		row = [ h.lead_owner, h.creation, doc[0].count ]
+		row = [ h.name, h.lead_owner, h.creation, h.count ]
 		data.append(row)
 	return data


### PR DESCRIPTION
## Feature description
- Optimizing Report by Defining a single Query instead of two.
- Adding Link to access Doc.

## Solution description
- Fetching details of the child table in a single query.
- adding a column to fetch the link of the given doc.

## Output screenshots (optional)
<img width="1044" alt="Screen Shot 2022-03-15 at 4 29 55 PM" src="https://user-images.githubusercontent.com/29017559/158388380-8683748b-6270-4329-8c93-d9951a2e4fc0.png">

## Areas affected and ensured
- Optimizing
- Column to list Doc 

## Is there any existing behavior change of other features due to this code change?
No.
## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
