### PR TITLE
[Fix] OT Roster - Keep days off

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2874,9 +2874,11 @@ function schedule_change_post(page) {
 //		});
 //	}
 	var hide_day_off_ot_check = 0;
+	var hide_keep_days_off_check = 0;
 	let element = get_wrapper_element();
 	if (element == ".rosterOtMonth") {
 		hide_day_off_ot_check = 1;
+		hide_keep_days_off_check = 1;
 	}
 	let d = new frappe.ui.Dialog({
 		'title': 'Schedule/Change Post',
@@ -2926,7 +2928,7 @@ function schedule_change_post(page) {
 				}
 			},
 			{ 'label': 'Project End Date', 'fieldname': 'project_end_date', 'fieldtype': 'Check' },
-			{ 'label': 'Keep Days Off', 'fieldname': 'keep_days_off', 'fieldtype': 'Check' },
+			{ 'label': 'Keep Days Off', 'fieldname': 'keep_days_off', 'fieldtype': 'Check', 'hidden': hide_keep_days_off_check },
 			{ 'label': 'Request Employee Schedule', 'fieldname': 'request_employee_schedule', 'fieldtype': 'Check' },
 			{ 'label': 'Day Off OT', 'fieldname': 'day_off_ot', 'fieldtype': 'Check' , 'hidden': hide_day_off_ot_check},
 			{ 'fieldname': 'cb1', 'fieldtype': 'Column Break' },

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.json
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.json
@@ -143,14 +143,13 @@
   },
   {
    "default": "0",
-   "depends_on": "eval: doc.roster_type == 'Over-Time'",
    "fieldname": "day_off_ot",
    "fieldtype": "Check",
    "label": "Day Off OT"
   }
  ],
  "links": [],
- "modified": "2022-12-05 16:13:19.862021",
+ "modified": "2022-12-09 19:13:50.004622",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Employee Schedule",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore


## Clearly and concisely describe the feature, chore or bug.
- Keep days off check box hide for OT Roster

## Is there a business logic within a doctype?
    - [x] No


## Is there any existing behavior change of other features due to this code change?
Yes, OT Roster Schedule not show the Keep days off checkbox


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome