### PR TITLE
[Fix] GRD Doctype - Ignore user perm for employee field

### DIFF
--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.json
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.json
@@ -252,6 +252,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_standard_filter": 1,
    "label": "Employee",
    "options": "Employee"
@@ -288,10 +289,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-09-26 19:13:10.137312",
+ "modified": "2022-11-08 07:38:16.062987",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Medical Insurance",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -337,5 +339,6 @@
  "search_fields": "civil_id,employee_id,date_of_application",
  "sort_field": "date_of_application",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "civil_id"
 }

--- a/one_fm/grd/doctype/moi_residency_jawazat/moi_residency_jawazat.json
+++ b/one_fm/grd/doctype/moi_residency_jawazat/moi_residency_jawazat.json
@@ -101,6 +101,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Employee",
    "options": "Employee",
    "reqd": 1
@@ -528,10 +529,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-07 11:18:29.962985",
+ "modified": "2022-11-08 07:36:46.568215",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "MOI Residency Jawazat",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -577,6 +579,7 @@
  ],
  "sort_field": "date_of_application",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "one_fm_civil_id",
  "track_changes": 1,
  "track_seen": 1,

--- a/one_fm/grd/doctype/paci/paci.json
+++ b/one_fm/grd/doctype/paci/paci.json
@@ -58,6 +58,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Employee",
    "options": "Employee",
    "reqd": 1
@@ -311,10 +312,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-09-26 19:23:12.960724",
+ "modified": "2022-11-08 07:38:45.220364",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "PACI",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -358,6 +360,7 @@
  "search_fields": "civil_id,date_of_application,employee_id",
  "sort_field": "date_of_application",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "civil_id",
  "track_changes": 1
 }

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -131,6 +131,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_standard_filter": 1,
    "label": "Employee",
    "options": "Employee",
@@ -885,10 +886,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-09-26 19:20:44.503307",
+ "modified": "2022-11-08 07:37:45.748526",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -942,6 +944,7 @@
  "search_fields": "date_of_application,employee_id,civil_id",
  "sort_field": "date_of_application",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "civil_id",
  "track_changes": 1
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
GRD Users not able to view Work Permit, MOI Residency Jawazath, Medical Insurance and PACI.

## Solution description
It is because of the user permission to the employee record of that users.

We set ignore user permission for Employee link in those records, since those record can only accessed by the users having GRD Roles

## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome