### PR TITLE
Fix: Penalty Issuance 

### DIFF
--- a/one_fm/api/v1/legal.py
+++ b/one_fm/api/v1/legal.py
@@ -54,7 +54,7 @@ def get_all_shifts():
 
 @frappe.whitelist()
 def issue_penalty(penalty_category, issuing_time, issuing_location, penalty_location, penalty_occurence_time,company_damage, customer_property_damage, asset_damage, other_damages, shift=None, site=None, project=None, site_location=None, penalty_employees=[], penalty_details=[]):
-	# try:
+	try:
 		employee, employee_name, designation = frappe.get_value("Employee", {"user_id": frappe.session.user}, ["name","employee_name", "designation"])
 
 		penalty_issuance = frappe.new_doc("Penalty Issuance")
@@ -110,9 +110,9 @@ def issue_penalty(penalty_category, issuing_time, issuing_location, penalty_loca
 		penalty_issuance.submit()
 		return response("Success", 201, penalty_issuance)
 
-	# except Exception as error:
-	# 	print(error)
-	# 	return response("Internal Server Error", 500, None, error)@frappe.whitelist()
+	except Exception as error:
+		frappe.log_error(error, 'Penalty Issance Error')
+		return response("Internal Server Error", 500, None, error)@frappe.whitelist()
 
 
 def get_penalties(employee_id: str = None, role: str = None) -> dict:

--- a/one_fm/legal/doctype/penalty_issuance_employees/penalty_issuance_employees.json
+++ b/one_fm/legal/doctype/penalty_issuance_employees/penalty_issuance_employees.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2020-06-13 18:44:10.150405",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -36,7 +37,9 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "employee_id",
    "fetch_from": "employee_id.designation",
+   "fetch_if_empty": 1,
    "fieldname": "designation",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -45,7 +48,8 @@
   }
  ],
  "istable": 1,
- "modified": "2021-07-12 11:18:37.943567",
+ "links": [],
+ "modified": "2022-06-26 15:39:39.557338",
  "modified_by": "Administrator",
  "module": "Legal",
  "name": "Penalty Issuance Employees",

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2570,3 +2570,10 @@ def set_expire_magic_link(reference_doctype, reference_docname, link_for):
         'reference_docname': reference_docname, 'link_for': link_for, 'expired': False})
     if magic_link:
         frappe.db.set_value('Magic Link', magic_link, 'expired', True)
+
+
+def check_path(path):
+    return os.path.isdir(path)
+
+def create_path(path):
+    os.mkdir(path)


### PR DESCRIPTION
## Feature description
Penalty Issuance on the mobile App did not work when queried. This was as a result of bugs in the API endpoint. It was fixed in this PR.

## Solution description
Legal directory for storing attachment is missing, the api checks if the directory exists or create it.
The Employee child table was corrected to be appended as a dict instead of a string.

API POST DATA SHOULd BE IN THE FOLLOWING FORMAT
{
issuing_time: "2022-06-21 14:50:00"
penalty_occurence_time: 2022-06-21 14:45:00
penalty_employees: ["HR-EMP-000000", "HR-EMP-00009"]
penalty_details: [{"attachments": "attachment by code", "attachment_name": "attachment_name.png"}]
}

## Output screenshots (optional)
Post the output screenshots, if a UI is affeced or added due to this feature.

## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
