### PR TITLE
Fix: Salary structure Assignment 

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -95,6 +95,7 @@ doctype_js = {
 	"Employee Transfer": "public/js/doctype_js/employee_transfer.js",
 	"Company" : "public/js/doctype_js/company.js",
 	"Leave Application" : "public/js/doctype_js/leave_application.js",
+	"Salary Structure Assignment" :  "public/js/doctype_js/salary_structure_assignment.js",
 }
 doctype_list_js = {
 	"Job Applicant" : "public/js/doctype_js/job_applicant_list.js",
@@ -292,7 +293,6 @@ doc_events = {
 		]
 	},
 	"Salary Structure Assignment": {
-		"before_save": "one_fm.api.doc_methods.salary_structure_assignment.fetch_salary_component",
 		"before_submit": [
 			"one_fm.api.doc_methods.salary_structure_assignment.calculate_indemnity_amount",
 			"one_fm.api.doc_methods.salary_structure_assignment.calculate_leave_allocation_amount",

--- a/one_fm/public/js/doctype_js/salary_structure_assignment.js
+++ b/one_fm/public/js/doctype_js/salary_structure_assignment.js
@@ -1,0 +1,31 @@
+
+
+frappe.ui.form.on('Salary Structure Assignment', {
+    salary_structure: function(frm){
+        fetch_salary_component(frm)
+    },
+    base: function(frm){
+        fetch_salary_component(frm)
+    },
+})
+ 
+function fetch_salary_component(frm){
+    if(frm.doc.base && frm.doc.salary_structure){
+        return frappe.call({
+            method: 'one_fm.api.doc_methods.salary_structure_assignment.fetch_salary_component',
+            args:{salary_structure: frm.doc.salary_structure, base:frm.doc.base},
+            freeze: true,
+            freeze_message: `Processing`,
+            callback: function(r) {
+                var component = r.message
+                frm.clear_table('salary_structure_components');
+                for (let c in component){
+                    var sal_com = frm.add_child('salary_structure_components');
+                    sal_com.salary_component = component[c]["salary_component"]
+                    sal_com.amount = component[c]["amount"]  
+                }
+                frm.refresh_fields();
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- The field for Salary Structure Component should be fetched and set on change in Salary Structure and Base. 

## Solution description
Use JS instead of frappe "before_save"

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://user-images.githubusercontent.com/29017559/204809841-ef4285e5-5b17-42a1-b83b-6a386107b79e.mov

## Areas affected and ensured
- Salary Structure Assignment Doc

## Is there any existing behavior change of other features due to this code change?
- The Value for Salary Structure Component table is fetched before saving.
- It gets updated everytime salary component or base is changed.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [ ] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
