### PR TITLE
[CHORE]Make abbreviation in Operations Role mandatory & fill empty abbreviation

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -463,7 +463,8 @@ scheduler_events = {
 		'one_fm.one_fm.depreciation_custom.post_depreciation_entries',
 		'one_fm.operations.doctype.contracts.contracts.auto_renew_contracts',
 		'one_fm.hiring.utils.update_leave_policy_assignments_expires_today',
-		'one_fm.tasks.execute.daily'
+		'one_fm.tasks.execute.daily',
+		"one_fm.utils.attach_abbreviation_to_roles"
 	],
 	"hourly": [
 		# "one_fm.api.tasks.send_checkin_hourly_reminder",

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -462,3 +462,30 @@ def enqueue_contracts_date(operations_post):
 		sch.post = operations_post.name
 		sch.date = cstr(date.date())
 		sch.save()
+
+
+def attach_abbreviation_to_roles():
+    list_of_roles = frappe.db.get_list("Operations Role", {"post_abbrv": ["=", ""]})
+    if list_of_roles:
+        for role_name in list_of_roles:
+            role = frappe.get_doc("Operations Role", role_name)
+            name = str(role.post_name).split()
+            if len(name) == 1:
+                role.post_abbrv = str(name[0][0:2]).upper()
+            elif len(name) > 1:
+                post_abbrv = ""
+                for ind, val in enumerate(name):
+                    if ind == (len(name) - 1):
+                        try:
+                            last_val = int(val)
+                            post_abbrv += f" {str(last_val)}"
+                        except:
+                            post_abbrv += val[0].upper()
+                    else:
+                        post_abbrv += val[0].upper()
+                role.post_abbrv = post_abbrv
+            role.save(ignore_permissions=True)
+            frappe.db.commit()
+
+
+

--- a/one_fm/operations/doctype/operations_role/operations_role.json
+++ b/one_fm/operations/doctype/operations_role/operations_role.json
@@ -29,7 +29,8 @@
    "fieldname": "post_abbrv",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Role Abbreviation"
+   "label": "Role Abbreviation",
+   "reqd": 1
   },
   {
    "fieldname": "sale_item",
@@ -87,7 +88,7 @@
   }
  ],
  "links": [],
- "modified": "2022-11-06 12:46:01.093018",
+ "modified": "2022-12-31 20:27:41.947124",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Role",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Made the docfield for roles abbreviations compulsory, and also, wrote an algorithim that generates abbreviation for already created roles


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Operations role doctype


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
