### PR TITLE
Hotfix: Operations Post save Error

### DIFF
--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -12,13 +12,12 @@ import pandas as pd
 
 class OperationsPost(Document):
 	def after_insert(self):
-		start_date = None
-		end_date = None
 		post_abbrv = frappe.db.get_value("Post Type", self.post_template, ["post_abbrv"])
 		if frappe.db.exists("Contracts", {'project': self.project}):
 			start_date, end_date = frappe.db.get_value("Contracts", {'project': self.project}, ["start_date", "end_date"])
-		frappe.enqueue(set_post_active, post=self, post_type=self.post_template, post_abbrv=post_abbrv, shift=self.site_shift, site=self.site, project=self.project, start_date=start_date, end_date=end_date, is_async=True, queue="long")
-
+			if start_date and end_date:
+				frappe.enqueue(set_post_active, post=self, post_type=self.post_template, post_abbrv=post_abbrv, shift=self.site_shift, site=self.site, project=self.project, start_date=start_date, end_date=end_date, is_async=True, queue="long")
+	
 	def on_update(self):
 		self.validate_name()
 

--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -18,6 +18,16 @@ class OperationsPost(Document):
 			if start_date and end_date:
 				frappe.enqueue(set_post_active, post=self, post_type=self.post_template, post_abbrv=post_abbrv, shift=self.site_shift, site=self.site, project=self.project, start_date=start_date, end_date=end_date, is_async=True, queue="long")
 	
+	def validate(self):
+		if not self.post_name:
+			frappe.throw("Post Name cannot be empty.")
+
+		if not self.gender:
+			frappe.throw("Gender cannot be empty.")
+
+		if not self.site_shift:
+			frappe.throw("Shift cannot be empty.")
+
 	def on_update(self):
 		self.validate_name()
 


### PR DESCRIPTION
- Set posts active only if start and end dates are set in the Contracts linked with the post's project.
- Validate if fields used in the naming series are set.