### PR TITLE
fix: Require items and POC in Contracts.

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -15,6 +15,11 @@ class Contracts(Document):
 		if self.overtime_rate == 0:
 			frappe.msgprint(_("Overtime rate not set."), alert=True, indicator='orange')
 
+	def before_submit(self):
+		# check if items and poc exists
+		if not (self.items and self.poc):
+			frappe.throw(_("Contracts Items and POC must be set before document is submitted"))
+
 	def calculate_contract_duration(self):
 		duration_in_days = date_diff(self.end_date, self.start_date)
 		self.duration_in_days = cstr(duration_in_days)


### PR DESCRIPTION
## Feature description
Contracts requires Items and POC as these are necessary to determine items signed up for and contact person for the contract.
This PR ensures items and POC are required before document is submitted.