### PR TITLE
HotFix: Remove sender to create system notification

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2347,9 +2347,7 @@ def notify_on_close(doc, method):
     '''
         This Method is used to notify the issuer, when the issue is closed.
     '''
-    #fetch Sender and Issuer's address
-    sender = frappe.get_value("Email Account",{"name":doc.email_account}, ["email_id"])
-        
+
     #Form Subject and Message 
     subject = """Your Issue {docname} has been closed!""".format(docname=doc.name)
     msg = """Hello user,<br>
@@ -2358,7 +2356,7 @@ def notify_on_close(doc, method):
     """.format(issue_id = doc.name, url= doc.get_url())
 
     if doc.status == "Closed":
-        sendemail(sender=sender, recipients= doc.raised_by, content=msg, subject=subject, delay=False)
+        sendemail( recipients= doc.raised_by, content=msg, subject=subject, delay=False)
 
 def assign_issue(doc, method):
     '''


### PR DESCRIPTION
## Feature description
Hot Fix: Notify users about issues being closed from the System rather than through support.

## Solution description
- Remove the sender which then creates notifications instead.

## Areas affected and ensured
- Remove sender

## Is there any existing behavior change of other features due to this code change?
Email is through Notification/Default email rather than through Support.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
