### PR TITLE
HotFix: Leave Application Patch

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -318,7 +318,7 @@ def checkin_checkout_query(date, shift_type, log_type):
 		permission_type = ("Leave Early", "Forget to Checkout", "Checkout Issue")
 
 	query = frappe.db.sql("""
-				SELECT DISTINCT emp.user_id, emp.name , emp.employee_name, tSA.shift FROM `tabShift Assignment` tSA, `tabEmployee` emp
+				SELECT DISTINCT emp.user_id, emp.name , emp.employee_name, emp.holiday_list, tSA.shift FROM `tabShift Assignment` tSA, `tabEmployee` emp
 					WHERE
 						tSA.employee=emp.name
 					AND tSA.start_date='{date}'
@@ -349,7 +349,7 @@ def checkin_checkout_query(date, shift_type, log_type):
 					AND DATE_FORMAT(empChkin.time,'%Y-%m-%d')='{date}'
 					AND empChkin.shift_type='{shift_type}')
 					AND tSA.start_date
-					NOT IN(SELECT holiday_date from `tabHoliday` h
+					AND NOT EXISTS(SELECT * from `tabHoliday` h
 					WHERE
 						h.parent = emp.holiday_list
 					AND h.holiday_date = '{date}')

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -17,3 +17,4 @@ one_fm.patches.v14_0.job_applicant_marital_status_list_updated
 one_fm.patches.v14_0.onboard_employee_marital_status_list_updated
 one_fm.patches.v14_0.employee_marital_status_list_updated
 one_fm.patches.v14_0.fix_issue_service_level_agreement #31
+one_fm.patches.v14_0.leave_application_proof_document_feild #2022-11-17

--- a/one_fm/patches/v14_0/leave_application_proof_document_feild.py
+++ b/one_fm/patches/v14_0/leave_application_proof_document_feild.py
@@ -1,0 +1,14 @@
+import frappe
+
+def execute():
+    p_doc = frappe.get_list("Leave Application", {"proof_document":("!=","")},["*"])
+    for p in p_doc:
+        doc = frappe.get_doc("Leave Application", p.name)
+        if p.proof_document:
+            doc.append("proof_documents",{"attachments": p.proof_document})
+        doc.proof_document = ""
+        if doc.status in ["Accepted", "Rejected","Cancelled"]:
+            doc.submit()
+        else:
+            doc.save()
+        frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Field 'proof_document' still exists in the database due to data in that field. To delete the field permanently, we need to transfer the data from the `proof_document` to the `proof_documents` table.
- Holiday condition is Checkin Checkout Query got re-added.

## Solution description
- Add patch to transfer data

## Output screenshots (optional)
Before:
<img width="400" alt="Screen Shot 2022-11-17 at 3 25 24 PM" src="https://user-images.githubusercontent.com/29017559/202446801-61ad30cc-c698-4ade-b816-71cc700eaa52.png">

After:
<img width="400" alt="Screen Shot 2022-11-17 at 3 29 31 PM" src="https://user-images.githubusercontent.com/29017559/202446683-1f6dc828-06c8-430a-bdb1-d51c9619e5f0.png">

## Areas affected and ensured
- Enable "Allow_on_submit" for 'proof_document'.
- Delete the field once patch is executed successfully.

## Is there any existing behavior change of other features due to this code change?
- Proof Document field will be deleted.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] Yes
- [x] No
    ## Was the patch test?
Yes.

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
