### PR TITLE
Fix: reference before assignment

### DIFF
--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -11,6 +11,8 @@ def sendemail(recipients, subject, header=None, message=None,
 	sender=None, cc=None , attachments=None, delay=None, args=None, template=None):
 	logo = "https://one-fm.com/files/ONEFM_Identity.png"
 	template = "default_email"
+	action=pdf_link=""
+	
 	head = header[0] if header else ""
 	if not message:
 		message = " "


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- variable 'actions' referenced before assignment

## Solution description
-Assign actions=""

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Areas affected and ensured
- assignment of variable, actions and pdf_link

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
