### PR TITLE
Fix job not found

### DIFF
--- a/one_fm/www/careers/opening/index.html
+++ b/one_fm/www/careers/opening/index.html
@@ -8,7 +8,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Careers</title>
-    <link rel="stylesheet" href="/assets/one_fm/careers/css/careers.css">
 </head>
 {% endblock %}
 
@@ -19,7 +18,6 @@
 <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 <script src="/assets/frappe/js/lib/socket.io.min.js"></script>
 <script type="text/javascript" src="/assets/js/frappe-web.min.js"></script>
-<script src="/careers/index.js"></script>
 {% endblock %}
 
 {% block content %}

--- a/one_fm/www/careers/opening/index.py
+++ b/one_fm/www/careers/opening/index.py
@@ -11,6 +11,6 @@ def get_context(context):
         designation, description = frappe.db.get_value("Job Opening", {'name': job_id}, ["designation", "description"])
         opening.update({'name': job_id})
         opening.update({'designation': designation})
-        opening.update({'description': remove_html_tags(description)})
+        opening.update({'description': remove_html_tags(description) if description else ""})
 
     context.opening = opening


### PR DESCRIPTION
- Handle case when no description is provided in Job Opening while viewing the `/careers/opening` page.
- Removed unused js and css assets.