### PR TITLE
fix: Work Permit - Employee doc update

### DIFF
--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -44,7 +44,7 @@ class WorkPermit(Document):
             self.grd_operator = frappe.db.get_single_value("GRD Settings", "default_grd_operator")
         if not self.grd_operator_transfer:
             self.grd_operator_transfer = frappe.db.get_single_value("GRD Settings", "default_grd_operator_transfer")
-   
+
     def notify(self):
         if self.workflow_state == "Pending By Supervisor":
             subject = ("Work Permit Needs Action")
@@ -269,22 +269,14 @@ class WorkPermit(Document):
         today = date.today()
         Find = False
         employee = frappe.get_doc('Employee', self.employee)
-        document_dic = frappe.get_list('Employee Document',fields={'attach','document_name','issued_on','valid_till'},filters={'parent':self.employee})
-        for index,document in enumerate(document_dic):
-            if document.document_name == "Work Permit":
-                Find = True
-                break
-        if Find:
-            document_dic.insert(index,{
-                "attach": work_permit_attachment,
-                "document_name": "Work Permit",
-                "issued_on":today,
-                "valid_till": new_expiry_date
-            })
-            employee.set('one_fm_employee_documents',[]) #clear the child table
-            for document in document_dic:                # append the sorted list
-                employee.append('one_fm_employee_documents',document)
-
+        if employee.one_fm_employee_documents:
+            for employee_document in employee.one_fm_employee_documents:
+                if employee_document.document_name == 'Work Permit':
+                    employee_document.attach = work_permit_attachment
+                    employee_document.issued_on = today
+                    valid_till.attach = new_expiry_date
+                    Find = True
+                    break
         if not Find:
             employee.append("one_fm_employee_documents", {
             "attach": work_permit_attachment,


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
![Screenshot 2023-01-16 at 6 41 03 PM](https://user-images.githubusercontent.com/20554466/212825375-d53e52de-9dec-429f-972e-5dd3f2d0203e.png)

## Solution description
 - Update the Employee Document table from the employee object

## Is there a business logic within a doctype?
    - [x] No


## Areas affected and ensured
 - `one_fm/grd/doctype/work_permit/work_permit.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data

## Did you delete custom field?
    - [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome