### PR TITLE
Fix: Work Permit

### DIFF
--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -60,7 +60,7 @@ class Preparation(Document):
         self.recall_create_medical_insurance_renewal() # create medical insurance record for renewals
         self.recall_create_moi_renewal_and_extend() # create moi record for all employee
         self.recall_create_paci() # create paci record for all
-        self.recall_create_fp()# create fp record for all
+        # self.recall_create_fp()# create fp record for all
         self.send_notifications()
 
     def validate_mandatory_fields_on_submit(self):

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -874,7 +874,7 @@
    "label": "Payment Details Section"
   },
   {
-   "depends_on": "eval: doc.work_permit_type != \"Local Transfer\" && (doc.work_permit_status == \"Pending by Operator\" || doc.work_permit_status == \"Completed\")",
+   "depends_on": "eval:frappe.session.user == doc.grd_operator &&\ndoc.work_permit_type != \"Local Transfer\" && (doc.work_permit_status == \"Pending by Operator\" || doc.work_permit_status == \"Completed\");",
    "fieldname": "work_permit_information_section",
    "fieldtype": "Section Break",
    "label": "Work Permit Information"
@@ -886,7 +886,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-15 18:31:39.072744",
+ "modified": "2023-01-09 12:36:55.434356",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- request to disable the Creation of FP on the Preparation list.
-  receive notification after the PRO applied for Work Permit on the ASHAL 0r PAM System.
-  Option of Uploading Work permit only to PRO and not the supervisor.

## Solution description
- Disable the Creation of a Fingerprint List on submission of the Preparation list.
- Send Notification to GRD supervisor on Application of Work Permit by GRD Operator.
- Allow only the GRD operator to upload/attach the Work permit in the doc.

## Is there a business logic within a doctype?
    - [x] Yes
    - [ ] No


## Areas affected and ensured
- Notification sent
- Disabled FP Creation
- Display the Work Permit section to GRD Supervisor.

## Is there any existing behavior change of other features due to this code change?
Yes.

<img width="400" alt="Screen Shot 2023-01-09 at 11 46 22 AM" src="https://user-images.githubusercontent.com/29017559/211279546-7fb7975f-eab5-421c-a025-2bf6c9df1ccc.png">

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
