### PR TITLE
Refactor `opening` object assignment

### DIFF
--- a/one_fm/www/careers/opening/index.py
+++ b/one_fm/www/careers/opening/index.py
@@ -7,10 +7,11 @@ def get_context(context):
 
     opening = {}
 
-    if job_id:
-        designation, description = frappe.db.get_value("Job Opening", {'name': job_id}, ["designation", "description"])
-        opening.update({'name': job_id})
-        opening.update({'designation': designation})
-        opening.update({'description': description})
+    job_opening = frappe.get_doc("Job Opening", {'name': job_id})
+    
+    if job_opening:
+        opening.update({'name': job_opening.name})
+        opening.update({'designation': job_opening.designation})
+        opening.update({'description': job_opening.description if job_opening.description else ""})
 
     context.opening = opening


### PR DESCRIPTION
- Check if document exists in database. Only then assign keys and values to `opening` object.