### PR TITLE
Fetch Site and then fetch location

### DIFF
--- a/one_fm/api/dashboard_utils.py
+++ b/one_fm/api/dashboard_utils.py
@@ -88,7 +88,8 @@ def get_employee_shift(employee_id, date_type='month'):
 		     limit=1,
 		 )
 		if(len(shift_assignment)):
-			shift_location = frappe.get_doc('Location', shift_assignment[0].site)
+			site = frappe.get_doc("Operations Site", shift_assignment[0].site)
+			shift_location = frappe.get_doc("Location", site.site_location)
 			shift_type = frappe.get_doc('Shift Type', shift_assignment[0].shift_type)
 			days_worked = frappe.db.get_list('Attendance',
 		    filters=[


### PR DESCRIPTION
## Feature description
Fix: Location Not Found in the API "get_employee_shift"

## Solution description
- Get Site from the Shift Assignment.
- Get the Location from the Operations Site.


## Areas affected and ensured
- API 'get_employee_shift'

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
