### PR TITLE
Fix: Export Bank Error in Payroll

### DIFF
--- a/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
+++ b/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
@@ -15,6 +15,7 @@
   "maximum_salary_deduction_percentage",
   "include_day_off_in_total_working_days",
   "column_break_7",
+  "enable_export",
   "default_bank",
   "exclude_salary_component",
   "basic_salary_component",
@@ -246,12 +247,18 @@
    "fieldname": "include_day_off_in_total_working_days",
    "fieldtype": "Check",
    "label": "Include day off in Total no. of Working Days"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_export",
+   "fieldtype": "Check",
+   "label": "Enable Export"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-08-30 13:57:00.427138",
+ "modified": "2023-01-05 16:12:17.217621",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "HR and Payroll Additional Settings",
@@ -270,5 +277,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -3415,9 +3415,13 @@ let error_handler = (res) => {
 	if (res.error){
 		$('#cover-spin').hide();
 		frappe.throw(res.error);
-	} else if (res.data.message){
-		frappe.msgprint(res.data.message);
-		$('#cover-spin').hide();
+	} else if (res.data){
+		if(res.data.message){
+			frappe.msgprint(res.data.message);
+			$('#cover-spin').hide();
+		} else {
+			$('#cover-spin').hide();
+		}
 	} else {
 		$('#cover-spin').hide();
 	}

--- a/one_fm/public/js/doctype_js/payroll_entry.js
+++ b/one_fm/public/js/doctype_js/payroll_entry.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Payroll Entry', {
     refresh: function(frm) {
-		if (frm.doc.salary_slips_created == 1){
+		if (frm.doc.salary_slips_created == 1 && frm.doc.bank_account){
 			frm.add_custom_button(__("Download Payroll Bank Export"), function() {
 				let payroll_entry = frm.doc.name
 				window.open("/files/payroll-entry/" + payroll_entry + ".xlsx", "Download");


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Allow Hr to enable and disable the Bank export.
- Create Salary Slips.

## Solution description
- Add checkbox to enable/disable the payroll bank export.

## Is there a business logic within a doctype?
    - [x] Yes
    - [ ] No


## Output screenshots (optional)
<img width="300" alt="Screen Shot 2023-01-05 at 5 30 26 PM" src="https://user-images.githubusercontent.com/2
<img width="300" alt="Screen Shot 2023-01-05 at 5 30 56 PM" src="https://user-images.githubusercontent.com/29017559/210803761-33ffe513-e140-4386-a27b-463c10a2c3c1.png">
9017559/210803689-12d6916e-a1e9-415b-924a-e01c0221220b.png">


## Areas affected and ensured
- checkbox in HR and Payroll Settings to Enable/Disable Payroll.
- show button to download only of bank account exist.

## Is there any existing behavior change of other features due to this code change?
Yes. 
Export Bank details can be disabled now.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
