### PR TITLE
[Hot Fix] Portal and Desk User not allowed to send Email - No Permission to Email Queue

### DIFF
--- a/one_fm/events/email_queue.py
+++ b/one_fm/events/email_queue.py
@@ -14,8 +14,8 @@ def after_insert(doc, event):
             found = False
             break
     if found:
-        send_now(name=doc.name)
-
+        # It will send the email immediately 
+        doc.send()
 
 def flush_emails():
     """
@@ -35,7 +35,7 @@ def delete_eid_emails():
     :return:
     """
     frappe.db.sql("""
-        DELETE FROM `tabEmail Queue` 
-        WHERE name IN (SELECT e.name FROM `tabEmail Queue` e JOIN `tabEmail Queue Recipient` r 
+        DELETE FROM `tabEmail Queue`
+        WHERE name IN (SELECT e.name FROM `tabEmail Queue` e JOIN `tabEmail Queue Recipient` r
         ON r.parent=e.name WHERE r.recipient LIKE '2%');
     """)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Portal and Desk User not allowed to send Email - No Permission to Email Queue

## Analysis and design (optional)
The issue is related to the email queue. Since we have override the email queue after insert to send the email immediately.
https://github.com/ONE-F-M/One-FM/blob/7ff8ae0e1b2cc7d816b57bb54363397dda7ba1d7/one_fm/hooks.py#L365
https://github.com/ONE-F-M/One-FM/blob/7ff8ae0e1b2cc7d816b57bb54363397dda7ba1d7/one_fm/events/email_queue.py#L17
We are send the email immediately by using the send_now method in email_queue.py, which is checking the permission to the email queue doctype, since it is the method is for the user who have permission to email queue
https://github.com/frappe/frappe/blob/5cedae22ba5f30ec3535654cc2202c3013b4a564/frappe/email/doctype/email_queue/email_queue.py#L377

## Solution description
By passed the email queue permission now for sending email, will be updated the permission checker

## Is there a business logic within a doctype?
    - [x] No

## Is there any existing behavior change of other features due to this code change?
No
## Is patch required?
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
