### PR TITLE
[Fix] Leave Application - status - read only

### DIFF
--- a/one_fm/public/js/doctype_js/leave_application.js
+++ b/one_fm/public/js/doctype_js/leave_application.js
@@ -7,7 +7,7 @@ frappe.ui.form.on("Leave Application", {
                     doc: frm.doc
                 },
                 callback: function(r) {
-                    var fields = ['is_proof_document_required', 'from_date','to_date', 'status','leave_approver']
+                    var fields = ['is_proof_document_required', 'from_date','to_date','leave_approver']
                     for (var i in fields){
                         if (r && r.message) {
                             cur_frm.set_df_property(fields[i],  'read_only', 0);


### PR DESCRIPTION
## Feature description
 - Leave Application - status - read only

## Is there any existing behavior change of other features due to this code change?
Yes, status readonly for Leave Application

## Was this feature tested on all the browsers?
  - [x] Chrome
  - [x] Safari
