### PR TITLE
Patch - update workflow state in Leave Application

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -10,3 +10,4 @@ one_fm.patches.v0_12.resize_customer_image_for_website
 one_fm.patches.v1_0.add_erf_approver_role
 one_fm.patches.v1_0.change_educational_qualification_options_in_job_applicant
 execute:frappe.delete_doc("DocType", 'Uniform Management Settings')
+one_fm.patches.v1_0.update_workflow_state #2022-08-11

--- a/one_fm/patches/v1_0/update_workflow_state.py
+++ b/one_fm/patches/v1_0/update_workflow_state.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+    frappe.enqueue(update_workflowstate, queue='long')
+
+#This Function is patch to update the Notification log with category, title and body. 
+def update_workflowstate():
+    leave_list = frappe.get_list("Leave Application", {"workflow_state":"Draft"},["name"])
+    for leave in leave_list:
+        frappe.set_value("Leave Application", leave.name, "workflow_state", "Open")
+    frappe.db.commit() 


### PR DESCRIPTION
- Fetch all the list of leave application that has workflow state = "Draft"
- Set the workflow state value = "Open"
- before running this patch, the workflow needs to be inactivated. `Don't Override Status` should be enabled.