### PR TITLE
chore: Remove Onboarding Role from doctypes

### DIFF
--- a/one_fm/grd/doctype/pifss_form_103/pifss_form_103.json
+++ b/one_fm/grd/doctype/pifss_form_103/pifss_form_103.json
@@ -628,7 +628,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-08-26 16:54:01.477324",
+ "modified": "2022-05-01 00:33:32.823620",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PIFSS Form 103",
@@ -666,7 +666,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Onboarding",
+   "role": "Onboarding Officer",
    "share": 1
   }
  ],


### PR DESCRIPTION
## Feature description
This PR removes Onboarding role from ONEFM doctypes since Onboarding Officer role serves same purpose.