### PR TITLE
[Feat] Email to company preferred email only

### DIFF
--- a/one_fm/accommodation/utils.py
+++ b/one_fm/accommodation/utils.py
@@ -38,7 +38,7 @@ def send_bulk_accommodation_policy_one_by_one(accommodation, recipients = ['j.po
             "reference_doctype": 'Accommodation Checkin Checkout',
             "reference_name": checkin.name
         }
-        enqueue(method=sendmail, queue='short', timeout=300, is_async=True, **email_args)
+        enqueue(method=sendemail, queue='short', timeout=300, is_async=True, **email_args)
 
 @frappe.whitelist()
 def send_bulk_accommodation_policy(accommodation, recipients = ['j.poil@armor-services.com']):

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.py
@@ -8,6 +8,7 @@ from frappe.model.document import Document
 from frappe import _
 from frappe.utils import cstr
 from one_fm.utils import get_week_start_end, get_month_start_end
+from one_fm.processor import sendemail
 
 class EmployeeSchedule(Document):
 	def before_insert(self):
@@ -33,9 +34,9 @@ class EmployeeSchedule(Document):
 			offs = self.get_off_category()
 			daterange = self.get_daterange(offs.category, str(self.date))
 			querystring = """
-				SELECT COUNT(name) as cnt FROM `tabEmployee Schedule` 
-					WHERE 
-				employee='{self.employee}' AND employee_availability='{self.employee_availability}' 
+				SELECT COUNT(name) as cnt FROM `tabEmployee Schedule`
+					WHERE
+				employee='{self.employee}' AND employee_availability='{self.employee_availability}'
 				AND date BETWEEN '{daterange.start}' AND '{daterange.end}'
 			""".format(self=self, daterange=daterange)
 			total_schedule = frappe.db.sql(querystring, as_dict=1)[0].cnt
@@ -49,7 +50,7 @@ class EmployeeSchedule(Document):
 					stopthrow = True
 			if stopthrow:
 				frappe.enqueue(
-					frappe.sendmail,
+					sendemail,
 					recipients=[frappe.session.user],
 					subject=frappe._('Employee Schedule Error'),
 					message=msg

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -7,33 +7,57 @@ import xml.etree.ElementTree as ET
 
 @frappe.whitelist()
 def sendemail(recipients, subject, header=None, message=None,
-        content=None, reference_name=None, reference_doctype=None,
-        sender=None, cc=None , attachments=None, delay=None):
-    logo = "https://one-fm.com/files/ONEFM_Identity.png"
+	content=None, reference_name=None, reference_doctype=None,
+	sender=None, cc=None , attachments=None, delay=None):
+	logo = "https://one-fm.com/files/ONEFM_Identity.png"
 
-    if attachments:
-            message += """
-            <p>Please find the attached Document in the mail below.</p>
-            """
-    if "Administrator" in recipients:
-        recipients.remove("Administrator")
-    if recipients and len(recipients) > 0:
-        frappe.sendmail(template = "default_email",
-                    recipients=recipients,
-                    sender= sender,
-                    cc=cc,
-                    reference_name= reference_name,
-                    reference_doctype = reference_doctype,
-                    subject=subject,
-                    args=dict(
-                        header=header[0] if header else "",
-                        subject=subject,
-                        message=message,
-                        content=content,
-                        logo=logo
-                    ),
-                    attachments = attachments,
-                    delayed=delay)
+	if attachments:
+		message += """
+			<p>Please find the attached Document in the mail below.</p>
+		"""
+	if "Administrator" in recipients:
+		recipients.remove("Administrator")
+
+	for recipient in recipients:
+		if is_user_id_not_company_prefred_email_in_employee(recipients):
+			recipients.remove(recipient)
+
+	if recipients and len(recipients) > 0:
+		frappe.sendmail(template = "default_email",
+			recipients=recipients,
+			sender= sender,
+			cc=cc,
+			reference_name= reference_name,
+			reference_doctype = reference_doctype,
+			subject=subject,
+			args=dict(
+				header=header[0] if header else "",
+				subject=subject,
+				message=message,
+				content=content,
+				logo=logo
+			),
+			attachments = attachments,
+			delayed=delay
+		)
+
+def is_user_id_not_company_prefred_email_in_employee(user_id):
+	'''
+		This method is used for finding the receiver is company prefered_email
+		in the employee record linked with the user_id
+		args:
+			user_id: email id (Text)(Email)
+		return True if user id is not company prefered email id
+		return False if employee not exists for the user id / user id is company prefered email id
+	'''
+	user_id_not_company_prefred_in_employee = False
+	employee = frappe.db.exists('Employee', {'user_id': user_id})
+	if employee:
+		user_id_not_company_prefred_in_employee = True
+		prefered_email, company_email, prefered_contact_email = frappe.db.get_value("Employee", employee, ["prefered_email", "company_email", "prefered_contact_email"])
+		if prefered_contact_email == 'Company Email' and prefered_email == company_email and prefered_email == email_id:
+			user_id_not_company_prefred_in_employee = False
+	return user_id_not_company_prefred_in_employee
 
 @frappe.whitelist()
 def send_whatsapp(sender_id, body):

--- a/one_fm/tasks/erpnext/purchase_order.py
+++ b/one_fm/tasks/erpnext/purchase_order.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import frappe
 from frappe import _
+from one_fm.processor import sendemail
 
 
 def due_purchase_order_payment_terms():
@@ -35,7 +36,7 @@ def due_purchase_order_payment_terms():
                 AND hr.parent LIKE '%@%' GROUP BY u.name;
             """, as_dict=1)]
             # send mail
-            frappe.sendmail(
+            sendemail(
                 recipients=recipients,
                 subject="Due Purchase Order Payment",
                 message=content)

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2651,7 +2651,7 @@ def send_workflow_action_email(doc, recipients):
             "reference_doctype": doc.doctype,
         }
         email_args.update(common_args)
-        frappe.enqueue(method=frappe.sendmail, queue="short", **email_args)
+        frappe.enqueue(method=sendemail, queue="short", **email_args)
     else:
         for d in [i for i in list(user_data_map[0].values()) if i.get('email') in recipients]:
             email_args = {
@@ -2661,7 +2661,7 @@ def send_workflow_action_email(doc, recipients):
                 "reference_doctype": doc.doctype,
             }
             email_args.update(common_args)
-            frappe.enqueue(method=frappe.sendmail, queue="short", **email_args)
+            frappe.enqueue(method=sendemail, queue="short", **email_args)
 
 
 def workflow_approve_reject(doc, recipients=None):
@@ -2674,7 +2674,7 @@ def workflow_approve_reject(doc, recipients=None):
         "reference_doctype": doc.doctype,
         "message": f"Your {doc.doctype} {doc.name} has been {doc.workflow_state}"
     }
-    frappe.enqueue(method=frappe.sendmail, queue="short", **email_args)
+    frappe.enqueue(method=sendemail, queue="short", **email_args)
 
 
 @frappe.whitelist()
@@ -2755,10 +2755,10 @@ def get_payroll_cycle(filters={}):
         }
     ## get other projects
     projects = frappe.db.sql("""
-        SELECT project FROM `tabEmployee` 
+        SELECT project FROM `tabEmployee`
             WHERE
         shift_working=1 and status='Active'
-            GROUP BY project 
+            GROUP BY project
     """, as_dict=1)
 
     default_payroll_cycle = settings.default_payroll_start_day
@@ -2772,5 +2772,3 @@ def get_payroll_cycle(filters={}):
         if not payroll_cycle.get(p.project) and p.project != None:
             payroll_cycle[p.project] = _date
     return payroll_cycle
-
-


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Send email to the user linked with employee having email company preferred email

## Solution description
 - Check employee exist for the user id and the preferred contact is company email then send email


## Areas affected and ensured
 - `one_fm/processor.py`


## Is there any existing behavior change of other features due to this code change?
Yes, Email will send to the employee set preferred contact is company email


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome