### PR TITLE
Fix: workflow email using custom template.

### DIFF
--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -3,20 +3,29 @@ import requests
 import json
 from twilio.rest import Client as TwilioClient
 import xml.etree.ElementTree as ET
-
+from frappe.utils.jinja import (get_email_from_template)
 
 @frappe.whitelist()
 def sendemail(recipients, subject, header=None, message=None,
 	content=None, reference_name=None, reference_doctype=None,
-	sender=None, cc=None , attachments=None, delay=None):
+	sender=None, cc=None , attachments=None, delay=None, args=None, template=None):
 	logo = "https://one-fm.com/files/ONEFM_Identity.png"
+
+	if not message:
+		message = " "
+
+	if "Administrator" in recipients:
+		recipients.remove("Administrator")
+	
+	if args:
+		extra_message, text_content = get_email_from_template("default_email", args)
+		if extra_message:
+			message += extra_message
 
 	if attachments:
 		message += """
 			<p>Please find the attached Document in the mail below.</p>
 		"""
-	if "Administrator" in recipients:
-		recipients.remove("Administrator")
 
 	for recipient in recipients:
 		if is_user_id_not_company_prefred_email_in_employee(recipient):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Email Notification failed for workflow action, since custom email method was used.

## Analysis and design (optional)
- The method `sendemail` missed the params required by workflow emails

## Solution description
Add args and template param in sendemail for workflow

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Areas affected and ensured
- The one_fm.processor.sendemail method was modified to take arguments from workflow.

## Is there any existing behavior change of other features due to this code change?
no.


## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
