### PR TITLE
hotfix: Ignore employee permission in Penalty Issuance

### DIFF
--- a/one_fm/legal/doctype/penalty_issuance/penalty_issuance.json
+++ b/one_fm/legal/doctype/penalty_issuance/penalty_issuance.json
@@ -243,7 +243,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-08-29 09:09:57.852442",
+ "modified": "2022-08-30 14:07:33.530263",
  "modified_by": "Administrator",
  "module": "Legal",
  "name": "Penalty Issuance",

--- a/one_fm/legal/doctype/penalty_issuance/penalty_issuance.json
+++ b/one_fm/legal/doctype/penalty_issuance/penalty_issuance.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "PI-.######",
  "creation": "2020-06-13 18:37:36.613900",
  "doctype": "DocType",
@@ -150,6 +151,7 @@
   {
    "fieldname": "issuing_employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Employee",
    "options": "Employee",
    "read_only": 1
@@ -240,8 +242,9 @@
   }
  ],
  "is_submittable": 1,
- "modified": "2021-07-05 10:33:42.020046",
- "modified_by": "o.asim@armor-services.com",
+ "links": [],
+ "modified": "2022-08-29 09:09:57.852442",
+ "modified_by": "Administrator",
  "module": "Legal",
  "name": "Penalty Issuance",
  "owner": "Administrator",

--- a/one_fm/legal/doctype/penalty_issuance_employees/penalty_issuance_employees.json
+++ b/one_fm/legal/doctype/penalty_issuance_employees/penalty_issuance_employees.json
@@ -50,7 +50,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-08-29 09:10:31.657854",
+ "modified": "2022-08-30 14:08:01.605330",
  "modified_by": "Administrator",
  "module": "Legal",
  "name": "Penalty Issuance Employees",

--- a/one_fm/legal/doctype/penalty_issuance_employees/penalty_issuance_employees.json
+++ b/one_fm/legal/doctype/penalty_issuance_employees/penalty_issuance_employees.json
@@ -15,6 +15,7 @@
   {
    "fieldname": "employee_id",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee Id",
    "options": "Employee"
@@ -49,7 +50,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-06-26 15:39:39.557338",
+ "modified": "2022-08-29 09:10:31.657854",
  "modified_by": "Administrator",
  "module": "Legal",
  "name": "Penalty Issuance Employees",


### PR DESCRIPTION
## Feature description
This hotfix checks ignore_user_permission on employee field in Penalty Issuance
