### PR TITLE
[Feat] A system for the contract end date and renewal

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.js
+++ b/one_fm/operations/doctype/contracts/contracts.js
@@ -88,6 +88,11 @@ frappe.ui.form.on('Contracts', {
 			}
 		}
 	},
+	start_date: function(frm){
+		if(frm.doc.start_date){
+			frm.set_value('end_date', frappe.datetime.add_days(frm.doc.start_date, 364))
+		}
+	},
 	before_insert: (frm)=>{
 		if(frm.is_new()){
 			frm.doc.workflow_state=null;
@@ -228,8 +233,10 @@ frappe.ui.form.on('Contracts', {
             }
         }
         frm.refresh_field("assets");
-		days = frappe.meta.get_docfield("Contract Item","days", frm.doc.name);
-		days.hidden = 1;
+		if(frm.doc.items){
+			days = frappe.meta.get_docfield("Contract Item","days", frm.doc.name);
+			days.hidden = 1;
+		}
 		set_hide_management_fee_fields(frm);
 
 	},

--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -33,15 +33,16 @@
   "engagement_type",
   "start_date",
   "end_date",
+  "is_auto_renewal",
+  "contract_date",
+  "column_break_27",
   "due_date",
   "month_of_invoice",
   "overtime_rate",
-  "column_break_27",
   "invoice_output_format",
   "invoice_frequency",
   "duration",
   "duration_in_days",
-  "is_auto_renewal",
   "section_break_26",
   "is_public_holiday_rate",
   "public_holiday_rate",
@@ -166,7 +167,8 @@
    "fieldname": "end_date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Contract End Date"
+   "label": "Contract End Date",
+   "reqd": 1
   },
   {
    "fieldname": "due_date",
@@ -444,13 +446,21 @@
    "fieldtype": "Select",
    "label": "Month of Invoice",
    "options": "Current Month\nPrevious Month"
+  },
+  {
+   "fieldname": "contract_date",
+   "fieldtype": "Table",
+   "label": "Contract Date",
+   "options": "Contracts Date",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2022-09-07 11:31:58.714181",
+ "modified": "2022-12-06 10:41:14.586289",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -470,6 +480,7 @@
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "project",
  "track_changes": 1
 }

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -7,7 +7,10 @@ from __future__ import unicode_literals
 import frappe, json
 from datetime import datetime
 from frappe.model.document import Document
-from frappe.utils import cstr,month_diff,today,getdate,date_diff,add_years, cint, add_to_date, get_first_day, get_last_day, get_datetime, flt
+from frappe.utils import (
+	cstr,month_diff,today,getdate,date_diff,add_years, cint, add_to_date, get_first_day,
+	get_last_day, get_datetime, flt, add_days
+)
 from frappe import _
 
 class Contracts(Document):
@@ -56,7 +59,7 @@ class Contracts(Document):
 			invoice_date = temp_invoice_year + "-" + temp_invoice_month + "-" + cstr(self.due_date)
 		else:
 			invoice_date = cstr(getdate())
-		
+
 		# sys_invoice_date = datetime.fromisoformat(invoice_date).date()
 		last_day = get_last_day(date)
 		if datetime.today().date() < last_day:
@@ -411,6 +414,10 @@ def auto_renew_contracts():
 	contracts_list = frappe.db.get_list('Contracts', fields="name", filters=filters, order_by="start_date")
 	for contract in contracts_list:
 		contract_doc = frappe.get_doc('Contracts', contract)
+		contract_date = contract_doc.append('contract_date')
+		contract_date.contract_start_date = contract_doc.start_date
+		contract_date.contract_end_date = contract_doc.end_date
+		contract_doc.start_date = add_days(contract_doc.end_date, 1)
 		contract_doc.end_date = add_years(contract_doc.end_date, 1)
 		contract_doc.save()
 		frappe.db.commit()
@@ -539,7 +546,7 @@ def get_item_hourly_amount(item, project, first_day_of_month, last_day_of_month,
 
 		previous_invoice_date = cstr(add_to_date(invoice_date, months=-1))
 		previous_month_last_day = cstr(get_last_day(add_to_date(getdate(), months=-1)))
-		
+
 		att_filters = {
 			'project': project,
 			'operations_role': ['in', operations_role_list],
@@ -642,7 +649,7 @@ def get_item_daily_amount(item, project, first_day_of_month, last_day_of_month, 
 
 		previous_invoice_date = cstr(add_to_date(invoice_date, months=-1))
 		previous_month_last_day = cstr(get_last_day(add_to_date(getdate(), months=-1)))
-		
+
 		att_filters = {
 			'project': project,
 			'operations_role': ['in', operations_role_list],
@@ -740,10 +747,10 @@ def get_item_monthly_amount(item, project, first_day_of_month, last_day_of_month
 		employee_schedules = len(frappe.db.get_list("Employee Schedule", pluck='name', filters=es_filters))
 
 		item_days += employee_schedules
-		
+
 		previous_invoice_date = cstr(add_to_date(invoice_date, months=-1))
 		previous_month_last_day = cstr(get_last_day(add_to_date(getdate(), months=-1)))
-		
+
 		att_filters = {
 			'project': project,
 			'operations_role': ['in', operations_role_list],
@@ -755,7 +762,7 @@ def get_item_monthly_amount(item, project, first_day_of_month, last_day_of_month
 
 		item_days -= previous_attendances
 
-		
+
 	# If total item days exceed expected days, apply overtime rate on extra days
 	if item_days > expected_item_days:
 		overtime_days = item_days - expected_item_days

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -417,8 +417,9 @@ def auto_renew_contracts():
 		contract_date = contract_doc.append('contract_date')
 		contract_date.contract_start_date = contract_doc.start_date
 		contract_date.contract_end_date = contract_doc.end_date
+		duration = date_diff(contract_doc.end_date, contract_doc.start_date)
 		contract_doc.start_date = add_days(contract_doc.end_date, 1)
-		contract_doc.end_date = add_years(contract_doc.end_date, 1)
+		contract_doc.end_date = add_days(contract_doc.end_date, duration+1)
 		contract_doc.save()
 		frappe.db.commit()
 

--- a/one_fm/operations/doctype/contracts_date/contracts_date.json
+++ b/one_fm/operations/doctype/contracts_date/contracts_date.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "autoname": "autoincrement",
+ "creation": "2022-12-06 10:20:43.881912",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "contract_start_date",
+  "contract_end_date"
+ ],
+ "fields": [
+  {
+   "fieldname": "contract_start_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Contract Start Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "contract_end_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Contract End Date",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2022-12-06 10:20:43.881912",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "Contracts Date",
+ "naming_rule": "Autoincrement",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/operations/doctype/contracts_date/contracts_date.py
+++ b/one_fm/operations/doctype/contracts_date/contracts_date.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, omar jaber and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ContractsDate(Document):
+	pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature


## Clearly and concisely describe the feature, chore or bug.
- Create a Child Table in Contracts Doctype Which Records the Start Date and End Date of Each Cycle of the Contract. If Auto renew is selected then the child table is filled on the date of End Contract and a new record is created with the exact duration.
- By Setting Start Date and End Date the Duration would be set and if Duration is changed then End date is changed as well. (Make sure there is a note, 1 year is 364 days.)

- Cron needs to check each contracts record everyday for end date that is = to today and if Auto Renew checked then add another record in child table and make start date the next day and end date the same duration as the previous record.



## Is there a business logic within a doctype?
    - [x] Yes


## Output screenshots (optional)
![Screenshot 2022-12-06 at 1 39 05 PM](https://user-images.githubusercontent.com/20554466/205857317-6271aac5-ec69-4e66-89c1-80af7cd5b1cc.png)

## Areas affected and ensured
 - Contracts renewal


## Is there any existing behavior change of other features due to this code change?
 No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
Yes
    - s attachment required? No

## Did you delete custom field?
    - [x] No

## Is patch required?
- [x] Yes
Contracts end date is not setting by adding a patch since there are only 13 records not set end date

## Which browser(s) did you use for testing?
  - [x] Chrome