### PR TITLE
[Hot Fix] Marital status list updated for Employee

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -15,3 +15,4 @@ one_fm.patches.v1_0.remove_any_nationality
 one_fm.patches.v14_0.fix_customizations
 one_fm.patches.v14_0.job_applicant_marital_status_list_updated
 one_fm.patches.v14_0.onboard_employee_marital_status_list_updated
+one_fm.patches.v14_0.employee_marital_status_list_updated

--- a/one_fm/patches/v14_0/employee_marital_status_list_updated.py
+++ b/one_fm/patches/v14_0/employee_marital_status_list_updated.py
@@ -1,0 +1,32 @@
+import frappe
+
+def execute():
+	query = '''
+		update
+			`tabEmployee`
+		set
+			marital_status = 'Unmarried'
+		where
+			marital_status = 'Single'
+	'''
+	frappe.db.sql(query)
+
+	query = '''
+		update
+			`tabEmployee`
+		set
+			marital_status = 'Widow'
+		where
+			marital_status = 'Widowed'
+	'''
+	frappe.db.sql(query)
+
+	query = '''
+		update
+			`tabEmployee`
+		set
+			marital_status = 'Divorce'
+		where
+			marital_status = 'Divorced'
+	'''
+	frappe.db.sql(query)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
 - Not able to create Employee from Onboard Employee, since marital status list is not updated

## Solution description
 - Update property setter for employee marital status field options updated

## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
