### PR TITLE
Feat: Make Wiki Arabic friendly.

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -16,6 +16,8 @@ from hrms.hr.doctype.leave_application.leave_application import LeaveApplication
 from one_fm.api.mobile.Leave_application import notify_leave_approver
 from erpnext.controllers.taxes_and_totals import calculate_taxes_and_totals
 from one_fm.operations.doctype.contracts.contracts import calculate_item_values
+from wiki.wiki.doctype.wiki_page.wiki_page import WikiPage
+from one_fm.overrides.wiki_page import get_context
 
 
 __version__ = '14.0.0'
@@ -36,3 +38,4 @@ ItemPrice.validate = validate
 ItemPrice.check_duplicates = check_duplicates
 LeaveApplication.notify_leave_approver = notify_leave_approver
 calculate_taxes_and_totals.calculate_item_values = calculate_item_values
+WikiPage.get_context = get_context

--- a/one_fm/data.py
+++ b/one_fm/data.py
@@ -1022,25 +1022,27 @@ def to_markdown(html):
 
 	return text
 
-def md_to_html(markdown_text):
+def md_to_html(markdown_text: str):
+	from markdown2 import MarkdownError
+	from markdown2 import markdown as _markdown
+
+	name = re.findall(r'[\u0600-\u06FF]+',markdown_text)
+	print(name)
+	if name:
+		markdown_text = '<p style="text-align: right;">'+markdown_text+'</p>'
 	extras = {
-		'fenced-code-blocks': None,
-		'tables': None,
-		'header-ids': None,
-		'highlightjs-lang': None,
-		'html-classes': {
-			'table': 'table table-bordered',
-			'img': 'screenshot'
-		}
+		"fenced-code-blocks": None,
+		"tables": None,
+		"header-ids": None,
+		"toc": None,
+		"highlightjs-lang": None,
+		"html-classes": {"table": "table table-bordered", "img": "screenshot",},
 	}
 
-	html = None
 	try:
-		html = markdown(markdown_text or '', extras=extras)
+		return _markdown(markdown_text or "", extras=extras)
 	except MarkdownError:
 		pass
-
-	return html
 
 def get_source_value(source, key):
 	'''Get value from source (object or dict) based on key'''

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -413,6 +413,8 @@ website_route_rules = [
 		"from_route": "/job_application/<path:job_title>",
 		"to_route": "job_application"
 	},
+	{"from_route": "/<path:wiki_page>/edit-wiki", "to_route": "wiki/edit"},
+	{"from_route": "/<path:wiki_page>/new-wiki", "to_route": "wiki/new"},
 ]
 
 # doc_events = {

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -680,8 +680,9 @@ fixtures = [
 # ------------------------------
 #
 override_whitelisted_methods = {
-	"hrms.hr.doctype.leave_application.leave_application.get_leave_approver" : "one_fm.api.mobile.Leave_application.fetch_leave_approver"
+	"hrms.hr.doctype.leave_application.leave_application.get_leave_approver" : "one_fm.api.mobile.Leave_application.fetch_leave_approver",
 	# "frappe.desk.doctype.event.event.get_events": "one_fm.event.get_events"
+	"wiki.wiki.doctype.wiki_page.wiki_page.preview":"one_fm.overrides.wiki_page.preview"
 }
 ShiftType.process_auto_attendance = process_auto_attendance
 

--- a/one_fm/overrides/wiki_page.py
+++ b/one_fm/overrides/wiki_page.py
@@ -1,0 +1,72 @@
+import frappe
+from one_fm.data import md_to_html
+
+@frappe.whitelist()
+def get_context(doc, context):
+    doc.verify_permission("read")
+    doc.set_breadcrumbs(context)
+    wiki_settings = frappe.get_single("Wiki Settings")
+    context.navbar_search = wiki_settings.add_search_bar
+    context.banner_image = wiki_settings.logo
+    context.script = wiki_settings.javascript
+    context.docs_search_scope = doc.get_docs_search_scope()
+    context.metatags = {
+        "title": doc.title, 
+        "description": doc.meta_description,
+        "keywords": doc.meta_keywords,
+        "image": doc.meta_image,
+        "og:image:width": "1200",
+        "og:image:height": "630",
+        }
+    context.last_revision = doc.get_last_revision()
+    context.number_of_revisions = frappe.db.count(
+        "Wiki Page Revision Item", {"wiki_page": doc.name}
+    )
+    html = md_to_html(doc.content)
+    context.content = html
+    context.page_toc_html = html.toc_html
+    context.show_sidebar = True
+    context.hide_login = True
+    context = context.update(
+        {
+            "post_login": [
+                {"label": ("My Account"), "url": "/me"},
+                {"label": ("Logout"), "url": "/?cmd=web_logout"},
+                {
+                    "label": ("Contributions ") + get_open_contributions(),
+                    "url": "/contributions",
+                },
+                {
+                    "label": ("My Drafts ") + get_open_drafts(),
+                    "url": "/drafts",
+                },
+            ]
+        }
+    )
+
+def get_open_contributions():
+	count = len(
+		frappe.get_list("Wiki Page Patch", filters=[["status", "=", "Under Review"]],)
+	)
+	return f'<span class="count">{count}</span>'
+
+def get_open_drafts():
+	count = len(
+		frappe.get_list("Wiki Page Patch", filters=[["status", "=", "Draft"], ["owner", '=', frappe.session.user]],)
+	)
+	return f'<span class="count">{count}</span>'
+
+@frappe.whitelist()
+def preview(content, name, new, type, diff_css=False):
+	html = md_to_html(content)
+	if new:
+		return {"html": html}
+	from ghdiff import diff
+
+	old_content = frappe.db.get_value("Wiki Page", name, "content")
+	diff = diff(old_content, content, css=diff_css)
+	return {
+		"html": html,
+		"diff": diff,
+		"orignal_preview": md_to_html(old_content),
+	}

--- a/one_fm/overrides/wiki_page.py
+++ b/one_fm/overrides/wiki_page.py
@@ -27,6 +27,8 @@ def get_context(doc, context):
     context.page_toc_html = html.toc_html
     context.show_sidebar = True
     context.hide_login = True
+    context.lang = frappe.local.lang
+
     context = context.update(
         {
             "post_login": [

--- a/one_fm/public/js/edit_asset.js
+++ b/one_fm/public/js/edit_asset.js
@@ -1,0 +1,556 @@
+window.EditAsset = class EditAsset {
+	constructor() {
+		this.make_code_field_group();
+		this.add_attachment_popover();
+		// remove this once the pr related to code editor max lines is merged
+		this.set_code_editor_height();
+		this.render_preview();
+		this.add_attachment_handler();
+		this.set_listeners();
+		this.create_comment_box();
+		this.make_title_editable();
+		this.render_sidebar_diff()
+	}
+
+	make_code_field_group() {
+		this.code_field_group = new frappe.ui.FieldGroup({
+			fields: [
+				{
+					fieldname: "type",
+					fieldtype: "Data",
+					default: "Rich Text",
+					options: "Rich Text",
+				},
+				{
+					fieldtype: "Section Break",
+				},
+				{
+					fieldname: "code_html",
+					fieldtype: "Text Editor",
+					default: $(".wiki-content-html").html(),
+					depends_on: 'eval:doc.type=="Rich Text"',
+				},
+			],
+			body: $(".wiki-write").get(0),
+		});
+		this.code_field_group.make();
+		$(".wiki-write .form-section:last").removeClass("empty-section");
+	}
+
+	get_attachment_controls_html() {
+		return `
+			<div class="attachment-controls">
+				<div class="show-attachments" tabindex="-1" data-trigger="focus">
+					${this.get_show_uploads_svg()}
+					<span class="number">0</span> attachments
+				</div>
+				<div class="add-attachment-wiki">
+					<span class="btn">
+						${this.get_upload_image_svg()}
+						Upload Attachment
+					</span>
+				</div>
+			</div>
+		`;
+	}
+
+	get_show_uploads_svg() {
+		return `<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path d="M12.6004 6.68841L7.6414 11.5616C6.23259 12.946 3.8658 12.946 2.45699 11.5616C1.04819 10.1772
+			1.04819 7.85132 2.45699 6.4669L6.85247 2.14749C7.86681 1.15071 9.44467 1.15071 10.459 2.14749C11.4733
+			3.14428 11.4733 4.69483 10.459 5.69162L6.40165 9.62339C5.83813 10.1772 4.93649 10.1772 4.42932 9.62339C3.8658
+			9.06962 3.8658 8.18359 4.42932 7.68519L7.81045 4.36257" stroke="#2D95F0" stroke-miterlimit="10" stroke-linecap="round"/>
+		</svg>`
+	}
+
+	get_upload_image_svg() {
+		return `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path d="M8 14.5C11.5899 14.5 14.5 11.5899 14.5 8C14.5 4.41015 11.5899 1.5 8 1.5C4.41015 1.5 1.5 4.41015 1.5 8C1.5 11.5899
+			 4.41015 14.5 8 14.5Z" stroke="#505A62" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+			<path d="M8 4.75V11.1351" stroke="#505A62" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+			<path d="M5.29102 7.45833L7.99935 4.75L10.7077 7.45833" stroke="#505A62" stroke-miterlimit="10" stroke-linecap="round"
+			stroke-linejoin="round"/>
+		</svg>`
+
+	}
+
+	add_attachment_popover() {
+		$(".show-attachments").popover({
+			placement: "bottom",
+			content: () => {
+				return this.build_attachment_table();
+			},
+			html: true,
+		});
+	}
+
+	build_attachment_table() {
+		var wrapper = $('<div class="wiki-attachment"></div>');
+		wrapper.empty();
+
+		var table = $(this.get_attachment_table_header_html()).appendTo(wrapper);
+		if (!this.attachments || !this.attachments.length)
+			return "No attachments uploaded";
+
+        const caption = file_url => file_url
+            .split("/").pop()                     // filename
+            .split(".").slice(0, -1).join(".")    // filename without extension
+            .replaceAll("_", " ")
+            .replaceAll("-", " ");
+
+		this.attachments.forEach((f) => {
+			const row = $("<tr></tr>").appendTo(table.find("tbody"));
+			$(`<td>${f.file_name}</td>`).appendTo(row);
+			$(`<td>
+			<a class="btn btn-default btn-xs btn-primary-light text-nowrap copy-link" data-link="![${caption(f.file_url)}](${f.file_url})" data-name = "${f.file_name}" >
+				Copy Link
+			</a>
+			</td>`).appendTo(row);
+			$(`<td>
+
+			<a class="btn btn-default btn-xs  center delete-button"  data-name = "${f.file_name}" >
+			<svg class="icon icon-sm"><use xlink:href="#icon-delete"></use></svg>
+
+			</a>
+			</td>`).appendTo(row);
+		});
+		return wrapper;
+	}
+
+	get_attachment_table_header_html() {
+		return `<table class="table  attachment-table" ">
+			<tbody></tbody>
+		</table>`;
+	}
+
+	set_code_editor_height() {
+		setTimeout(() => {
+			// expand_code_editor
+			const code_md = this.code_field_group.get_field("code_md");
+			code_md.expanded = !this.expanded;
+			code_md.refresh_height();
+			code_md.toggle_label();
+		}, 120);
+	}
+
+	raise_patch(draft = false) {
+		var side = {};
+
+		let name = $(".doc-sidebar .web-sidebar").get(0).dataset.name;
+		side[name] = [];
+		let items = $($(".doc-sidebar .web-sidebar").get(0))
+			.children(".sidebar-items")
+			.children("ul")
+			.not(".hidden")
+			.children("li");
+		items.each((item) => {
+			if (!items[item].dataset.name) return;
+			side[name].push({
+				name: items[item].dataset.name,
+				type: items[item].dataset.type,
+				new: items[item].dataset.new,
+				title: items[item].dataset.title,
+				group_name: items[item].dataset.groupName,
+			});
+		});
+
+		$('.doc-sidebar [data-type="Wiki Sidebar"]').each(function () {
+			let name = $(this).get(0).dataset.groupName;
+			side[name] = [];
+			let items = $(this).children("ul").children("li");
+			items.each((item) => {
+				if (!items[item].dataset.name) return;
+				side[name].push({
+					name: items[item].dataset.name,
+					type: items[item].dataset.type,
+					new: items[item].dataset.new,
+					title: items[item].dataset.title,
+					group_name: items[item].dataset.groupName,
+				});
+			});
+		});
+
+		var me = this;
+		var dfs = [];
+		const title_of_page = $('.edit-title span').text();
+		dfs.push(
+			{
+				fieldname: "edit_message",
+				fieldtype: "Text",
+				label: "Message",
+				default: $('[name="new"]').val()
+					? `Add new page: ${title_of_page}`
+					: `Edited ${title_of_page}`,
+				mandatory: 1,
+			},
+			{
+				fieldname: "sidebar_edited",
+				fieldtype: "Check",
+				label: "I updated the sidebar",
+				default: $('[name="new"]').val() ? 1 : 0,
+			}
+		);
+
+		let dialog = new frappe.ui.Dialog({
+			fields: dfs,
+			title: __("Please describe your changes"),
+			primary_action_label: __("Submit Changes"),
+			primary_action: function () {
+				frappe.call({
+					method: "wiki.wiki.doctype.wiki_page.wiki_page.update",
+					args: {
+						name: $('[name="wiki_page"]').val(),
+						wiki_page_patch: $('[name="wiki_page_patch"]').val(),
+						message: this.get_value("edit_message"),
+						sidebar_edited: this.get_value("sidebar_edited"),
+						content: me.content,
+						type: me.code_field_group.get_value("type"),
+						attachments: me.attachments,
+						new: $('[name="new"]').val(),
+						title: $('.edit-title span').text(),
+						new_sidebar: $(".doc-sidebar").get(0).innerHTML,
+						new_sidebar_items: side,
+						draft:draft ? draft : null
+					},
+					callback: (r) => {
+						if (!r.message.approved && r.message.route == 'contributions') {
+							frappe.msgprint({
+								message:
+									"A Change Request has been created. You can track your requests on the contributions page",
+								indicator: "green",
+								title: "Change Request Created",
+								alert: 1
+							});
+						}
+						else if (!r.message.approved && r.message.route == 'drafts') {
+							frappe.msgprint({
+								message:
+									"Draft Saved",
+								indicator: "green",
+								title: "Change Request Created",
+								alert: 1
+							});
+						}
+
+						// route back to the main page
+						window.location.href = '/' + r.message.route;
+					},
+					freeze: true,
+				});
+				dialog.hide();
+				$("#freeze").addClass("show");
+			},
+		});
+		dialog.show();
+	}
+
+	render_preview() {
+		$('a[data-toggle="tab"]').on("click", (e) => {
+			let activeTab = $(e.target);
+
+			if (
+				activeTab.prop("id") === "preview-tab" ||
+				activeTab.prop("id") === "diff-tab"
+			) {
+				let $preview = $(".wiki-preview");
+				let $diff = $(".wiki-diff");
+				const type = this.code_field_group.get_value("type");
+				let content = "";
+				if (type == "Markdown") {
+					content = this.code_field_group.get_value("code_md");
+				} else {
+					content = this.code_field_group.get_value("code_html");
+					var turndownService = new TurndownService();
+					turndownService = turndownService.keep(["div class", "iframe"]);
+					content = turndownService.turndown(content);
+				}
+				if (!content) {
+					this.set_empty_message($preview, $diff);
+					return;
+				}
+				this.set_loading_message($preview, $diff);
+
+				frappe.call({
+					method: "wiki.wiki.doctype.wiki_page.wiki_page.preview",
+					args: {
+						content: content,
+						type: type,
+						path: this.route,
+						name: $('[name="wiki_page"]').val(),
+						attachments: this.attachments,
+						new: $('[name="new"]').val(),
+					},
+					callback: (r) => {
+						if (r.message) {
+							$preview.html(r.message.html);
+							if (!$('[name="new"]').val()) {
+								const empty_diff = `<div class="text-muted center"> No Changes made</div>`
+								const diff_html = $(r.message.diff).find('.insert, .delete').length?r.message.diff:empty_diff
+								$diff.html(diff_html);
+							}
+						}
+					},
+				});
+			}
+		});
+	}
+
+	set_empty_message($preview, $diff) {
+		$preview.html("<div>Please add some code</div>");
+		$diff.html("<div>Please add some code</div>");
+	}
+
+	set_loading_message($preview, $diff) {
+		$preview.html("Loading preview...");
+		$diff.html("Loading diff...");
+	}
+
+	add_attachment_handler() {
+		var me = this;
+		$(".add-attachment-wiki").click(function () {
+			me.new_attachment();
+		});
+		$(".submit-wiki-page").click(function () {
+			me.get_markdown();
+		});
+
+		$(".draft-wiki-page").click(function () {
+			// setting draft as true
+			me.get_markdown(true);
+		});
+	}
+
+	new_attachment() {
+		if (this.dialog) {
+			// remove upload dialog
+			this.dialog.$wrapper.remove();
+		}
+
+		new frappe.ui.FileUploader({
+			folder: "Home/Attachments",
+			on_success: (file_doc) => {
+				if (!this.attachments) this.attachments = [];
+				if (!this.save_paths) this.save_paths = {};
+				this.attachments.push(file_doc);
+				$(".wiki-attachment").empty().append(this.build_attachment_table());
+				$(".attachment-controls").find(".number").text(this.attachments.length);
+			},
+		});
+	}
+
+	get_markdown(draft = false) {
+		var me = this;
+
+		if (me.code_field_group.get_value("type") == "Markdown") {
+			this.content = me.code_field_group.get_value("code_md");
+			this.raise_patch(draft);
+		} else {
+			this.content = this.code_field_group.get_value("code_html");
+
+			frappe.call({
+				method:
+					"wiki.wiki.doctype.wiki_page.wiki_page.extract_images_from_html",
+				args: {
+					content: this.content,
+				},
+				callback: (r) => {
+					if (r.message) {
+						me.content = r.message;
+						var turndownService = new TurndownService();
+						turndownService = turndownService.keep(["div class", "iframe"]);
+						me.content = turndownService.turndown(me.content);
+						me.raise_patch(draft);
+					}
+				},
+			});
+		}
+	}
+
+	set_listeners() {
+		var me = this;
+
+		$(`body`).on("click", `.copy-link`, function () {
+			frappe.utils.copy_to_clipboard($(this).attr("data-link"));
+		});
+
+		$(`body`).on("click", `.delete-button`, function () {
+			frappe.confirm(
+				`Are you sure you want to delete the file "${$(this).attr(
+					"data-name"
+				)}"`,
+				() => {
+					me.attachments.forEach((f, index, object) => {
+						if (f.file_name == $(this).attr("data-name")) {
+							object.splice(index, 1);
+						}
+					});
+					$(".wiki-attachment").empty().append(me.build_attachment_table());
+					$(".attachment-controls").find(".number").text(me.attachments.length);
+				}
+			);
+		});
+	}
+
+	create_comment_box() {
+		this.comment_box = frappe.ui.form.make_control({
+			parent: $(".comment-box"),
+			df: {
+				fieldname: "new_comment",
+				fieldtype: "Comment",
+			},
+			enable_mentions: false,
+			render_input: true,
+			only_input: true,
+			on_submit: (comment) => {
+				this.add_comment_to_patch(comment);
+			},
+		});
+	}
+
+	add_comment_to_patch(comment) {
+		if (strip_html(comment).trim() != "") {
+			this.comment_box.disable();
+
+			frappe.call({
+				method:
+					"wiki.wiki.doctype.wiki_page_patch.wiki_page_patch.add_comment_to_patch",
+				args: {
+					reference_name: $('[name="wiki_page_patch"]').val(),
+					content: comment,
+					comment_email: frappe.session.user,
+					comment_by: frappe.session.user_fullname,
+				},
+				callback: (r) => {
+					comment = r.message;
+
+					this.display_new_comment(comment, this.comment_box);
+				},
+				always: () => {
+					this.comment_box.enable();
+				},
+			});
+		}
+	}
+
+	display_new_comment(comment, comment_box) {
+		if (comment) {
+			comment_box.set_value("");
+
+			const new_comment = this.get_comment_html(
+				comment.owner,
+				comment.creation,
+				comment.timepassed,
+				comment.content
+			);
+
+			$(".timeline-items").prepend(new_comment);
+		}
+	}
+
+	get_comment_html(owner, creation, timepassed, content) {
+		return $(`
+			<div class="timeline-item">
+				<div class="timeline-badge">
+					<svg class="icon icon-md">
+						<use href="#icon-small-message"></use>
+					</svg>
+				</div>
+				<div class="timeline-content frappe-card">
+					<div class="timeline-message-box">
+						<span class="flex justify-between">
+							<span class="text-color flex">
+								<span>
+									${owner}
+									<span class="text-muted margin-left">
+										<span class="frappe-timestamp "
+											data-timestamp="${creation}"
+											title="${creation}">${timepassed}</span>
+									</span>
+								</span>
+							</span>
+						</span>
+						<div class="content">
+							${content}
+						</div>
+					</div>
+				</div>
+			</div>
+		`);
+	}
+
+	make_title_editable() {
+		const title_span = $(".edit-title>span");
+		const title_handle = $(".edit-title>i");
+		const title_input = $(".edit-title>input");
+		title_handle.click(() => {
+			title_span.addClass("hide");
+			title_handle.addClass("hide");
+			title_input.removeClass("hide");
+			title_input.val(title_span.text());
+			title_input.focus();
+		});
+		title_input.focusout(() => {
+			title_span.removeClass("hide");
+			title_handle.removeClass("hide");
+			title_input.addClass("hide");
+			title_span.text(title_input.val());
+		});
+		title_input.on('change', (e) => {
+			$(".doc-sidebar .sidebar-items a.active").text(title_input.val())
+		});
+	}
+
+	approve_wiki_page() {
+		frappe.call({
+			method: "wiki.wiki.doctype.wiki_page.wiki_page.approve",
+			args: {
+				wiki_page_patch: $('[name="wiki_page_patch"]').val(),
+			},
+			callback: () => {
+				frappe.msgprint({
+					message:
+						"The Change has been approved.",
+					indicator: "green",
+					title: "Approved",
+				});
+				window.location.href = '/' + $('[name="wiki_page"]').val();
+			},
+			freeze: true,
+		});
+
+	}
+
+	render_sidebar_diff() {
+		const lis = $(".sidebar-diff");
+		let $new_sidebar_items = $('[name="new_sidebar_items"]').val();
+		const sidebar_items = $new_sidebar_items && JSON.parse($new_sidebar_items);
+		lis.empty();
+		for (let sidebar in sidebar_items) {
+			for (let item in sidebar_items[sidebar]) {
+				let class_name = ("." + sidebar).replaceAll("/", "\\/");
+				let target = lis.find(class_name);
+				if (!target.length) {
+					target = $(".sidebar-diff");
+				}
+				if (sidebar_items[sidebar][item].type == "Wiki Sidebar") {
+					$(target).append(
+						"<li>" +
+							sidebar_items[sidebar][item].title +
+							"</li>" +
+							"<ul class=" +
+							sidebar_items[sidebar][item].group_name +
+							"></ul>"
+					);
+				} else {
+					$(target).append(
+						"<li class=" +
+							sidebar_items[sidebar][item].group_name +
+							">" +
+							sidebar_items[sidebar][item].title +
+							"</li>"
+					);
+				}
+			}
+		}
+	}
+};

--- a/one_fm/public/js/edit_asset_ar.js
+++ b/one_fm/public/js/edit_asset_ar.js
@@ -1,0 +1,556 @@
+window.EditAssetAr = class EditAssetAr {
+	constructor() {
+		this.make_code_field_group();
+		this.add_attachment_popover();
+		// remove this once the pr related to code editor max lines is merged
+		this.set_code_editor_height();
+		this.render_preview();
+		this.add_attachment_handler();
+		this.set_listeners();
+		this.create_comment_box();
+		this.make_title_editable();
+		this.render_sidebar_diff()
+	}
+
+	make_code_field_group() {
+		this.code_field_group = new frappe.ui.FieldGroup({
+			fields: [
+				{
+					fieldname: "type",
+					fieldtype: "Data",
+					default: "Rich Text",
+					options: "Rich Text",
+				},
+				{
+					fieldtype: "Section Break",
+				},
+				{
+					fieldname: "code_html",
+					fieldtype: "Text Editor",
+					default: $(".wiki-content-html").html(),
+					depends_on: 'eval:doc.type=="Rich Text"',
+				},
+			],
+			body: $(".wiki-write").get(0),
+		});
+		this.code_field_group.make();
+		$(".wiki-write .form-section:last").removeClass("empty-section");
+	}
+
+	get_attachment_controls_html() {
+		return `
+			<div class="attachment-controls">
+				<div class="show-attachments" tabindex="-1" data-trigger="focus">
+					${this.get_show_uploads_svg()}
+					<span class="number">0</span> المرفق
+				</div>
+				<div class="add-attachment-wiki">
+					<span class="btn">
+						${this.get_upload_image_svg()}
+						تحميل المرفق
+					</span>
+				</div>
+			</div>
+		`;
+	}
+
+	get_show_uploads_svg() {
+		return `<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path d="M12.6004 6.68841L7.6414 11.5616C6.23259 12.946 3.8658 12.946 2.45699 11.5616C1.04819 10.1772
+			1.04819 7.85132 2.45699 6.4669L6.85247 2.14749C7.86681 1.15071 9.44467 1.15071 10.459 2.14749C11.4733
+			3.14428 11.4733 4.69483 10.459 5.69162L6.40165 9.62339C5.83813 10.1772 4.93649 10.1772 4.42932 9.62339C3.8658
+			9.06962 3.8658 8.18359 4.42932 7.68519L7.81045 4.36257" stroke="#2D95F0" stroke-miterlimit="10" stroke-linecap="round"/>
+		</svg>`
+	}
+
+	get_upload_image_svg() {
+		return `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path d="M8 14.5C11.5899 14.5 14.5 11.5899 14.5 8C14.5 4.41015 11.5899 1.5 8 1.5C4.41015 1.5 1.5 4.41015 1.5 8C1.5 11.5899
+			 4.41015 14.5 8 14.5Z" stroke="#505A62" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+			<path d="M8 4.75V11.1351" stroke="#505A62" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+			<path d="M5.29102 7.45833L7.99935 4.75L10.7077 7.45833" stroke="#505A62" stroke-miterlimit="10" stroke-linecap="round"
+			stroke-linejoin="round"/>
+		</svg>`
+
+	}
+
+	add_attachment_popover() {
+		$(".show-attachments").popover({
+			placement: "bottom",
+			content: () => {
+				return this.build_attachment_table();
+			},
+			html: true,
+		});
+	}
+
+	build_attachment_table() {
+		var wrapper = $('<div class="wiki-attachment"></div>');
+		wrapper.empty();
+
+		var table = $(this.get_attachment_table_header_html()).appendTo(wrapper);
+		if (!this.attachments || !this.attachments.length)
+			return "No attachments uploaded";
+
+        const caption = file_url => file_url
+            .split("/").pop()                     // filename
+            .split(".").slice(0, -1).join(".")    // filename without extension
+            .replaceAll("_", " ")
+            .replaceAll("-", " ");
+
+		this.attachments.forEach((f) => {
+			const row = $("<tr></tr>").appendTo(table.find("tbody"));
+			$(`<td>${f.file_name}</td>`).appendTo(row);
+			$(`<td>
+			<a class="btn btn-default btn-xs btn-primary-light text-nowrap copy-link" data-link="![${caption(f.file_url)}](${f.file_url})" data-name = "${f.file_name}" >
+				Copy Link
+			</a>
+			</td>`).appendTo(row);
+			$(`<td>
+
+			<a class="btn btn-default btn-xs  center delete-button"  data-name = "${f.file_name}" >
+			<svg class="icon icon-sm"><use xlink:href="#icon-delete"></use></svg>
+
+			</a>
+			</td>`).appendTo(row);
+		});
+		return wrapper;
+	}
+
+	get_attachment_table_header_html() {
+		return `<table class="table  attachment-table" ">
+			<tbody></tbody>
+		</table>`;
+	}
+
+	set_code_editor_height() {
+		setTimeout(() => {
+			// expand_code_editor
+			const code_md = this.code_field_group.get_field("code_md");
+			code_md.expanded = !this.expanded;
+			code_md.refresh_height();
+			code_md.toggle_label();
+		}, 120);
+	}
+
+	raise_patch(draft = false) {
+		var side = {};
+
+		let name = $(".doc-sidebar .web-sidebar").get(0).dataset.name;
+		side[name] = [];
+		let items = $($(".doc-sidebar .web-sidebar").get(0))
+			.children(".sidebar-items")
+			.children("ul")
+			.not(".hidden")
+			.children("li");
+		items.each((item) => {
+			if (!items[item].dataset.name) return;
+			side[name].push({
+				name: items[item].dataset.name,
+				type: items[item].dataset.type,
+				new: items[item].dataset.new,
+				title: items[item].dataset.title,
+				group_name: items[item].dataset.groupName,
+			});
+		});
+
+		$('.doc-sidebar [data-type="Wiki Sidebar"]').each(function () {
+			let name = $(this).get(0).dataset.groupName;
+			side[name] = [];
+			let items = $(this).children("ul").children("li");
+			items.each((item) => {
+				if (!items[item].dataset.name) return;
+				side[name].push({
+					name: items[item].dataset.name,
+					type: items[item].dataset.type,
+					new: items[item].dataset.new,
+					title: items[item].dataset.title,
+					group_name: items[item].dataset.groupName,
+				});
+			});
+		});
+
+		var me = this;
+		var dfs = [];
+		const title_of_page = $('.edit-title span').text();
+		dfs.push(
+			{
+				fieldname: "edit_message",
+				fieldtype: "Text",
+				label: "Message",
+				default: $('[name="new"]').val()
+					? `Add new page: ${title_of_page}`
+					: `${title_of_page} تم تحريره`,
+				mandatory: 1,
+			},
+			{
+				fieldname: "sidebar_edited",
+				fieldtype: "Check",
+				label: "لقد قمت بتحديث الشريط الجانبي",
+				default: $('[name="new"]').val() ? 1 : 0,
+			}
+		);
+
+		let dialog = new frappe.ui.Dialog({
+			fields: dfs,
+			title: __("رجى وصف التغييرات الخاصة بك"),
+			primary_action_label: __("أرسل التغييرات"),
+			primary_action: function () {
+				frappe.call({
+					method: "wiki.wiki.doctype.wiki_page.wiki_page.update",
+					args: {
+						name: $('[name="wiki_page"]').val(),
+						wiki_page_patch: $('[name="wiki_page_patch"]').val(),
+						message: this.get_value("edit_message"),
+						sidebar_edited: this.get_value("sidebar_edited"),
+						content: me.content,
+						type: me.code_field_group.get_value("type"),
+						attachments: me.attachments,
+						new: $('[name="new"]').val(),
+						title: $('.edit-title span').text(),
+						new_sidebar: $(".doc-sidebar").get(0).innerHTML,
+						new_sidebar_items: side,
+						draft:draft ? draft : null
+					},
+					callback: (r) => {
+						if (!r.message.approved && r.message.route == 'contributions') {
+							frappe.msgprint({
+								message:
+									"تم إنشاء طلب تغيير. يمكنك تتبع طلباتك على صفحة المساهمات",
+								indicator: "green",
+								title: "تم إنشاء طلب التغيير",
+								alert: 1
+							});
+						}
+						else if (!r.message.approved && r.message.route == 'drafts') {
+							frappe.msgprint({
+								message:
+									"تم حفظ المسودة",
+								indicator: "green",
+								title: "تم إنشاء طلب التغيير",
+								alert: 1
+							});
+						}
+
+						// route back to the main page
+						window.location.href = '/' + r.message.route;
+					},
+					freeze: true,
+				});
+				dialog.hide();
+				$("#freeze").addClass("show");
+			},
+		});
+		dialog.show();
+	}
+
+	render_preview() {
+		$('a[data-toggle="tab"]').on("click", (e) => {
+			let activeTab = $(e.target);
+
+			if (
+				activeTab.prop("id") === "preview-tab" ||
+				activeTab.prop("id") === "diff-tab"
+			) {
+				let $preview = $(".wiki-preview");
+				let $diff = $(".wiki-diff");
+				const type = this.code_field_group.get_value("type");
+				let content = "";
+				if (type == "Markdown") {
+					content = this.code_field_group.get_value("code_md");
+				} else {
+					content = this.code_field_group.get_value("code_html");
+					var turndownService = new TurndownService();
+					turndownService = turndownService.keep(["div class", "iframe"]);
+					content = turndownService.turndown(content);
+				}
+				if (!content) {
+					this.set_empty_message($preview, $diff);
+					return;
+				}
+				this.set_loading_message($preview, $diff);
+
+				frappe.call({
+					method: "wiki.wiki.doctype.wiki_page.wiki_page.preview",
+					args: {
+						content: content,
+						type: type,
+						path: this.route,
+						name: $('[name="wiki_page"]').val(),
+						attachments: this.attachments,
+						new: $('[name="new"]').val(),
+					},
+					callback: (r) => {
+						if (r.message) {
+							$preview.html(r.message.html);
+							if (!$('[name="new"]').val()) {
+								const empty_diff = `<div class="text-muted center"> لم يتم إجراء أي تغييرات</div>`
+								const diff_html = $(r.message.diff).find('.insert, .delete').length?r.message.diff:empty_diff
+								$diff.html(diff_html);
+							}
+						}
+					},
+				});
+			}
+		});
+	}
+
+	set_empty_message($preview, $diff) {
+		$preview.html("<div>الرجاء إضافة بعض الكو</div>");
+		$diff.html("<div>الرجاء إضافة بعض الكو</div>");
+	}
+
+	set_loading_message($preview, $diff) {
+		$preview.html("...معاينة التحميل");
+		$diff.html("...فرق التحميل");
+	}
+
+	add_attachment_handler() {
+		var me = this;
+		$(".add-attachment-wiki").click(function () {
+			me.new_attachment();
+		});
+		$(".submit-wiki-page").click(function () {
+			me.get_markdown();
+		});
+
+		$(".draft-wiki-page").click(function () {
+			// setting draft as true
+			me.get_markdown(true);
+		});
+	}
+
+	new_attachment() {
+		if (this.dialog) {
+			// remove upload dialog
+			this.dialog.$wrapper.remove();
+		}
+
+		new frappe.ui.FileUploader({
+			folder: "Home/Attachments",
+			on_success: (file_doc) => {
+				if (!this.attachments) this.attachments = [];
+				if (!this.save_paths) this.save_paths = {};
+				this.attachments.push(file_doc);
+				$(".wiki-attachment").empty().append(this.build_attachment_table());
+				$(".attachment-controls").find(".number").text(this.attachments.length);
+			},
+		});
+	}
+
+	get_markdown(draft = false) {
+		var me = this;
+
+		if (me.code_field_group.get_value("type") == "Markdown") {
+			this.content = me.code_field_group.get_value("code_md");
+			this.raise_patch(draft);
+		} else {
+			this.content = this.code_field_group.get_value("code_html");
+
+			frappe.call({
+				method:
+					"wiki.wiki.doctype.wiki_page.wiki_page.extract_images_from_html",
+				args: {
+					content: this.content,
+				},
+				callback: (r) => {
+					if (r.message) {
+						me.content = r.message;
+						var turndownService = new TurndownService();
+						turndownService = turndownService.keep(["div class", "iframe"]);
+						me.content = turndownService.turndown(me.content);
+						me.raise_patch(draft);
+					}
+				},
+			});
+		}
+	}
+
+	set_listeners() {
+		var me = this;
+
+		$(`body`).on("click", `.copy-link`, function () {
+			frappe.utils.copy_to_clipboard($(this).attr("data-link"));
+		});
+
+		$(`body`).on("click", `.delete-button`, function () {
+			frappe.confirm(
+				`هل أنت متأكد أنك تريد حذف الملف "${$(this).attr(
+					"data-name"
+				)}"`,
+				() => {
+					me.attachments.forEach((f, index, object) => {
+						if (f.file_name == $(this).attr("data-name")) {
+							object.splice(index, 1);
+						}
+					});
+					$(".wiki-attachment").empty().append(me.build_attachment_table());
+					$(".attachment-controls").find(".number").text(me.attachments.length);
+				}
+			);
+		});
+	}
+
+	create_comment_box() {
+		this.comment_box = frappe.ui.form.make_control({
+			parent: $(".comment-box"),
+			df: {
+				fieldname: "new_comment",
+				fieldtype: "Comment",
+			},
+			enable_mentions: false,
+			render_input: true,
+			only_input: true,
+			on_submit: (comment) => {
+				this.add_comment_to_patch(comment);
+			},
+		});
+	}
+
+	add_comment_to_patch(comment) {
+		if (strip_html(comment).trim() != "") {
+			this.comment_box.disable();
+
+			frappe.call({
+				method:
+					"wiki.wiki.doctype.wiki_page_patch.wiki_page_patch.add_comment_to_patch",
+				args: {
+					reference_name: $('[name="wiki_page_patch"]').val(),
+					content: comment,
+					comment_email: frappe.session.user,
+					comment_by: frappe.session.user_fullname,
+				},
+				callback: (r) => {
+					comment = r.message;
+
+					this.display_new_comment(comment, this.comment_box);
+				},
+				always: () => {
+					this.comment_box.enable();
+				},
+			});
+		}
+	}
+
+	display_new_comment(comment, comment_box) {
+		if (comment) {
+			comment_box.set_value("");
+
+			const new_comment = this.get_comment_html(
+				comment.owner,
+				comment.creation,
+				comment.timepassed,
+				comment.content
+			);
+
+			$(".timeline-items").prepend(new_comment);
+		}
+	}
+
+	get_comment_html(owner, creation, timepassed, content) {
+		return $(`
+			<div class="timeline-item">
+				<div class="timeline-badge">
+					<svg class="icon icon-md">
+						<use href="#icon-small-message"></use>
+					</svg>
+				</div>
+				<div class="timeline-content frappe-card">
+					<div class="timeline-message-box">
+						<span class="flex justify-between">
+							<span class="text-color flex">
+								<span>
+									${owner}
+									<span class="text-muted margin-left">
+										<span class="frappe-timestamp "
+											data-timestamp="${creation}"
+											title="${creation}">${timepassed}</span>
+									</span>
+								</span>
+							</span>
+						</span>
+						<div class="content">
+							${content}
+						</div>
+					</div>
+				</div>
+			</div>
+		`);
+	}
+
+	make_title_editable() {
+		const title_span = $(".edit-title>span");
+		const title_handle = $(".edit-title>i");
+		const title_input = $(".edit-title>input");
+		title_handle.click(() => {
+			title_span.addClass("hide");
+			title_handle.addClass("hide");
+			title_input.removeClass("hide");
+			title_input.val(title_span.text());
+			title_input.focus();
+		});
+		title_input.focusout(() => {
+			title_span.removeClass("hide");
+			title_handle.removeClass("hide");
+			title_input.addClass("hide");
+			title_span.text(title_input.val());
+		});
+		title_input.on('change', (e) => {
+			$(".doc-sidebar .sidebar-items a.active").text(title_input.val())
+		});
+	}
+
+	approve_wiki_page() {
+		frappe.call({
+			method: "wiki.wiki.doctype.wiki_page.wiki_page.approve",
+			args: {
+				wiki_page_patch: $('[name="wiki_page_patch"]').val(),
+			},
+			callback: () => {
+				frappe.msgprint({
+					message:
+						"The Change has been approved.",
+					indicator: "green",
+					title: "Approved",
+				});
+				window.location.href = '/' + $('[name="wiki_page"]').val();
+			},
+			freeze: true,
+		});
+
+	}
+
+	render_sidebar_diff() {
+		const lis = $(".sidebar-diff");
+		let $new_sidebar_items = $('[name="new_sidebar_items"]').val();
+		const sidebar_items = $new_sidebar_items && JSON.parse($new_sidebar_items);
+		lis.empty();
+		for (let sidebar in sidebar_items) {
+			for (let item in sidebar_items[sidebar]) {
+				let class_name = ("." + sidebar).replaceAll("/", "\\/");
+				let target = lis.find(class_name);
+				if (!target.length) {
+					target = $(".sidebar-diff");
+				}
+				if (sidebar_items[sidebar][item].type == "Wiki Sidebar") {
+					$(target).append(
+						"<li>" +
+							sidebar_items[sidebar][item].title +
+							"</li>" +
+							"<ul class=" +
+							sidebar_items[sidebar][item].group_name +
+							"></ul>"
+					);
+				} else {
+					$(target).append(
+						"<li class=" +
+							sidebar_items[sidebar][item].group_name +
+							">" +
+							sidebar_items[sidebar][item].title +
+							"</li>"
+					);
+				}
+			}
+		}
+	}
+};

--- a/one_fm/public/js/edit_wiki.js
+++ b/one_fm/public/js/edit_wiki.js
@@ -1,0 +1,224 @@
+window.EditWiki = class EditWiki extends Wiki {
+	constructor() {
+		super();
+		frappe.provide("frappe.ui.keys");
+		$("document").ready(() => {
+			frappe
+				.call("wiki.wiki.doctype.wiki_page.wiki_page.get_sidebar_for_page", {
+					wiki_page: $('[name="wiki_page"]').val(),
+				})
+				.then((result) => {
+					$(".doc-sidebar").empty().append(result.message);
+					this.activate_sidebars();
+					this.set_active_sidebar();
+					this.set_empty_ul();
+					this.set_sortable();
+					this.set_add_item();
+					this.scrolltotop()
+				});
+		});
+	}
+
+	activate_sidebars() {
+		$(".sidebar-item").each(function (index) {
+			const active_class = "active";
+			let page_href = window.location.pathname;
+			if (page_href.indexOf("#") !== -1) {
+				page_href = page_href.slice(0, page_href.indexOf("#"));
+			}
+			if (page_href.split('/').slice(0,-1).join('/')== $(this).data("route")) {
+
+				if ($('[name="new"]').first().val()) {
+					$(`
+					<li class="sidebar-item active" data-type="Wiki Page" data-name="new-wiki-page" data-new=1>
+						<div><div>
+							<a href="#"  class ='active'>New Wiki Page</a>
+						</div></div>
+					</li>
+				`).insertAfter($(this));
+				} else {
+					$(this).addClass(active_class);
+					$(this).find("a").addClass(active_class);
+				}
+			}
+		});
+		// scroll the active sidebar item into view
+		let active_sidebar_item = $(".sidebar-item.active");
+		if (active_sidebar_item.length > 0) {
+			active_sidebar_item.get(0).scrollIntoView(true, {
+				behavior: "smooth",
+				block: "nearest",
+			});
+		}
+	}
+
+	set_empty_ul() {
+		$(".collapsible").each(function () {
+			if ($(this).parent().find("ul").length == 0) {
+				$(this)
+					.parent()
+					.append(
+						$(`<ul class="list-unstyled hidden" style="min-height:20px;"> </ul`)
+					);
+			}
+		});
+	}
+
+	set_sortable() {
+		$(".web-sidebar ul").each(function () {
+			new Sortable(this, {
+				group: {
+					name: "qux",
+					put: ["qux"],
+					pull: ["qux"],
+				},
+			});
+		});
+	}
+
+	set_add_item() {
+		$(`<div class="text-muted add-sidebar-item small">+ Add Item</div>
+			<div class="text-muted small mt-3"><i>Drag items to re-order</i></div>`).appendTo(
+			$(".web-sidebar")
+		);
+		var me = this;
+		$(".add-sidebar-item").click(function () {
+			var dfs = me.get_add_new_item_dialog_fields();
+
+			var dialog = new frappe.ui.Dialog({
+				title: "Add to sidebar",
+				fields: dfs,
+				primary_action: function (fields) {
+					if (fields.type == "Add Wiki Page") {
+						me.add_wiki_page(fields);
+					} else {
+						me.add_wiki_sidebar(fields);
+					}
+					dialog.hide();
+				},
+			});
+			dialog.show();
+		});
+	}
+
+	get_add_new_item_dialog_fields() {
+		return [
+			{
+				fieldname: "type",
+				label: "Do you want to add a page or group?",
+				fieldtype: "Select",
+				options: ["Page", "Group"],
+			},
+			{
+				fieldname: "wiki_page",
+				label: "Wiki Page",
+				fieldtype: "Link",
+				options: "Wiki Page",
+				depends_on: "eval: doc.type=='Page'",
+				mandatory_depends_on: "eval: doc.type=='Page'",
+			},
+			{
+				fieldname: "route",
+				label: "Route",
+				fieldtype: "Data",
+				depends_on: "eval: doc.type=='Group'",
+				mandatory_depends_on: "eval: doc.type=='Group'",
+			},
+			{
+				fieldname: "title",
+				label: "Title",
+				fieldtype: "Data",
+				depends_on: "eval: doc.type=='Group'",
+				mandatory_depends_on: "eval: doc.type=='Group'",
+			},
+		];
+	}
+
+	add_wiki_page(fields) {
+		var me = this;
+		frappe.call({
+			method: "frappe.client.get_value",
+			args: {
+				doctype: "Wiki Page",
+				fieldname: "title",
+				filters: fields.wiki_page,
+			},
+			callback: function (r) {
+				let $new_page = me.get_new_page_html(r, fields);
+
+				$new_page.appendTo(
+					$(".doc-sidebar .sidebar-items")
+						.children(".list-unstyled")
+						.not(".hidden")
+						.first()
+				);
+			},
+		});
+	}
+
+	get_new_page_html(r, fields) {
+		return $(`
+		<li class="sidebar-item" data-type="Wiki Page"
+			data-name="${fields.wiki_page}" data-new=1 >
+			<div>
+				<div>
+					<a href="#" class="green" >
+							${r.message.title}
+					</a>
+				</div>
+			</div>
+		</li>
+		`);
+	}
+
+	add_wiki_sidebar(fields) {
+		let $new_page = this.get_wiki_sidebar_html(fields);
+
+		$new_page.appendTo(
+			$(".doc-sidebar .sidebar-items")
+				.children(".list-unstyled")
+				.not(".hidden")
+				.first()
+		);
+
+		$(".web-sidebar ul").each(function () {
+			new Sortable(this, {
+				group: {
+					name: "qux",
+					put: ["qux"],
+					pull: ["qux"],
+				},
+			});
+		});
+	}
+
+	get_wiki_sidebar_html(fields) {
+		return $(`
+			<li class="sidebar-group" data-type="Wiki Sidebar"
+				data-name="new-sidebar" data-group-name="${fields.route}"
+				data-new=1 data-title="${fields.title}" draggable="false">
+
+				<div class="collapsible">
+					<span class="drop-icon hidden">
+							<svg width="24" height="24" viewBox="0 0 24 24" fill="none"
+								xmlns="http://www.w3.org/2000/svg">
+								<path d="M8 10L12 14L16 10" stroke="#4C5A67"
+								stroke-miterlimit="10" stroke-linecap="round"
+								stroke-linejoin="round"></path>
+							</svg>
+					</span>
+
+					<span class="drop-left">
+							<svg width="24" height="24" viewBox="0 0 24 24"
+								fill="none" xmlns="http://www.w3.org/2000/svg">
+								<path d="M10 16L14 12L10 8" stroke="#4C5A67"
+								stroke-linecap="round" stroke-linejoin="round"></path>
+							</svg>
+					</span>
+					<span class="h6">${fields.title}</span>
+					</div>
+					<ul class="list-unstyled hidden" style="min-height:20px;"> </ul>
+			</li>
+			`);
+	}
+};

--- a/one_fm/public/js/edit_wiki_ar.js
+++ b/one_fm/public/js/edit_wiki_ar.js
@@ -1,0 +1,224 @@
+window.EditWikiAr = class EditWikiAr extends Wiki {
+	constructor() {
+		super();
+		frappe.provide("frappe.ui.keys");
+		$("document").ready(() => {
+			frappe
+				.call("wiki.wiki.doctype.wiki_page.wiki_page.get_sidebar_for_page", {
+					wiki_page: $('[name="wiki_page"]').val(),
+				})
+				.then((result) => {
+					$(".doc-sidebar").empty().append(result.message);
+					this.activate_sidebars();
+					this.set_active_sidebar();
+					this.set_empty_ul();
+					this.set_sortable();
+					this.set_add_item();
+					this.scrolltotop()
+				});
+		});
+	}
+
+	activate_sidebars() {
+		$(".sidebar-item").each(function (index) {
+			const active_class = "active";
+			let page_href = window.location.pathname;
+			if (page_href.indexOf("#") !== -1) {
+				page_href = page_href.slice(0, page_href.indexOf("#"));
+			}
+			if (page_href.split('/').slice(0,-1).join('/')== $(this).data("route")) {
+
+				if ($('[name="new"]').first().val()) {
+					$(`
+					<li class="sidebar-item active" data-type="Wiki Page" data-name="new-wiki-page" data-new=1>
+						<div><div>
+							<a href="#"  class ='active'>صفحة ويكي جديدة</a>
+						</div></div>
+					</li>
+				`).insertAfter($(this));
+				} else {
+					$(this).addClass(active_class);
+					$(this).find("a").addClass(active_class);
+				}
+			}
+		});
+		// scroll the active sidebar item into view
+		let active_sidebar_item = $(".sidebar-item.active");
+		if (active_sidebar_item.length > 0) {
+			active_sidebar_item.get(0).scrollIntoView(true, {
+				behavior: "smooth",
+				block: "nearest",
+			});
+		}
+	}
+
+	set_empty_ul() {
+		$(".collapsible").each(function () {
+			if ($(this).parent().find("ul").length == 0) {
+				$(this)
+					.parent()
+					.append(
+						$(`<ul class="list-unstyled hidden" style="min-height:20px;"> </ul`)
+					);
+			}
+		});
+	}
+
+	set_sortable() {
+		$(".web-sidebar ul").each(function () {
+			new Sortable(this, {
+				group: {
+					name: "qux",
+					put: ["qux"],
+					pull: ["qux"],
+				},
+			});
+		});
+	}
+
+	set_add_item() {
+		$(`<div class="text-muted add-sidebar-item small">+ اضافة عنصر </div>
+			<div class="text-muted small mt-3"><i>اسحب العناصر لإعادة ترتيبها </i></div>`).appendTo(
+			$(".web-sidebar")
+		);
+		var me = this;
+		$(".add-sidebar-item").click(function () {
+			var dfs = me.get_add_new_item_dialog_fields();
+
+			var dialog = new frappe.ui.Dialog({
+				title: "Add to sidebar",
+				fields: dfs,
+				primary_action: function (fields) {
+					if (fields.type == "Add Wiki Page") {
+						me.add_wiki_page(fields);
+					} else {
+						me.add_wiki_sidebar(fields);
+					}
+					dialog.hide();
+				},
+			});
+			dialog.show();
+		});
+	}
+
+	get_add_new_item_dialog_fields() {
+		return [
+			{
+				fieldname: "type",
+				label: "Do you want to add a page or group?",
+				fieldtype: "Select",
+				options: ["Page", "Group"],
+			},
+			{
+				fieldname: "wiki_page",
+				label: "Wiki Page",
+				fieldtype: "Link",
+				options: "Wiki Page",
+				depends_on: "eval: doc.type=='Page'",
+				mandatory_depends_on: "eval: doc.type=='Page'",
+			},
+			{
+				fieldname: "route",
+				label: "Route",
+				fieldtype: "Data",
+				depends_on: "eval: doc.type=='Group'",
+				mandatory_depends_on: "eval: doc.type=='Group'",
+			},
+			{
+				fieldname: "title",
+				label: "Title",
+				fieldtype: "Data",
+				depends_on: "eval: doc.type=='Group'",
+				mandatory_depends_on: "eval: doc.type=='Group'",
+			},
+		];
+	}
+
+	add_wiki_page(fields) {
+		var me = this;
+		frappe.call({
+			method: "frappe.client.get_value",
+			args: {
+				doctype: "Wiki Page",
+				fieldname: "title",
+				filters: fields.wiki_page,
+			},
+			callback: function (r) {
+				let $new_page = me.get_new_page_html(r, fields);
+
+				$new_page.appendTo(
+					$(".doc-sidebar .sidebar-items")
+						.children(".list-unstyled")
+						.not(".hidden")
+						.first()
+				);
+			},
+		});
+	}
+
+	get_new_page_html(r, fields) {
+		return $(`
+		<li class="sidebar-item" data-type="Wiki Page"
+			data-name="${fields.wiki_page}" data-new=1 >
+			<div>
+				<div>
+					<a href="#" class="green" >
+							${r.message.title}
+					</a>
+				</div>
+			</div>
+		</li>
+		`);
+	}
+
+	add_wiki_sidebar(fields) {
+		let $new_page = this.get_wiki_sidebar_html(fields);
+
+		$new_page.appendTo(
+			$(".doc-sidebar .sidebar-items")
+				.children(".list-unstyled")
+				.not(".hidden")
+				.first()
+		);
+
+		$(".web-sidebar ul").each(function () {
+			new Sortable(this, {
+				group: {
+					name: "qux",
+					put: ["qux"],
+					pull: ["qux"],
+				},
+			});
+		});
+	}
+
+	get_wiki_sidebar_html(fields) {
+		return $(`
+			<li class="sidebar-group" data-type="Wiki Sidebar"
+				data-name="new-sidebar" data-group-name="${fields.route}"
+				data-new=1 data-title="${fields.title}" draggable="false">
+
+				<div class="collapsible">
+					<span class="drop-icon hidden">
+							<svg width="24" height="24" viewBox="0 0 24 24" fill="none"
+								xmlns="http://www.w3.org/2000/svg">
+								<path d="M8 10L12 14L16 10" stroke="#4C5A67"
+								stroke-miterlimit="10" stroke-linecap="round"
+								stroke-linejoin="round"></path>
+							</svg>
+					</span>
+
+					<span class="drop-left">
+							<svg width="24" height="24" viewBox="0 0 24 24"
+								fill="none" xmlns="http://www.w3.org/2000/svg">
+								<path d="M10 16L14 12L10 8" stroke="#4C5A67"
+								stroke-linecap="round" stroke-linejoin="round"></path>
+							</svg>
+					</span>
+					<span class="h6">${fields.title}</span>
+					</div>
+					<ul class="list-unstyled hidden" style="min-height:20px;"> </ul>
+			</li>
+			`);
+	}
+};

--- a/one_fm/public/js/render_wiki.js
+++ b/one_fm/public/js/render_wiki.js
@@ -1,0 +1,91 @@
+window.RenderWiki = class RenderWiki extends Wiki {
+	constructor(opts) {
+		super();
+		$("document").ready(() => {
+			if (
+				window.location.pathname != "/revisions" &&
+				window.location.pathname != "/compare"
+			) {
+				this.activate_sidebars();
+				this.set_active_sidebar();
+				this.set_nav_buttons();
+				this.set_toc_highlighter();
+				this.scrolltotop()
+			}
+		});
+	}
+
+	set_toc_highlighter() {
+		$(document).ready(function () {
+			$(window).scroll(function () {
+				if (currentAnchor().not('.no-underline').hasClass("active")) return
+				$(".page-toc a").removeClass("active");
+				currentAnchor().addClass("active");
+			});
+		});
+
+		function tocItem(anchor) {
+			return $('[href="' + anchor + '"]');
+		}
+
+		function heading(anchor) {
+			return $("[id=" + anchor.substr(1) + "]");
+		}
+
+		var _anchors = null;
+		function anchors() {
+			if (!_anchors) {
+				_anchors = $(".page-toc a").map(function () {
+					return $(this).attr("href");
+				});
+			}
+			return _anchors;
+		}
+
+		function currentAnchor() {
+			var winY = window.pageYOffset;
+			var currAnchor = null;
+			anchors().each(function () {
+				var y = heading(this).position().top;
+				if (y < winY + window.innerHeight * 0.23) {
+					currAnchor = this;
+					return;
+				}
+			});
+			return tocItem(currAnchor);
+		}
+	}
+
+	set_nav_buttons() {
+		var current_index = -1;
+
+		$(".sidebar-column")
+			.find("a")
+			.each(function (index) {
+				if ($(this).attr("class")) {
+					let dish = $(this).attr("class").split(/\s+/)[0];
+					if (dish === "active") {
+						current_index = index;
+					}
+				}
+			});
+
+		if (current_index > 0) {
+			$(".btn.left")[0].href =
+				$(".sidebar-column").find("a")[current_index - 1].href;
+			$(".btn.left")[0].innerHTML =
+				"←" + $(".sidebar-column").find("a")[current_index - 1].innerHTML;
+		} else {
+			$(".btn.left").hide();
+		}
+
+		if (current_index >= 0 && current_index < $(".sidebar-column").find("a").length - 1) {
+			$(".btn.right")[0].href =
+				$(".sidebar-column").find("a")[current_index + 1].href;
+			$(".btn.right")[0].innerHTML =
+				$(".sidebar-column").find("a")[current_index + 1].innerHTML + "→";
+		} else {
+			$(".btn.right").hide();
+		}
+	}
+};

--- a/one_fm/public/js/wiki.js
+++ b/one_fm/public/js/wiki.js
@@ -1,0 +1,55 @@
+window.Wiki = class Wiki {
+	activate_sidebars() {
+		$(".sidebar-item").each(function (index) {
+			const active_class = "active";
+			let page_href = window.location.pathname;
+			if (page_href.indexOf("#") !== -1) {
+				page_href = page_href.slice(0, page_href.indexOf("#"));
+			}
+			if ($(this).data("route") == page_href) {
+				$(this).addClass(active_class);
+				$(this).find("a").addClass(active_class);
+			}
+		});
+		// scroll the active sidebar item into view
+		let active_sidebar_item = $(".sidebar-item.active");
+		if (active_sidebar_item.length > 0) {
+			active_sidebar_item.get(1).scrollIntoView(true, {
+				behavior: "smooth",
+				block: "nearest",
+			});
+		}
+	}
+
+	toggle_sidebar(event) {
+		$(event.currentTarget).parent().children("ul").toggleClass("hidden");
+		$(event.currentTarget).find(".drop-icon").toggleClass("hidden");
+		$(event.currentTarget).find(".drop-left").toggleClass("hidden");
+		event.stopPropagation();
+	}
+
+	set_active_sidebar() {
+		$(".doc-sidebar,.web-sidebar").on(
+			"click",
+			".collapsible",
+			this.toggle_sidebar
+		);
+		$(".sidebar-group").children("ul").addClass("hidden");
+		$(".sidebar-item.active")
+			.parents(" .web-sidebar .sidebar-group>ul")
+			.removeClass("hidden");
+		const sidebar_groups = $(".sidebar-item.active").parents(
+			".web-sidebar .sidebar-group"
+		);
+		sidebar_groups.each(function () {
+			$(this).children(".collapsible").find(".drop-left").addClass("hidden");
+		});
+		sidebar_groups.each(function () {
+			$(this).children(".collapsible").find(".drop-icon").removeClass("hidden");
+		});
+	}
+
+	scrolltotop() {
+		$('html,body').animate({scrollTop:0},0);
+	}
+};

--- a/one_fm/public/js/wiki_override.bundle.js
+++ b/one_fm/public/js/wiki_override.bundle.js
@@ -1,0 +1,6 @@
+import './edit_asset'
+import './wiki'
+import './edit_wiki'
+import './render_wiki'
+import './edit_wiki_ar'
+import './edit_asset_ar'

--- a/one_fm/templates/wiki_page/templates/edit.html
+++ b/one_fm/templates/wiki_page/templates/edit.html
@@ -1,0 +1,165 @@
+<div class='edit-page-head'>
+
+	<div class='edit-title'>
+		<span class="h3" >{{ doc.title }}</span>
+		<i>
+			<svg class="icon icon-lg">
+				<use href="#icon-edit"></use>
+			</svg>
+ 		</i>
+		<input type="text" class="hide">
+	</div>
+	
+	
+	<div class='btn btn-primary-light mr-3 draft-wiki-page'>{% if "ar" in lang%} مسودة التغييرات {% else %} Draft Changes{%- endif -%}</div>
+	<div class='btn btn-primary submit-wiki-page'>{% if "ar" in lang%} أرسل التغييرات {% else %} Draft Changes{%- endif -%}</div>
+</div>
+<form class="mt-8 edit-form" method="POST">
+	<input class="d-none" type="text" name="csrf_token" value="{{ frappe.session.csrf_token }}">
+	<input class="d-none" type="text" name="wiki_page" value="{{ doc.name }}">
+	<input class="d-none" type="text" name="wiki_page_patch" value="{{ wiki_page_patch or ''}}">
+	<input class="d-none" type="text" name="new_sidebar_items" value='{{ new_sidebar_items or ""}}'>
+	<input class="d-none" type="text" name="new" value="{{ frappe.form_dict.new or ''}}">
+
+	<div class="form-group">
+
+		<ul class="nav nav-tabs" role="tablist">
+
+			<li class="nav-item" role="presentation">
+				<a {% if not wiki_page_patch %} class="nav-link active" {% else %} class="nav-link" {% endif %}
+					id="write-tab" data-toggle="tab" href="#write" role="tab" aria-controls="write"
+					aria-selected="true">{% if "ar" in lang%} يكتب {% else %} Write {%- endif -%}</a>
+			</li>
+
+			<li class="nav-item" role="presentation">
+				<a class="nav-link" id="preview-tab" data-toggle="tab" href="#preview" role="tab"
+					aria-controls="preview" aria-selected="false">{% if "ar" in lang%} معاينة {% else %} Preview {%- endif -%}</a>
+			</li>
+
+			{%- if not frappe.form_dict.new -%}
+			<li class="nav-item" role="presentation">
+				<a class="nav-link" id="diff-tab" data-toggle="tab" href="#diff" role="tab" aria-controls="diff"
+					aria-selected="false">{% if "ar" in lang%} قارن {% else %} Compare {%- endif -%}</a>
+			</li>
+			{%- endif -%}
+
+			{% if wiki_page_patch %}
+			<li class="nav-item" role="presentation">
+				<a {% if wiki_page_patch %} class="nav-link active" {% else %} class="nav-link" {% endif %}
+					id="discussion-tab" data-toggle="tab" href="#discussion" role="tab" aria-controls="discussion"
+					aria-selected="false">{% if "ar" in lang%} مناقشة {% else %} Discussion {%- endif -%}</a>
+			</li>
+			{% endif %}
+
+			<li class="nav-item" role="presentation">
+				<a class="nav-link" id="help-tab" data-toggle="tab" href="#help" role="tab"
+					aria-controls="help" aria-selected="false">{% if "ar" in lang%} مساعدة {% else %} Help {%- endif -%}</a>
+			</li>
+
+		</ul>
+
+		<div class="mt-4 tab-content">
+
+			<div {% if not wiki_page_patch %} class="tab-pane fade show active" {% else %} class="tab-pane fade" {%
+				endif %} id="write" role="tabpanel" aria-labelledby="write-tab">
+				<div class="form-control wiki-content-md" hidden>{{ content_md }}</div>
+				<div class="form-control wiki-content-html" hidden>{{ content_html }}</div>
+				<div class="wiki-write"></div>
+			</div>
+
+			<div class="tab-pane fade" id="preview" role="tabpanel" aria-labelledby="preview-tab">
+				<div class="from-markdown wiki-preview"></div>
+			</div>
+
+			{%- if not frappe.form_dict.new -%}
+			<div class="tab-pane fade" id="diff" role="tabpanel" aria-labelledby="preview-tab">
+				{% if "ar" in lang%}<h4>الصفحة المحررة </h4>{% else %} <h4>Edited Page</h3>{%- endif -%}
+				
+				<div class="from-markdown wiki-diff"></div>
+				{%- if sidebar_edited -%}
+				<hr>
+				{% if "ar" in lang%}<h4>تحرير الشريط الجانبي</h4> </h4>{% else %} <h4>Edited Sidebar</h3>{%- endif -%}
+				<div class=" sidebar-diff"></div>
+				{%- endif -%}
+
+			</div>
+
+			{%- endif -%}
+
+			{% if wiki_page_patch %}
+			<div {% if wiki_page_patch %} class="tab-pane fade show active" {% else %} class="tab-pane fade" {% endif %}
+				id="discussion" role="tabpanel" aria-labelledby="discussion-tab">
+
+				{% include "wiki/doctype/wiki_page/templates/comment.html" %}
+			</div>
+			{% endif %}
+
+			<div class="tab-pane fade" id="help" role="tabpanel" aria-labelledby="help-tab">
+				<div class="wiki-help">
+					<ul>
+						<li> Items in the left sidebar can be reordered by dragging and dropping.</li>
+						<li> Choose the dropdown above the editor to try out the Rich Text Editor.</li>
+						<li>Choose the dropdown above the editor to try out the Rich Text Editor.</li>
+						<li>In the "markdown mode' images can be uploaded using the upload image button, and links can be copied using the attachments list.</li>
+						<li>Click on the draft changes button to save your work as a draft.</li>
+						<li>You can view your drafts and pending contributions by clicking on the appropriate links under profile in the top right corner.</li>
+						<li>If you create a new page, you will find an entry named New Wiki Page in the left sidebar, which can also be moved.</li>
+					</ul>
+				</div>
+			</div>
+
+		</div>
+
+	</div>
+</form>
+
+{% block base_scripts %}
+
+<!-- js should be loaded in body! -->
+<script type="text/javascript" src="/assets/frappe/js/lib/jquery/jquery.min.js"></script>
+<script src="https://unpkg.com/turndown@7.0.0/dist/turndown.js"></script>
+{{ include_script('libs.bundle.js') }}
+
+{{ include_script('frappe-web.bundle.js') }}
+{{ include_script('controls.bundle.js') }}
+{{ include_script('dialog.bundle.js') }}
+{{ include_script('bootstrap-4-web.bundle.js') }}
+<script type="text/javascript" src="/assets/frappe/node_modules/moment/min/moment-with-locales.min.js"></script>
+<script type="text/javascript"
+	src="/assets/frappe/node_modules/moment-timezone/builds/moment-timezone-with-data.min.js"></script>
+{{ include_script('desk.bundle.js') }}
+{{ include_script('file_uploader.bundle.js') }}
+{{ include_script('wiki_override.bundle.js') }}
+
+<script>
+
+	let frappe_version = "{{ frappe_version }}";
+	if (parseInt(frappe_version.split(".")[0]) <= 14 && !frappe_version.endsWith("-dev")) {
+		Vue.prototype.__ = window.__;
+		Vue.prototype.frappe = window.frappe;
+	}
+
+	frappe.boot = {{ boot }};
+	var languague = frappe.boot.lang
+	if(languague =="ar"){
+		new EditWikiAr();
+		var edit = new EditAssetAr();
+	}
+	else{
+		new EditWiki();
+		var edit = new EditAsset();
+	}
+
+	
+
+</script>
+
+{%- if frappe.form_dict.new -%}
+
+{%- if script -%}
+<script>{ { script } }</script>
+{%- endif -%}
+
+{%- endif -%}
+
+{% endblock %}

--- a/one_fm/templates/wiki_page/templates/navbar_items.html
+++ b/one_fm/templates/wiki_page/templates/navbar_items.html
@@ -1,0 +1,83 @@
+{% macro render_item(item, submenu=False, parent=False) %}
+{% if item.child_items %}
+
+	{% if parent %}
+
+		{%- set dropdown_id = 'id-' + frappe.utils.generate_hash('Dropdown', 12) -%}
+		<li class="nav-item dropdown {% if submenu %} dropdown-submenu {% endif %}">
+			<a class="nav-link dropdown-toggle" href="#" id="{{ dropdown_id }}" role="button"
+				data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				{{ _(item.label) }}
+			</a>
+		  	<ul class="dropdown-menu" aria-labelledby="{{ dropdown_id }}">
+				{% for child in item.child_items %}
+					{{ render_item(child, True) }}
+			  {% endfor %}
+			</ul>
+		</li>
+	{% else %}
+		{%- set dropdown_id = 'id-' + frappe.utils.generate_hash('Dropdown', 12) -%}
+		<li class="dropdown {% if submenu %} dropdown-submenu {% endif %}">
+			<a class="dropdown-item dropdown-toggle" href="#" id="{{ dropdown_id }}" role="button"
+				data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				{{ _(item.label) }}
+			</a>
+			<ul class="dropdown-menu" aria-labelledby="{{ dropdown_id }}">
+				{% for child in item.child_items %}
+					{{ render_item(child, True) }}
+			{% endfor %}
+			</ul>
+		</li>
+	{% endif %}
+
+{% else %}
+
+	{% if parent %}
+	<li class="nav-item">
+		<a class="nav-link" href="{{ (item.url or '')|abs_url }}"
+			{% if item.open_in_new_tab %} target="_blank" {% endif %}>
+			{{ _(item.label) }}
+		</a>
+	</li>
+	{% else %}
+	<a class="dropdown-item" href="{{ (item.url or '') | abs_url }}"
+		{% if item.open_in_new_tab %} target="_blank" {% endif %}>
+		{{ _(item.label) }}
+	</a>
+	{% endif %}
+
+{% endif %}
+{% endmacro %}
+
+{% if top_bar_items -%}
+<ul class="mr-auto navbar-nav">
+	{%- for item in top_bar_items -%}
+		{% if not item.parent_label and not item.right -%}
+			{{ render_item(item, parent=True) }}
+		{%- endif -%}
+	{%- endfor %}
+</ul>
+{%- endif %}
+<ul class="ml-auto navbar-nav navbar-light">
+	{% include "wiki/doctype/wiki_page/templates/navbar_search.html" %}
+	{%- for item in top_bar_items -%}
+		{% if not item.parent_label and item.right -%}
+			{{ render_item(item, parent=True) }}
+		{%- endif -%}
+	{%- endfor %}
+	{% if not only_static %}
+		{% block navbar_right_extension %}{% endblock %}
+	{% endif %}
+	<div class="d-block d-sm-none sm-sidebar">
+		<!--sidebar-->
+		<hr>
+	</div>
+	{% include "templates/includes/navbar/navbar_login.html" %}
+
+
+</ul>
+{%- if call_to_action -%}
+<a class="btn btn-primary navbar-cta" href="{{ call_to_action_url | abs_url }}">
+	{{ call_to_action }}
+</a>
+{%- endif -%}

--- a/one_fm/templates/wiki_page/templates/new.html
+++ b/one_fm/templates/wiki_page/templates/new.html
@@ -1,0 +1,55 @@
+<div class="from-markdown">
+	<h1>{{ title }}</h1>
+</div>
+
+<form class="mt-8" action="/api/method/wiki.wiki.doctype.wiki_page.wiki_page.new" method="POST">
+	<input class="d-none" type="text" name="csrf_token" value="{{ frappe.session.csrf_token }}">
+	<div class="form-group">
+		<label for="title">{% if "ar" in lang%} عنوان  {% else %}Title{%- endif -%}</label>
+		<input id="title" class="form-control" type="text" name="title" placeholder="Page Title">
+	</div>
+	<div class="form-group">
+		<label class="sr-only" for="content">{% if "ar" in lang%} مسودة التغييرات {% else %}Content{%- endif -%}</label>
+		<ul class="nav nav-tabs" role="tablist">
+			<li class="nav-item" role="presentation">
+				<a class="nav-link active" id="write-tab" data-toggle="tab" href="#write" role="tab"
+					aria-controls="write" aria-selected="true">{% if "ar" in lang%} اكتب{% else %}Write{%- endif -%}</a>
+			</li>
+			<li class="nav-item" role="presentation">
+				<a class="nav-link" id="preview-tab" data-toggle="tab" href="#preview" role="tab"
+					aria-controls="preview" aria-selected="false">{% if "ar" in lang%} معاينة{% else %}Preview{%- endif -%}</a>
+			</li>
+		</ul>
+		<div class="mt-4 tab-content">
+			<div class="tab-pane fade show active" id="write" role="tabpanel" aria-labelledby="write-tab">
+				<textarea id="content" class="form-control wiki-content" name="content" rows="30"></textarea>
+			</div>
+			<div class="tab-pane fade" id="preview" role="tabpanel" aria-labelledby="preview-tab">
+				<div class="from-markdown wiki-preview"></div>
+			</div>
+		</div>
+	</div>
+	<button type="submit" class="btn btn-primary">{% if "ar" in lang%} مسودة التغييرات {% else %}إنشاء صفحة{%- endif -%}</button>
+</form>
+
+{%- block script -%}
+<script>
+	frappe.ready(() => {
+		$('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+			let activeTab = $(e.target);
+
+			if (activeTab.prop('id') === 'preview-tab') {
+				let content = $('textarea#content').val();
+				let $preview = $('.wiki-preview');
+				$preview.html('Loading preview...');
+				frappe.call('wiki.wiki.doctype.wiki_page.wiki_page.preview', { content })
+					.then(r => {
+						if (r.message) {
+							$preview.html(r.message);
+						}
+					});
+			}
+		})
+	})
+</script>
+{%- endblock -%}

--- a/one_fm/templates/wiki_page/templates/show.html
+++ b/one_fm/templates/wiki_page/templates/show.html
@@ -1,0 +1,42 @@
+<div class="from-markdown">
+	<div class="d-flex justify-content-between align-items-center">
+		<h1>{{ title }}</h1>
+
+	</div>
+	{{ content }}
+</div>
+<div class="wiki-footer">
+	<div class="my-4 wiki-revision-meta">
+		<ul class="user-contributions">
+
+			{%- if last_revision -%}
+			{{ last_revision.raised_by_username or last_revision.owner }} تم تحريره {{ frappe.utils.pretty_date(last_revision.creation) }}
+			{%- if number_of_revisions > 0 %}
+			&middot;
+			{% if "ar" in lang%} مسودة التغييرات {% else %}إنشاء صفحة{%- endif -%}
+			<li><a href="/{{ path }}/revisions">{% if "ar" in lang%}{{ number_of_revisions }} التنقيحات {% else %} {{ number_of_revisions }} Revisions {%- endif -%}</a>&nbsp;</li>
+			{%- endif -%}
+			{%- endif -%}
+			<li><a href="/{{ path }}/edit-wiki">{% if "ar" in lang%} تعديل الصفحة {% else %}Edit Page{%- endif -%}</a>&nbsp;</li>
+			<li><a href="/{{ path }}/new-wiki">{% if "ar" in lang%}صفحة جديدة {% else %}New Page{%- endif -%}</a>&nbsp;</li>
+		</ul>
+	</div>
+
+	<div class = "forward-back">
+		<a href="#" class="btn left">Left</a>
+		<a href="#" class="btn pull-right right">Right</a>
+	</div>
+
+</div>
+
+<script type="text/javascript" src="/assets/frappe/js/lib/jquery/jquery.min.js"></script>
+{{ include_script('wiki.bundle.js') }}
+
+<script>
+	new RenderWiki();
+
+</script>
+
+{%- if script -%}
+<script>{{ script }}</script>
+{%- endif -%}

--- a/one_fm/templates/wiki_page/templates/wiki_doc.html
+++ b/one_fm/templates/wiki_page/templates/wiki_doc.html
@@ -1,0 +1,116 @@
+{% extends "templates/base.html" %}
+{%- from "templates/includes/navbar/navbar_items.html" import render_item -%}
+{%- block head_include %}
+<link rel="stylesheet" href="/assets/frappe/css/hljs-night-owl.css">
+{% endblock -%}
+
+{%- block navbar -%}
+
+<nav class="navbar navbar-light navbar-expand-lg doc-navbar fixed-top">
+	<div class="container-fluid doc-container">
+		<div class="row no-gutters w-100">
+			<div class="col-12 col-lg-2">
+				<a class="navbar-brand" href="{{ url_prefix }}{{ home_page or "/" }}">
+					{%- if brand_html -%}
+					{{ brand_html }}
+					{%- elif banner_image -%}
+					<img src='{{ banner_image }}'>
+					{%- else -%}
+					<span>{{ (frappe.get_hooks("brand_html") or [_("Home")])[0] }}</span>
+					{%- endif -%}
+				</a>
+			</div>
+			<div class="col-12 col-lg-8">
+				<div class="doc-search-container">
+					<div class="website-search doc-search" id="search-container">
+					</div>
+					<button class="navbar-toggler" type="button"
+						data-toggle="collapse"
+						data-target="#navbarSupportedContent"
+						aria-controls="navbarSupportedContent"
+						aria-expanded="false"
+						aria-label="Toggle navigation">
+						<span class="navbar-toggler-icon"></span>
+					</button>
+				</div>
+			</div>
+			<div class="col-12 col-lg-2">
+				<div class="collapse navbar-collapse" id="navbarSupportedContent">
+					<ul class="navbar-nav">
+						{%- set items = docs_navbar_items or [] -%}
+						{%- for item in items -%}
+						{{ render_item(item, parent=True) }}
+						{%- endfor -%}
+					</ul>
+					{% include "templates/includes/web_sidebar.html" %}
+				</div>
+			</div>
+		</div>
+	</div>
+</nav>
+{%- endblock -%}
+
+{% block content %}
+
+
+{% macro container_attributes() -%}
+id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
+{%- if page_or_generator=="Generator" %}source-type="Generator" data-doctype="{{ doctype }}"{%- endif %}
+{%- if source_content_type %}source-content-type="{{ source_content_type }}"{%- endif %}
+{%- endmacro %}
+
+<div class="container-fluid doc-layout doc-container">
+	<div class="row no-gutters wiki-flex" {{ container_attributes() }}>
+		{%- if  not no_sidebar -%}
+
+			<div class="sidebar-column">
+				<aside class="doc-sidebar">
+					{% block page_sidebar %}
+					{% include "templates/includes/web_sidebar.html" %}
+					{% endblock %}
+				</aside>
+			</div>
+		{%- endif -%}
+
+		<div class="main-column doc-main">
+			<div class="page-content-wrapper">
+				{% block page_container %}
+				<main>
+					<div class="page_content page-content doc-content">
+						{%- if add_breadcrumbs -%}
+						{% include "one_fm/templates/wiki_page/templates/breadcrumbs.html" %}
+						{%- endif -%}
+						{%- block page_content -%}{%- endblock -%}
+					</div>
+				</main>
+				{% endblock %}
+			</div>
+		</div>
+		{%- if page_toc_html -%}
+		<div class="page-toc d-none d-xl-block">
+			{% block page_toc %}
+			{% if page_toc_html %}
+			<div class='list-unstyled'>
+				<h5>On this page</h5>
+				{{ page_toc_html }}
+			</div>
+			{% endif %}
+			{% endblock %}
+		</div>
+		{%- endif -%}
+	</div>
+</div>
+
+{% endblock %}
+</div>
+{%- block script -%}
+<script>
+	frappe.ready(() => {
+		frappe.setup_search('#search-container', '{{ docs_search_scope or "" }}');
+
+		$('.web-footer .container')
+			.removeClass('container')
+			.addClass('container-fluid doc-container');
+	});
+</script>
+{%- endblock -%}

--- a/one_fm/templates/wiki_page/templates/wiki_doc.html
+++ b/one_fm/templates/wiki_page/templates/wiki_doc.html
@@ -78,7 +78,7 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 				<main>
 					<div class="page_content page-content doc-content">
 						{%- if add_breadcrumbs -%}
-						{% include "one_fm/templates/wiki_page/templates/breadcrumbs.html" %}
+						{% include "wiki/doctype/wiki_page/templates/breadcrumbs.html" %}
 						{%- endif -%}
 						{%- block page_content -%}{%- endblock -%}
 					</div>

--- a/one_fm/templates/wiki_page/templates/wiki_page.html
+++ b/one_fm/templates/wiki_page/templates/wiki_page.html
@@ -1,0 +1,28 @@
+{% extends "one_fm/templates/wiki_page/templates/wiki_doc.html" %}
+{%- block page_sidebar -%}
+<!--sidebar-->
+{%- endblock -%}
+
+{%- block head_include %}
+{{ super() }}
+{{ include_style('wiki.bundle.css') }}
+{%- if frappe.form_dict.edit or frappe.form_dict.new -%}
+{{ include_style('edit_wiki.bundle.css') }}
+{%- endif -%}
+
+{% endblock -%}
+
+{% block page_content %}
+{%- if frappe.form_dict.edit or frappe.form_dict.new -%}
+{% include "one_fm/templates/wiki_page/templates/edit.html" %}
+{%- else -%}
+{% include "one_fm/templates/wiki_page/templates/show.html" %}
+{%- endif -%}
+{% endblock %}
+
+
+{%- block navbar -%}
+{% include "one_fm/templates/wiki_page/templates/wiki_navbar.html" %}
+
+{%- endblock -%}
+

--- a/one_fm/templates/wiki_page/templates/wiki_page.html
+++ b/one_fm/templates/wiki_page/templates/wiki_page.html
@@ -22,7 +22,7 @@
 
 
 {%- block navbar -%}
-{% include "one_fm/templates/wiki_page/templates/wiki_navbar.html" %}
+{% include "wiki/doctype/wiki_page/templates/wiki_navbar.html" %}
 
 {%- endblock -%}
 

--- a/one_fm/templates/wiki_page/templates/wiki_page_row.html
+++ b/one_fm/templates/wiki_page/templates/wiki_page_row.html
@@ -1,0 +1,3 @@
+<div>
+	<a href="{{ doc.route }}">{{ doc.title or doc.name }}</a>
+</div>

--- a/one_fm/www/wiki/edit.html
+++ b/one_fm/www/wiki/edit.html
@@ -1,0 +1,1 @@
+{% extends "one_fm/templates/wiki_page/templates/wiki_page.html"%}

--- a/one_fm/www/wiki/edit.py
+++ b/one_fm/www/wiki/edit.py
@@ -1,0 +1,91 @@
+import re
+import frappe
+from frappe.desk.form.load import get_comments
+from wiki.wiki.doctype.wiki_page.wiki_page import get_open_contributions
+from wiki.wiki.doctype.wiki_page.wiki_page import get_open_drafts
+from frappe import _
+from frappe.utils.jinja_globals import is_rtl
+
+def get_context(context):
+	context.no_cache = 1
+	frappe.form_dict.edit = True
+	wiki_page_name = frappe.db.get_value("Wiki Page",
+		filters={'route':frappe.form_dict.wiki_page},
+		fieldname='name')
+	context.doc = frappe.get_doc("Wiki Page", wiki_page_name)
+
+	context.doc.verify_permission("read")
+
+	try:
+		boot = frappe.sessions.get()
+	except Exception as e:
+		boot = frappe._dict(status="failed", error=str(e))
+		print(frappe.get_traceback())
+
+	boot_json = frappe.as_json(boot)
+
+	# remove script tags from boot
+	boot_json = re.sub(r"\<script[^<]*\</script\>", "", boot_json)
+
+	# TODO: Find better fix
+	boot_json = re.sub(r"</script\>", "", boot_json)
+
+	context.boot = boot_json
+	context.frappe_version = frappe.__version__
+	wiki_settings = frappe.get_single("Wiki Settings")
+	context.banner_image = wiki_settings.logo
+	context.script = wiki_settings.javascript
+	context.docs_search_scope = ""
+	can_edit = frappe.session.user != "Guest"
+	context.can_edit = can_edit
+	context.show_my_account = False
+	context.doc.set_breadcrumbs(context)
+	context.lang = frappe.local.lang
+	context.layout_direction = "rtl" if is_rtl() else "ltr"
+	if not can_edit:
+		context.doc.redirect_to_login("edit")
+
+	if  "ar" in context.lang :
+		context.title =  context.doc.title + " التحرير "
+	else:
+		context.title = "Editing " + context.doc.title
+
+	if frappe.form_dict.wiki_page_patch:
+		context.wiki_page_patch = frappe.form_dict.wiki_page_patch
+		print(context.wiki_page_patch)
+		context.doc.content = frappe.db.get_value(
+			"Wiki Page Patch", context.wiki_page_patch, "new_code"
+		)
+		context.comments = get_comments(
+			"Wiki Page Patch", frappe.form_dict.wiki_page_patch, "Comment"
+		)
+		context.sidebar_edited = frappe.db.get_value(
+			"Wiki Page Patch", context.wiki_page_patch, "sidebar_edited"
+		)
+		context.new_sidebar_items = frappe.db.get_value(
+			"Wiki Page Patch", context.wiki_page_patch, "new_sidebar_items"
+		)
+
+	context.content_md = context.doc.content
+	context.content_html = frappe.utils.md_to_html(context.doc.content)
+	context.sidebar_items, context.docs_search_scope = context.doc.get_sidebar_items(
+		context
+	)
+
+	context = context.update(
+		{
+			"post_login": [
+				{"label": _("My Account"), "url": "/me"},
+				{"label": _("Logout"), "url": "/?cmd=web_logout"},
+				{
+					"label": _("Contributions ") + get_open_contributions(),
+					"url": "/contributions",
+				},
+				{
+					"label": _("My Drafts ") + get_open_drafts(),
+					"url": "/drafts",
+				},
+			]
+		}
+	)
+	return context

--- a/one_fm/www/wiki/new.html
+++ b/one_fm/www/wiki/new.html
@@ -1,0 +1,1 @@
+{% extends "one_fm/templates/wiki_page/templates/wiki_page.html"%}

--- a/one_fm/www/wiki/new.py
+++ b/one_fm/www/wiki/new.py
@@ -1,0 +1,68 @@
+import re
+import frappe
+from frappe.desk.form.load import get_comments
+
+
+def get_context(context):
+	context.no_cache = 1
+	frappe.form_dict.edit = True
+	frappe.form_dict.new = "true"
+	wiki_page_name = frappe.db.get_value("Wiki Page",
+		filters={'route':frappe.form_dict.wiki_page},
+		fieldname='name')
+	context.doc = frappe.get_doc("Wiki Page", wiki_page_name)
+	# context = context.doc.get_context(context)
+
+	context.doc.verify_permission("read")
+	context.lang = frappe.local.lang
+
+	try:
+		boot = frappe.sessions.get()
+	except Exception as e:
+		boot = frappe._dict(status="failed", error=str(e))
+		print(frappe.get_traceback())
+
+	boot_json = frappe.as_json(boot)
+
+	# remove script tags from boot
+	boot_json = re.sub(r"\<script[^<]*\</script\>", "", boot_json)
+
+	# TODO: Find better fix
+	boot_json = re.sub(r"</script\>", "", boot_json)
+
+	context.boot = boot_json
+	wiki_settings = frappe.get_single("Wiki Settings")
+	context.banner_image = wiki_settings.logo
+	context.script = wiki_settings.javascript
+	context.docs_search_scope = ""
+	can_edit = frappe.session.user != "Guest"
+	context.can_edit = can_edit
+	context.show_my_account = False
+	context.doc.set_breadcrumbs(context)
+
+	if not can_edit:
+		context.doc.redirect_to_login("create")
+	context.sidebar_items, context.docs_search_scope = context.doc.get_sidebar_items(
+		context
+	)
+	if context.lang == "ar":
+		context.title = "New Wiki Page"
+		context.doc.title = "New Wiki Page"
+		context.content_md = "New Wiki Page"
+		context.content_html = "New Wiki Page"
+	else:
+		context.title = "صفحة ويكي جديدة"
+		context.doc.title = "صفحة ويكي جديدة"
+		context.content_md = "صفحة ويكي جديدة"
+		context.content_html = "صفحة ويكي جديدة"
+	if frappe.form_dict.wiki_page_patch:
+		context.wiki_page_patch = frappe.form_dict.wiki_page_patch
+		context.doc.content = frappe.db.get_value(
+			"Wiki Page Patch", context.wiki_page_patch, "new_code"
+		)
+		context.comments = get_comments(
+			"Wiki Page Patch", frappe.form_dict.wiki_page_patch, "Comment"
+		)
+		context.content_md = context.doc.content
+		context.content_html = frappe.utils.md_to_html(context.doc.content)
+	return context


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- If selected language of user is arabic, he should be able to edit wiki page in arabic

## Solution description
- override wiki edits using `website_route_rules`
- check language using frappe.local.lang
- if lang=ar, use Arabic text for everything.
- Preview content in arabic

## Is there a business logic within a doctype?
    - [x] Yes
    - [ ] No


## Output screenshots (optional)

<img width="1181" alt="Screen Shot 2022-12-12 at 4 20 48 PM" src="https://user-images.githubusercontent.com/29017559/207055331-a29399ad-1422-4647-8ba5-36f3a72075d8.png">
<img width="1181" alt="Screen Shot 2022-12-12 at 4 21 15 PM" src="https://user-images.githubusercontent.com/29017559/207055336-5a0c8bc2-89e7-426e-979d-7ee7069241e2.png">

## Areas affected and ensured
- Wiki page 

## Is there any existing behavior change of other features due to this code change?
Wiki Page available in english

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
