### PR TITLE
[Feat] Show stock level of item in RFM

### DIFF
--- a/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
+++ b/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "item_code",
+  "show_stock_level",
   "requested_item_name",
   "item_name",
   "item_group",
@@ -414,17 +415,25 @@
    "fieldtype": "Float",
    "label": "Reserve Quantity",
    "read_only": 1
+  },
+  {
+   "depends_on": "item_code",
+   "fieldname": "show_stock_level",
+   "fieldtype": "Button",
+   "label": "Show Stock Level"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-10-18 10:50:18.217277",
+ "modified": "2022-11-27 15:01:56.293959",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Request for Material Item",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- For the stock manager, show the warehouse wise stock level of item selected in RFM item lines


## Solution description
- Introduced a button in item lines to show stock level, the button will display only if the item code selected.

## Is there a business logic within a doctype?
    - [x] Yes

## Output screenshots (optional)
![Screenshot 2022-11-27 at 5 37 59 PM](https://user-images.githubusercontent.com/20554466/204195669-e7e9207d-d42c-41e7-920d-3cb59c20e774.png)


## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Is patch required?
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
 