### PR TITLE
#182572028: Fix: Calculate Penalty Deduction

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -825,12 +825,16 @@ def update_shift_details_in_attendance(doc, method):
 			where name = %s """, (project, site, shift, post_type, post_abbrv, roster_type, doc.name))
 
 def generate_payroll():
-	start_date = add_to_date(getdate(), months=-1)
-	end_date = get_end_date(start_date, 'monthly')['end_date']
+	# start_date = add_to_date(getdate(), months=-1)
+	# end_date = get_end_date(start_date, 'monthly')['end_date']
 
-	# Hardcoded dates for testing, remove below 2 lines for live
-	#start_date = "2021-08-01"
-	#end_date = "2021-08-31"
+	#fetch Payroll date's day
+	date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
+
+	#calculate Payroll date, start and end date.
+	payroll_date = datetime.datetime(getdate().year, getdate().month, cint(date)).strftime("%Y-%m-%d")
+	start_date = add_to_date(payroll_date, months=-1)
+	end_date = add_to_date(payroll_date, days=-1)
 
 	try:
 			create_payroll_entry(start_date, end_date)

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -841,8 +841,13 @@ def generate_penalties():
 	# start_date = add_to_date(getdate(), months=-1)
 	# end_date = get_end_date(start_date, 'monthly')['end_date']
 
-	start_date = "2022-05-24"
-	end_date = "2022-06-23"
+	#fetch Payroll date's day
+	date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
+
+	#calculate Payroll date, start and end date.
+	payroll_date = datetime.datetime(getdate().year, getdate().month, cint(date)).strftime("%Y-%m-%d")
+	start_date = add_to_date(payroll_date, months=-1)
+	end_date = add_to_date(payroll_date, days=-1)
 
 	filters = {
 		'penalty_issuance_time': ['between', (start_date, end_date)],
@@ -866,7 +871,7 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		'docstatus': 1,
 		'employee': employee
 	}
-	
+
 	if frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component'):
 		basic_salary_component = frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component')
 	else:

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -875,6 +875,8 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		'docstatus': 1,
 		'employee': employee
 	}
+	if frappe.db.exists('Employee', {'employee':employee, 'status':'Left'})):
+		return
 
 	if frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component'):
 		basic_salary_component = frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component')

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -866,6 +866,11 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		'docstatus': 1,
 		'employee': employee
 	}
+	
+	if frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component'):
+		basic_salary_component = frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component')
+	else:
+		frappe.throw("Please Add Basic Salary Component in HR and Payroll Additional Settings.")
 
 	salary_structure, base = frappe.get_value("Salary Structure Assignment", filters, ["salary_structure","base"], order_by="from_date desc")
 
@@ -874,8 +879,8 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		SELECT amount,amount_based_on_formula,formula FROM `tabSalary Detail`
 		WHERE parenttype="Salary Structure"
 		AND parent=%s
-		AND salary_component="Basic Salary"
-		""",(salary_structure), as_dict=1)
+		AND salary_component=%s
+		""",(salary_structure, basic_salary_component), as_dict=1)
 		if basic[0].amount_based_on_formula == 1:
 			formula = basic[0].formula
 			percent = formula.replace('base*','')

--- a/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
+++ b/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
@@ -12,11 +12,13 @@ class PenaltyDeduction(Document):
 		self.create_additional_salary()
 
 	def create_additional_salary(self):
+		if frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date'):
+			payroll_date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
 		additional_salary = frappe.new_doc("Additional Salary")
 		additional_salary.employee = self.employee
 		additional_salary.salary_component = "Penalty"
 		additional_salary.amount = self.deducted_amount
-		additional_salary.payroll_date = "2022-06-23"
+		additional_salary.payroll_date = payroll_date if payroll_date else getdate()
 		additional_salary.company = erpnext.get_default_company()
 		additional_salary.overwrite_salary_structure_amount = 1
 		additional_salary.notes = "Penalty Deduction for Payroll Period: {start} to {end} including previous unsettled balance amount, if applicable.".format(start=self.from_date, end=self.to_date)

--- a/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
+++ b/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
@@ -10,11 +10,13 @@
   "auto_generate_employee_id_on_employee_creation",
   "auto_create_erpnext_user_on_employee_creation_using_employee_id",
   "payroll_settings_section",
+  "payroll_date",
   "holiday_additional_salary_component",
   "maximum_salary_deduction_percentage",
-  "exclude_salary_component",
   "column_break_7",
   "default_bank",
+  "exclude_salary_component",
+  "basic_salary_component",
   "overtime_additional_salary_section",
   "overtime_additional_salary_component",
   "working_day_overtime_rate",
@@ -178,12 +180,25 @@
    "fieldname": "checkin_deadline",
    "fieldtype": "Check",
    "label": "Checkin Deadline"
+  },
+  {
+   "fieldname": "basic_salary_component",
+   "fieldtype": "Link",
+   "label": "Basic Salary Component",
+   "options": "Salary Component"
+  },
+  {
+   "default": "24",
+   "fieldname": "payroll_date",
+   "fieldtype": "Select",
+   "label": "Payroll Date",
+   "options": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-06-19 11:04:00.714463",
+ "modified": "2022-06-28 09:13:15.942901",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "HR and Payroll Additional Settings",


### PR DESCRIPTION
- Fetch Payroll Date from setting
- Fetch Salary Component from settings.
- Calculate penalties for active employees only.

<img width="974" alt="Screen Shot 2022-06-28 at 10 27 21 AM" src="https://user-images.githubusercontent.com/29017559/176119452-5f9dfc89-9c77-4caa-80b4-8f9c749db45c.png">
