### PR TITLE
Fix: Payroll Creation - Income Tax Slab Error

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -20,7 +20,7 @@ from wiki.wiki.doctype.wiki_page.wiki_page import WikiPage
 from one_fm.overrides.wiki_page import get_context
 from frappe.desk.doctype.notification_log.notification_log import NotificationLog
 from one_fm.api.notification import after_insert
-
+from one_fm.one_fm.payroll_utils import add_tax_components
 
 __version__ = '14.0.0'
 
@@ -36,6 +36,7 @@ PayrollEntry.fill_employee_details = fill_employee_details
 SalarySlip.get_working_days_details = get_working_days_details
 SalarySlip.get_unmarked_days_based_on_doj_or_relieving = get_unmarked_days_based_on_doj_or_relieving
 SalarySlip.get_unmarked_days = get_unmarked_days
+SalarySlip.add_tax_components = add_tax_components
 ItemPrice.validate = validate
 ItemPrice.check_duplicates = check_duplicates
 LeaveApplication.notify_leave_approver = notify_leave_approver


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Error created in the creation of salary slip due to missing Income Tax Slab Error.

## Analysis and design (optional)
- The method checked for the salary component that is "variable_based_on_taxable_salary".
- It would not check if a deduction exists in the salary structure, hence causing the error.

## Solution description
- Check if the salary Structure has a Deduction component.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="400" alt="Screen Shot 2023-01-15 at 1 53 40 PM" src="https://user-images.githubusercontent.com/29017559/212536565-a08cf5dd-fd68-4bf4-af00-2eb4a5e2c7c8.png">

## Areas affected and ensured
- Salary Slip method override.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [] Firefox
