### PR TITLE
added: Days off category and number

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.json
+++ b/one_fm/one_fm/doctype/erf/erf.json
@@ -24,6 +24,8 @@
   "erf_initiation",
   "erf_finalized",
   "work_section",
+  "day_off_category",
+  "number_of_days_off",
   "working_days",
   "off_days",
   "vacation_days",
@@ -35,6 +37,7 @@
   "type_of_travel",
   "shift_working_html",
   "shift_working",
+  "default_shift",
   "night_shift_html",
   "night_shift",
   "shift_hours_html",
@@ -230,15 +233,15 @@
    "description": "30 Days Month",
    "fieldname": "working_days",
    "fieldtype": "Int",
-   "label": "Working Days In a Month",
-   "reqd": 1
+   "hidden": 1,
+   "label": "Working Days In a Month"
   },
   {
    "description": "30 Days Month",
    "fieldname": "off_days",
    "fieldtype": "Int",
-   "label": "Off Days In a Month",
-   "read_only": 1
+   "hidden": 1,
+   "label": "Off Days In a Month"
   },
   {
    "default": "30",
@@ -839,11 +842,31 @@
    "fieldtype": "Currency",
    "label": "Base",
    "permlevel": 1
+  },
+  {
+   "default": "Monthly",
+   "fieldname": "day_off_category",
+   "fieldtype": "Select",
+   "label": "Day Off Category",
+   "options": "Monthly\nWeekly",
+   "reqd": 1
+  },
+  {
+   "fieldname": "number_of_days_off",
+   "fieldtype": "Int",
+   "label": "Number of Days Off"
+  },
+  {
+   "depends_on": "eval:doc.shift_working==0",
+   "fieldname": "default_shift",
+   "fieldtype": "Link",
+   "label": "Default Shift",
+   "options": "Shift Type"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-26 11:14:33.133102",
+ "modified": "2022-08-10 16:27:22.799213",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ERF",


### PR DESCRIPTION
## Feature description
The following fields were added:
1) Day Off Category: Weekly Monthly.
2) Number of Days Off

## Affected Doctype

1. Job Applicant: made days of category and type fetched from ERF, removed js days_off computation.
2. utils.py: 1472 removed and replaced with pass
3. Job Offer: made days of category and type fetched from ERF, edited terms.value to "str(hours)+' hours a day, (Subject to Operational Requirements), '+str(erf.number_of_days_off)+' days off per '+str(erf.day_off_category)"
4. 

## Output screenshots (optional)
![image](https://user-images.githubusercontent.com/10146518/183914060-d61172ca-32ed-410f-b975-66827983373f.png)

