### PR TITLE
Feat: Added mobile app version check API

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -14,7 +14,7 @@ from erpnext.controllers.taxes_and_totals import calculate_taxes_and_totals
 from one_fm.operations.doctype.contracts.contracts import calculate_item_values
 
 
-__version__ = '0.12.2'
+__version__ = '0.12.3'
 
 
 ShiftRequest.on_submit = shift_request_submit

--- a/one_fm/api/v1/utils.py
+++ b/one_fm/api/v1/utils.py
@@ -3,7 +3,7 @@ from frappe.utils import getdate, cint, cstr, random_string, now_datetime
 import datetime
 
 def response(message, status_code, data=None, error=None):
-    """This method generates a response for an API call with appropriate data and status code. 
+    """This method generates a response for an API call with appropriate data and status code.
 
     Args:
         message (str): Message to be shown depending upon API result. Eg: Success/Error/Forbidden/Bad Request.
@@ -48,7 +48,7 @@ def validate_date(date: str) -> bool:
     """
     if "-" not in date:
         return False
-    
+
     date_elements = date.split("-")
 
     if len(date_elements) != 3:
@@ -60,16 +60,16 @@ def validate_date(date: str) -> bool:
 
     if len(year) != 4:
         return False
-    
+
     if len(month) > 2:
         return False
-    
+
     if int(month) > 12 or int(month) < 1:
         return False
 
     if len(day) > 2:
         return False
-    
+
     if int(day) > 31 or int(day) < 1:
         return False
 
@@ -132,9 +132,21 @@ def get_current_shift(employee):
 					if start_time <= time <= end_time:
 						return shift
 		elif len(shifts)==0:
-			return shifts		
+			return shifts
 		else:
 			return shifts[0].shift
 	except Exception as e:
 		print(frappe.get_traceback())
 		return frappe.utils.response.report_error(e.http_status_code)
+
+
+@frappe.whitelist(allow_guest=True)
+def get_mobile_version():
+    """
+        Retrieve the version number of the mobile app
+    """
+    try:
+        version = frappe.db.get_single_value("ONEFM General Setting", 'mobile_app_version')
+        return response(message='Successful', status_code=200, data={'version':version}, error=None)
+    except Exception as e:
+        return response(message='Failed', status_code=500, data={}, error=str(e))

--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.js
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, omar jaber and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('ONEFM General Setting', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
@@ -1,0 +1,40 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-06-09 12:09:59.006662",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "mobile_app_version"
+ ],
+ "fields": [
+  {
+   "fieldname": "mobile_app_version",
+   "fieldtype": "Data",
+   "label": "Mobile App Version"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-06-09 12:09:59.006662",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "ONEFM General Setting",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.py
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, omar jaber and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ONEFMGeneralSetting(Document):
+	pass

--- a/one_fm/one_fm/doctype/onefm_general_setting/test_onefm_general_setting.py
+++ b/one_fm/one_fm/doctype/onefm_general_setting/test_onefm_general_setting.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, omar jaber and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestONEFMGeneralSetting(unittest.TestCase):
+	pass

--- a/one_fm/one_fm/workspace/one_fm_settings/one_fm_settings.json
+++ b/one_fm/one_fm/workspace/one_fm_settings/one_fm_settings.json
@@ -47,9 +47,18 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "General Setting",
+   "link_to": "ONEFM General Setting",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2022-06-01 17:00:02.899265",
+ "modified": "2022-06-09 12:11:07.563300",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ONE FM Settings",


### PR DESCRIPTION
## Feature description
This PR added feature to check for mobile app version number via API, as well as introduced a general settings doctype that could be used for various configurations.

## Solution description
A doctype named ONEFM General Settings was created with a field mobile_app_version that will be used to store the version number.
The doctype can be accessed via ONE FM Settings link on the left sidebar -> General Settings.
An API was created that could be pinged to check the mobile app version

## Sample Response
# endpoint: /api/method/one_fm.api.v1.utils.get_mobile_version

{"message":"Successful","status_code":200,"data":{"version":"1.2.3"}} #success

{"message":"Failed","status_code":500,"error":"name 'fjd' is not defined"} # failed

