### PR TITLE
Feat: Exclude WFH employees from geofence enforcement

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -258,6 +258,7 @@ doc_events = {
 		"on_cancel": "one_fm.one_fm.utils.manage_attendance_on_holiday"
 	},
 	"Attendance Request": {
+		"after_insert": "one_fm.api.doc_events.after_insert_attendance_request",
 		"before_submit": "one_fm.api.doc_events.before_submit_attendance_request"
 	},
 	"Asset":{
@@ -374,6 +375,7 @@ website_route_rules = [
 
 override_doctype_class = {
     "Leave Policy Assignment": "one_fm.overrides.leave_policy_assignment.LeavePolicyAssignmentOverride",
+	"Attendance Request": "one_fm.overrides.attendance_request.AttendanceRequestOverride"
 }
 
 

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -257,6 +257,9 @@ doc_events = {
 		],
 		"on_cancel": "one_fm.one_fm.utils.manage_attendance_on_holiday"
 	},
+	"Attendance Request": {
+		"before_submit": "one_fm.api.doc_events.before_submit_attendance_request"
+	},
 	"Asset":{
 		"after_insert" : "one_fm.one_fm.asset_custom.after_insert_asset",
 		"on_submit": "one_fm.one_fm.asset_custom.on_asset_submit"

--- a/one_fm/overrides/attendance_request.py
+++ b/one_fm/overrides/attendance_request.py
@@ -1,0 +1,7 @@
+import frappe
+from erpnext.hr.doctype.attendance_request.attendance_request import AttendanceRequest
+
+
+class AttendanceRequestOverride(AttendanceRequest):
+    def create_attendance(self):
+        pass


### PR DESCRIPTION
## Feature description
As a work from home employee I would like to be excluded from the enforcement of location based checkin/checkout.

## Solution description
- Attendance Request doctype has been used and controllers added to handle events such as notify approver on creating a document and update attendance on submitting the document.
- Approver is set as employee's reports to person.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
