### PR TITLE
fix: speed up unschedule roster and change api params

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2736,12 +2736,7 @@ function displayWeekCalendar(weekCalendarSettings, page) {
 }
 
 function unschedule_staff(page) {
-	let employees = [];
-	let selected = [... new Set(classgrt)];
-	selected.forEach(function (i) {
-		let [employee, date] = i.split("|");
-		employees.push({ employee, date });
-	});
+	let employees = window.employees_list;
 	let date = frappe.datetime.add_days(frappe.datetime.nowdate(), '1');
 	let d = new frappe.ui.Dialog({
 		'title': 'Unschedule Staff',


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
This chore change the api params to unschedule staff by reducing the input size, removing the loops. This speeds up the process by 10x the original process time.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
