### PR TITLE
feat: Save and submit career history from portal

### DIFF
--- a/one_fm/one_fm/doctype/career_history/career_history.py
+++ b/one_fm/one_fm/doctype/career_history/career_history.py
@@ -51,7 +51,7 @@ class CareerHistory(Document):
 		if not self.name:
 			# hack! if name is null, it could cause problems with !=
 			self.name = "New "+self.doctype
-		career_history = frappe.db.exists('Career History', {'job_applicant': self.job_applicant, 'name': ['!=', self.name], 'docstatus': ['<', 2]})
+		career_history = frappe.db.exists('Career History', {'job_applicant': self.job_applicant, 'name': ['!=', self.name], 'docstatus': ['>', 1]})
 		if career_history:
 			frappe.throw(_("""Career History <b><a href="#Form/Career History/{0}">{0}</a></b> is exists against \
 				Job Applicant {1}.!""").format(career_history, self.applicant_name))

--- a/one_fm/templates/pages/career_history.js
+++ b/one_fm/templates/pages/career_history.js
@@ -366,7 +366,7 @@ career_history = Class.extend({
 		$(`.promotion_details_section_${company_no}${promotion_no}`).empty();
 		$(`.promotion_details_section_${company_no}${promotion_no}`).append(promotion_details_html);
 		if(promotion.promotion_value > 0){
-			me.set_promotion_section_html(company_no, promotion_no+1)
+			this.set_promotion_section_html(company_no, promotion_no+1)
 			PROMOTIONS_IN_COMPANY[company_no] = promotion_no+1;
 		}
 		else{

--- a/one_fm/templates/pages/career_history.py
+++ b/one_fm/templates/pages/career_history.py
@@ -8,6 +8,7 @@ from one_fm.utils import set_expire_magic_link
 
 def get_context(context):
 	context.title = _("Career History")
+	frappe.clear_cache()
 
 	# Authorize Magic Link
 	magic_link = authorize_magic_link(frappe.form_dict.magic_link, 'Job Applicant', 'Career History')
@@ -17,12 +18,88 @@ def get_context(context):
 		context.job_applicant = frappe.get_doc('Job Applicant', job_applicant)
 		draft_career_history_exists = frappe.db.exists('Career History', {'job_applicant': job_applicant, 'docstatus': 0})
 		if draft_career_history_exists:
-			context.career_history = frappe.get_doc('Career History', draft_career_history_exists)
+			frappe.cache().set('career_history', draft_career_history_exists)
+			context.career_history = True
 		else:
+			frappe.clear_cache()
+			frappe.cache().set('career_history', 'career_history')
 			context.career_history = False
 
 		# Get Country List to the context to show in the portal
 		context.country_list = frappe.get_all('Country', fields=['name'])
+
+@frappe.whitelist(allow_guest=True)
+def get_the_company_details(which_company):
+	company_details = []
+	career_history_id = frappe.cache().get('career_history').decode('utf-8')
+	if career_history_id == 'career_history':
+		return company_details
+
+	career_history = frappe.get_doc('Career History', career_history_id)
+	company = []
+	prev_salary = False
+	prev_job_title = False
+	promotions = 0
+	company_no = 0
+	which_company = int(which_company)
+	for ch_company in career_history.career_history_company:
+		if ch_company.company_name not in company:
+			promotions = 0
+			company_no += 1
+			if which_company == company_no:
+				prev_salary = ch_company.monthly_salary_in_kwd
+				prev_job_title = ch_company.job_title
+
+				company_details.append({'company_name': ch_company.company_name,
+				'country_of_employment': ch_company.country_of_employment, 'start_date': ch_company.start_date,
+				'monthly_salary_in_kwd': ch_company.monthly_salary_in_kwd, 'job_title': ch_company.job_title,
+				'reason_for_leaving_job': ch_company.why_do_you_plan_to_leave_the_job, 'end_date': ch_company.end_date})
+			if company_details and len(company_details) > (which_company - 1):
+				company_details[which_company-1]['working_now'] = 'Yes'
+			company.append(ch_company.company_name)
+		else:
+			if which_company == company_no:
+				promotion = False
+				salary_hike = False
+				if prev_salary != ch_company.monthly_salary_in_kwd:
+					salary_hike = True
+				if prev_job_title != ch_company.job_title:
+					promotion = True
+				if promotion or salary_hike:
+					prev_salary = ch_company.monthly_salary_in_kwd
+					prev_job_title = ch_company.job_title
+					promotions += 1
+					promotion_value = 0
+					if promotion and salary_hike:
+						promotion_value = 1
+					elif promotion:
+						promotion_value = 2
+					elif salary_hike:
+						promotion_value = 3
+					if 'promotions' not in company_details[company_no-1]:
+						company_details[company_no-1]['promotions'] = [
+							{
+								'promotion_value': promotion_value, 'start_date': ch_company.start_date,
+								'monthly_salary_in_kwd': ch_company.monthly_salary_in_kwd, 'job_title': ch_company.job_title,
+								'reason_for_leaving_job': ch_company.why_do_you_plan_to_leave_the_job, 'end_date': ch_company.end_date
+							}
+						]
+					else:
+						company_details[company_no-1]['promotions'].append({
+							'promotion_value': promotion_value, 'start_date': ch_company.start_date,
+							'monthly_salary_in_kwd': ch_company.monthly_salary_in_kwd, 'job_title': ch_company.job_title,
+							'reason_for_leaving_job': ch_company.why_do_you_plan_to_leave_the_job, 'end_date': ch_company.end_date
+						})
+		if which_company == company_no and company_details and len(company_details) > (which_company - 1):
+			if ch_company.end_date:
+				company_details[company_no-1]['end_date'] = ch_company.end_date
+				company_details[company_no-1]['working_now'] = 'No'
+			if ch_company.why_do_you_plan_to_leave_the_job:
+				company_details[company_no-1]['reason_for_leaving_job'] = ch_company.why_do_you_plan_to_leave_the_job
+
+
+	return company_details
+
 
 @frappe.whitelist(allow_guest=True)
 def create_career_history_from_portal(job_applicant, career_history_details):
@@ -34,20 +111,16 @@ def create_career_history_from_portal(job_applicant, career_history_details):
 		Return Boolean
 	'''
 	# Create Career History
-	career_history = frappe.new_doc('Career History')
-	career_history.job_applicant = job_applicant
+	draft_career_history_exists = frappe.db.exists('Career History', {'job_applicant': job_applicant, 'docstatus': 0})
+	if draft_career_history_exists:
+		career_history = frappe.get_doc('Career History', draft_career_history_exists)
+		career_history.career_history_company = []
+	else:
+		career_history = frappe.new_doc('Career History')
+		career_history.job_applicant = job_applicant
 
 	career_histories = json.loads(career_history_details)
 	for history in career_histories:
-		print(history)
-		"""
-		{'company_name': 'c1', 'country_of_employment': 'India', 'start_date': '2021-01-01',
-		'monthly_salary_in_kwd': '250', 'job_title': 'PET', 'reason_for_leaving_job': '          cadsca',
-		'promotions': [{'start_date': '2021-02-01', 'job_title': 'JrPE', 'monthly_salary_in_kwd': '300'},
-		{'start_date': '2021-03-01', 'job_title': 'PE'}, {'start_date': '2021-04-01',
-		'monthly_salary_in_kwd': '350'}, {}]}
-
-		"""
 		career_history_fields = ['company_name', 'country_of_employment', 'start_date', 'responsibility_one',
 			'responsibility_two', 'responsibility_three', 'job_title', 'monthly_salary_in_kwd']
 
@@ -73,7 +146,6 @@ def create_career_history_from_portal(job_applicant, career_history_details):
 		if history.get('left_the_company'):
 			company.end_date = history.get('left_the_company')
 		if history.get('reason_for_leaving_job'):
-			company.end_date = today()
 			company.why_do_you_plan_to_leave_the_job = history.get('reason_for_leaving_job')
 
 	career_history.save(ignore_permissions=True)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Feature to save and then submit the career history from the portal
- Bug - Career history saving for different date

## Areas affected and ensured
 - `one_fm/one_fm/doctype/career_history/career_history.py`
 - `one_fm/templates/pages/career_history.py`
 - `one_fm/templates/pages/career_history.js`

## Is there any existing behavior change of other features due to this code change?
Yes, able to save and then submit the career history from the magic link

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome