### PR TITLE
[Fix] Remove html_escape in career description

### DIFF
--- a/one_fm/www/careers/opening/index.py
+++ b/one_fm/www/careers/opening/index.py
@@ -11,6 +11,6 @@ def get_context(context):
         designation, description = frappe.db.get_value("Job Opening", {'name': job_id}, ["designation", "description"])
         opening.update({'name': job_id})
         opening.update({'designation': designation})
-        opening.update({'description': remove_html_tags(description) if description else ""})
+        opening.update({'description': description})
 
     context.opening = opening


### PR DESCRIPTION
## Feature description
 - fix: Remove html_escape in career description

The Job Opening Description
![Screenshot 2022-04-28 at 11 33 52 AM](https://user-images.githubusercontent.com/20554466/165688761-5afacebe-be14-44ea-9ce2-6067fa7633b1.png)

In Careers portal - Job Opening Description:
- before the PR
![Screenshot 2022-04-28 at 11 34 11 AM](https://user-images.githubusercontent.com/20554466/165688844-1eb6be96-a66a-4092-8f23-734a475ba2c1.png)

- after the PR
![Screenshot 2022-04-28 at 11 42 47 AM](https://user-images.githubusercontent.com/20554466/165688987-c3eb7278-fe28-4e88-9831-c871a7b1592a.png)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
