### PR TITLE
Fix: Adding Docname to subject and message

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2352,14 +2352,15 @@ def notify_on_close(doc, method):
     #fetch Sender and Issuer's address
     sender = frappe.get_value("Email Account",{"name":doc.email_account}, ["email_id"])
         
-    #Form Message
-    msg = """Hello user,<br><br>
-    Your issue {issue_id} has been closed. If you are still experiencing 
+    #Form Subject and Message 
+    subject = """Your Issue {docname} has been closed!""".format(docname=doc.name)
+    msg = """Hello user,<br>
+        Your issue <a href={url}>{issue_id}</a> has been closed. If you are still experiencing 
     the issue you may reply back to this email and we will do our best to help.
-    """.format(issue_id = doc.name)
+    """.format(issue_id = doc.name, url= doc.get_url())
 
     if doc.status == "Closed":
-        sendemail(sender=sender, recipients= doc.raised_by, content=msg, subject="Your Issue has been closed!", delay=False)
+        sendemail(sender=sender, recipients= doc.raised_by, content=msg, subject=subject, delay=False)
 
 def assign_issue(doc, method):
     '''


### PR DESCRIPTION
## Feature description
Adding Docname to subject and message

## Solution description
- Forming Subject with docname
- add link to docname

## Output screenshots (optional)
<img width="1323" alt="Screen Shot 2022-03-29 at 3 39 26 PM" src="https://user-images.githubusercontent.com/29017559/160622869-662b0ea8-e6be-436b-a6b4-9c03ee495cff.png">

## Areas affected and ensured
-Subject has an issue doc name.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
