### PR TITLE
Issue Type Report

### DIFF
--- a/one_fm/one_fm/report/issue_type/issue_type.js
+++ b/one_fm/one_fm/report/issue_type/issue_type.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, omar jaber and contributors
+// For license information, please see license.txt
+/* eslint-disable */
+
+function set_user_department(){
+	frappe.db.get_value("Employee", {'user_id': frappe.user.name}, ["department"])
+		.then(res => {
+			let {department} = res.message;
+			frappe.query_reports["Issue Type"].filters[0].default = department;
+		})
+}
+
+frappe.query_reports["Issue Type"] = {
+	"filters": [
+		{
+			"fieldname":"department",
+			"label": __("Department"),
+			"fieldtype": "Link",
+			"options": "Department",
+			"reqd": 0,
+			"default": ""
+		},
+		{
+			"fieldname":"issue_type",
+			"label": __("Issue Type"),
+			"fieldtype": "Link",
+			"options": "Issue Type",
+			"reqd": 1,
+			"default": 'Other',
+			get_query: function() {
+				return {
+					query: "one_fm.one_fm.report.issue_type.issue_type.get_filtered_issue_types",
+					filters: {"department": frappe.query_report.get_filter_value('department')}
+				};
+			}
+		},
+	]
+};
+
+set_user_department()

--- a/one_fm/one_fm/report/issue_type/issue_type.js
+++ b/one_fm/one_fm/report/issue_type/issue_type.js
@@ -29,7 +29,7 @@ frappe.query_reports["Issue Type"] = {
 			"default": 'Other',
 			get_query: function() {
 				return {
-					query: "one_fm.one_fm.report.issue_type.issue_type.get_filtered_issue_types",
+					query: "one_fm.utils.get_issue_type_in_department",
 					filters: {"department": frappe.query_report.get_filter_value('department')}
 				};
 			}

--- a/one_fm/one_fm/report/issue_type/issue_type.json
+++ b/one_fm/one_fm/report/issue_type/issue_type.json
@@ -1,0 +1,36 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2022-03-23 08:59:20.763634",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "ONE FM - Job Offer",
+ "modified": "2022-03-23 08:59:20.763634",
+ "modified_by": "Administrator",
+ "module": "one_fm",
+ "name": "Issue Type",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Issue",
+ "report_name": "Issue Type",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Support Team"
+  },
+  {
+   "role": "Employee"
+  },
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Issue Responder"
+  }
+ ]
+}

--- a/one_fm/one_fm/report/issue_type/issue_type.py
+++ b/one_fm/one_fm/report/issue_type/issue_type.py
@@ -50,13 +50,3 @@ def get_data(filters=None):
 		result.append(row)
 	
 	return result
-
-@frappe.whitelist()
-def get_filtered_issue_types(doctype, txt, searchfield, start, page_len, filters):
-	res = []
-	dept = frappe.get_doc("Department", filters.get("department"))
-
-	for d in dept.issue_types:
-		res.append([d.issue_type])
-
-	return res

--- a/one_fm/one_fm/report/issue_type/issue_type.py
+++ b/one_fm/one_fm/report/issue_type/issue_type.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2013, omar jaber and contributors
+# For license information, please see license.txt
+
+from warnings import filters
+import frappe
+from frappe import _
+
+def execute(filters=None):
+	columns, data = get_columns(filters), get_data(filters)
+	return columns, data
+
+def get_columns(filters):
+	return [
+		_("Department") + ":Link/Department:250",
+		_("Issue Type") + ":Data:250",
+		_("Custom Issue Type") + ":Data:250",
+		_("Count") + ":Int:250"
+	]
+
+def get_conditions(filters=None):
+	conditions = {}
+	if filters:
+		if filters.get("department"):
+			conditions.update({'department': filters.get("department")})
+		
+		if filters.get("issue_type"):
+			conditions.update({'issue_type': filters.get("issue_type")})
+
+	return conditions
+
+def get_data(filters=None):
+	conditions = get_conditions(filters)
+	result = []
+
+	query_res = frappe.db.sql("""
+		SELECT department, issue_type, your_issue_type, count(*) from `tabIssue`
+		WHERE issue_type = %(issue_type)s AND department = %(department)s
+		GROUP BY department, your_issue_type
+		HAVING count(*) > 0
+	""", {'issue_type': conditions.get("issue_type"), 'department': conditions.get("department")}, as_dict=1)
+
+	for record in query_res:
+		row = [
+			record["department"],
+			record["issue_type"],
+			record["your_issue_type"] if record["your_issue_type"] else "",
+			record["count(*)"]
+		]
+
+		result.append(row)
+	
+	return result
+
+@frappe.whitelist()
+def get_filtered_issue_types(doctype, txt, searchfield, start, page_len, filters):
+	res = []
+	dept = frappe.get_doc("Department", filters.get("department"))
+
+	for d in dept.issue_types:
+		res.append([d.issue_type])
+
+	return res


### PR DESCRIPTION
## Feature description
As Management, I would like a report with issues list, so that we could create new issue types depending on the current problems that are arising.

## Solution description
- Created a standard script report named Issue Type.
- Added columns: Department, Issue Type, Custom Issue Type and Count.
- Default filters are user's assigned department and issue type 'Other'.

## Output screenshots
<img width="1440" alt="Screen Shot 2022-03-23 at 4 27 44 PM" src="https://user-images.githubusercontent.com/45887110/159710316-955f8304-06e6-4026-8eaa-670f8e4da524.png">

## Areas affected and ensured
None.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
