### PR TITLE
chore: reformat get_roster_view API response

### DIFF
--- a/one_fm/api/v1/flutter/roster.py
+++ b/one_fm/api/v1/flutter/roster.py
@@ -171,6 +171,15 @@ def get_roster_view(start_date: str, end_date: str, assigned: int = 0, scheduled
 			for record in v:
 				employees_data.append(record)
 		master_data['employees_data'] = employees_data
+		
+		# reformat operations role data
+		operations_roles_data = []
+		for k, v in master_data['operations_roles_data'].items():
+			for record in v:
+				record['operations_role'] = k
+				operations_roles_data.append(record)
+		master_data['operations_roles_data'] = operations_roles_data
+
 		response("Success", 200, master_data)
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), 'Get Roster View')


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
This chore reformat API response data for operations role in get_roster_view endpoint. The end result is an array of objects from previous object of objects.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
