### PR TITLE
feat: Email to Task Assignment

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -368,6 +368,9 @@ doc_events = {
 	"Stock Entry": {
 		"on_submit": "one_fm.api.doc_methods.stock_entry.validate_budget"
 	},
+	"Communication": {
+		"after_insert": "one_fm.one_fm.task_assignment_from_email.assign_task_to_user_from_communication_content"
+	},
 	# "Additional Salary" :{
 	# 	"on_submit": "one_fm.grd.utils.validate_date"
 	# }

--- a/one_fm/one_fm/doctype/project_additional_settings/project_additional_settings.js
+++ b/one_fm/one_fm/doctype/project_additional_settings/project_additional_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, omar jaber and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Project Additional Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/one_fm/one_fm/doctype/project_additional_settings/project_additional_settings.json
+++ b/one_fm/one_fm/doctype/project_additional_settings/project_additional_settings.json
@@ -1,0 +1,75 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-12-23 13:40:25.592770",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "task_settings_section",
+  "assign_task_from_email",
+  "differentiate_assignment_from_email_content_by",
+  "start_tag",
+  "end_tag"
+ ],
+ "fields": [
+  {
+   "fieldname": "task_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Task Settings"
+  },
+  {
+   "default": "0",
+   "description": "Assign Task to User Defined in Incoming Email Content",
+   "fieldname": "assign_task_from_email",
+   "fieldtype": "Check",
+   "label": "Assign Task from Email"
+  },
+  {
+   "depends_on": "eval:(doc.differentiate_assignment_from_email_content_by == 'Start and End Tag' || doc.differentiate_assignment_from_email_content_by == 'Start and End Tag or Mail to Tag') && doc.assign_task_from_email",
+   "fieldname": "start_tag",
+   "fieldtype": "Data",
+   "label": "Start Tag",
+   "mandatory_depends_on": "eval:(doc.differentiate_assignment_from_email_content_by == 'Start and End Tag' || doc.differentiate_assignment_from_email_content_by == 'Start and End Tag or Mail to Tag') && doc.assign_task_from_email"
+  },
+  {
+   "depends_on": "eval:(doc.differentiate_assignment_from_email_content_by == 'Start and End Tag' || doc.differentiate_assignment_from_email_content_by == 'Start and End Tag or Mail to Tag') && doc.assign_task_from_email",
+   "fieldname": "end_tag",
+   "fieldtype": "Data",
+   "label": "End Tag"
+  },
+  {
+   "depends_on": "assign_task_from_email",
+   "description": "Get assignments from the email content by tag selected.",
+   "fieldname": "differentiate_assignment_from_email_content_by",
+   "fieldtype": "Select",
+   "label": "Differentiate Assignment from Email Content by",
+   "mandatory_depends_on": "assign_task_from_email",
+   "options": "\nStart and End Tag\nMail to Tag\nStart and End Tag or Mail to Tag"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-12-23 14:18:49.272630",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Project Additional Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/one_fm/one_fm/doctype/project_additional_settings/project_additional_settings.py
+++ b/one_fm/one_fm/doctype/project_additional_settings/project_additional_settings.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2022, omar jaber and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+class ProjectAdditionalSettings(Document):
+	def validate(self):
+		if self.assign_task_from_email:
+			if not self.differentiate_assignment_from_email_content_by:
+				frappe.throw(_("Select Differentiate Assignment from Email Content by"))
+			elif self.differentiate_assignment_from_email_content_by in \
+				['Start and End Tag', 'Start and End Tag or Mail to Tag']:
+				if not self.start_tag:
+					frappe.throw(_("Start Tag is Mandatory!"))
+			else:
+				self.start_tag = ''
+				self.end_tag = ''
+		else:
+			self.differentiate_assignment_from_email_content_by = ''
+			self.start_tag = ''
+			self.end_tag = ''

--- a/one_fm/one_fm/doctype/project_additional_settings/test_project_additional_settings.py
+++ b/one_fm/one_fm/doctype/project_additional_settings/test_project_additional_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, omar jaber and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestProjectAdditionalSettings(FrappeTestCase):
+	pass

--- a/one_fm/one_fm/task_assignment_from_email.py
+++ b/one_fm/one_fm/task_assignment_from_email.py
@@ -1,0 +1,101 @@
+import frappe
+from frappe import _
+import re
+from frappe.desk.form.assign_to import add as add_assignment, DuplicateToDoError
+
+def assign_task_to_user_from_communication_content(doc, method):
+	# Check if task reference exist in the communication
+	if doc.reference_doctype == 'Task' and doc.reference_name:
+		# Check if Do we needs to assign rask to the users mentioned in the email
+		assign_task_from_email = frappe.db.get_single_value('Project Additional Settings', 'assign_task_from_email')
+		if assign_task_from_email:
+			# Get assignees(email) from communicaion content
+			assignees = get_assignees_from_communication_content(doc, assign_task_from_email)
+			# Check user exist for the assignees and assign to the task
+			for assigne in assignees:
+				if frappe.db.exists('User', {'email': assigne}):
+					try:
+						add_assignment({
+							'doctype': doc.reference_doctype,
+							'name': doc.reference_name,
+							'assign_to': [assigne],
+							'description': _('')
+						})
+						doc.add_comment("Info", "Task {0} Assigned to {1}".format(doc.reference_name, assigne))
+					except DuplicateToDoError:
+						frappe.message_log.pop()
+						pass
+				else:
+					doc.add_comment("Info", "There is no user exist for the email {0} in the ERP".format(assigne))
+
+
+def get_assignees_from_communication_content(doc, assign_task_from_email):
+	start = end = False
+	differentiate_assignment_from_email_content_by = frappe.db.get_single_value('Project Additional Settings', 'differentiate_assignment_from_email_content_by')
+	if differentiate_assignment_from_email_content_by in ['Start and End Tag', 'Start and End Tag or Mail to Tag']:
+		start = frappe.db.get_single_value('Project Additional Settings', 'start_tag')
+	if start:
+		return get_assignment_from_start_and_end_tag(doc, start.lower(), differentiate_assignment_from_email_content_by)
+	if differentiate_assignment_from_email_content_by == 'Mail to Tag':
+		# Looking for mailto tag
+		return get_assignment_from_mailto_tag(doc)
+	return False
+
+def get_assignment_from_start_and_end_tag(doc, start, differentiate_assignment_from_email_content_by):
+	assign_start = doc.content.lower().split(start)
+	'''
+		If length of assign_start equal to or less than 1, then there is no Assign tag, So there is no assignment
+		If length of assign_start greater than 1, then there is Assign tag, So there are assignments
+	'''
+	assignment_tag_found = False
+	if assign_start and len(assign_start) > 1:
+		end = frappe.db.get_single_value('Project Additional Settings', 'end_tag')
+		if not end:
+			end = 'end assign'
+		if end:
+			assign_end = assign_start[1].split(end.lower())
+		else:
+			assign_end = assign_start[1]
+		'''
+			If length of assign_end equal to or less than 1, then there is no Assign End tag
+			If length of assign_end greater than 1, then there is Assign End tag
+
+			assign_end[0], The first element of assign_end will be the content which is having the assigned users
+		'''
+		if assign_end and len(assign_end) > 0:
+			if len(assign_end) == 0:
+				doc.add_comment("Info", "There is no assignment tag 'End Assign' found in message content!")
+			assignment_tag_found = True
+			assignment = re.findall(r"[A-Za-z0-9._%+-]+"
+				r"@[A-Za-z0-9.-]+"
+				r"\.[A-Za-z]{2,4}", assign_end[0])
+			# Remove duplicate items from list
+			return remove_duplicate_assignees(doc, assignment)
+	if not assignment_tag_found:
+		doc.add_comment("Info", "There is no assignment tag 'Assign' 'End Assign' found in message content!")
+		if differentiate_assignment_from_email_content_by == 'Start and End Tag or Mail to Tag':
+			# Looking for mailto tag
+			return get_assignment_from_mailto_tag(doc)
+	return False
+
+def get_assignment_from_mailto_tag(doc):
+	assign = doc.content.split('mailto')
+	if assign and len(assign) > 0:
+		assignment = []
+		for mailto in assign:
+			assignment += re.findall(r"[A-Za-z0-9._%+-]+"
+				r"@[A-Za-z0-9.-]+"
+				r"\.[A-Za-z]{2,4}", mailto)
+		# Remove duplicate items from list
+		assignment = remove_duplicate_assignees(doc, assignment)
+		if len(assignment) <= 0:
+			doc.add_comment("Info", "There is no mailto(@) tag found in message content!")
+		return assignment
+	return False
+
+def remove_duplicate_assignees(doc, assignment):
+	# Remove duplicate items from list
+	assignment = [*set(assignment)]
+	if doc.sender in assignment:
+		assignment.remove(doc.sender)
+	return assignment


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- As an Employee, I would like to send emails to ERPNext to create Tasks and assign at the same time So i can organize the coordination between external and internal parties.

## Solution description
 - Create task from email by using feature in frappe for append to document from email, then fetch the assignees from the message content. Search for tag to get the assignees and check if they exists in user then assign the task to them

## Is there a business logic within a doctype?
    - [x] Yes

## Is there any existing behavior change of other features due to this code change?
Yes, Task creation and assignment from incoming email to a specific email id

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created? Yes
    - Is attachment required? Yes

## Did you delete custom field?
    - [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome