### PR TITLE
Fix:Leave Approval stalling on attendance

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -23,6 +23,9 @@ class LeaveApplicationOverride(LeaveApplication):
             self.validate_optional_leave()
         self.validate_applicable_after()
 
+    def validate_attendance(self):
+        pass
+
     def validate_dates(self):
         if frappe.db.get_single_value("HR Settings", "restrict_backdated_leave_application"):
             if self.from_date and getdate(self.from_date) < getdate(self.posting_date):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Leave application couldn't be approved if Attendance for the employee with status "Present" already exist.

## Solution description
- Override validation of attendance in leave application.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://user-images.githubusercontent.com/29017559/211369236-9933ec9c-cfe8-4380-be30-507786c64fb8.mov

## Areas affected and ensured
- Validate_attendance method.

## Is there any existing behavior change of other features due to this code change?
- Attendance will be overridden regardless of the status of the existing attendance.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
