### PR TITLE
Feat: Notify issue raiser after support ticket is created

### DIFF
--- a/one_fm/api/doc_methods/issue.py
+++ b/one_fm/api/doc_methods/issue.py
@@ -64,10 +64,7 @@ def notify_issue_raiser(doc, method):
             You will be notified when a response is made by email. The details of your ticket are shown below:<br>
             <br>
             Issue ID: {issue_id}<br>
-            Issue subject: {issue_subject}<br>
-            <br>
-            Sincerely,
-            ONE FM Support Team
+            Issue subject: {issue_subject}<br><br>
             """
             
             sendemail(recipients=[doc.raised_by], subject=email_subject, header=header, message=message)

--- a/one_fm/api/doc_methods/issue.py
+++ b/one_fm/api/doc_methods/issue.py
@@ -43,3 +43,34 @@ def log_pivotal_tracker():
     except Exception as e:
         frappe.throw(f"Pivotal Tracker story could not be created:\n {str(e)}")
         frappe.log_error(str(e), 'Issue Pivotal Tracker')
+
+def notify_issue_raiser(doc, method):
+    """This method notifies the issue raiser via email upon creating an issue."""
+    
+    from one_fm.processor import sendemail
+
+    try:
+        if doc.raised_by and doc.communication_medium in ["System", "Email", "Mobile App"]:
+
+            issue_id = doc.name
+            issue_subject = doc.subject
+            email_subject = f"ONE FM Support - {issue_id}"
+            
+            header = ['Support Ticket', 'blue']
+            
+            message = f"""
+            Dear user, <br><br>
+            Thank you for contacting our support team. A support ticket has now been opened for your request.<br>
+            You will be notified when a response is made by email. The details of your ticket are shown below:<br>
+            <br>
+            Issue ID: {issue_id}<br>
+            Issue subject: {issue_subject}<br>
+            <br>
+            Sincerely,
+            ONE FM Support Team
+            """
+            
+            sendemail(recipients=[doc.raised_by], subject=email_subject, header=header, message=message)
+
+    except Exception as error:
+        frappe.log_error(error)

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -292,7 +292,10 @@ doc_events = {
 		"validate": "one_fm.hiring.utils.calculate_interview_feedback_average_rating",
 	},
 	"Issue": {
-		"after_insert": "one_fm.utils.assign_issue"
+		"after_insert": [
+			"one_fm.utils.assign_issue",
+			"one_fm.api.doc_methods.issue.notify_issue_raiser"
+		]
 	}
 	# "Additional Salary" :{
 	# 	"on_submit": "one_fm.grd.utils.validate_date"


### PR DESCRIPTION
## Feature description
Receive an email confirmation when an issue has been created.

## Solution description
- Added method to send email to issue raiser upon creating an Issue.
- Added method to hooks.

## Areas affected and ensured
None.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
