### PR TITLE
Fix: Payroll Report

### DIFF
--- a/one_fm/one_fm/report/payroll_report/payroll_report.py
+++ b/one_fm/one_fm/report/payroll_report/payroll_report.py
@@ -244,6 +244,15 @@ def get_attendance(projects, employee_list):
 	absent_dict = {}
 	day_off_dict = {}
 
+	all_project = frappe.db.get_list("Project", pluck="name")
+
+	for key, value in projects.items():
+		if key in all_project:
+			all_project.remove(key)
+	
+	all_project = tuple(all_project)
+
+
 	for e in employee_list:
 		attendance_dict[e]={'working_days': 0,'number_of_days_off':0, 'ot': 0, 'sl':0, 'al':0, 'ab':0, 'ol':0, 'do_ot':0}
 
@@ -251,11 +260,14 @@ def get_attendance(projects, employee_list):
 		start_date = projects[key]['start_date']
 		end_date = projects[key]['end_date']
 		condition = ""
+
 		if key != "Other":
 			condition += f" AND project='{key}' "
+		else:
+			condition += f" AND project IN {all_project} "
 
 		present_list = frappe.db.sql(f"""
-			SELECT employee, COUNT(employee) as working_days FROM `tabAttendance` 
+			SELECT employee, COUNT(*) as working_days FROM `tabAttendance` 
 			WHERE attendance_date BETWEEN '{start_date}' AND '{end_date}' 
 			AND status IN ("Present", "Work From Home")
 			AND roster_type='Basic'


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Payroll Report total days exceeded 30 days.

## Solution description
- Projects outside the payroll cycle got added twice. 
- Correct the query by checking the attendance for projects that did not exist in the payroll cycle list.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="400" alt="Screen Shot 2022-12-13 at 5 36 26 AM" src="https://user-images.githubusercontent.com/29017559/207188740-b00e11a4-6eb3-44af-9c41-ae2cabed81ee.png">



## Areas affected and ensured
- Payroll Report project condition

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
