### PR TITLE
patch: patch: Remove index key iban_number_2 from Payroll Employee Detail

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -5,3 +5,4 @@ one_fm.patches.v1_0.assign_roles #2021-09-13
 one_fm.patches.v1_0.update_notification_logs #2021-12-15
 one_fm.patches.v1_0.delete_interview_doctype
 one_fm.patches.v1_0.delete_unused_interview_related_cutom_fields
+one_fm.patches.v0_12.fix_payroll_duplicate_iban_number_2

--- a/one_fm/patches/v0_12/fix_payroll_duplicate_iban_number_2.py
+++ b/one_fm/patches/v0_12/fix_payroll_duplicate_iban_number_2.py
@@ -1,0 +1,9 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+    print('Preparing Payroll Employee Detail')
+    frappe.reload_doctype('Payroll Employee Detail')
+    print('Removing index key iban_number_2 from iban_number....')
+    frappe.db.sql("""ALTER TABLE `tabPayroll Employee Detail` DROP INDEX iban_number_2;""")
+    print('Done')


### PR DESCRIPTION
## Feature description
This PR fixes database index issue with Payroll Employee Detail. There is an index key for iban_number (iban_number_2) that restricts payroll generation. It was fixed by using a patch to remove the index key in the database table.
