### PR TITLE
#181649822

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -292,7 +292,8 @@ doc_events = {
 		"validate": "one_fm.hiring.utils.calculate_interview_feedback_average_rating",
 	},
 	"Issue": {
-		"after_insert": "one_fm.utils.assign_issue"
+		"after_insert": "one_fm.utils.assign_issue",
+		"on_update": "one_fm.utils.notify_on_close"
 	}
 	# "Additional Salary" :{
 	# 	"on_submit": "one_fm.grd.utils.validate_date"

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2354,8 +2354,8 @@ def notify_on_close(doc, method):
     if doc.contact:
         issuer_name, issuer_id = frappe.get_value("Contact", {"name":doc.contact}, ["first_name","email_id"])
     else:
-        frappe.throw(_('Kindly, fill in the contact!')
-
+        frappe.throw(_('Kindly, fill in the contact!'))
+        
     #Form Message
     msg = """Hello {name},<br><br>
     Your issue {issue_id} has been closed. If you are still experiencing 

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2345,6 +2345,26 @@ def get_issue_type_in_department(doctype, txt, searchfield, start, page_len, fil
         }
     )
 
+def notify_on_close(doc, method):
+    '''
+        This Method is used to notify the issuer, when the issue is closed.
+    '''
+    #fetch Sender and Issuer's address
+    sender = frappe.get_value("Email Account",{"name":doc.email_account}, ["email_id"])
+    if doc.contact:
+        issuer_name, issuer_id = frappe.get_value("Contact", {"name":doc.contact}, ["first_name","email_id"])
+    else:
+        frappe.throw(_('Kindly, fill in the contact!')
+
+    #Form Message
+    msg = """Hello {name},<br><br>
+    Your issue {issue_id} has been closed. If you are still experiencing 
+    the issue you may reply back to this email and we will do our best to help.
+    """.format(name= issuer_name, issue_id = doc.name)
+
+    if doc.status == "Closed":
+        sendemail(sender=sender, recipients= issuer_id, content=msg, subject="Your Issue has been closed!", delay=False)
+
 def assign_issue(doc, method):
     '''
         This Method is used to assign issue.

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2351,19 +2351,15 @@ def notify_on_close(doc, method):
     '''
     #fetch Sender and Issuer's address
     sender = frappe.get_value("Email Account",{"name":doc.email_account}, ["email_id"])
-    if doc.contact:
-        issuer_name, issuer_id = frappe.get_value("Contact", {"name":doc.contact}, ["first_name","email_id"])
-    else:
-        frappe.throw(_('Kindly, fill in the contact!'))
         
     #Form Message
-    msg = """Hello {name},<br><br>
+    msg = """Hello user,<br><br>
     Your issue {issue_id} has been closed. If you are still experiencing 
     the issue you may reply back to this email and we will do our best to help.
-    """.format(name= issuer_name, issue_id = doc.name)
+    """.format(issue_id = doc.name)
 
     if doc.status == "Closed":
-        sendemail(sender=sender, recipients= issuer_id, content=msg, subject="Your Issue has been closed!", delay=False)
+        sendemail(sender=sender, recipients= doc.raised_by, content=msg, subject="Your Issue has been closed!", delay=False)
 
 def assign_issue(doc, method):
     '''


### PR DESCRIPTION
## Feature description
- Send an Email to the Issuer when the issue has been closed.

## Solution description
- On update, if the status of the issue is closed, send an email to the issuer.

## Output screenshots (optional)
<img width="1101" alt="Screen Shot 2022-03-24 at 4 40 31 PM" src="https://user-images.githubusercontent.com/29017559/159929061-5f546038-8cc5-4eb7-98b9-c8fe4cf0d119.png">

## Areas affected and ensured
- check if contact of the issuer exists. 
- check if the status is close.
- send an email if the status is close.

## Is there any existing behavior change of other features due to this code change?
Yes, An email is sent when the issue has been closed.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
