### PR TITLE
Fix: Date ParserError in filter

### DIFF
--- a/one_fm/one_fm/report/payroll_report/payroll_report.py
+++ b/one_fm/one_fm/report/payroll_report/payroll_report.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.utils import *
+import datetime
 
 def execute(filters=None):
 	if not filters: filters = {}
@@ -208,18 +209,21 @@ def get_employee_list(query):
 def get_payroll_cycle(filters):
 	settings = frappe.get_doc("HR and Payroll Additional Settings").project_payroll_cycle
 	default_date = frappe.get_doc("HR and Payroll Additional Settings").payroll_date
+
+	start_date = datetime.date(int(filters["year"]), int(filters["month"]), int(default_date))
 	payroll_cycle = {
 		'Other': {
-			'start_date': f'{filters.year}-{filters.month}-{default_date}', 
-			'end_date': add_days(add_months(f'{filters.year}-{filters.month}-{default_date}', 1), -1)
+			'start_date': datetime.date(int(filters["year"]), int(filters["month"]), int(default_date)), 
+			'end_date': add_days(add_months(datetime.date(int(filters["year"]), int(filters["month"]), int(default_date)), 1), -1)
 			}
 		}
+
 	for row in settings:
 		if row.payroll_start_day == 'Month Start':
 			row.payroll_start_day = 1
 		payroll_cycle[row.project] = {
-			'start_date':f'{filters.year}-{filters.month}-{row.payroll_start_day}',
-			'end_date':add_days(add_months(f'{filters.year}-{filters.month}-{row.payroll_start_day}', 1), -1)
+			'start_date':datetime.date(int(filters["year"]), int(filters["month"]), int(row.payroll_start_day)),
+			'end_date':add_days(add_months(datetime.date(int(filters["year"]), int(filters["month"]), int(row.payroll_start_day)), 1), -1)
 		}
 	
 	return payroll_cycle


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Frappe created Parse Error with the current filter in add_month method.
<img width="300" alt="Screen Shot 2022-11-29 at 12 13 51 PM" src="https://user-images.githubusercontent.com/29017559/204487964-7c2d3ca7-09cc-42f5-a115-1f14aa38b5ef.png">

## Solution description
- Use DateTime instead to create strat and end date

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Areas affected and ensured
- Instead of string date,  date_time is used.

## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
