### PR TITLE
HotFix: Variable bank_account_no Doesnt Exist in PayrollEmployeeDetail

### DIFF
--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -237,7 +237,7 @@ def export_payroll(doc, method):
 		if employee.salary_mode == "Cash":
 			cash_salary_employees.append(employee)
 		elif employee.salary_mode == "Bank":
-			if not employee.iban_number or not employee.bank_account_no:
+			if not employee.iban_number:
 				frappe.throw(_("No Iban/Bank account set for employee: {employee}".format(employee=employee.employee)))
 		elif not employee.salary_mode:
 			frappe.throw(_("No salary mode set for employee: {employee}".format(employee=employee.employee)))


### PR DESCRIPTION
## Feature description
HotFix: Variable "bank_account_no" Doesn't Exist in PayrollEmployeeDetail

## Solution description
Remove "bank_account_no" 

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
