### PR TITLE
fix: Issue in Job Offer

### DIFF
--- a/one_fm/one_fm/doctype/erf_salary_detail/erf_salary_detail.json
+++ b/one_fm/one_fm/doctype/erf_salary_detail/erf_salary_detail.json
@@ -19,6 +19,7 @@
    "reqd": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -29,7 +30,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-12-16 08:27:47.551800",
+ "modified": "2022-05-18 09:16:51.789071",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ERF Salary Detail",


### PR DESCRIPTION
## Feature description
- Issue in Job Offer - "Not allowed to change Amount after submission"

## Analysis and design (optional)
- In Job Offer we have a child table with field amount, but the amount field is setting based on the base and the salary structure selected and the field is read only too.

## Solution description
- We can set allow_on_submit true for the amount field in the child table

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
