### PR TITLE
fix: Not bound to db in __init__

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -4,14 +4,12 @@ from erpnext.hr.doctype.shift_request.shift_request import ShiftRequest
 from erpnext.payroll.doctype.payroll_entry.payroll_entry import PayrollEntry
 from erpnext.payroll.doctype.salary_slip.salary_slip import SalarySlip
 from erpnext.stock.doctype.item_price.item_price import ItemPrice
-from erpnext.hr.doctype.leave_policy_assignment.leave_policy_assignment import LeavePolicyAssignment
 from one_fm.api.doc_methods.shift_request import shift_request_submit
 from one_fm.api.doc_methods.payroll_entry import validate_employee_attendance, get_count_holidays_of_employee, get_count_employee_attendance, fill_employee_details
 from one_fm.api.doc_methods.salary_slip import get_holidays_for_employee,get_leave_details
 from one_fm.api.doc_methods.item_price import validate,check_duplicates
 from erpnext.hr.doctype.leave_application.leave_application import LeaveApplication
 from one_fm.api.mobile.Leave_application import notify_leave_approver
-# from one_fm.hiring.utils import grant_leave_alloc_for_employee
 from erpnext.controllers.taxes_and_totals import calculate_taxes_and_totals
 from one_fm.operations.doctype.contracts.contracts import calculate_item_values
 
@@ -29,5 +27,4 @@ SalarySlip.get_leave_details = get_leave_details
 ItemPrice.validate = validate
 ItemPrice.check_duplicates = check_duplicates
 LeaveApplication.notify_leave_approver = notify_leave_approver
-# LeavePolicyAssignment.grant_leave_alloc_for_employee = grant_leave_alloc_for_employee
 calculate_taxes_and_totals.calculate_item_values = calculate_item_values

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -369,6 +369,11 @@ website_route_rules = [
 #	}
 # }
 
+override_doctype_class = {
+    "Leave Policy Assignment": "one_fm.overrides.leave_policy_assignment.LeavePolicyAssignmentOverride",
+}
+
+
 # Scheduled Tasks
 # ---------------
 

--- a/one_fm/overrides/leave_policy_assignment.py
+++ b/one_fm/overrides/leave_policy_assignment.py
@@ -1,0 +1,29 @@
+import frappe
+
+from erpnext.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
+    LeavePolicyAssignment, get_leave_type_details,
+)
+
+
+class LeavePolicyAssignmentOverride(LeavePolicyAssignment):
+    # overide default class
+    @frappe.whitelist()
+    def grant_leave_alloc_for_employee(self):
+        if not self.leaves_allocated:
+            leave_allocations = {}
+            leave_type_details = get_leave_type_details()
+
+            leave_policy = frappe.get_doc("Leave Policy", self.leave_policy)
+            date_of_joining = frappe.db.get_value("Employee", self.employee, "date_of_joining")
+
+            for leave_policy_detail in leave_policy.leave_policy_details:
+                if not leave_type_details.get(leave_policy_detail.leave_type).is_lwp:
+                    leave_allocation, new_leaves_allocated = self.create_leave_allocation(
+                        leave_policy_detail.leave_type, leave_policy_detail.annual_allocation,
+                        leave_type_details, date_of_joining
+                    )
+
+                    leave_allocations[leave_policy_detail.leave_type] = {"name": leave_allocation, "leaves": new_leaves_allocated}
+
+            self.db_set("leaves_allocated", 1)
+            return leave_allocations


### PR DESCRIPTION
## Feature description
This PR fixes issue with  No Object Bound to DB. This was as a result of Leave Assignment Policy override in __init__.py which interferes with system boot cycle thereby restricting Werkzeug from starting up properly as well as breaking Gunicorn functionality.

## Solution description
Leave Policy Assignment override was done with Hooks class override. By inheriting the class then overriding the method directly. 