### PR TITLE
[Fix] Accommodation checkin checkout validation issue

### DIFF
--- a/one_fm/accommodation/doctype/accommodation_checkin_checkout/accommodation_checkin_checkout.py
+++ b/one_fm/accommodation/doctype/accommodation_checkin_checkout/accommodation_checkin_checkout.py
@@ -68,7 +68,7 @@ class AccommodationCheckinCheckout(Document):
 				frappe.db.set_value('Employee', self.employee, 'one_fm_accommodation_policy', self.attach_print_accommodation_policy)
 
 	def validate_checkin_checkout(self):
-		if self.type == 'IN':
+		if self.type == 'IN' and self.tenant_category == 'Granted Service':
 			exists_checkin = frappe.db.exists('Accommodation Checkin Checkout', {
 				'employee': self.employee,
 				'type': 'IN',


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Accommodation checkin checkout is not possible since it throws an error from Paid Service accommodation checkin checkout

## Solution description
- Rewrite the validation logic with respect to the Paid Service

## Areas affected and ensured
- `one_fm/accommodation/doctype/accommodation_checkin_checkout/accommodation_checkin_checkout.py`


## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome