### PR TITLE
Fix: User not assigned to shift

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -662,8 +662,8 @@ def fetch_non_shift(date, s_type):
 				WHERE E.shift_working = 0
 				AND E.default_shift IN(
 					SELECT name from `tabShift Type` st
-					WHERE st.start_time >= '00:00:00'
-					AND  st.start_time < '12:00:00')
+					WHERE st.start_time >= '01:00:00'
+					AND  st.start_time < '13:00:00')
 				AND NOT EXISTS(SELECT * from `tabHoliday` h
 					WHERE
 						h.parent = E.holiday_list
@@ -674,7 +674,9 @@ def fetch_non_shift(date, s_type):
 				WHERE E.shift_working = 0
 				AND E.default_shift IN(
 					SELECT name from `tabShift Type` st
-					WHERE st.start_time >= '12:00:00')
+					WHERE st.start_time >= '13:00:00'
+					AND  st.start_time < '01:00:00'
+					)
 				AND NOT EXISTS(SELECT * from `tabHoliday` h
 					WHERE
 						h.parent = E.holiday_list
@@ -694,8 +696,8 @@ def assign_am_shift():
 			AND ES.roster_type = "Basic"
 			AND ES.shift_type IN(
 				SELECT name from `tabShift Type` st
-				WHERE st.start_time >= '00:00:00'
-				AND  st.start_time < '12:00:00')
+				WHERE st.start_time >= '01:00:00'
+				AND  st.start_time < '13:00:00')
 	""".format(date=cstr(date)), as_dict=1)
 
 	non_shift = fetch_non_shift(date, "AM")
@@ -715,7 +717,9 @@ def assign_pm_shift():
 			AND ES.roster_type = "Basic"
 			AND ES.shift_type IN(
 				SELECT name from `tabShift Type` st
-				WHERE st.start_time >= '12:00:00')
+				WHERE st.start_time >= '13:00:00'
+				AND  st.start_time < '01:00:00'
+				)
 	""".format(date=cstr(date)), as_dict=1)
 
 	non_shift = fetch_non_shift(date, "PM")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Employees with shift start at peak 12 receive "User not assigned to the shift" since shift assignment is created at 12. 

## Solution description
- Change the timing frame from '00:00:00 - 12:00:00' to '01:00:00 - 13:00:00'.

## Areas affected and ensured
- Start Time filter Time frame changed.

## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
