### PR TITLE
patch contract items

### DIFF
--- a/one_fm/operations/doctype/contract_item/contract_item.json
+++ b/one_fm/operations/doctype/contract_item/contract_item.json
@@ -222,6 +222,7 @@
    "options": "\nWeekly\nMonthly"
   },
   {
+   "default": "0",
    "depends_on": "eval:doc.days_off_category",
    "fieldname": "no_of_days_off",
    "fieldtype": "Int",
@@ -230,7 +231,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-12-18 19:54:01.185966",
+ "modified": "2022-12-27 10:03:20.535288",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contract Item",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -20,3 +20,4 @@ one_fm.patches.v14_0.fix_issue_service_level_agreement #31
 one_fm.patches.v14_0.fix_employee_and_PAM_FIle
 one_fm.patches.v14_0.remove_salary_structure
 one_fm.patches.v14_0.set_job_offer_field_valuse_from_applicant
+one_fm.patches.v14_0.patch_contract_items

--- a/one_fm/patches/v14_0/patch_contract_items.py
+++ b/one_fm/patches/v14_0/patch_contract_items.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+    """"
+        no_of_days_off in contract items is an integer field but NULL fills empty spots.
+    """
+    frappe.db.sql("""
+        UPDATE `tabContract Item` SET no_of_days_off=0 WHERE no_of_days_off IS NULL;
+    """)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
This is a patch for contract items, number_of_days_off is an integer field but it encounters pymysql.err.DataError: (1265, "Data truncated for column 'no_of_days_off' at row 1") because NULL is found were no value is assigned, default should be 0

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
