### PR TITLE
fix: date range selection for future attendance

### DIFF
--- a/one_fm/overrides/attendance_request.py
+++ b/one_fm/overrides/attendance_request.py
@@ -130,9 +130,9 @@ def validate_future_dates(doc, from_date, to_date):
 	)
 	if getdate(from_date) > getdate(to_date):
 		frappe.throw(_("To date can not be less than from date"))
-	elif (getdate(from_date) > getdate(nowdate()) and (not doc.future_request)):
+	elif (getdate(from_date) > getdate(nowdate()) or (getdate(to_date) > getdate(nowdate()))) and (not doc.future_request):
 		frappe.throw(_("Future dates not allowed"))
-	elif (getdate(from_date) < getdate(nowdate()) and (doc.future_request)):
+	elif ((getdate(from_date) < getdate(nowdate())) or (getdate(from_date) < getdate(nowdate()))) and (doc.future_request):
 		frappe.throw(_("Past dates not allowed"))
 	elif date_of_joining and getdate(from_date) < getdate(date_of_joining):
 		frappe.throw(_("From date can not be less than employee's joining date"))


### PR DESCRIPTION
## Feature description
This PR fix date selection crossing issue where from_date is in the past and to_date is in the future

## Solution description
Backdated attendance to_date should not not exceed current date (nowdate)
Future Request from and to date should only start from nowdate into the future 

## Output screenshots (optional)

![image](https://user-images.githubusercontent.com/10146518/170990094-16f1c674-2a2e-4a28-8b0f-2bb4ee59996f.png)

![Uploading image.png…]()
