### PR TITLE
[Hot Fix] Marital status list by the Government PAM List [#183702128]

### DIFF
--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.json
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.json
@@ -414,7 +414,7 @@
    "fieldname": "marital_status",
    "fieldtype": "Select",
    "label": "Marital Status",
-   "options": "\nSingle\nMarried\nDivorced\nWidowed"
+   "options": "\nUnmarried\nMarried\nDivorce\nWidow\nUnknown"
   },
   {
    "fieldname": "nationality",
@@ -1484,10 +1484,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-10-16 10:08:48.174281",
+ "modified": "2022-11-03 07:24:56.922865",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Onboard Employee",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -1536,6 +1537,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "employee_name",
  "track_changes": 1
 }

--- a/one_fm/one_fm/doctype/pam_visa/pam_visa.json
+++ b/one_fm/one_fm/doctype/pam_visa/pam_visa.json
@@ -564,7 +564,7 @@
    "fieldname": "marital_status",
    "fieldtype": "Select",
    "label": "Marital Status",
-   "options": "\nSingle\nMarried\nDivorced\nWidowed",
+   "options": "\nUnmarried\nMarried\nDivorce\nWidow\nUnknown",
    "read_only": 1
   },
   {
@@ -605,10 +605,11 @@
   }
  ],
  "links": [],
- "modified": "2020-08-13 08:49:22.354054",
+ "modified": "2022-11-03 07:20:15.600923",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "PAM Visa",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -662,5 +663,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -14,3 +14,4 @@ one_fm.patches.v1_0.update_workflow_state #2022-08-11
 one_fm.patches.v1_0.remove_any_nationality
 one_fm.patches.v14_0.fix_customizations
 one_fm.patches.v14_0.job_applicant_marital_status_list_updated
+one_fm.patches.v14_0.onboard_employee_marital_status_list_updated

--- a/one_fm/patches/v14_0/onboard_employee_marital_status_list_updated.py
+++ b/one_fm/patches/v14_0/onboard_employee_marital_status_list_updated.py
@@ -1,0 +1,32 @@
+import frappe
+
+def execute():
+	query = '''
+		update
+			`tabOnboard Employee`
+		set
+			marital_status = 'Unmarried'
+		where
+			marital_status = 'Single'
+	'''
+	frappe.db.sql(query)
+
+	query = '''
+		update
+			`tabOnboard Employee`
+		set
+			marital_status = 'Widow'
+		where
+			marital_status = 'Widowed'
+	'''
+	frappe.db.sql(query)
+
+	query = '''
+		update
+			`tabOnboard Employee`
+		set
+			marital_status = 'Divorce'
+		where
+			marital_status = 'Divorced'
+	'''
+	frappe.db.sql(query)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Not able to create Onboard Employee doctype, since marital status value issue
- ![Screenshot 2022-11-03 at 10 04 35 AM](https://user-images.githubusercontent.com/20554466/199648266-3189253d-f801-4cca-add1-3b45947b630a.png)

## Solution description
 - Update marital status list in Onboard Employee
 - Create patch to update existing onboard employee marital status

## Areas affected and ensured
 - Onboard Employee doctype
 - PAM Visa doctype

## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] Yes

## Which browser(s) did you use for testing?
 - [x] Chrome
