### PR TITLE
Remove len(shift) since shift is an object/dict

### DIFF
--- a/one_fm/api/mobile/face_recognition.py
+++ b/one_fm/api/mobile/face_recognition.py
@@ -83,7 +83,7 @@ def verify(video, log_type, skip_attendance, latitude, longitude):
 def get_site_location(employee):
 	try:
 		shift = get_current_shift(employee)
-		if shift and len(shift) != 0:
+		if shift:
 			site = frappe.get_value("Operations Shift", shift.shift, "site")
 			location= frappe.db.sql("""
 			SELECT loc.latitude, loc.longitude, loc.geofence_radius

--- a/one_fm/api/mobile/roster.py
+++ b/one_fm/api/mobile/roster.py
@@ -568,18 +568,33 @@ def get_handover_posts(shift=None):
 
 @frappe.whitelist()
 def get_current_shift(employee):
+	"""This function is to return employee's current Shift,
+	based on Shift Assignment. 
+
+	Args:
+		employee (str): Employee's ERP ID
+
+	Returns:
+		string: Operation Shift of the assigned shift if it exist.
+	"""
 	try:
 		current_datetime = now_datetime().strftime("%Y-%m-%d %H:%M:%S")
 		date, time = current_datetime.split(" ")
 		shifts = frappe.get_list("Shift Assignment", {"employee":employee, 'start_date': ['>=', date]}, ["shift", "shift_type"])
+		
+		#convert to datetime
+		time = time.split(":")
+		time = datetime.timedelta(hours=cint(time[0]), minutes=cint(time[1]), seconds=cint(time[2]))
+		
 		if len(shifts) > 0:
 			for shift in shifts:
-				time = time.split(":")
-				time = datetime.timedelta(hours=cint(time[0]), minutes=cint(time[1]), seconds=cint(time[2]))
 				shift_type, start_time, end_time ,before_time, after_time= frappe.get_value("Shift Type", shift.shift_type, ["shift_type","start_time", "end_time","begin_check_in_before_shift_start_time","allow_check_out_after_shift_end_time"])
+				
 				#include early entry and late exit time
 				start_time = start_time - datetime.timedelta(minutes=before_time)
 				end_time = end_time + datetime.timedelta(minutes=after_time)
+				
+				#if the shift type is "Night", the timing range could vary comparing morning shift.
 				if shift_type == "Night":
 					if start_time <= time >= end_time or start_time >= time <= end_time:
 						return shift


### PR DESCRIPTION
## Feature description
Hot-fix: Remove len(shift) since shift is an object/dict

## Solution description
- Remove len(shift) since the shift is an object/dict, and not a list.
- Change time to datetime before the loop to keep it constant.

## Areas affected and ensured
- 'get_current_shift' returns shift object as usual in object form.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari