### PR TITLE
[Fix] Day off OT - Roster

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2873,6 +2873,11 @@ function schedule_change_post(page) {
 //			employees = [... new Set(employees)];
 //		});
 //	}
+	var hide_day_off_ot_check = 0;
+	let element = get_wrapper_element();
+	if (element == ".rosterOtMonth") {
+		hide_day_off_ot_check = 1;
+	}
 	let d = new frappe.ui.Dialog({
 		'title': 'Schedule/Change Post',
 		'fields': [
@@ -2923,7 +2928,7 @@ function schedule_change_post(page) {
 			{ 'label': 'Project End Date', 'fieldname': 'project_end_date', 'fieldtype': 'Check' },
 			{ 'label': 'Keep Days Off', 'fieldname': 'keep_days_off', 'fieldtype': 'Check' },
 			{ 'label': 'Request Employee Schedule', 'fieldname': 'request_employee_schedule', 'fieldtype': 'Check' },
-			{ 'label': 'Day Off OT', 'fieldname': 'day_off_ot', 'fieldtype': 'Check' },
+			{ 'label': 'Day Off OT', 'fieldname': 'day_off_ot', 'fieldtype': 'Check' , 'hidden': hide_day_off_ot_check},
 			{ 'fieldname': 'cb1', 'fieldtype': 'Column Break' },
 			{
 				'label': 'Till Date', 'fieldname': 'end_date', 'fieldtype': 'Date', 'depends_on': 'eval:doc.project_end_date==0', onchange: function () {
@@ -2955,16 +2960,6 @@ function schedule_change_post(page) {
 				otRoster = false;
 			}
 
-			// Validate day off ot while scheduling
-			if (otRoster == false && parseInt(day_off_ot) == 1){
-				$('#cover-spin').hide();
-				frappe.msgprint(
-					msg='Please select OT Roster tab to roster employees in Day Off OT.',
-					title='Error',
-					raise_exception=1
-				)
-				frappe.throw()
-			}
 			if (!employees){
 			    frappe.throw(__('Please select employees to roster.'))
 			}

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.json
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.json
@@ -143,13 +143,14 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.roster_type == 'Over-Time'",
    "fieldname": "day_off_ot",
    "fieldtype": "Check",
    "label": "Day Off OT"
   }
  ],
  "links": [],
- "modified": "2022-11-07 20:27:14.252669",
+ "modified": "2022-12-05 16:13:19.862021",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Employee Schedule",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Day off OT needs to be done from the basic roster
- Hide Day off OT check in the Day off OT roster

## Solution description
 - Hide the day of ot check by checking the roster type
 - pass day off ot value by checking the conditions

## Is there a business logic within a doctype?
    - [x] No


## Areas affected and ensured
 - Roster page - Schedule/Post Change 


## Is there any existing behavior change of other features due to this code change?
 Yes, We can roster day off ot from the basic roster


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [x] No

## Is patch required?
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome