### PR TITLE
HotFix: Create Shift Assignment

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -503,7 +503,7 @@ def issue_penalty(employee, date, penalty_code, shift, issuing_user, penalty_loc
 def automatic_shift_assignment():
 	date = cstr(getdate())
 	end_previous_shifts()
-	roster = frappe.get_all("Employee Schedule", {"date": date, "employee_availability": "Working" }, ["*"])
+	roster = frappe.get_all("Employee Schedule", {"date": date, "employee_availability": "Working" , "roster_type": "Basic"}, ["*"])
 	errored_shift = []
 	for schedule in roster:
 		# skip errors and continue
@@ -531,20 +531,49 @@ def end_previous_shifts():
 		doc.submit()
 
 def create_shift_assignment(schedule, date):
-	shift_assignment = frappe.new_doc("Shift Assignment")
-	shift_assignment.start_date = date
-	shift_assignment.employee = schedule.employee
-	shift_assignment.employee_name = schedule.employee_name
-	shift_assignment.department = schedule.department
-	shift_assignment.post_type = schedule.post_type
-	shift_assignment.shift = schedule.shift
-	shift_assignment.site = schedule.site
-	shift_assignment.project = schedule.project
-	shift_assignment.shift_type = schedule.shift_type
-	shift_assignment.post_type = schedule.post_type
-	shift_assignment.post_abbrv = schedule.post_abbrv
-	shift_assignment.roster_type = schedule.roster_type
-	shift_assignment.submit()
+	try:
+		shift_assignment = frappe.new_doc("Shift Assignment")
+		shift_assignment.start_date = date
+		shift_assignment.employee = schedule.employee
+		shift_assignment.employee_name = schedule.employee_name
+		shift_assignment.department = schedule.department
+		shift_assignment.post_type = schedule.post_type
+		shift_assignment.shift = schedule.shift
+		shift_assignment.site = schedule.site
+		shift_assignment.project = schedule.project
+		shift_assignment.shift_type = schedule.shift_type
+		shift_assignment.post_type = schedule.post_type
+		shift_assignment.post_abbrv = schedule.post_abbrv
+		shift_assignment.roster_type = schedule.roster_type
+		shift_assignment.submit()
+	except Exception:
+			frappe.log_error(frappe.get_traceback())
+
+def overtime_shift_assignment():
+	"""
+	This method is to generate Shift Assignment for Employee Scheduling 
+	with roster type 'Over_Time'. It first looks up for Shift Assignment
+	of the employee for the day if he has any. Change the Status to "Inactive"
+	and proceeds with creating New shift Assignments with Roster Type OverTime.
+	"""
+	date = cstr(getdate())
+	now_time = now_datetime().strftime("%H:%M:00")
+	roster = frappe.get_all("Employee Schedule", {"date": date, "employee_availability": "Working" , "roster_type": "Over-Time"}, ["*"])
+	frappe.enqueue(process_overtime_shift,roster=roster, date=date, time=now_time, is_async=True, queue='long')
+
+def process_overtime_shift(roster, date, time):
+	for schedule in roster:	
+		#Check for employee's shift assignment of the day, if he has any.
+		shift_assignment = frappe.get_doc("Shift Assignment", {"employee":schedule.employee, "start_date": date},["name","shift_type"])
+		if shift_assignment:
+			shift_end_time = frappe.get_value("Shift Type",shift_assignment.shift_type, "end_time")
+			#check if the given shift has ended
+			# Set status inactive before creating new shift
+			if str(shift_end_time) == str(time):
+				frappe.set_value("Shift Assignment", shift_assignment.name,'status', "Inactive")
+				create_shift_assignment(schedule, date)
+		else:
+			create_shift_assignment(schedule, date)
 
 def update_shift_type():
 	today_datetime = now_datetime()

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -444,7 +444,8 @@ scheduler_events = {
 		"0/5 * * * *": [
 			"one_fm.api.tasks.checkin_checkout_supervisor_reminder",
 			"one_fm.api.tasks.checkin_checkout_final_reminder",
-			"one_fm.api.tasks.checkin_deadline"
+			"one_fm.api.tasks.checkin_deadline",
+			"one_fm.api.tasks.overtime_shift_assignment"
 			#"one_fm.api.tasks.automatic_checkout"
 		],
 		"0/15 * * * *": [


### PR DESCRIPTION
## Feature description
Create Shift assignment for both Roster Type: Basic and Overtime.

## Analysis and design (optional)
 Since one could not have two active shift assignments, we create one after the other. We do this by inactivating the first before creating the next.

## Solution description
Step 1: Create Shift Assignment for all the Schedule with Roster Type "Basic".
Step 2:  Fetch all the schedules with Roster type "Over-Time".
Step3: Check if the employee has a Shift Assignment for the given date, and set the status of it as "InActive".
Step4: Create Shift Assignments for the fetched schedules.

## Output screenshots (optional)
<img width="300" alt="Screen Shot 2022-04-19 at 2 12 25 AM" src="https://user-images.githubusercontent.com/29017559/163891376-ce7bc5e2-f40b-4eee-85f9-4749cfc45ea9.png">
<img width="300" alt="Screen Shot 2022-04-19 at 2 12 10 AM" src="https://user-images.githubusercontent.com/29017559/163891396-20a74fd3-a4f6-42a4-9df0-2f3fb20ef85b.png">

## Areas affected and ensured
Shift Assignment Roster Type is "Basic" is created first, and the Roster type "Over-Time" is created later.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari