### PR TITLE
fix: Authorised signatory - error message

### DIFF
--- a/one_fm/hiring/doctype/work_contract/work_contract.py
+++ b/one_fm/hiring/doctype/work_contract/work_contract.py
@@ -44,7 +44,7 @@ class WorkContract(Document):
 			self.validate_autority_signature()
 		if self.workflow_state == 'Completed':
 			self.validate_employee_signature()
-	
+
 	def validate_autority_signature(self):
 		if not self.authorized_signatory_document:
 			frappe.throw(_("Please Attach Document from Authorized Signatory!"))
@@ -89,6 +89,8 @@ class WorkContract(Document):
 			pam_auth_sign = pam_authorized_signatory.as_dict()
 			for auth_sign in pam_auth_sign["authorized_signatory"]:
 				authorize_signatory.append(auth_sign["authorized_signatory_name_english"])
+		else:
+			frappe.msgprint(_("Please select a PAM File in ERF({0}) to get Authorised Signatory").format(self.erf))
 		return authorize_signatory
 
 	@frappe.whitelist()
@@ -96,7 +98,7 @@ class WorkContract(Document):
 		if not self.select_authorised_signatory_signed_work_contract:
 			frappe.throw(_("Please select Authorized Signatory!"))
 		elif not self.pam_file_number:
-			frappe.throw(_("Please select PAM File Number!"))
+			frappe.msgprint(_("Please select a PAM File in ERF({0}) to set PAM File Number in Work Contract").format(self.erf))
 		else:
 			pam_authorized_signatory = frappe.get_doc("PAM Authorized Signatory List",{'pam_file_number':self.pam_file_number},["authorized_signatory"],as_dict = True)
 			pam_auth_sign = pam_authorized_signatory.as_dict()


### PR DESCRIPTION
## Feature description
 - Not able to find why the error message is coming, since PAM File Number is read only and Authorised Signatory field is depends on the PAM File Number field 
 
![Screenshot 2022-05-31 at 1 51 21 PM](https://user-images.githubusercontent.com/20554466/171127248-2850cffa-05c7-4899-af34-1796700d252a.png)

## Solution description
- Authorised signatory - validation message updated

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
