### PR TITLE
hotfix: fix slef in accommodation

### DIFF
--- a/one_fm/accommodation/doctype/bed/bed.py
+++ b/one_fm/accommodation/doctype/bed/bed.py
@@ -30,7 +30,7 @@ class Bed(Document):
 			self.visa_number = ''
 			self.email = ''
 			self.employee_status = ''
-			slef.project = ''
+			self.project = ''
 			self.designation = ''
 			self.civil_id = ''
 			self.employee_id = ''

--- a/one_fm/accommodation/doctype/book_bed/book_bed.py
+++ b/one_fm/accommodation/doctype/book_bed/book_bed.py
@@ -23,7 +23,7 @@ class BookBed(Document):
 			status = 'Booked'
 		if self.book_for == 'Single':
 			frappe.db.set_value('Bed', self.bed, 'status', status)
-		elif self.book_for == 'Bulk' and slef.bulk_book_bed:
+		elif self.book_for == 'Bulk' and self.bulk_book_bed:
 			for bed in self.bulk_book_bed:
 				frappe.db.set_value('Bed', bed.bed, 'status', status)
 


### PR DESCRIPTION
## Feature description
An error in accommodation checkin checkout restrict saving document because of spelling error 'self' not 'slef'. This has been fixed. 
