### PR TITLE
Fix: Log_type Condition

### DIFF
--- a/one_fm/api/v1/face_recognition.py
+++ b/one_fm/api/v1/face_recognition.py
@@ -202,7 +202,8 @@ def get_site_location(employee_id: str = None, latitude: float = None, longitude
         employee = frappe.db.get_value("Employee", {"employee_id": employee_id})
         date = cstr(getdate())
         log = check_existing()
-        if log == True:
+
+        if log == False:
             log_type = "IN"
         else:
             log_type = "OUT"


### PR DESCRIPTION
## Is this a Feature, Chore, or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- When a Shift Request is created, It shows the wrong location.
- Apparently, it was fetching Checkout Value. 

## Solution description
- Change the conditioning to fetch the log type.

## Areas affected and ensured
- get_site_location if condition

## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
