### PR TITLE
Fetched Approver cannot be self.

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -364,7 +364,7 @@ def get_action_user(employee, shift):
 	operations_site = frappe.get_doc("Operations Site", operations_shift.site)
 	project = frappe.get_doc("Project", operations_site.project)
 	report_to = frappe.get_value("Employee", {"name":employee},["reports_to"])
-	current_user = frappe.get_value("Employee", {"name":employee},["user_id")
+	current_user = frappe.get_value("Employee", {"name":employee},["user_id"])
 
 	if report_to:
 		action_user = get_employee_user_id(report_to)

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -359,10 +359,12 @@ def get_action_user(employee, shift):
 	"""
 	action_user = None
 	Role = None
+
 	operations_shift = frappe.get_doc("Operations Shift", shift)
 	operations_site = frappe.get_doc("Operations Site", operations_shift.site)
 	project = frappe.get_doc("Project", operations_site.project)
 	report_to = frappe.get_value("Employee", {"name":employee},["reports_to"])
+	current_user = frappe.get_value("Employee", {"name":employee},["user_id")
 
 	if report_to:
 		action_user = get_employee_user_id(report_to)
@@ -370,20 +372,20 @@ def get_action_user(employee, shift):
 	else:
 		if operations_shift.supervisor:
 			shift_supervisor = get_employee_user_id(operations_shift.supervisor)
-			if shift_supervisor != operations_shift.owner:
+			if shift_supervisor != operations_shift.owner and shift_supervisor != current_user:
 				action_user = shift_supervisor
 				Role = "Shift Supervisor"
 
 		elif operations_site.account_supervisor:
 			site_supervisor = get_employee_user_id(operations_site.account_supervisor)
-			if site_supervisor != operations_shift.owner:
+			if site_supervisor != operations_shift.owner and site_supervisor != current_user:
 				action_user = site_supervisor
 				Role = "Site Supervisor"
 
 		elif operations_site.project:
 			if project.account_manager:
 				project_manager = get_employee_user_id(project.account_manager)
-				if project_manager != operations_shift.owner:
+				if project_manager != operations_shift.owner and project_manager != current_user:
 					action_user = project_manager
 					Role = "Project Manager"
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Cannot fetch self as Approver.

## Analysis and design (optional)
- when an employee is a shift or site supervisor, he cannot be fetched as his own approver. 

## Solution description
- add a condition to check if an approver is a current user.

## Areas affected and ensured
- Approver Fetching Method.

## Output screenshots (optional)
https://user-images.githubusercontent.com/29017559/200173394-320b8bbe-3afe-4fb1-bda9-f7e5da159c2e.mov


## Is there any existing behavior change of other features due to this code change?
- no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
