### PR TITLE
[Fix] RFP - local variable reports_to referenced before assignment

### DIFF
--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
@@ -21,6 +21,7 @@ class RequestforPurchase(Document):
 	def set_accepter_and_approver(self):
 		accepter = frappe.db.get_value('Purchase Settings', None, 'request_for_purchase_accepter')
 		approver = frappe.db.get_value('Purchase Settings', None, 'request_for_purchase_approver')
+		reports_to = False
 		if self.type == 'Project' and self.project:
 			reports_to = frappe.db.get_value('Project', self.project, 'account_manager')
 		elif self.employee:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- In RFP - local variable reports_to referenced before assignment


## Solution description
 - Declare the reports_to initially as False

## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data

## Is patch required?
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
