### PR TITLE
Fix: Populate passport issue of place with country list

### DIFF
--- a/one_fm/templates/pages/applicant_docs.js
+++ b/one_fm/templates/pages/applicant_docs.js
@@ -65,6 +65,7 @@ window.onload = () => {
     $(".required_indicator").show()
   }
   populate_nationality();
+  populate_country();
 }
 
 let civil_id_image;
@@ -124,9 +125,22 @@ function populate_nationality(){
       langArray = r.message;
       if(langArray){
         var nationality = document.getElementById("Nationality");
-        var place_of_issue = document.getElementById("Passport_Place_of_Issue");
         for (let i=0; i<=langArray.length;i++) {
           nationality.options[nationality.options.length] = new Option(langArray[i], langArray[i]);
+        }
+      }
+    }
+  });
+}
+function populate_country(){
+  frappe.call({
+    type: "GET",
+    method: "one_fm.templates.pages.applicant_docs.populate_country",
+    callback: function(r) {
+      langArray = r.message;
+      if(langArray){
+        var place_of_issue = document.getElementById("Passport_Place_of_Issue");
+        for (let i=0; i<=langArray.length;i++) {
           place_of_issue.options[place_of_issue.options.length] = new Option(langArray[i], langArray[i]);
         }
       }

--- a/one_fm/templates/pages/applicant_docs.py
+++ b/one_fm/templates/pages/applicant_docs.py
@@ -39,7 +39,10 @@ def fetch_nationality(code):
     country = frappe.get_value('Country', {'code_alpha3':code},["country_name"])
     return frappe.get_value('Nationality', {'country':country},["name"])
 
-
+@frappe.whitelist(allow_guest=True)
+def populate_country():
+    return frappe.get_list('Country', pluck='name', ignore_permissions=True)
+    
 @frappe.whitelist(allow_guest=True)
 def token():
     return frappe.local.session.data.csrf_token


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- The place of issue in the applicant doc needs to be a select field of country, just like in the job application doc.

## Solution description
- change the field type to select.
- populate the select field from the `Country` doctype.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="1244" alt="Screen Shot 2022-12-06 at 4 29 43 PM" src="https://user-images.githubusercontent.com/29017559/205926541-02efbfc5-37c9-4b25-bda1-3ade51be15f4.png">



## Areas affected and ensured
- `passport place of issue` changed to select the field type. 
- The input values are from the country doc.

## Is there any existing behavior change of other features due to this code change?
`passport place of issue` changed to select the field type, instead of the text field.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
