### PR TITLE
[Feat] V1 API - Shift Permission for Checkin Checkout issue

### DIFF
--- a/one_fm/api/v1/shift_permission.py
+++ b/one_fm/api/v1/shift_permission.py
@@ -5,7 +5,7 @@ from one_fm.api.v1.utils import response, validate_date, validate_time
 
 @frappe.whitelist()
 def create_shift_permission(employee_id: str = None, permission_type: str = None, date: str = None, reason: str = None,
-    leaving_time: str = None, arrival_time: str = None) -> dict:
+    leaving_time: str = None, arrival_time: str = None, latitude: str = None, longitude: str = None) -> dict:
     """This method creates a shift permission for a given employee.
 
     Args:
@@ -15,6 +15,8 @@ def create_shift_permission(employee_id: str = None, permission_type: str = None
         reason (str): reason to create a shift permission
         leaving_time (str): time for leave in hh:mm:ss
         arrival_time (str): time for arriving in hh:mm:ss
+        latitude (float, optional): Latitude od user.
+        longitude (float, optional): Longitude od user.
 
     Returns:
         dict: {
@@ -37,8 +39,11 @@ def create_shift_permission(employee_id: str = None, permission_type: str = None
     if not reason:
         return response("Bad Request", 400, None, "reason required.")
 
-    if not arrival_time and not leaving_time:
-        return response("Bad Request", 400, None, "either arrival_time or leaving time required.")
+    if permission_type == "Arrive Late" and not arrival_time:
+        return response("Bad Request", 400, None, "Arrival time required for late arrival shift permission.")
+
+    if permission_type == "Leave Early" and not leaving_time:
+        return response("Bad Request", 400, None, "Leaving time required for early exit shift permission")
 
     if not isinstance(employee_id, str):
         return response("Bad Request", 400, None, "employee must be of type str.")
@@ -46,8 +51,15 @@ def create_shift_permission(employee_id: str = None, permission_type: str = None
     if not isinstance(permission_type, str):
         return response("Bad Request", 400, None, "permission_type must be of type str.")
 
-    if permission_type not in ["Arrive Late", "Leave Early"]:
-        return response("Bad Request", 400, None, "permission type must be either 'Arrive Late' or 'Leave Early'.")
+    if permission_type not in ["Arrive Late", "Leave Early", "Checkin Issue", "Checkout Issue"]:
+        return response("Bad Request", 400, None, "permission type must be either 'Arrive Late' or 'Leave Early' or 'Checkin Issue' or 'Checkout Issue'.")
+
+    if permission_type in ["Checkin Issue", "Checkout Issue"] and latitude and longitude:
+        try:
+            latitude = float(latitude)
+            longitude = float(longitude)
+        except:
+            return response("Bad Request", 400, None, "Latitude and longitude must be float.")
 
     if not isinstance(date, str):
         return response("Bad Request", 400, None, "date must be of type str.")
@@ -68,7 +80,7 @@ def create_shift_permission(employee_id: str = None, permission_type: str = None
     if leaving_time:
         if not isinstance(leaving_time, str):
             return response("Bad Request", 400, None, "leaving_time must be of type str.")
-        
+
         if not validate_time(leaving_time):
             return response("Bad Request", 400, None, "leaving_time must be of type hh:mm:ss.")
 
@@ -86,7 +98,7 @@ def create_shift_permission(employee_id: str = None, permission_type: str = None
 
         if not shift_type:
             return response("Resource Not Found", 404, None, "shift type not found in employee schedule for {employee}".format(employee=employee))
-        
+
         if not shift_assignment:
             return response("Resource Not Found", 404, None, "shift assingment not found for {employee}".format(employee=employee))
 
@@ -103,6 +115,9 @@ def create_shift_permission(employee_id: str = None, permission_type: str = None
                 shift_permission_doc.arrival_time = arrival_time
             if permission_type == "Leave Early" and leaving_time:
                 shift_permission_doc.leaving_time = leaving_time
+            if permission_type in ["Checkin Issue", "Checkout Issue"]:
+                shift_permission_doc.latitude = latitude if latitude else 0.0
+                shift_permission_doc.longitude = longitude if longitude else 0.0
             shift_permission_doc.assigned_shift = shift_assignment
             shift_permission_doc.shift_supervisor = shift_supervisor
             shift_permission_doc.shift = shift
@@ -110,10 +125,10 @@ def create_shift_permission(employee_id: str = None, permission_type: str = None
             shift_permission_doc.save()
             frappe.db.commit()
             return response("Success", 201, shift_permission_doc.as_dict())
-        
+
         else:
             return response("Duplicate", 422, None, "Shift permission already created for {employee}".format(employee=employee_id))
-           
+
     except Exception as error:
         return response("Internal Server Error", 500, None, error)
 
@@ -123,7 +138,7 @@ def get_shift_details(employee, date):
     shift_type = None
     shift_assignment = None
     shift_supervisor = None
-    
+
     employee_schedule = frappe.db.get_value('Employee Schedule', {'employee': employee, 'employee_availability': 'Working', 'date': date, 'roster_type': 'Basic'}, ['shift', 'shift_type'])
     if not employee_schedule:
         return frappe._dict({'found':False})
@@ -131,17 +146,17 @@ def get_shift_details(employee, date):
     if shift and shift_type:
         shift_supervisor = frappe.db.get_value('Operations Shift', {'name': shift}, ['supervisor'])
         shift_assignment = frappe.db.get_value('Shift Assignment', {'employee': employee, 'start_date': date}, ['name'])
-        
+
     return frappe._dict({'found':True, 'data':[shift, shift_type, shift_assignment, shift_supervisor]})
 
 @frappe.whitelist()
 def list_shift_permission(employee_id: str = None):
     if not employee_id:
         return response("Bad Request", 400, None, "employee_id required.")
-    
+
     if not isinstance(employee_id, str):
-        return response("Bad Request", 400, None, "employee_id must be of type str.") 
-    
+        return response("Bad Request", 400, None, "employee_id must be of type str.")
+
     try:
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
 
@@ -150,7 +165,7 @@ def list_shift_permission(employee_id: str = None):
 
         shift_permission_list = frappe.get_list("Shift Permission", filters={'employee': employee}, fields=["name", "date", "workflow_state"])
         return response("Success", 200, shift_permission_list)
-    
+
     except Exception as error:
         return response("Internal Server Error", 500, None, error)
 
@@ -160,8 +175,8 @@ def shift_permission_details(shift_permission_id: str = None):
         return response("Bad Request", 400, None, "shift_permission_id required.")
 
     if not isinstance(shift_permission_id, str):
-        return response("Bad Request", 400, None, "shift_permission_id must be of type str.") 
-    
+        return response("Bad Request", 400, None, "shift_permission_id must be of type str.")
+
     try:
         shift_permission_doc = frappe.get_doc("Shift Permission", {'name': shift_permission_id})
 
@@ -169,7 +184,7 @@ def shift_permission_details(shift_permission_id: str = None):
             return response("Resource Not Found", 404, None, "Shift permission with {shift_permission_id} not found".format(shift_permission_id=shift_permission_id))
 
         return response("Success", 200, shift_permission_doc.as_dict())
-    
+
     except Exception as error:
         return response("Internal Server Error", 500, None, error)
 
@@ -177,7 +192,7 @@ def shift_permission_details(shift_permission_id: str = None):
 def approve_shift_permission(employee_id: str = None, shift_permission_id: str = None):
     if not employee_id:
         return response("Bad Request", 400, None, "employee_id required.")
-    
+
     if not isinstance(employee_id, str):
         return response("Bad Request", 400, None, "employee_id must be of type str.")
 
@@ -186,7 +201,7 @@ def approve_shift_permission(employee_id: str = None, shift_permission_id: str =
 
     if not isinstance(shift_permission_id, str):
         return response("Bad Request", 400, None, "shift_permission_id must be of type str.")
-    
+
     try:
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
 
@@ -196,29 +211,29 @@ def approve_shift_permission(employee_id: str = None, shift_permission_id: str =
         shift_permission_doc = frappe.get_doc('Shift Permission', shift_permission_id)
         if not shift_permission_doc:
             return response("Resource Not Found", 404, None, "shift permission with {shift_permission_id} not found".format(shift_permission_id=shift_permission_id))
-        
-        shift_supervisor = frappe.db.get_value('Shift Permission', {'name': shift_permission_id},['shift_supervisor']) 
+
+        shift_supervisor = frappe.db.get_value('Shift Permission', {'name': shift_permission_id},['shift_supervisor'])
         if not shift_supervisor:
             return response("Resource Not Found", 404, None, "No shift supervisor found for {shift_permission_id}".format(shift_permission_id=shift_permission_id))
-        
+
         if shift_supervisor != employee:
             return response("Forbidden", 403, None, "{employee_id} cannot approve this shift permission.".format(employee_id=employee_id))
-        
+
         if shift_permission_doc.workflow_state == "Pending":
             shift_permission_doc.workflow_state="Approved"
             shift_permission_doc.save()
             frappe.db.commit()
-            
+
             user_id, supervisor_name = frappe.db.get_value('Employee', {'name': shift_supervisor}, ['user_id', 'employee_name'])
             subject = _("{name} has approved the permission to {type} on {date}.".format(name=supervisor_name, type=shift_permission_doc.permission_type.lower(), date=shift_permission_doc.date))
             message = _("{name} has approved the permission to {type} on {date}.".format(name=supervisor_name, type=shift_permission_doc.permission_type.lower(), date=shift_permission_doc.date))
             notify_for_shift_permission_status(subject, message, user_id, shift_permission_doc, 1)
-            
+
             return response("Success", 201, shift_permission_doc.as_dict())
-        
+
         else:
             return response("Bad Request", 400, None, "Shift permission not in 'Pending' state.")
-        
+
     except Exception as error:
         return response("Internal Server Error", 500, None, error)
 
@@ -226,7 +241,7 @@ def approve_shift_permission(employee_id: str = None, shift_permission_id: str =
 def reject_shift_permission(employee_id: str = None, shift_permission_id: str = None):
     if not employee_id:
         return response("Bad Request", 400, None, "employee_id required.")
-    
+
     if not isinstance(employee_id, str):
         return response("Bad Request", 400, None, "employee_id must be of type str.")
 
@@ -235,7 +250,7 @@ def reject_shift_permission(employee_id: str = None, shift_permission_id: str = 
 
     if not isinstance(shift_permission_id, str):
         return response("Bad Request", 400, None, "shift_permission_id must be of type str.")
-    
+
     try:
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
 
@@ -245,29 +260,29 @@ def reject_shift_permission(employee_id: str = None, shift_permission_id: str = 
         shift_permission_doc = frappe.get_doc('Shift Permission', shift_permission_id)
         if not shift_permission_doc:
             return response("Resource Not Found", 404, None, "shift permission with {shift_permission_id} not found".format(shift_permission_id=shift_permission_id))
-        
-        shift_supervisor = frappe.db.get_value('Shift Permission', {'name': shift_permission_id},['shift_supervisor']) 
+
+        shift_supervisor = frappe.db.get_value('Shift Permission', {'name': shift_permission_id},['shift_supervisor'])
         if not shift_supervisor:
             return response("Resource Not Found", 404, None, "No shift supervisor found for {shift_permission_id}".format(shift_permission_id=shift_permission_id))
-        
+
         if shift_supervisor != employee:
             return response("Forbidden", 403, None, "{employee_id} cannot approve this shift permission.".format(employee_id=employee_id))
-        
+
         if shift_permission_doc.workflow_state == "Pending":
             shift_permission_doc.workflow_state="Rejected"
             shift_permission_doc.save()
             frappe.db.commit()
-            
+
             user_id, supervisor_name= frappe.db.get_value('Employee',{'name':shift_supervisor},['user_id','employee_name'])
             subject = _("{name} has rejected the permission to {type} on {date}.".format(name=supervisor_name, type=shift_permission_doc.permission_type.lower(), date=shift_permission_doc.date))
             message = _("{name} has rejected the permission to {type} on {date}.".format(name=supervisor_name, type=shift_permission_doc.permission_type.lower(), date=shift_permission_doc.date))
             notify_for_shift_permission_status(subject, message,user_id, shift_permission_doc, 1)
-            
+
             return response("Success", 201, shift_permission_doc.as_dict())
-        
+
         else:
             return response("Bad Request", 400, None, "Shift permission not in 'Pending' state.")
-    
+
     except Exception as error:
         return response("Internal Server Error", 500, None, error)
 

--- a/one_fm/operations/doctype/shift_permission/shift_permission.json
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.json
@@ -20,6 +20,9 @@
   "section_break_12",
   "arrival_time",
   "leaving_time",
+  "latitude",
+  "longitude",
+  "section_break_17",
   "reason",
   "amended_from"
  ],
@@ -136,11 +139,27 @@
    "in_list_view": 1,
    "label": "Employee Name",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.permission_type == \"Checkin Issue\" || doc.permission_type == \"Checkout Issue\"",
+   "fieldname": "latitude",
+   "fieldtype": "Float",
+   "label": "Latitude"
+  },
+  {
+   "depends_on": "eval:doc.permission_type == \"Checkin Issue\" || doc.permission_type == \"Checkout Issue\"",
+   "fieldname": "longitude",
+   "fieldtype": "Float",
+   "label": "Longitude"
+  },
+  {
+   "fieldname": "section_break_17",
+   "fieldtype": "Section Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-06-21 09:46:03.607107",
+ "modified": "2022-07-05 11:34:44.996887",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Shift Permission",


### PR DESCRIPTION
## Feature description
 - Shift Permission for Checkin Checkout issue can solve the checkin checkout by the supervisor.

## Solution description
 - On checkin checkout issue the employee can create a Shift Permission with type `Checkin Issue` or `Checkout Issue`
 - On submission of the above Shift Permission by the supervisor, the checkin or checkout will be created for the employee
 - Employee location latitude and longitude can be saved in the shift permission for further verification

## Areas affected and ensured
 - V1 API for Shift Permission

## Is there any existing behavior change of other features due to this code change?
 Yes, V1 API is capable for creating shift permission if an employee having checkin checkout issue.
