### PR TITLE
Fix: Night Shift Assignment

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -718,7 +718,6 @@ def assign_pm_shift():
 			AND ES.shift_type IN(
 				SELECT name from `tabShift Type` st
 				WHERE st.start_time >= '13:00:00'
-				AND  st.start_time < '01:00:00'
 				)
 	""".format(date=cstr(date)), as_dict=1)
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Night Shift Assignment List was turning empty due to conditions in query.

## Solution description
- Remove extra condition

## Areas affected and ensured
- one_fm.api.tasks.assign_pm_shift

## Is there any existing behavior change of other features due to this code change?
-no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
