### PR TITLE
Fix: SQL Quey to update Attendance.

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -845,21 +845,20 @@ def update_shift_details_in_attendance(doc, method):
 		shift_assignment = frappe.get_list("Shift Assignment",{"employee": doc.employee, "start_date": doc.attendance_date},["name", "site", "project", "shift", "shift_type", "operations_role", "start_datetime","end_datetime", "roster_type"])
 
 		shift_data = shift_assignment[0]
-		condition += " shift_assignment='{shift_assignment[0].name}'".format(shift_assignment=shift_assignment)
+		condition += """ shift_assignment="{shift_assignment[0].name}" """.format(shift_assignment=shift_assignment)
 		
 		for key in shift_assignment[0]:
 			if shift_data[key] and key not in ["name","start_datetime","end_datetime", "shift", "shift_type"]: 
-				condition += ", {key}='{value}'".format(key= key,value=shift_data[key])
+				condition += """, {key}="{value}" """.format(key= key,value=shift_data[key])
 			if key == "shift" and shift_data["shift"]:
-				condition += ", operations_shift='{shift}'".format(shift=shift_data["shift"])
+				condition += """, operations_shift="{shift}" """.format(shift=shift_data["shift"])
 			if key == "shift_type" and shift_data["shift_type"]:
-				print(shift_data["shift_type"])
-				condition += ", shift='{shift_type}'".format(shift_type=shift_data["shift_type"])
+				condition += """, shift='{shift_type}' """.format(shift_type=shift_data["shift_type"])
 
 		if doc.attendance_request or frappe.db.exists("Shift Permission", {"employee": doc.employee, "date":doc.attendance_date,"workflow_state":"Approved"}):
-			condition += f', in_time="{cstr(start_datetime)}", out_time="{cstr(end_datetime)}"'
+			condition += f""", in_time="{cstr(start_datetime)}", out_time="{cstr(end_datetime)}" """
 	if condition:
-		query = """UPDATE `tabAttendance` SET {condition} WHERE name= '{name}' """.format(condition=condition, name = doc.name)
+		query = """UPDATE `tabAttendance` SET {condition} WHERE name= "{name}" """.format(condition=condition, name = doc.name)
 		return frappe.db.sql(query)
 	return
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Following error due to quote issue in SQL query:
 `"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'l Gen Trad & Cont W.L.L.', operations_shift='Security-Lulu Hypermarket Egaila...' at line 1"` 

## Solution description
- Use triple quotes before and after the statement.

## Areas affected and ensured
- SQL Query to update Shift Details in Attendance: `one_fm.api.tasks.update_shift_details_in_attendance`

## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
