### PR TITLE
feat: Scheduled Roster Projection Report

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -557,7 +557,8 @@ scheduler_events = {
 			'one_fm.api.tasks.generate_payroll'
 		],
 		"1 23 1-31 * *": [
-			'one_fm.tasks.one_fm.daily.mark_future_attendance_request'
+			'one_fm.tasks.one_fm.daily.mark_future_attendance_request',
+			'one_fm.tasks.one_fm.daily.roster_projection_view_task',
 		],
 		"30 0 1 * *": [
 			'one_fm.tasks.one_fm.monthly.execute'

--- a/one_fm/operations/report/roster_projection_view/roster_projection_view.js
+++ b/one_fm/operations/report/roster_projection_view/roster_projection_view.js
@@ -32,7 +32,24 @@ frappe.query_reports["Roster Projection View"] = {
             "options": [2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032, 2033],
             "reqd": 1,
             "default": Number(frappe.datetime.get_today().split('-')[0])
-        },
+        }
 
-	]
+	],
+	"formatter": function (value, row, column, data, default_formatter) {
+        if(window.location.href.includes('prepared_report_name')){
+            let message = $('.form-message.text-muted.small');
+            message[0].style.display = 'block';
+            message[0].innerHTML = `<span style="color:blue;">
+                <b>NOTE:</b><br />
+                1) Projection Data is based on Roster Data only and is a snapshot from the first of the month. Any Roster Changes that Occurred After the First Day of the Month does not reflect in the Projection Column.<br>
+                2) Live Projection Data is Real Live Data of the Roster and Actual attendance. As well the attendance data is based on the Day before yesterday's Attendance and Yesterdays's Roster.
+            </span>
+            `;
+        }
+
+        return value
+	}
 };
+
+
+

--- a/one_fm/operations/report/roster_projection_view/roster_projection_view.json
+++ b/one_fm/operations/report/roster_projection_view/roster_projection_view.json
@@ -1,6 +1,14 @@
 {
  "add_total_row": 0,
- "columns": [],
+ "columns": [
+  {
+   "fieldname": "client",
+   "fieldtype": "Link",
+   "label": "Client",
+   "options": "Customer",
+   "width": 180
+  }
+ ],
  "creation": "2022-07-25 08:34:20.429528",
  "disable_prepared_report": 0,
  "disabled": 0,
@@ -10,7 +18,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letter_head": "ONEFM",
- "modified": "2022-07-25 08:34:20.429528",
+ "modified": "2022-08-17 14:37:42.818984",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Roster Projection View",

--- a/one_fm/tasks/one_fm/daily.py
+++ b/one_fm/tasks/one_fm/daily.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-import frappe
+import frappe, json
 from frappe.utils import getdate, nowdate, get_last_day
+from frappe.desk.query_report import *
 
 
 def generate_contracts_invoice():
@@ -41,3 +42,15 @@ def mark_future_attendance_request():
             frappe.get_doc("Attendance Request", row.name).create_future_attendance()
         except Exception as e:
             frappe.log_error(str(e), 'Attendance Request')
+
+
+def roster_projection_view_task():
+    """
+        Generate ROSTER projection
+    """
+    report = frappe.get_doc("Report", 'Roster Projection View')
+    background_enqueue_run(report.name,
+        filters=json.dumps(
+            {'month':datetime.today().month, 'year':datetime.today().year}), user='Administrator'
+    )
+


### PR DESCRIPTION
## Feature description
This PR auto generate Roster Projection Report on a daily basis. The output report is stored 'Prepared Report List' with name 'Roster Projection View'


## Output screenshots (optional)
![image](https://user-images.githubusercontent.com/10146518/185350169-3518d8c0-3b7e-4d5e-9dcd-32592328892e.png)
