### PR TITLE
Webhook to Sent Google Chat when Issue is created.

### DIFF
--- a/one_fm/events/issue.py
+++ b/one_fm/events/issue.py
@@ -1,4 +1,7 @@
 import frappe
+from json import dumps
+import re
+from httplib2 import Http
 
 def validate(doc, event):
     doc.issue_type = "Technical Issue"
@@ -9,3 +12,71 @@ def validate(doc, event):
         })
     if sla_list:
         doc.service_level_agreement = sla_list[0].name
+
+def send_google_chat_notification(doc, method):
+    """Hangouts Chat incoming webhook to send the Issues Created, in Card Format."""
+    
+    # Fetch the Key and Token for the API
+    default_api_integration = frappe.get_doc("Default API Integration")
+
+    google_chat = frappe.get_doc("API Integration",
+        [i for i in default_api_integration.integration_setting
+            if i.app_name=='Google Chat'][0].app_name)
+
+    # Construct the request URL
+    url = f"""{google_chat.url}/spaces/{google_chat.api_parameter[0].get_password('value')}/messages?key={google_chat.get_password('api_key')}&token={google_chat.get_password('api_token')}"""
+
+    # Construct Message Body
+    message = f"""<b>A new Issue has been created</b><br>
+        <i>Details:</i> <br>
+        Subject: {doc.subject} <br>
+        Name: {doc.name} <br>
+        Raised By (Email): {doc.raised_by} <br>
+        Body: {doc.description}<br>
+        """
+
+    # Construct Card the allows Button action
+    bot_message = {
+        "cards_v2": [
+            {
+            "card_id": "IssueCard",
+            "card": {
+            "sections": [
+            {
+                "widgets": [
+                    {
+                    "textParagraph": {
+                    "text": message
+                    }
+                    },
+                {
+                "buttonList": {
+                    "buttons": [
+                    {
+                        "text": "Open Document",
+                        "onClick": {
+                        "openLink": {
+                            "url": frappe.utils.get_url(doc.get_url()),
+                        }
+                        }
+                    },
+                    ]
+                }
+                }
+              ]
+             }
+            ]
+          }
+         }
+        ]
+    }
+    
+    # Call the API
+    message_headers = {'Content-Type': 'application/json; charset=UTF-8'}
+    http_obj = Http()
+    response = http_obj.request(
+        uri=url,
+        method='POST',
+        headers=message_headers,
+        body=dumps(bot_message),
+    )

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -317,6 +317,7 @@ doc_events = {
 		"after_insert": [
 			"one_fm.utils.assign_issue",
 			"one_fm.api.doc_methods.issue.notify_issue_raiser",
+			"one_fm.events.issue.send_google_chat_notification"
 		],
     "on_update": "one_fm.utils.notify_on_close",
 	},


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Send a google chat when an issue is submitted. We do this using webhook.
Reference Document: https://developers.google.com/chat/how-tos/webhooks

## Solution description
- Message is in the form of a card, that allows attaching URLs, Pictures as well as Buttons. As per requirement, Button was needed. Hence Card was used. 
Reference Document for Card with button: https://developers.google.com/chat/ui/widgets/button-list#json 

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
<img width="905" alt="Screen Shot 2022-11-27 at 10 30 22 PM" src="https://user-images.githubusercontent.com/29017559/204156306-8af46c46-b120-486d-b4e7-6c4fdf1a3973.png">

## Areas affected and ensured
- google chat API Integration
- API Integration needs Key and Token Stored. 

## Is there any existing behavior change of other features due to this code change?
yes, Google Chat receives messages on issue creation.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
