### PR TITLE
Fix: Not allow self approval.

### DIFF
--- a/one_fm/api/mobile/shift_permission.py
+++ b/one_fm/api/mobile/shift_permission.py
@@ -54,12 +54,16 @@ def validate_record(employee, date, assigned_shift, permission_type):
 def get_shift_details(employee, date):
     shift, type = frappe.db.get_value('Employee Schedule',{'employee':employee,'employee_availability':'Working','date':date,'roster_type':'Basic'},['shift','shift_type']) 
     if shift and type:
+        reports_to = frappe.get_value("Employee", employee, ["reports_to"])
         shift_supervisor = frappe.db.get_value('Operations Shift',{'name':shift},['supervisor'])
+        
+        approver = reports_to if reports_to else shift_supervisor
+            
         assigned_shift = frappe.db.get_value('Shift Assignment',{'employee':employee,'start_date':date},['name']) # start date and end date of HO employee are the same in the shift assignment
         if not assigned_shift:
             return response("You Don't Have Shift Assignment on {date}".format(date=date), {}, False, 400)
         elif assigned_shift:
-            return shift, type, assigned_shift, shift_supervisor
+            return shift, type, assigned_shift, approver
     elif not shift or not type:
         return response("You Don't Have Shift on {date}".format(date=date), {}, False, 400)
         

--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -3047,7 +3047,7 @@
   "doctype": "Workflow",
   "document_type": "Shift Permission",
   "is_active": 1,
-  "modified": "2021-11-18 01:44:03.912134",
+  "modified": "2022-11-20 09:54:47.575941",
   "name": "Shift Permission",
   "override_status": 0,
   "send_email_alert": 0,
@@ -3108,7 +3108,7 @@
   "transitions": [
    {
     "action": "Approve",
-    "allow_self_approval": 1,
+    "allow_self_approval": 0,
     "allowed": "Shift Supervisor",
     "condition": null,
     "next_state": "Approved",
@@ -3119,7 +3119,7 @@
    },
    {
     "action": "Reject",
-    "allow_self_approval": 1,
+    "allow_self_approval": 0,
     "allowed": "Shift Supervisor",
     "condition": null,
     "next_state": "Rejected",
@@ -3130,7 +3130,7 @@
    },
    {
     "action": "Cancel",
-    "allow_self_approval": 1,
+    "allow_self_approval": 0,
     "allowed": "Shift Supervisor",
     "condition": null,
     "next_state": "Cancelled",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Employee should not be able to approve his own shift permission. 

## Solution description
- disable self-approval from workflow
- fetch reports_to as shift approver if available.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Output screenshots (optional)
<img width="300" alt="Screen Shot 2022-11-20 at 10 26 46 AM" src="https://user-images.githubusercontent.com/29017559/202890843-c0c046af-1d05-46b1-846e-10a54edc41f9.png">

## Areas affected and ensured
- workflow -> shift permission

## Is there any existing behavior change of other features due to this code change?
yes. self-approval is disabled.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was the child table created?
No.
    - [ ] is the attachment required?
        did you test the attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
