### PR TITLE
Contracts set to non submittable doctype

### DIFF
--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -295,99 +295,6 @@
  {
   "docstatus": 0,
   "doctype": "Workflow",
-  "document_type": "Leave Application",
-  "is_active": 1,
-  "modified": "2022-08-03 15:01:59.953677",
-  "name": "Leave Application",
-  "override_status": 0,
-  "parent": "Leave Application",
-  "parentfield": null,
-  "parenttype": null,
-  "send_email_alert": 0,
-  "states": [
-   {
-    "allow_edit": "Employee",
-    "doc_status": "0",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": "Leave Approval Notification",
-    "parent": "Leave Application",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Open",
-    "update_field": null,
-    "update_value": null
-   },
-   {
-    "allow_edit": "Leave Approver",
-    "doc_status": "1",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": "",
-    "parent": "Leave Application",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Approved",
-    "update_field": "status",
-    "update_value": "Approved"
-   },
-   {
-    "allow_edit": "Leave Approver",
-    "doc_status": "1",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": "",
-    "parent": "Leave Application",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Rejected",
-    "update_field": "status",
-    "update_value": "Rejected"
-   },
-   {
-    "allow_edit": "Employee",
-    "doc_status": "2",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": null,
-    "parent": "Leave Application",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Cancelled",
-    "update_field": "status",
-    "update_value": "Cancelled"
-   }
-  ],
-  "transitions": [
-   {
-    "action": "Approve",
-    "allow_self_approval": 1,
-    "allowed": "Leave Approver",
-    "condition": "frappe.session.user == doc.leave_approver",
-    "next_state": "Approved",
-    "parent": "Leave Application",
-    "parentfield": "transitions",
-    "parenttype": "Workflow",
-    "state": "Open"
-   },
-   {
-    "action": "Reject",
-    "allow_self_approval": 1,
-    "allowed": "Leave Approver",
-    "condition": "frappe.session.user == doc.recipient_user",
-    "next_state": "Rejected",
-    "parent": "Leave Application",
-    "parentfield": "transitions",
-    "parenttype": "Workflow",
-    "state": "Open"
-   }
-  ],
-  "workflow_name": "Leave Application",
-  "workflow_state_field": "workflow_state"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow",
   "document_type": "Request Employee Assignment",
   "is_active": 1,
   "modified": "2021-10-07 10:34:37.383278",
@@ -5038,7 +4945,7 @@
   "doctype": "Workflow",
   "document_type": "Contracts",
   "is_active": 1,
-  "modified": "2022-02-21 16:14:18.374606",
+  "modified": "2022-09-07 11:49:11.926106",
   "name": "Contracts",
   "override_status": 0,
   "parent": null,
@@ -5061,7 +4968,7 @@
    },
    {
     "allow_edit": "Finance Manager",
-    "doc_status": "1",
+    "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,
@@ -5074,7 +4981,7 @@
    },
    {
     "allow_edit": "Finance Manager",
-    "doc_status": "1",
+    "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,
@@ -5446,6 +5353,99 @@
    }
   ],
   "workflow_name": "Attendance Request",
+  "workflow_state_field": "workflow_state"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
+  "document_type": "Leave Application",
+  "is_active": 1,
+  "modified": "2022-08-03 15:01:59.953677",
+  "name": "Leave Application",
+  "override_status": 0,
+  "parent": "Leave Application",
+  "parentfield": null,
+  "parenttype": null,
+  "send_email_alert": 0,
+  "states": [
+   {
+    "allow_edit": "Employee",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": "Leave Approval Notification",
+    "parent": "Leave Application",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Open",
+    "update_field": null,
+    "update_value": null
+   },
+   {
+    "allow_edit": "Leave Approver",
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": "",
+    "parent": "Leave Application",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Approved",
+    "update_field": "status",
+    "update_value": "Approved"
+   },
+   {
+    "allow_edit": "Leave Approver",
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": "",
+    "parent": "Leave Application",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Rejected",
+    "update_field": "status",
+    "update_value": "Rejected"
+   },
+   {
+    "allow_edit": "Employee",
+    "doc_status": "2",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Leave Application",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Cancelled",
+    "update_field": "status",
+    "update_value": "Cancelled"
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Leave Approver",
+    "condition": "frappe.session.user == doc.leave_approver",
+    "next_state": "Approved",
+    "parent": "Leave Application",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Open"
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Leave Approver",
+    "condition": "frappe.session.user == doc.recipient_user",
+    "next_state": "Rejected",
+    "parent": "Leave Application",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Open"
+   }
+  ],
+  "workflow_name": "Leave Application",
   "workflow_state_field": "workflow_state"
  }
 ]

--- a/one_fm/fixtures/workflow_action_master.json
+++ b/one_fm/fixtures/workflow_action_master.json
@@ -468,5 +468,15 @@
   "parentfield": null,
   "parenttype": null,
   "workflow_action_name": "Send to Supervisor"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow Action Master",
+  "modified": "2022-09-07 11:49:10.373503",
+  "name": "Submit",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "workflow_action_name": "Submit"
  }
 ]

--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -446,9 +446,8 @@
    "options": "Current Month\nPrevious Month"
   }
  ],
- "is_submittable": 1,
  "links": [],
- "modified": "2022-06-20 17:03:07.002247",
+ "modified": "2022-09-07 11:31:58.714181",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",

--- a/one_fm/tasks/one_fm/daily.py
+++ b/one_fm/tasks/one_fm/daily.py
@@ -10,7 +10,6 @@ def generate_contracts_invoice():
     """
     try:
         contracts = frappe.get_list('Contracts', filters={
-            'docstatus':0, 
             'workflow_state':'Active',
             # 'due_date':str(datetime.today().date().day)
         })

--- a/one_fm/tasks/one_fm/daily.py
+++ b/one_fm/tasks/one_fm/daily.py
@@ -10,8 +10,8 @@ def generate_contracts_invoice():
     """
     try:
         contracts = frappe.get_list('Contracts', filters={
-            'docstatus':1, 
-            'workflow_state':'Active', 
+            'docstatus':0, 
+            'workflow_state':'Active',
             # 'due_date':str(datetime.today().date().day)
         })
         # generate
@@ -34,7 +34,7 @@ def mark_future_attendance_request():
     """
     attendance_requests = frappe.db.sql(f"""
         SELECT name FROM `tabAttendance Request`
-        WHERE '{nowdate()}' BETWEEN from_date AND to_date AND future_request=1 
+        WHERE '{nowdate()}' BETWEEN from_date AND to_date AND future_request=1
         AND docstatus=1
     """, as_dict=1)
     for row in attendance_requests:
@@ -53,4 +53,3 @@ def roster_projection_view_task():
         filters=json.dumps(
             {'month':datetime.today().month, 'year':datetime.today().year}), user='Administrator'
     )
-


### PR DESCRIPTION
## Feature description
- Contracts set to non submittable doctype

## Solution description
- Change the Contracts Doctype to non submittable
- Update Workflow 
	Update Docstatus from 1 to 0 in States section
- Updated line#10 one_fm/tasks/one_fm/daily.py for docstatus(changed with workflow state value only)
- To make editable the existing submitted Contracts, update all existing submitted contracts docstatus to 0


## Was this feature tested on all the browsers?
  - [x] Chrome
