### PR TITLE
Hotfix: Allow site supervisors to view all sites

### DIFF
--- a/one_fm/api/mobile/roster.py
+++ b/one_fm/api/mobile/roster.py
@@ -362,7 +362,7 @@ def get_assigned_sites(employee_id, project=None):
 		filters = {}
 		if project:
 			filters.update({"project": project})
-		if project is None and ("Operations Manager" in user_roles or "Projects Manager" in user_roles):
+		if project is None and ("Operations Manager" in user_roles or "Projects Manager" in user_roles or "Site Supervisor" in user_roles):
 			return frappe.get_list("Operations Site", limit_page_length=9999, order_by="name asc")
 
 		elif "Operations Manager" in user_roles or "Projects Manager" in user_roles:


### PR DESCRIPTION
- Check if user is a Site Supervisor and return all sites in roster Site filter.