### PR TITLE
feat: Hide earning in salary slip

### DIFF
--- a/one_fm/public/js/doctype_js/salary_slip.js
+++ b/one_fm/public/js/doctype_js/salary_slip.js
@@ -3,5 +3,19 @@ frappe.ui.form.on('Salary Slip', {
 		if (frm.doc.justification_needed_on_deduction == 1){
 			frm.set_intro(__("Justification Needed on Deduction is True, Prepare Justification for PAM"), 'yellow');
 		}
+		// SET FIELDS DISPLAY FOR ROLES
+		setFieldDisplay(frm);
 	}
 });
+
+
+let setFieldDisplay = frm => {
+	// hide earnings and gross for employee
+	if (!(frappe.user_roles.includes('HR User')||frappe.user_roles.includes('HR Manager'))){
+		['earnings', 'gross_pay', 'gross_year_to_date',
+			'year_to_date', 'month_to_date'].forEach((item, i) => {
+				frm.toggle_display(item, 0);
+			});
+
+	}
+}


### PR DESCRIPTION
## Feature description
This PR hides earning and gross pay in salary slip for Employee users.

## Solution description
Permlevel in doctype could be used to hide/display field based on role, but it does not work but eliminate all permissions to salary slip to Employee user, the alternate solution was to use custom script to filter out session users who does not have HR Manager and User role, then hide the related fields. 

## Output screenshots (optional)
![image](https://user-images.githubusercontent.com/10146518/163779405-c17fa2f2-0599-4290-a5a0-5d6cf6549580.png)

