### PR TITLE
Feat: Checkin/Checkout initial reminder

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -149,8 +149,8 @@ def checkin_checkout_reminder():
 
 			if len(recipients) > 0:
 				
-				notification_title = _("Checkin reminder")
-				notification_body = _("Don't forget to checkin!")
+				notification_title = _("Checkout reminder")
+				notification_body = _("Don't forget to checkout!")
 				
 				for recipient in recipients:
 

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -56,110 +56,113 @@ def checkin_checkout_reminder():
 	"""
 	This function sends a push notification to users to remind them to checkin/checkout at the start/end time of their shift.
 	"""
-	if not frappe.db.get_single_value('HR and Payroll Additional Settings', 'remind_employee_checkin_checkout'):
-		return
+	try:
+		if not frappe.db.get_single_value('HR and Payroll Additional Settings', 'remind_employee_checkin_checkout'):
+			return
 
-	# Get current date and time
-	date = getdate()
-	now_time = now_datetime().strftime("%Y-%m-%d %H:%M")
+		# Get current date and time
+		date = getdate()
+		now_time = now_datetime().strftime("%Y-%m-%d %H:%M")
 
-	# Get list of active shifts
-	shifts_list = get_active_shifts(now_time)
+		# Get list of active shifts
+		shifts_list = get_active_shifts(now_time)
 
-	for shift in shifts_list:
+		for shift in shifts_list:
 
-		# Current time == shift start time => Checkin
-		if strfdelta(shift.start_time, '%H:%M:%S') == cstr((get_datetime(now_time)).time()):
-			recipients = frappe.db.sql("""
-				SELECT DISTINCT emp.user_id, emp.name FROM `tabShift Assignment` tSA, `tabEmployee` emp
-				WHERE
-					tSA.employee=emp.name
-				AND tSA.start_date='{date}'
-				AND tSA.shift_type='{shift_type}'
-				AND tSA.docstatus=1
-				AND tSA.employee
-				NOT IN(SELECT employee FROM `tabShift Permission` emp_sp
-				WHERE
-					emp_sp.employee=emp.name
-				AND emp_sp.workflow_state='Approved'
-				AND emp_sp.shift_type='{shift_type}'
-				AND emp_sp.date='{date}'
-				AND emp_sp.permission_type="Arrive Late")
-				AND tSA.employee
-				NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
-				WHERE
-					empChkin.log_type="IN"
-				AND DATE_FORMAT(empChkin.time,'%Y-%m-%d')='{date}'
-				AND empChkin.shift_type='{shift_type}')
-				AND tSA.start_date
-				NOT IN(SELECT holiday_date from `tabHoliday` h
-				WHERE
-					h.parent = emp.holiday_list
-				AND h.holiday_date = '{date}')
-			""".format(date=cstr(date), shift_type=shift.name), as_dict=1)
+			# Current time == shift start time => Checkin
+			if strfdelta(shift.start_time, '%H:%M:%S') == cstr((get_datetime(now_time)).time()):
+				recipients = frappe.db.sql("""
+					SELECT DISTINCT emp.user_id, emp.name FROM `tabShift Assignment` tSA, `tabEmployee` emp
+					WHERE
+						tSA.employee=emp.name
+					AND tSA.start_date='{date}'
+					AND tSA.shift_type='{shift_type}'
+					AND tSA.docstatus=1
+					AND tSA.employee
+					NOT IN(SELECT employee FROM `tabShift Permission` emp_sp
+					WHERE
+						emp_sp.employee=emp.name
+					AND emp_sp.workflow_state='Approved'
+					AND emp_sp.shift_type='{shift_type}'
+					AND emp_sp.date='{date}'
+					AND emp_sp.permission_type="Arrive Late")
+					AND tSA.employee
+					NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
+					WHERE
+						empChkin.log_type="IN"
+					AND DATE_FORMAT(empChkin.time,'%Y-%m-%d')='{date}'
+					AND empChkin.shift_type='{shift_type}')
+					AND tSA.start_date
+					NOT IN(SELECT holiday_date from `tabHoliday` h
+					WHERE
+						h.parent = emp.holiday_list
+					AND h.holiday_date = '{date}')
+				""".format(date=cstr(date), shift_type=shift.name), as_dict=1)
 
-			if len(recipients) > 0:
-				
-				notification_title = _("Checkin reminder")
-				notification_body = _("Don't forget to checkin!")
-				
-				for recipient in recipients:
-
-					# Get Employee ID and User Role for the given recipient
-					employee_id = recipient.name
-					user_roles = frappe.get_roles(recipient.user_id)
+				if len(recipients) > 0:
 					
-					# Send push notifications
-					if "Head Office Employee" in user_roles:
-						# Arrive late option is true only if the employee has the user role "Head Office Employee".
-						push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=True, arriveLate=True, checkout=False)
-					else:
-						push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=True, arriveLate=False, checkout=False)
-
-		
-		# current time == shift end time => Checkout
-		if strfdelta(shift.end_time, '%H:%M:%S') == cstr((get_datetime(now_time)).time()):
-			recipients = frappe.db.sql("""
-				SELECT DISTINCT emp.user_id, emp.name FROM `tabShift Assignment` tSA, `tabEmployee` emp
-				WHERE
-			  		tSA.employee = emp.name
-				AND tSA.start_date='{date}'
-				AND tSA.shift_type='{shift_type}'
-				AND tSA.docstatus=1
-				AND tSA.employee
-				NOT IN(SELECT employee FROM `tabShift Permission` emp_sp
-				WHERE
-					emp_sp.employee=emp.name
-				AND emp_sp.workflow_state='Approved'
-				AND emp_sp.shift_type='{shift_type}'
-				AND emp_sp.date='{date}'
-				AND emp_sp.permission_type="Leave Early")
-				AND tSA.employee
-				NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
-				WHERE
-					empChkin.log_type="OUT"
-				AND DATE_FORMAT(empChkin.time,'%Y-%m-%d')='{date}'
-				AND empChkin.shift_type='{shift_type}')
-				AND tSA.start_date
-				NOT IN(SELECT holiday_date from `tabHoliday` h
-				WHERE
-					h.parent = emp.holiday_list
-				AND h.holiday_date = '{date}')
-			""".format(date=cstr(date), shift_type=shift.name), as_dict=1)
-
-			if len(recipients) > 0:
-				
-				notification_title = _("Checkout reminder")
-				notification_body = _("Don't forget to checkout!")
-				
-				for recipient in recipients:
-
-					# Get Employee ID and User Role for the given recipient
-					employee_id = recipient.name
-					user_roles = frappe.get_roles(recipient.user_id)
+					notification_title = _("Checkin reminder")
+					notification_body = _("Don't forget to checkin!")
 					
-					push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=False, arriveLate=False, checkout=True)
+					for recipient in recipients:
 
+						# Get Employee ID and User Role for the given recipient
+						employee_id = recipient.name
+						user_roles = frappe.get_roles(recipient.user_id)
+						
+						# Send push notifications
+						if "Head Office Employee" in user_roles:
+							# Arrive late option is true only if the employee has the user role "Head Office Employee".
+							push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=True, arriveLate=True, checkout=False)
+						else:
+							push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=True, arriveLate=False, checkout=False)
+
+			
+			# current time == shift end time => Checkout
+			if strfdelta(shift.end_time, '%H:%M:%S') == cstr((get_datetime(now_time)).time()):
+				recipients = frappe.db.sql("""
+					SELECT DISTINCT emp.user_id, emp.name FROM `tabShift Assignment` tSA, `tabEmployee` emp
+					WHERE
+						tSA.employee = emp.name
+					AND tSA.start_date='{date}'
+					AND tSA.shift_type='{shift_type}'
+					AND tSA.docstatus=1
+					AND tSA.employee
+					NOT IN(SELECT employee FROM `tabShift Permission` emp_sp
+					WHERE
+						emp_sp.employee=emp.name
+					AND emp_sp.workflow_state='Approved'
+					AND emp_sp.shift_type='{shift_type}'
+					AND emp_sp.date='{date}'
+					AND emp_sp.permission_type="Leave Early")
+					AND tSA.employee
+					NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
+					WHERE
+						empChkin.log_type="OUT"
+					AND DATE_FORMAT(empChkin.time,'%Y-%m-%d')='{date}'
+					AND empChkin.shift_type='{shift_type}')
+					AND tSA.start_date
+					NOT IN(SELECT holiday_date from `tabHoliday` h
+					WHERE
+						h.parent = emp.holiday_list
+					AND h.holiday_date = '{date}')
+				""".format(date=cstr(date), shift_type=shift.name), as_dict=1)
+
+				if len(recipients) > 0:
+					
+					notification_title = _("Checkout reminder")
+					notification_body = _("Don't forget to checkout!")
+					
+					for recipient in recipients:
+
+						# Get Employee ID and User Role for the given recipient
+						employee_id = recipient.name
+						user_roles = frappe.get_roles(recipient.user_id)
+						
+						push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=False, arriveLate=False, checkout=True)
+
+	except Exception as error:
+		frappe.log_error(str(error), 'Checkin/checkout initial reminder failed')
 
 
 def checkin_checkout_final_reminder():

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -52,6 +52,116 @@ def send_checkin_hourly_reminder():
 			message = _('<a class="btn btn-warning" href="/app/face-recognition">Hourly Check In</a>')
 			send_notification(title, subject, message, category, recipients)
 
+def checkin_checkout_reminder():
+	"""
+	This function sends a push notification to users to remind them to checkin/checkout at the start/end time of their shift.
+	"""
+	if not frappe.db.get_single_value('HR and Payroll Additional Settings', 'remind_employee_checkin_checkout'):
+		return
+
+	# Get current date and time
+	date = getdate()
+	now_time = now_datetime().strftime("%Y-%m-%d %H:%M")
+
+	# Get list of active shifts
+	shifts_list = get_active_shifts(now_time)
+
+	for shift in shifts_list:
+
+		# Current time == shift start time => Checkin
+		if strfdelta(shift.start_time, '%H:%M:%S') == cstr((get_datetime(now_time)).time()):
+			recipients = frappe.db.sql("""
+				SELECT DISTINCT emp.user_id, emp.name FROM `tabShift Assignment` tSA, `tabEmployee` emp
+				WHERE
+					tSA.employee=emp.name
+				AND tSA.start_date='{date}'
+				AND tSA.shift_type='{shift_type}'
+				AND tSA.docstatus=1
+				AND tSA.employee
+				NOT IN(SELECT employee FROM `tabShift Permission` emp_sp
+				WHERE
+					emp_sp.employee=emp.name
+				AND emp_sp.workflow_state='Approved'
+				AND emp_sp.shift_type='{shift_type}'
+				AND emp_sp.date='{date}'
+				AND emp_sp.permission_type="Arrive Late")
+				AND tSA.employee
+				NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
+				WHERE
+					empChkin.log_type="IN"
+				AND DATE_FORMAT(empChkin.time,'%Y-%m-%d')='{date}'
+				AND empChkin.shift_type='{shift_type}')
+				AND tSA.start_date
+				NOT IN(SELECT holiday_date from `tabHoliday` h
+				WHERE
+					h.parent = emp.holiday_list
+				AND h.holiday_date = '{date}')
+			""".format(date=cstr(date), shift_type=shift.name), as_dict=1)
+
+			if len(recipients) > 0:
+				
+				notification_title = _("Checkin reminder")
+				notification_body = _("Don't forget to checkin!")
+				
+				for recipient in recipients:
+
+					# Get Employee ID and User Role for the given recipient
+					employee_id = recipient.name
+					user_roles = frappe.get_roles(recipient.user_id)
+					
+					# Send push notifications
+					if "Head Office Employee" in user_roles:
+						# Arrive late option is true only if the employee has the user role "Head Office Employee".
+						push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=True, arriveLate=True, checkout=False)
+					else:
+						push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=True, arriveLate=False, checkout=False)
+
+		
+		# current time == shift end time => Checkout
+		if strfdelta(shift.end_time, '%H:%M:%S') == cstr((get_datetime(now_time)).time()):
+			recipients = frappe.db.sql("""
+				SELECT DISTINCT emp.user_id, emp.name FROM `tabShift Assignment` tSA, `tabEmployee` emp
+				WHERE
+			  		tSA.employee = emp.name
+				AND tSA.start_date='{date}'
+				AND tSA.shift_type='{shift_type}'
+				AND tSA.docstatus=1
+				AND tSA.employee
+				NOT IN(SELECT employee FROM `tabShift Permission` emp_sp
+				WHERE
+					emp_sp.employee=emp.name
+				AND emp_sp.workflow_state='Approved'
+				AND emp_sp.shift_type='{shift_type}'
+				AND emp_sp.date='{date}'
+				AND emp_sp.permission_type="Leave Early")
+				AND tSA.employee
+				NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
+				WHERE
+					empChkin.log_type="OUT"
+				AND DATE_FORMAT(empChkin.time,'%Y-%m-%d')='{date}'
+				AND empChkin.shift_type='{shift_type}')
+				AND tSA.start_date
+				NOT IN(SELECT holiday_date from `tabHoliday` h
+				WHERE
+					h.parent = emp.holiday_list
+				AND h.holiday_date = '{date}')
+			""".format(date=cstr(date), shift_type=shift.name), as_dict=1)
+
+			if len(recipients) > 0:
+				
+				notification_title = _("Checkin reminder")
+				notification_body = _("Don't forget to checkin!")
+				
+				for recipient in recipients:
+
+					# Get Employee ID and User Role for the given recipient
+					employee_id = recipient.name
+					user_roles = frappe.get_roles(recipient.user_id)
+					
+					push_notification_rest_api_for_checkin(employee_id, notification_title, notification_body, checkin=False, arriveLate=False, checkout=True)
+
+
+
 def checkin_checkout_final_reminder():
 	if not frappe.db.get_single_value('HR and Payroll Additional Settings', 'remind_employee_checkin_checkout'):
 		return

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -442,6 +442,7 @@ scheduler_events = {
 		],
 		"0/5 * * * *": [
 			"one_fm.api.tasks.checkin_checkout_supervisor_reminder",
+			"one_fm.api.tasks.checkin_checkout_reminder",
 			"one_fm.api.tasks.checkin_checkout_final_reminder",
 			"one_fm.api.tasks.checkin_deadline",
 			"one_fm.api.tasks.overtime_shift_assignment"

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -691,7 +691,7 @@ function bind_events(page) {
 	let wrapper_element = $(get_wrapper_element());
 	paginateTable(page);
 	// console.log(wrapper_element.find('#paginate-parent'));
-	wrapper_element.find('#paginate-parent').pageMe({ pagerSelector: '#myPager', showPrevNext: false, hidePageNumbers: false, perPage: 100 });
+	wrapper_element.find('#paginate-parent').pageMe({ pagerSelector: '#myPager', showPrevNext: false, hidePageNumbers: false, perPage: 9999 });
 	if (["Operations Manager", "Site Supervisor", "Shift Manager", "Shift Supervisor", "Projects Manager"].some(i => frappe.user_roles.includes(i))) {
 		let $rosterMonth = $('.rosterMonth');
 		let $rosterOtMonth = $('.rosterOtMonth');

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -81,7 +81,7 @@ def get_staff_filters_data():
 
 
 @frappe.whitelist()
-def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_search_id=None, employee_search_name=None, project=None, site=None, shift=None, department=None, post_type=None, designation=None, isOt=None, limit_start=0, limit_page_length=100):
+def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_search_id=None, employee_search_name=None, project=None, site=None, shift=None, department=None, post_type=None, designation=None, isOt=None, limit_start=0, limit_page_length=9999):
 	start = time.time()
 		
 	master_data, formatted_employee_data, post_count_data, employee_filters, additional_assignment_filters={}, {}, {}, {}, {}


### PR DESCRIPTION
## Feature description
Notify user to checkin/checkout at start/end time of shift.

## Solution description
- Created a function to get a list of users with active shifts and send them push notifications at the start and end times of their shifts.
- Added function to cron scheduler to run every five minutes. 

## Areas affected and ensured
Nothing affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
