### PR TITLE
#182948616: Leave Notification 

### DIFF
--- a/one_fm/api/api.py
+++ b/one_fm/api/api.py
@@ -225,12 +225,12 @@ def push_notification_rest_api_for_checkin(employee_id, title, body, checkin, ar
     return response
 
 @frappe.whitelist()
-def push_notification_rest_api_for_leave_application(employee_id, title, body, supervisor_button):
+def push_notification_rest_api_for_leave_application(employee_id, title, body, leave_id):
     """ 
     This function is used to send notification through Firebase CLoud Message. 
     It is a rest API that sends request to "https://fcm.googleapis.com/fcm/send"
     
-    Params: employee_id e.g. HR_EMP_00001, , title:"Title of your message", body:"Body of your message"
+    Params: employee_id e.g. HR_EMP_00001, , title:"Title of your message", body:"Body of your message", leave_id: Leave Application ID
 
     serverToken is fetched from firebase -> project settings -> Cloud Messaging -> Project credentials
     Device Token and Device OS is store in employee doctype using 'store_fcm_token' on device end.
@@ -255,7 +255,8 @@ def push_notification_rest_api_for_leave_application(employee_id, title, body, s
                 "body" : body,
                 "showButtonCheckIn": False,
                 "showButtonCheckOut": False,
-                "showButtonArrivingLate": False
+                "showButtonArrivingLate": False,
+                "type": leave_id
                 }
             }
     else:
@@ -266,7 +267,8 @@ def push_notification_rest_api_for_leave_application(employee_id, title, body, s
                 "body" : body,
                 "showButtonCheckIn": False,
                 "showButtonCheckOut": False,
-                "showButtonArrivingLate": False
+                "showButtonArrivingLate": False,
+                "type": leave_id
                 },
             "notification": {
                 "body": body,

--- a/one_fm/api/mobile/Leave_application.py
+++ b/one_fm/api/mobile/Leave_application.py
@@ -222,7 +222,7 @@ def notify_leave_approver(doc):
             date = "from "+cstr(doc.from_date)+" to "+cstr(doc.to_date)
 
         push_notication_message = doc.employee_name+" has applied for "+doc.leave_type+" "+date+". Kindly, take action."
-        push_notification_rest_api_for_leave_application(employee_id,"Leave Application", push_notication_message, False)
+        push_notification_rest_api_for_leave_application(employee_id,"Leave Application", push_notication_message, doc.name)
 
 
 def proof_document_required_for_leave_type(leave_type):

--- a/one_fm/api/v1/leave_application.py
+++ b/one_fm/api/v1/leave_application.py
@@ -50,9 +50,16 @@ def get_leave_detail(employee_id: str = None, leave_id: str = None) -> dict:
                 return response("Resource Not Found", 404, None, "No leaves found for {employee_id}".format(employee_id=employee_id))
         
         elif leave_id:
-            leave_data = frappe.get_doc("Leave Application", leave_id)
-            if leave_data:
-                return response("Success", 200, leave_data.as_dict())
+            leave_details = frappe.get_doc("Leave Application", leave_id)
+            if leave_details.leave_approver == frappe.session.user:
+                is_leave_approver = 1
+            else:
+                is_leave_approver = 0
+            data = leave_details.as_dict()
+            data.update({"is_leave_approver":is_leave_approver})
+
+            if leave_details:
+                return response("Success", 200, data)
             else:
                 return response("Resource Not Found", 404, None, "No leave data found for {leave_id}".format(leave_id=leave_id))
     

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -559,7 +559,7 @@ def notify_employee(doc, method):
             date = "from "+cstr(doc.from_date)+" to "+cstr(doc.to_date)
         
         message = "Hello, Your "+doc.leave_type+" Application "+date+" has been "+doc.workflow_state
-        push_notification_rest_api_for_leave_application(doc.employee,"Leave Application", message, False)
+        push_notification_rest_api_for_leave_application(doc.employee,"Leave Application", message, doc.name)
 
 @frappe.whitelist(allow_guest=True)
 def leave_appillication_on_cancel(doc, method):


### PR DESCRIPTION
- Fetch if the current session user is the leave approver, so the app knows when to display the button.
- Provide Leave Application ID to allow notification to navigate to the correct screen.