### PR TITLE
[Chore] Change the ERF approver to role based rather to user based

### DIFF
--- a/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
+++ b/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
@@ -1,12 +1,11 @@
 {
+ "actions": [],
  "creation": "2020-07-28 11:11:40.087475",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "erf_settings_section",
-  "erf_approver",
-  "unplanned_erf_approver",
   "hr_for_a_quick_workshop",
   "hrm_to_fill_hr_and_salary_compensation",
   "close_erf_automatically",
@@ -28,14 +27,6 @@
    "label": "ERF Settings"
   },
   {
-   "fieldname": "unplanned_erf_approver",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Unplanned ERF Approver",
-   "options": "User",
-   "reqd": 1
-  },
-  {
    "fieldname": "column_break_5",
    "fieldtype": "Column Break"
   },
@@ -48,14 +39,6 @@
    "fieldname": "performance_profile_guid",
    "fieldtype": "Attach",
    "label": "Guid to Create Performance Profile"
-  },
-  {
-   "fieldname": "erf_approver",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "ERF Approver",
-   "options": "User",
-   "reqd": 1
   },
   {
    "fieldname": "hr_for_a_quick_workshop",
@@ -118,7 +101,8 @@
   }
  ],
  "issingle": 1,
- "modified": "2021-06-15 14:41:04.325648",
+ "links": [],
+ "modified": "2022-07-04 18:55:02.190977",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Hiring Settings",

--- a/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.js
+++ b/one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.js
@@ -12,7 +12,7 @@ frappe.ui.form.on('Accounts Additional Settings', {
 	create_collection_officer_role: function(frm) {
 		frappe.call({
 			method: 'one_fm.one_fm.utils.create_role_if_not_exists',
-			args: {'role': 'Collection Officer'},
+			args: {'roles': ['Collection Officer']},
 			callback: function(r) {
 				if(!r.exc){
 					frm.reload_doc();

--- a/one_fm/one_fm/doctype/erf/erf.js
+++ b/one_fm/one_fm/doctype/erf/erf.js
@@ -49,7 +49,7 @@ frappe.ui.form.on('ERF', {
 				__('Set a Date With {0} For a Quick Workshop',[frm.doc.__onload.okr_workshop_with_full_name]))
 		}
 		if (frm.doc.docstatus == 1 && frm.doc.__onload && 'erf_approver' in frm.doc.__onload){
-			if(frappe.session.user==frm.doc.__onload.erf_approver && frm.doc.status == "Draft"){
+			if(frm.doc.__onload.erf_approver.includes(frappe.session.user) && frm.doc.status == "Draft"){
 				frm.add_custom_button(__('Accept'), () => frm.events.confirm_accept_decline_erf(frm, 'Accepted', false)).addClass('btn-primary');
 				frm.add_custom_button(__('Decline'), () => frm.events.decline_erf(frm, 'Declined')).addClass('btn-danger');
 			}

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -414,7 +414,8 @@ def create_role_if_not_exists(roles, desk_access=True):
 			roles: list of Name of the Role, Text
 			desk_access: Boolean for Desk Access
 	'''
-	roles = json.loads(roles)
+	if not isinstance(roles, list):
+		roles = json.loads(roles)
 	for role in roles:
 		if not frappe.db.exists("Role", {"role_name": role}):
 			doc = frappe.new_doc("Role")

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -8,6 +8,7 @@ from frappe.integrations.offsite_backup_utils import get_latest_backup_file, sen
 from one_fm.api.notification import create_notification_log
 from frappe.utils.user import get_users_with_role
 from erpnext.hr.utils import get_holidays_for_employee
+import json
 
 @frappe.whitelist()
 def employee_grade_validate(doc, method):
@@ -406,17 +407,19 @@ def get_workflow_sates(doctype):
     return workflow_states
 
 @frappe.whitelist()
-def create_role_if_not_exists(role, desk_access=True):
-    '''
-        Method is used to create Role.
-        args:
-            role: Name of the Role, Text
-            desk_access: Boolean for Desk Access
-    '''
-    if not frappe.db.exists("Role", {"role_name": role}):
-        doc = frappe.new_doc("Role")
-        doc.update({
-            "role_name": role,
-            "desk_access": desk_access
-        })
-        doc.insert(ignore_permissions=True)
+def create_role_if_not_exists(roles, desk_access=True):
+	'''
+		Method is used to create Role.
+		args:
+			roles: list of Name of the Role, Text
+			desk_access: Boolean for Desk Access
+	'''
+	roles = json.loads(roles)
+	for role in roles:
+		if not frappe.db.exists("Role", {"role_name": role}):
+			doc = frappe.new_doc("Role")
+			doc.update({
+				"role_name": role,
+				"desk_access": desk_access
+			})
+			doc.insert(ignore_permissions=True)

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -7,3 +7,4 @@ one_fm.patches.v1_0.delete_interview_doctype
 one_fm.patches.v1_0.delete_unused_interview_related_cutom_fields
 one_fm.patches.v0_12.fix_payroll_duplicate_iban_number_2
 one_fm.patches.v0_12.resize_customer_image_for_website
+one_fm.patches.v1_0.add_erf_approver_role

--- a/one_fm/patches/v1_0/add_erf_approver_role.py
+++ b/one_fm/patches/v1_0/add_erf_approver_role.py
@@ -1,0 +1,6 @@
+from __future__ import unicode_literals
+import frappe
+from one_fm.one_fm.utils import create_role_if_not_exists
+
+def execute():
+	create_role_if_not_exists(['ERF Approver', 'Unplanned ERF Approver'])


### PR DESCRIPTION
## Feature description
 - Change the ERF approver to role based rather to user based

## Solution description
 - ERF approver changed from user to `ERF Approver` and `Unplanned ERF Approver` role
 - Update `create_role_if_not_exists` method for list of roles
 - Patch for create `ERF Approver` and `Unplanned ERF Approver` role

## Areas affected and ensured
 - Removed ERF Approver and Unplanned ERF Approver fields form Hiring Settings
   `one_fm/hiring/doctype/hiring_settings/hiring_settings.json` 
 - Update `create_role_if_not_exists` method for list of roles
   `one_fm/one_fm/utils.py`
   `one_fm/one_fm/doctype/accounts_additional_settings/accounts_additional_settings.js`
 - Patch for create `ERF Approver` and `Unplanned ERF Approver` role
   `one_fm/patches.txt`

## Is there any existing behavior change of other features due to this code change?
Yes, after this PR any user who is having `ERF Approver` role can Accept or Decline an ERF

## Was this feature tested on all the browsers?
  - [x] Chrome
