### PR TITLE
fix: Ignore user permission for employee link in accommodation doctypes

### DIFF
--- a/one_fm/accommodation/doctype/accommodation_asset_and_consumable/accommodation_asset_and_consumable.json
+++ b/one_fm/accommodation/doctype/accommodation_asset_and_consumable/accommodation_asset_and_consumable.json
@@ -62,6 +62,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
@@ -192,7 +193,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-12-29 07:37:56.975431",
+ "modified": "2022-05-18 10:04:24.906943",
  "modified_by": "Administrator",
  "module": "Accommodation",
  "name": "Accommodation Asset and Consumable",

--- a/one_fm/accommodation/doctype/accommodation_checkin_checkout/accommodation_checkin_checkout.json
+++ b/one_fm/accommodation/doctype/accommodation_checkin_checkout/accommodation_checkin_checkout.json
@@ -66,6 +66,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Employee",
@@ -412,7 +413,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-10-06 11:48:13.222242",
+ "modified": "2022-05-18 10:03:25.617357",
  "modified_by": "Administrator",
  "module": "Accommodation",
  "name": "Accommodation Checkin Checkout",

--- a/one_fm/accommodation/doctype/bed/bed.json
+++ b/one_fm/accommodation/doctype/bed/bed.json
@@ -163,6 +163,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
@@ -365,7 +366,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-08-26 07:13:43.584160",
+ "modified": "2022-05-18 10:03:47.482957",
  "modified_by": "Administrator",
  "module": "Accommodation",
  "name": "Bed",


### PR DESCRIPTION
## Feature description
- Not able to access Accommodation Doctype from the reports

## Analysis and design (optional)
- User Permission can be ignored for Employee field Accommodation Doctypes. So any of the user having access to accommodation module can see the records and we dont want to remove the user permission for the employee record.

## Solution description
- Set ignore_user_permission true for the Employee link field in the accommodation doctypes

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
