### PR TITLE
allow_on_submit_skill_erf

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.json
+++ b/one_fm/one_fm/doctype/erf/erf.json
@@ -347,6 +347,7 @@
    "options": "Employee Language Requirement"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "designation_skill",
    "fieldtype": "Table",
    "label": "Skills",
@@ -876,7 +877,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-12-17 20:35:19.371446",
+ "modified": "2022-12-29 12:15:24.302917",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ERF",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Unable to create employee, cos skill is not editable after submit. After investigating, i found out that the skill table is present on erf and job applicant doctype(relation to the bug), and only erf is a submittable doctype. Ergo, i set the skill table on erf doctype to allow on submit


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
ERF doctype


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
