### PR TITLE
#181914777: Assign Shift Hourly, instead of daily.

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -520,6 +520,12 @@ def issue_penalty(employee, date, penalty_code, shift, issuing_user, penalty_loc
 	penalty_issuance.submit()
 	frappe.msgprint(_('A penalty has been issued against {0}'.format(employee_name)))
 
+def check_schedule_time():
+	schedule = frappe.get_doc("Employee Schedule","2022-05-22/HR-EMP-00001/Basic")
+	shift_start_time, before_time  = frappe.get_value("Shift Type", {"name":schedule.shift_type},["start_time", "begin_check_in_before_shift_start_time"])
+	now_time = now_datetime().strftime("%H:%M:00")
+	
+
 
 def automatic_shift_assignment():
 	date = cstr(getdate())

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -395,7 +395,7 @@ scheduler_events = {
 		'one_fm.utils.check_pam_visa_approval_submission_daily',
 		'one_fm.utils.check_upload_original_visa_submission_daily',
 		'one_fm.hiring.utils.notify_finance_job_offer_salary_advance',
-		'one_fm.api.tasks.automatic_shift_assignment',
+		#'one_fm.api.tasks.automatic_shift_assignment',
 		'one_fm.uniform_management.doctype.employee_uniform.employee_uniform.notify_gsd_and_employee_before_uniform_expiry',
 		'one_fm.operations.doctype.mom_followup.mom_followup.mom_followup_reminder',
 		'one_fm.one_fm.depreciation_custom.post_depreciation_entries',
@@ -421,6 +421,9 @@ scheduler_events = {
 	],
 
 	"cron": {
+		"0 * * * *": [
+			"one_fm.api.tasks.automatic_shift_assignment",
+		],
 		"0 8 * * 0,1,2,3,4":[#run durring working days only
 			'one_fm.grd.doctype.work_permit.work_permit.system_remind_renewal_operator_to_apply',#wp
 			'one_fm.grd.doctype.work_permit.work_permit.system_remind_transfer_operator_to_apply',


### PR DESCRIPTION
## Feature description
- Assign Shift Hourly, instead of daily.

## Solution description
- Fetch all the roster with Type Basic, and schedule them based on "begin_check_in_before_shift_start_time" 
- Schedule Every Hour.

Note: this feature needs to be tested well before being pushed to Prod.