### PR TITLE
feat: enrollment checker and reset API for v1

### DIFF
--- a/one_fm/api/v1/leave_application.py
+++ b/one_fm/api/v1/leave_application.py
@@ -226,7 +226,6 @@ def create_new_leave_application(employee_id: str = None, from_date: str = None,
             proof_doc_json = json.loads(proof_document)
             attachment = proof_doc_json['attachment']
             attachment_name = proof_doc_json['attachment_name']
-            print(attachment_name)
             if not attachment or not attachment_name:
                 return response('proof_document key requires attachment and attachment_name', {}, 400)
 

--- a/one_fm/api/v1/leave_application.py
+++ b/one_fm/api/v1/leave_application.py
@@ -209,10 +209,10 @@ def create_new_leave_application(employee_id: str = None, from_date: str = None,
         import base64, json
 
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
-
         if not employee:
             return response("Resource Not Found", 404, None, "No employee found with {employee_id}".format(employee_id=employee_id))
-        
+
+        employee_doc = frappe.get_doc("Employee", employee)
         leave_approver = get_leave_approver(employee)
         
         if not leave_approver:
@@ -226,7 +226,7 @@ def create_new_leave_application(employee_id: str = None, from_date: str = None,
             proof_doc_json = json.loads(proof_document)
             attachment = proof_doc_json['attachment']
             attachment_name = proof_doc_json['attachment_name']
-
+            print(attachment_name)
             if not attachment or not attachment_name:
                 return response('proof_document key requires attachment and attachment_name', {}, 400)
 
@@ -234,26 +234,16 @@ def create_new_leave_application(employee_id: str = None, from_date: str = None,
             content = base64.b64decode(attachment)
             filename = hashlib.md5((attachment_name + str(datetime.datetime.now())).encode('utf-8')).hexdigest() + file_ext
 
-            Path(frappe.utils.cstr(frappe.local.site)+f"/public/files/leave-application/{frappe.session.user}").mkdir(parents=True, exist_ok=True)
-            OUTPUT_FILE_PATH = frappe.utils.cstr(frappe.local.site)+f"/public/files/leave-application/{frappe.session.user}/{filename}"
+            Path(frappe.utils.cstr(frappe.local.site)+f"/public/files/leave-application/{employee_doc.user_id}").mkdir(parents=True, exist_ok=True)
+            OUTPUT_FILE_PATH = frappe.utils.cstr(frappe.local.site)+f"/public/files/leave-application/{employee_doc.user_id}/{filename}"
             with open(OUTPUT_FILE_PATH, "wb") as fh:
                 fh.write(content)
 
-            attachment_path = f"/files/leave-application/{frappe.session.user}/{filename}"
-
+            attachment_path = f"/files/leave-application/{employee_doc.user_id}/{filename}"
 
         # Approve leave application for "Sick Leave"
-        if str(leave_type).lower() == "sick leave":
-            doc = new_leave_application(employee, from_date, to_date, leave_type, "Approved", reason, leave_approver)
-        if leave_type == "Sick Leave":
-            doc = new_leave_application(employee, from_date, to_date, leave_type, "Approved", reason, leave_approver, attachment_path)
-            doc.submit()
-            frappe.db.commit()
-            return response("Success", 201, doc)
-
-        else:
-            doc = new_leave_application(employee, from_date, to_date, leave_type, "Open", reason, leave_approver, attachment_path)
-            return response("Success", 201, doc)
+        doc = new_leave_application(employee, from_date, to_date, leave_type, "Open", reason, leave_approver, attachment_path)
+        return response("Success", 201, doc)
     
     except Exception as error:
         return response("Internal Server Error", 500, None, error)
@@ -269,9 +259,8 @@ def new_leave_application(employee: str, from_date: str,to_date: str,leave_type:
     leave.status=status
     leave.leave_approver = leave_approver
     if attachment_path:
-        leave.proof_document = attachment_path
+        leave.proof_document = frappe.utils.get_url()+attachment_path
     leave.save()
-    frappe.db.commit()
     return leave.as_dict()
 
 

--- a/one_fm/api/v1/utils.py
+++ b/one_fm/api/v1/utils.py
@@ -183,7 +183,6 @@ def enrollment_reset(employee_id: str = None) -> dict:
         if get_employee.status:
             employee = frappe.get_doc("Employee", get_employee.message)
             employee.db_set("enrolled", 0)
-            employee.db_set("fcm_token", '')
             return response(message='Enrollment reset successful, re-enrollment can be done by logging off the app then click register',
                 status_code=200, data={'status':True}, error=None)
         else:

--- a/one_fm/api/v1/utils.py
+++ b/one_fm/api/v1/utils.py
@@ -150,3 +150,59 @@ def get_mobile_version():
         return response(message='Successful', status_code=200, data={'version':version}, error=None)
     except Exception as e:
         return response(message='Failed', status_code=500, data={}, error=str(e))
+
+
+@frappe.whitelist()
+def enrollment_status(employee_id: str = None) -> dict:
+    """
+        Check if an employee is enrolled on the mobile app
+    :param employee:
+    :return: True or False
+    """
+    try:
+        get_employee = get_employee_by_id(employee_id)
+        if get_employee.status:
+            employee = frappe.get_doc("Employee", get_employee.message)
+            if employee.enrolled and employee.fcm_token:
+                return response(message='Employee is enrolled on the mobile app.', status_code=200, data={'enrolled':True}, error=None)
+            return response(message='Employee not enrolled.', status_code=get_employee.http_status_code, data={'enrolled':False}, error=None)
+        else:
+            return response(message=get_employee.message, status_code=get_employee.http_status_code, data={'status':False}, error=None)
+    except Exception as e:
+        return response(message='Failed', status_code=500, data={}, error=str(e))
+
+@frappe.whitelist()
+def enrollment_reset(employee_id: str = None) -> dict:
+    """
+    Check if an employee is enrolled on the mobile app
+    :param employee:
+    :return: True or False
+    """
+    try:
+        get_employee = get_employee_by_id(employee_id)
+        if get_employee.status:
+            employee = frappe.get_doc("Employee", get_employee.message)
+            employee.db_set("enrolled", 0)
+            employee.db_set("fcm_token", '')
+            return response(message='Enrollment reset successful, re-enrollment can be done by logging off the app then click register',
+                status_code=200, data={'status':True}, error=None)
+        else:
+            return response(message=get_employee.message, status_code=get_employee.http_status_code,
+                data={'status':False}, error=None)
+    except Exception as e:
+        return response(message='Failed', status_code=500, data={}, error=str(e))
+
+@frappe.whitelist()
+def get_employee_by_id(employee_id):
+    """
+    Get employee pk by employee id
+    :param employee_id:
+    :return:
+    """
+    try:
+        employee = frappe.get_value("Employee", {"employee_id": employee_id}, ["name"], as_dict=1)
+        if employee:
+            return frappe._dict({'status': True, 'message': employee.name})
+        return frappe._dict({'status': False, 'message': f'Employee with ID {employee_id} does not exist', 'http_status_code':404})
+    except Exception as e:
+        frappe._dict({'status': False, 'message': str(e), 'http_status_code':500})


### PR DESCRIPTION
## Feature description
This PR adds employee enrollment checker and reset API as well as minor fixes to create_leave application.

# enrollment_checker_endpoint is: one_fm.api.v1.utils.enrollment_status(employee_id) # 20201212XY313
this will return true of false


enrollment_reset_endpoint: one_fm.api.v1.utils.enrollment_reset(employee_id) 