### PR TITLE
[Feat] Create employee checkin on shift permission approval

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -825,12 +825,16 @@ def update_shift_details_in_attendance(doc, method):
 			where name = %s """, (project, site, shift, post_type, post_abbrv, roster_type, doc.name))
 
 def generate_payroll():
-	start_date = add_to_date(getdate(), months=-1)
-	end_date = get_end_date(start_date, 'monthly')['end_date']
+	# start_date = add_to_date(getdate(), months=-1)
+	# end_date = get_end_date(start_date, 'monthly')['end_date']
 
-	# Hardcoded dates for testing, remove below 2 lines for live
-	#start_date = "2021-08-01"
-	#end_date = "2021-08-31"
+	#fetch Payroll date's day
+	date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
+
+	#calculate Payroll date, start and end date.
+	payroll_date = datetime.datetime(getdate().year, getdate().month, cint(date)).strftime("%Y-%m-%d")
+	start_date = add_to_date(payroll_date, months=-1)
+	end_date = add_to_date(payroll_date, days=-1)
 
 	try:
 			create_payroll_entry(start_date, end_date)

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -841,8 +841,13 @@ def generate_penalties():
 	# start_date = add_to_date(getdate(), months=-1)
 	# end_date = get_end_date(start_date, 'monthly')['end_date']
 
-	start_date = "2022-05-24"
-	end_date = "2022-06-23"
+	#fetch Payroll date's day
+	date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
+
+	#calculate Payroll date, start and end date.
+	payroll_date = datetime.datetime(getdate().year, getdate().month, cint(date)).strftime("%Y-%m-%d")
+	start_date = add_to_date(payroll_date, months=-1)
+	end_date = add_to_date(payroll_date, days=-1)
 
 	filters = {
 		'penalty_issuance_time': ['between', (start_date, end_date)],
@@ -866,7 +871,7 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		'docstatus': 1,
 		'employee': employee
 	}
-	
+
 	if frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component'):
 		basic_salary_component = frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component')
 	else:

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -262,8 +262,9 @@ def notify_checkin_checkout_final_reminder(recipients,log_type):
 	notification_category = "Attendance"
 	checkout_subject = _("Final Reminder: Please checkout in the next five minutes.")
 	checkout_message = _("""
-		Submit a Shift Permission if you are plannig to leave early or is there any issue in checkout or forget to checkout
 		<a class="btn btn-danger" href="/app/face-recognition">Check Out</a>
+		Submit a Shift Permission if you are plannig to leave early or is there any issue in checkout or forget to checkout
+		<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 		""")
 	Notification_title = "Final Reminder"
 	Notification_body = "Please checkin in the next five minutes."
@@ -309,7 +310,10 @@ def checkin_checkout_supervisor_reminder():
 		t = shift.supervisor_reminder_shift_start
 		b = strfdelta(shift.start_time, '%H:%M:%S')
 
-		# Send notification to supervisor of those who haven't checked in and don't have accepted Arrive Late shift permission
+		"""
+			Send notification to supervisor of those who haven't checked in and don't have accepted shift permission
+			with permission type Arrive Late/Forget to Checkin/Checkin Issue
+		"""
 		if strfdelta(shift.start_time, '%H:%M:%S') == cstr((get_datetime(now_time) - timedelta(minutes=cint(shift.supervisor_reminder_shift_start))).time()):
 			date = getdate() if shift.start_time < shift.end_time else (getdate() - timedelta(days=1))
 			checkin_time = today_datetime + " " + strfdelta(shift.start_time, '%H:%M:%S')
@@ -327,7 +331,7 @@ def checkin_checkout_supervisor_reminder():
 				AND emp_sp.workflow_state="Approved"
 				AND emp_sp.shift_type='{shift_type}'
 				AND emp_sp.date='{date}'
-				AND emp_sp.permission_type="Arrive Late")
+				AND emp_sp.permission_type IN ("Arrive Late", "Forget to Checkin", "Checkin Issue"))
 				AND tSA.employee
 				NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
 					WHERE
@@ -349,6 +353,8 @@ def checkin_checkout_supervisor_reminder():
 					subject = _("{employee} has not checked in yet.".format(employee=recipient.employee_name))
 					action_message = _("""
 					<a class="btn btn-success checkin" id='{employee}_{time}'>Approve</a>
+					Submit a Shift Permission for the employee to give an excuse and not need to penalize
+					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 					<br><br><div class='btn btn-primary btn-danger no-punch-in' id='{employee}_{date}_{shift}'>Issue Penalty</div>
 					""").format(shift=recipient.shift, date=cstr(now_time), employee=recipient.name, time=checkin_time)
 					if action_user is not None:
@@ -360,7 +366,10 @@ def checkin_checkout_supervisor_reminder():
 						if notify_user is not None:
 							send_notification(title, subject, notify_message, category, notify_user)
 
-		#Send notification to supervisor of those who haven't checked out and don't have accepted Leave Early shift permission
+		"""
+			Send notification to supervisor of those who haven't checked in and don't have accepted shift permission
+			with permission type Leave Early/Forget to Checkout/Checkout Issue
+		"""
 		if strfdelta(shift.end_time, '%H:%M:%S') == cstr((get_datetime(now_time) - timedelta(minutes=cint(shift.supervisor_reminder_start_ends))).time()):
 		 	date = getdate() if shift.start_time < shift.end_time else (getdate() - timedelta(days=1))
 		 	checkin_time = today_datetime + " " + strfdelta(shift.end_time, '%H:%M:%S')
@@ -378,7 +387,7 @@ def checkin_checkout_supervisor_reminder():
 				AND emp_sp.workflow_state="Approved"
 				AND emp_sp.shift_type='{shift_type}'
 				AND emp_sp.date='{date}'
-				AND emp_sp.permission_type="Leave Early")
+				AND emp_sp.permission_type IN ("Leave Early", "Forget to Checkout", "Checkout Issue"))
 				AND tSA.employee
 		 		NOT IN(SELECT employee FROM `tabEmployee Checkin` empChkin
 		 			WHERE
@@ -399,9 +408,11 @@ def checkin_checkout_supervisor_reminder():
 					#for_user = get_employee_user_id(recipient.reports_to) if get_employee_user_id(recipient.reports_to) else get_notification_user(op_shift)
 		 			subject = _('{employee} has not checked in yet.'.format(employee=recipient.employee_name))
 		 			action_message = _("""
-						 <a class="btn btn-success checkin" id='{employee}_{time}'>Approve</a>
-						 <br><br><div class='btn btn-primary btn-danger no-punch-in' id='{employee}_{date}_{shift}'>Issue Penalty</div>
-						 """).format(shift=recipient.shift, date=cstr(now_time), employee=recipient.name, time=checkout_time)
+						<a class="btn btn-success checkin" id='{employee}_{time}'>Approve</a>
+						Submit a Shift Permission for the employee to give an excuse and not need to penalize
+	 					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
+						<br><br><div class='btn btn-primary btn-danger no-punch-in' id='{employee}_{date}_{shift}'>Issue Penalty</div>
+						""").format(shift=recipient.shift, date=cstr(now_time), employee=recipient.name, time=checkout_time)
 		 			if action_user is not None:
 						 send_notification(title, subject, action_message, category, [action_user])
 

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -875,6 +875,8 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		'docstatus': 1,
 		'employee': employee
 	}
+	if frappe.db.exists('Employee', {'employee':employee, 'status':'Left'})):
+		return
 
 	if frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component'):
 		basic_salary_component = frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component')

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -838,8 +838,11 @@ def generate_payroll():
 			frappe.log_error(frappe.get_traceback())
 
 def generate_penalties():
-	start_date = add_to_date(getdate(), months=-1)
-	end_date = get_end_date(start_date, 'monthly')['end_date']
+	# start_date = add_to_date(getdate(), months=-1)
+	# end_date = get_end_date(start_date, 'monthly')['end_date']
+
+	start_date = "2022-05-24"
+	end_date = "2022-06-23"
 
 	filters = {
 		'penalty_issuance_time': ['between', (start_date, end_date)],

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -866,6 +866,11 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		'docstatus': 1,
 		'employee': employee
 	}
+	
+	if frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component'):
+		basic_salary_component = frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component')
+	else:
+		frappe.throw("Please Add Basic Salary Component in HR and Payroll Additional Settings.")
 
 	salary_structure, base = frappe.get_value("Salary Structure Assignment", filters, ["salary_structure","base"], order_by="from_date desc")
 
@@ -874,8 +879,8 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		SELECT amount,amount_based_on_formula,formula FROM `tabSalary Detail`
 		WHERE parenttype="Salary Structure"
 		AND parent=%s
-		AND salary_component="Basic Salary"
-		""",(salary_structure), as_dict=1)
+		AND salary_component=%s
+		""",(salary_structure, basic_salary_component), as_dict=1)
 		if basic[0].amount_based_on_formula == 1:
 			formula = basic[0].formula
 			percent = formula.replace('base*','')

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -875,7 +875,7 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		'docstatus': 1,
 		'employee': employee
 	}
-	if frappe.db.exists('Employee', {'employee':employee, 'status':'Left'})):
+	if frappe.db.exists('Employee', {'employee':employee, 'status':'Left'}):
 		return
 
 	if frappe.db.get_single_value('HR and Payroll Additional Settings', 'basic_salary_component'):

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -871,7 +871,7 @@ def calculate_penalty_amount(employee, start_date, end_date, logs):
 		SELECT amount,amount_based_on_formula,formula FROM `tabSalary Detail`
 		WHERE parenttype="Salary Structure"
 		AND parent=%s
-		AND salary_component="Basic"
+		AND salary_component="Basic Salary"
 		""",(salary_structure), as_dict=1)
 		if basic[0].amount_based_on_formula == 1:
 			formula = basic[0].formula

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -256,11 +256,15 @@ def notify_checkin_checkout_final_reminder(recipients,log_type):
 	checkin_subject = _("Please checkin in the next five minutes.")
 	checkin_message = _("""
 					<a class="btn btn-success" href="/app/face-recognition">Check In</a>&nbsp;
-					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Planning to arrive late?</a>&nbsp;
+					Submit a Shift Permission if you are plannig to arrive late or is there any issue in checkin or forget to checkin
+					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 					""")
 	notification_category = "Attendance"
 	checkout_subject = _("Final Reminder: Please checkout in the next five minutes.")
-	checkout_message = _("""<a class="btn btn-danger" href="/app/face-recognition">Check Out</a>""")
+	checkout_message = _("""
+		Submit a Shift Permission if you are plannig to leave early or is there any issue in checkout or forget to checkout
+		<a class="btn btn-danger" href="/app/face-recognition">Check Out</a>
+		""")
 	Notification_title = "Final Reminder"
 	Notification_body = "Please checkin in the next five minutes."
 	user_id_list = []

--- a/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
+++ b/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
@@ -16,7 +16,7 @@ class PenaltyDeduction(Document):
 		additional_salary.employee = self.employee
 		additional_salary.salary_component = "Penalty"
 		additional_salary.amount = self.deducted_amount
-		additional_salary.payroll_date = getdate()
+		additional_salary.payroll_date = "2022-06-23"
 		additional_salary.company = erpnext.get_default_company()
 		additional_salary.overwrite_salary_structure_amount = 1
 		additional_salary.notes = "Penalty Deduction for Payroll Period: {start} to {end} including previous unsettled balance amount, if applicable.".format(start=self.from_date, end=self.to_date)

--- a/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
+++ b/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
@@ -12,11 +12,13 @@ class PenaltyDeduction(Document):
 		self.create_additional_salary()
 
 	def create_additional_salary(self):
+		if frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date'):
+			payroll_date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
 		additional_salary = frappe.new_doc("Additional Salary")
 		additional_salary.employee = self.employee
 		additional_salary.salary_component = "Penalty"
 		additional_salary.amount = self.deducted_amount
-		additional_salary.payroll_date = "2022-06-23"
+		additional_salary.payroll_date = payroll_date if payroll_date else getdate()
 		additional_salary.company = erpnext.get_default_company()
 		additional_salary.overwrite_salary_structure_amount = 1
 		additional_salary.notes = "Penalty Deduction for Payroll Period: {start} to {end} including previous unsettled balance amount, if applicable.".format(start=self.from_date, end=self.to_date)

--- a/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
+++ b/one_fm/legal/doctype/penalty_deduction/penalty_deduction.py
@@ -5,7 +5,10 @@
 from __future__ import unicode_literals
 import frappe, erpnext
 from frappe.model.document import Document
-from frappe.utils import getdate
+from frappe.utils import getdate, cint
+from datetime import datetime
+import datetime
+
 
 class PenaltyDeduction(Document):
 	def on_submit(self):
@@ -13,7 +16,10 @@ class PenaltyDeduction(Document):
 
 	def create_additional_salary(self):
 		if frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date'):
-			payroll_date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
+			date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
+			#calculate Payroll date, start and end date.
+			payroll_date = datetime.datetime(getdate().year, getdate().month, cint(date)).strftime("%Y-%m-%d")	
+				
 		additional_salary = frappe.new_doc("Additional Salary")
 		additional_salary.employee = self.employee
 		additional_salary.salary_component = "Penalty"

--- a/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
+++ b/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
@@ -9,6 +9,8 @@
   "holiday_compensatory_leave_type",
   "auto_generate_employee_id_on_employee_creation",
   "auto_create_erpnext_user_on_employee_creation_using_employee_id",
+  "attendance_settings_section",
+  "validate_shift_permission_on_employee_checkin",
   "payroll_settings_section",
   "payroll_date",
   "holiday_additional_salary_component",
@@ -193,12 +195,24 @@
    "fieldtype": "Select",
    "label": "Payroll Date",
    "options": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "attendance_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Attendance Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "validate_shift_permission_on_employee_checkin",
+   "fieldtype": "Check",
+   "label": "Validate Shift Permission on Employee Checkin"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-06-28 09:13:15.942901",
+ "modified": "2022-06-28 12:11:55.867100",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "HR and Payroll Additional Settings",

--- a/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
+++ b/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
@@ -10,11 +10,13 @@
   "auto_generate_employee_id_on_employee_creation",
   "auto_create_erpnext_user_on_employee_creation_using_employee_id",
   "payroll_settings_section",
+  "payroll_date",
   "holiday_additional_salary_component",
   "maximum_salary_deduction_percentage",
-  "exclude_salary_component",
   "column_break_7",
   "default_bank",
+  "exclude_salary_component",
+  "basic_salary_component",
   "overtime_additional_salary_section",
   "overtime_additional_salary_component",
   "working_day_overtime_rate",
@@ -178,12 +180,25 @@
    "fieldname": "checkin_deadline",
    "fieldtype": "Check",
    "label": "Checkin Deadline"
+  },
+  {
+   "fieldname": "basic_salary_component",
+   "fieldtype": "Link",
+   "label": "Basic Salary Component",
+   "options": "Salary Component"
+  },
+  {
+   "default": "24",
+   "fieldname": "payroll_date",
+   "fieldtype": "Select",
+   "label": "Payroll Date",
+   "options": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-06-19 11:04:00.714463",
+ "modified": "2022-06-28 09:13:15.942901",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "HR and Payroll Additional Settings",

--- a/one_fm/operations/doctype/shift_permission/shift_permission.json
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.json
@@ -80,7 +80,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Permission Type",
-   "options": "\nArrive Late\nLeave Early",
+   "options": "\nArrive Late\nLeave Early\nForget to Checkin\nForget to Checkout\nCheckin Checkout Issue",
    "reqd": 1
   },
   {
@@ -140,7 +140,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-06 16:56:05.624791",
+ "modified": "2022-06-02 08:04:35.015017",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Shift Permission",

--- a/one_fm/operations/doctype/shift_permission/shift_permission.json
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.json
@@ -80,7 +80,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Permission Type",
-   "options": "\nArrive Late\nLeave Early\nForget to Checkin\nForget to Checkout\nCheckin Checkout Issue",
+   "options": "\nArrive Late\nLeave Early\nForget to Checkin\nForget to Checkout\nCheckin Issue\nCheckout Issue",
    "reqd": 1
   },
   {
@@ -140,7 +140,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-06-02 08:04:35.015017",
+ "modified": "2022-06-21 09:46:03.607107",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Shift Permission",

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -76,7 +76,8 @@ def create_employee_checkin_for_shift_permission(shift_permission):
 		args:
 			shift_permission: Object of Shift Permission
 	"""
-	if not not frappe.db.exists('Employee Checkin', {'shift_permission': shift_permission.name}):
+	if not frappe.db.get_single_value("HR and Payroll Additional Settings", 'validate_shift_permission_on_employee_checkin')\
+		and not frappe.db.exists('Employee Checkin', {'shift_permission': shift_permission.name, 'docstatus': 1}):
 		log_type = False
 		if shift_permission.permission_type in ["Arrive Late", "Forget to Checkin", "Checkin Issue"]:
 			log_type = "IN"
@@ -86,7 +87,7 @@ def create_employee_checkin_for_shift_permission(shift_permission):
 			return False
 
 		# Get shift details for the employee
-		shift_details = get_shift_details(shift_permission.employee, getdate(shift_permission.date))
+		shift_details = get_shift_details(shift_permission.shift_type, getdate(shift_permission.date))
 
 		employee_checkin = frappe.new_doc('Employee Checkin')
 		employee_checkin.employee = shift_permission.employee

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -66,7 +66,7 @@ class ShiftPermission(Document):
 		message = _("{employee} has applied for permission to {type} on {date}.".format(employee=self.emp_name, type=self.permission_type.lower(), date=date))
 		create_notification_log(subject, message, [user], self)
 
-	def on_submit(self):
+	def on_update(self):
 		if self.workflow_state == 'Approved':
 			create_employee_checkin_for_shift_permission(self)
 


### PR DESCRIPTION
## Feature description
 - Send shift permission creation link to supervisor and employee on the final reminder
 - On shift permission approval create employee checkin with respect to the reason and log type

## Solution description
 - Validate employee checkin against shift permission is made configurable
 - Create employee checking in on approval workflow of shift permission

## Output screenshots (optional)
https://user-images.githubusercontent.com/20554466/176147639-f529cce4-f511-4c00-972d-bdd4b0f40a52.mov

## Areas affected and ensured
 - `one_fm/api/doc_events.py`
 - `one_fm/api/tasks.py`
 - `one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json`
 - `one_fm/operations/doctype/shift_permission/shift_permission.json`
 - `one_fm/operations/doctype/shift_permission/shift_permission.py

## Is there any existing behavior change of other features due to this code change?
Yes, 
Before the PR, Shift Permission is checking against the Employee Checkin.
After the PR, We can do validate Shift Permission is checking against the Employee Checkin or We can create employee checkin with respect to the reason and log type

## Was this feature tested on all the browsers?
  - [x] Chrome

