### PR TITLE
Ignore Permission for employee

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -64,6 +64,7 @@
   {
    "fieldname": "supervisor",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Shift Supervisor",
    "options": "Employee"
   },
@@ -152,7 +153,7 @@
    "link_fieldname": "shift"
   }
  ],
- "modified": "2022-09-20 09:14:46.025351",
+ "modified": "2022-10-25 11:04:00.722838",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Shift",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Employees are unable to view Operation shift if the Shift Supervisor is not listed under their reports_to.

## Solution description
- Ignore User Permission for the "Shift Supervisor" field.

## Areas affected and ensured
- Modification in Operation Shift Doctype

## Is there any existing behavior change of other features due to this code change?
Yes, Anyone who is able to select operation shift will be able to fetch the full list, without permission issue.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch tested?

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
