### PR TITLE
[Fix] Career History interviewer

### DIFF
--- a/one_fm/one_fm/doctype/career_history/career_history.py
+++ b/one_fm/one_fm/doctype/career_history/career_history.py
@@ -164,7 +164,8 @@ def create_interview(career_history):
 		interview.from_time = now()
 		interview.to_time = now()
 		interview_details = interview.append('interview_details')
-		interview_details.interviewer = frappe.session.user
+		if frappe.session.user != "Guest":
+			interview_details.interviewer = frappe.session.user
 		interview.expected_average_rating = 5
 		interview.save(ignore_permissions = True)
 		return interview.name


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Career History interviewer set as Guest when it is created from the portal

## Solution description
- If the CH created form the portal, then it will not set the session user as the interviewer

## Is there a business logic within a doctype?
    - [x] No


## Areas affected and ensured
- Career History Interview


## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome