### PR TITLE
chore: Configurable the auto preparation record creation

### DIFF
--- a/one_fm/grd/doctype/grd_settings/grd_settings.js
+++ b/one_fm/grd/doctype/grd_settings/grd_settings.js
@@ -2,7 +2,17 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('GRD Settings', {
-	// refresh: function(frm) {
-
-	// }
+  create_preparation_record_manually: function(frm) {
+    frappe.call({
+      method: 'one_fm.grd.doctype.preparation.preparation.create_preparation_record',
+      callback: function(r) {
+        if(!r.exc){
+          frappe.msgprint(__("Preparation record created succssefully!"));
+          frm.reload_doc();
+        }
+      },
+      freeze: true,
+      freeze_message: (__("Creating Preparation..!"))
+    });
+  }
 });

--- a/one_fm/grd/doctype/grd_settings/grd_settings.json
+++ b/one_fm/grd/doctype/grd_settings/grd_settings.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2020-08-21 15:28:44.847979",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -7,13 +8,17 @@
   "section_break_1",
   "default_grd_supervisor",
   "default_grd_operator",
+  "column_break_4",
   "default_grd_operator_pifss",
-  "default_grd_operator_transfer"
+  "default_grd_operator_transfer",
+  "preparation_record_settings_section",
+  "preparation_record_creation_day"
  ],
  "fields": [
   {
    "fieldname": "section_break_1",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "GSD Default Settings"
   },
   {
    "fieldname": "default_grd_supervisor",
@@ -40,10 +45,28 @@
    "fieldtype": "Link",
    "label": "Default GRD Operator (Transfer)",
    "options": "User"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "15",
+   "description": "Preparation Record Creation for Next Month on the Day of Current Month<br>You can enter a value from 1 to 28.",
+   "fieldname": "preparation_record_creation_day",
+   "fieldtype": "Int",
+   "label": "Preparation Record Creation Day"
+  },
+  {
+   "description": "Preparation record that contain list of all employees that their residency expiry date will be between the first and the last date of the next month.\nThis record will go to HR user to set value for each employee either renewal or extend and on the submit of this record it will ask for hr permission and approval.\nThen, it will create wp, mi, moi, and paci records for all employees in the list.",
+   "fieldname": "preparation_record_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Preparation Record Settings"
   }
  ],
  "issingle": 1,
- "modified": "2021-06-30 13:16:44.299264",
+ "links": [],
+ "modified": "2022-05-18 14:37:00.889505",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "GRD Settings",

--- a/one_fm/grd/doctype/grd_settings/grd_settings.json
+++ b/one_fm/grd/doctype/grd_settings/grd_settings.json
@@ -12,7 +12,11 @@
   "default_grd_operator_pifss",
   "default_grd_operator_transfer",
   "preparation_record_settings_section",
-  "preparation_record_creation_day"
+  "preparation_record_creation_day",
+  "create_preparation_record_manually",
+  "column_break_10",
+  "last_preparation_record_created_on",
+  "last_preparation_record_created_by"
  ],
  "fields": [
   {
@@ -62,11 +66,33 @@
    "fieldname": "preparation_record_settings_section",
    "fieldtype": "Section Break",
    "label": "Preparation Record Settings"
+  },
+  {
+   "fieldname": "create_preparation_record_manually",
+   "fieldtype": "Button",
+   "label": "Create Preparation Record Manually"
+  },
+  {
+   "fieldname": "column_break_10",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "last_preparation_record_created_on",
+   "fieldtype": "Datetime",
+   "label": "Last Preparation Record Created on",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_preparation_record_created_by",
+   "fieldtype": "Link",
+   "label": "Last Preparation Record Created by",
+   "options": "User",
+   "read_only": 1
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2022-05-18 14:37:00.889505",
+ "modified": "2022-05-20 08:50:40.970850",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "GRD Settings",

--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -107,6 +107,13 @@ class Preparation(Document):
             send_email(self, [self.grd_operator], message, subject)
             create_notification_log(subject, message, [self.grd_operator], self)
 
+    def after_insert(self):
+        self.update_last_preparation_details_to_grd_settings()
+
+    def update_last_preparation_details_to_grd_settings(self):
+        frappe.db.set_value("GRD Settings", None, "last_preparation_record_created_on", self.creation)
+        frappe.db.set_value("GRD Settings", None, "last_preparation_record_created_by", self.owner)
+
 # Calculate the date of the next month (First & Last) (monthly cron in hooks)
 def auto_create_preparation_record():
     """
@@ -121,6 +128,7 @@ def auto_create_preparation_record():
         if getdate(preparation_record_creation_day_date) == getdate(today()):
             create_preparation_record()
 
+@frappe.whitelist()
 def create_preparation_record():
     """
         This method will create preparation record for next month from the date of execution.

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -433,9 +433,6 @@ scheduler_events = {
 			'one_fm.grd.doctype.paci.paci.notify_operator_to_take_hawiyati_renewal',#paci hawiyati
 			'one_fm.grd.doctype.paci.paci.notify_operator_to_take_hawiyati_transfer'
 		],
-		"0 8 15 * *": [
-			'one_fm.grd.doctype.preparation.preparation.create_preparation',
-		],
 		"15 3 * * *": [
 			'one_fm.tasks.one_fm.daily.generate_contracts_invoice', #Generate contracts sales invoice
 		],
@@ -468,7 +465,7 @@ scheduler_events = {
 		"30 4 * * *": [
 			'one_fm.utils.check_grp_operator_submission_four_half'
 		],
-		"0 8 * * *": [
+		"0 8 * * *": [# Runs everyday at 8:00 am.
 			'one_fm.utils.send_gp_letter_attachment_reminder2',
 			'one_fm.utils.send_gp_letter_attachment_no_response',
 			'one_fm.grd.doctype.fingerprint_appointment.fingerprint_appointment.before_one_day_of_appointment_date',
@@ -480,7 +477,8 @@ scheduler_events = {
 			'one_fm.grd.utils.sendmail_reminder_to_book_appointment_for_pifss',
 			'one_fm.grd.utils.sendmail_reminder_to_collect_pifss_documents',
 			'one_fm.hiring.doctype.transfer_paper.transfer_paper.check_signed_workContract_employee_completed',
-			'one_fm.utils.issue_roster_actions'
+			'one_fm.utils.issue_roster_actions',
+			'one_fm.grd.doctype.preparation.preparation.auto_create_preparation_record',
 		],
 		"0 9 * * *": [
 			'one_fm.utils.check_upload_tasriah_submission_nine',


### PR DESCRIPTION
## Feature description
 - Make configurable the auto preparation record creation
 - Remove unused imports and code cleanup in `preparation.py`

## Solution description
 - Removed the cron for creating preparation on 15th of each month
 - Added cron for creating preparation on everyday and the preparation record will create on the day configured in the GRD Settings.

## Output screenshots (optional)
<img width="1440" alt="Screenshot 2022-05-19 at 10 58 12 PM" src="https://user-images.githubusercontent.com/20554466/169218868-4cbfe96e-815b-4b67-ac59-3d1e943439c1.png">

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
