### PR TITLE
Feat: Generate sales invoice for service items based on current/previous month

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -34,6 +34,7 @@
   "start_date",
   "end_date",
   "due_date",
+  "month_of_invoice",
   "overtime_rate",
   "column_break_27",
   "invoice_output_format",
@@ -171,7 +172,7 @@
    "fieldname": "due_date",
    "fieldtype": "Select",
    "label": "Invoice Due Date",
-   "options": "\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28"
+   "options": "5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\nEnd of Month"
   },
   {
    "fieldname": "invoice_output_format",
@@ -437,11 +438,17 @@
    "fieldtype": "Select",
    "label": "Create Auto Sales Invoice as",
    "options": "Single Invoice\nSeparate Item Line for Each Site\nSeparate Invoice for Each Site\nSeparate Item Line for Days of Work and Service Item\nInvoice for Full Amount in the Contract\nInvoice for Airport"
+  },
+  {
+   "fieldname": "month_of_invoice",
+   "fieldtype": "Select",
+   "label": "Month of Invoice",
+   "options": "Current Month\nPrevious Month"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-02-21 15:57:13.588811",
+ "modified": "2022-06-20 17:03:07.002247",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -634,6 +634,20 @@ def get_item_daily_amount(item, project, first_day_of_month, last_day_of_month, 
 
 		item_days += employee_schedules
 
+		previous_invoice_date = cstr(add_to_date(invoice_date, months=-1))
+		previous_month_last_day = cstr(get_last_day(add_to_date(getdate(), months=-1)))
+		
+		att_filters = {
+			'project': project,
+			'post_type': ['in', post_type_list],
+			'status': 'Absent',
+			'attendance_date': ['between', (previous_invoice_date, previous_month_last_day)]
+		}
+
+		previous_attendances = frappe.db.get_list("Attendance", att_filters, ["operations_shift", "in_time", "out_time", "working_hours"])
+
+		item_days -= previous_attendances
+
 	# If total item days exceed expected days, apply overtime rate on extra days
 	if item_days > expected_item_days:
 		normal_amount = item_rate * expected_item_days

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -734,7 +734,22 @@ def get_item_monthly_amount(item, project, first_day_of_month, last_day_of_month
 		employee_schedules = len(frappe.db.get_list("Employee Schedule", pluck='name', filters=es_filters))
 
 		item_days += employee_schedules
+		
+		previous_invoice_date = cstr(add_to_date(invoice_date, months=-1))
+		previous_month_last_day = cstr(get_last_day(add_to_date(getdate(), months=-1)))
+		
+		att_filters = {
+			'project': project,
+			'post_type': ['in', post_type_list],
+			'status': 'Absent',
+			'attendance_date': ['between', (previous_invoice_date, previous_month_last_day)]
+		}
 
+		previous_attendances = frappe.db.get_list("Attendance", att_filters, ["operations_shift", "in_time", "out_time", "working_hours"])
+
+		item_days -= previous_attendances
+
+		
 	# If total item days exceed expected days, apply overtime rate on extra days
 	if item_days > expected_item_days:
 		overtime_days = item_days - expected_item_days

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -644,7 +644,7 @@ def get_item_daily_amount(item, project, first_day_of_month, last_day_of_month, 
 			'attendance_date': ['between', (previous_invoice_date, previous_month_last_day)]
 		}
 
-		previous_attendances = frappe.db.get_list("Attendance", att_filters, ["operations_shift", "in_time", "out_time", "working_hours"])
+		previous_attendances = len(frappe.db.get_list("Attendance", att_filters, ["operations_shift", "in_time", "out_time", "working_hours"]))
 
 		item_days -= previous_attendances
 
@@ -745,7 +745,7 @@ def get_item_monthly_amount(item, project, first_day_of_month, last_day_of_month
 			'attendance_date': ['between', (previous_invoice_date, previous_month_last_day)]
 		}
 
-		previous_attendances = frappe.db.get_list("Attendance", att_filters, ["operations_shift", "in_time", "out_time", "working_hours"])
+		previous_attendances = len(frappe.db.get_list("Attendance", att_filters, ["operations_shift", "in_time", "out_time", "working_hours"]))
 
 		item_days -= previous_attendances
 


### PR DESCRIPTION
## Feature description
As a contracts user, I want invoices to be generated based on Current/previous month selection and due date so I can output invoices for different requirements of different clients

## Solution description
- Added field "month of invoice" in contracts.
- Updated values in invoice due date field - removed values 1-4 and added "end of month".
- Compute absentees for the previous month if the month of invoice is the current month.

## Areas affected and ensured
None.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
