### PR TITLE
feat: Status in Operations Role

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -170,6 +170,10 @@ has_permission = {
 	"Issue": "one_fm.utils.has_permission_to_issue"
 }
 
+standard_queries = {
+	"Operations Role": "one_fm.operations.doctype.operations_role.operations_role.get_operations_role_list",
+}
+
 doc_events = {
 	"Stock Entry": {
 		"on_submit": "one_fm.purchase.doctype.request_for_material.request_for_material.update_completed_and_requested_qty",

--- a/one_fm/operations/doctype/operations_role/operations_role.js
+++ b/one_fm/operations/doctype/operations_role/operations_role.js
@@ -10,5 +10,18 @@ frappe.ui.form.on('Operations Role', {
 				}
 			};
 		});
+		let roles = ['HR Manager', 'HR User', 'Project User', 'Project Manager']
+		let has_role = false;
+		roles.every((item, i) => {
+			if(frappe.user.has_role(item)){
+				has_role = true;
+				return false
+			}
+		});
+		if(has_role){
+			frm.set_df_property('status', 'read_only', false);
+		} else {
+			frm.set_df_property('status', 'read_only', true);
+		}
 	}
 });

--- a/one_fm/operations/doctype/operations_role/operations_role.json
+++ b/one_fm/operations/doctype/operations_role/operations_role.json
@@ -7,16 +7,17 @@
  "engine": "InnoDB",
  "field_order": [
   "post_name",
-  "column_break_2",
   "post_abbrv",
-  "column_break_4",
+  "column_break_2",
   "sale_item",
+  "status",
   "section_break_6",
   "shift",
   "site",
   "column_break_9",
   "project",
-  "requirements_section"
+  "requirements_section",
+  "data_14"
  ],
  "fields": [
   {
@@ -40,10 +41,6 @@
   },
   {
    "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_4",
    "fieldtype": "Column Break"
   },
   {
@@ -85,10 +82,22 @@
    "fieldname": "requirements_section",
    "fieldtype": "Section Break",
    "label": "Requirements"
+  },
+  {
+   "default": "Active",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "\nActive\nHold\nStop\nCancelled",
+   "read_only": 1
+  },
+  {
+   "fieldname": "data_14",
+   "fieldtype": "Data"
   }
  ],
  "links": [],
- "modified": "2022-12-31 20:27:41.947124",
+ "modified": "2023-01-16 21:33:11.641781",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Role",

--- a/one_fm/operations/doctype/operations_role/operations_role.py
+++ b/one_fm/operations/doctype/operations_role/operations_role.py
@@ -8,6 +8,7 @@ from frappe.model.document import Document
 from frappe.model.rename_doc import rename_doc
 from frappe.utils import cstr, getdate, add_to_date
 import pandas as pd
+from frappe.desk.reportview import build_match_conditions, get_filters_cond
 
 class OperationsRole(Document):
 	def after_insert(self):
@@ -38,3 +39,42 @@ def set_post_active(post, operations_role, post_abbrv, shift, site, project, sta
 		sch.date = cstr(date.date())
 		sch.post_status = "Planned"
 		sch.save()
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_operations_role_list(doctype, txt, searchfield, start, page_len, filters=None):
+	from erpnext.controllers.queries import get_fields
+
+	fields = ["name"]
+
+	fields = get_fields("Operations Role", fields)
+
+	match_conditions = build_match_conditions("Operations Role")
+	match_conditions = "and {}".format(match_conditions) if match_conditions else ""
+
+	if filters:
+		filter_exist = False
+		for filter in filters:
+			if filters[filter]:
+				filter_exist = True
+		if filter_exist:
+			filter_conditions = get_filters_cond(doctype, filters, [])
+			match_conditions += "{}".format(filter_conditions)
+
+	return frappe.db.sql(
+		"""
+		select %s
+		from `tabOperations Role`
+		where docstatus < 2
+			and (%s like %s or post_name like %s)
+			{match_conditions}
+		order by
+			case when name like %s then 0 else 1 end,
+			case when post_name like %s then 0 else 1 end,
+			name, post_name limit %s, %s
+		""".format(
+			match_conditions=match_conditions
+		)
+		% (", ".join(fields), searchfield, "%s", "%s", "%s", "%s", "%s", "%s"),
+		("%%%s%%" % txt, "%%%s%%" % txt, "%%%s%%" % txt, "%%%s%%" % txt, start, page_len),
+	)

--- a/one_fm/operations/doctype/operations_role/operations_role_list.js
+++ b/one_fm/operations/doctype/operations_role/operations_role_list.js
@@ -1,10 +1,15 @@
 frappe.listview_settings['Operations Role'] = {
-	add_fields: ["paused"],
 	get_indicator: function(doc) {
-		if(!doc.paused) {
-			return [__("Active"), "green", "paused,=,No"];
-		} else if(doc.paused) {
-			return [__("Paused"), "red", "paused,=,Yes"];
+		if(!doc.status) {
+			return [__("Active"), "green", "status,=,Active"];
+		} else if(doc.status == 'Active') {
+			return [__("Active"), "green", "status,=,Active"]
+		} else if(doc.status == 'Hold') {
+			return [__("Hold"), "orange", "status,=,Hold"]
+		} else if(doc.status == 'Stop') {
+			return [__("Stop"), "red", "status,=,Stop"]
+		} else if(doc.status == 'Cancelled') {
+			return [__("Cancelled"), "grey", "status,=,Cancelled"]
 		}
 	}
 };


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- User needs to update the Operations role status Active, Hold, Stop or Cancelled
- Currently there is no status in the Operations Role

## Solution description
- Added new status field with values Active, Hold, Stop and Cancelled
- Set a standard query for Operations Role, It will filter only Active Operations Role
- Update the indicators with respect to the status value
- Status can be updated by the user having Role, HR User, HR Manager, Project User and Project Manager

## Areas affected and ensured
- `one_fm/hooks.py`
- `one_fm/operations/doctype/operations_role/operations_role.json`
- `one_fm/operations/doctype/operations_role/operations_role_list.js`
- `one_fm/operations/doctype/operations_role/operations_role.py`

## Is there any existing behavior change of other features due to this code change?
Yes, Now the User can change the status of Operations Role and Active Operations Role only will shows in the link

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome