### PR TITLE
fix: Active Inactive status in Operations Role

### DIFF
--- a/one_fm/operations/doctype/operations_role/operations_role.js
+++ b/one_fm/operations/doctype/operations_role/operations_role.js
@@ -19,9 +19,9 @@ frappe.ui.form.on('Operations Role', {
 			}
 		});
 		if(has_role){
-			frm.set_df_property('status', 'read_only', false);
+			frm.set_df_property('is_active', 'read_only', false);
 		} else {
-			frm.set_df_property('status', 'read_only', true);
+			frm.set_df_property('is_active', 'read_only', true);
 		}
 	}
 });

--- a/one_fm/operations/doctype/operations_role/operations_role.json
+++ b/one_fm/operations/doctype/operations_role/operations_role.json
@@ -10,14 +10,12 @@
   "post_abbrv",
   "column_break_2",
   "sale_item",
-  "status",
+  "is_active",
   "section_break_6",
   "shift",
   "site",
   "column_break_9",
-  "project",
-  "requirements_section",
-  "data_14"
+  "project"
  ],
  "fields": [
   {
@@ -79,25 +77,15 @@
    "read_only": 1
   },
   {
-   "fieldname": "requirements_section",
-   "fieldtype": "Section Break",
-   "label": "Requirements"
-  },
-  {
-   "default": "Active",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "label": "Status",
-   "options": "\nActive\nHold\nStop\nCancelled",
+   "default": "1",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "label": "Active",
    "read_only": 1
-  },
-  {
-   "fieldname": "data_14",
-   "fieldtype": "Data"
   }
  ],
  "links": [],
- "modified": "2023-01-16 21:33:11.641781",
+ "modified": "2023-01-17 14:53:04.218934",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Role",

--- a/one_fm/operations/doctype/operations_role/operations_role.py
+++ b/one_fm/operations/doctype/operations_role/operations_role.py
@@ -66,6 +66,7 @@ def get_operations_role_list(doctype, txt, searchfield, start, page_len, filters
 		select %s
 		from `tabOperations Role`
 		where docstatus < 2
+			and is_active = 1
 			and (%s like %s or post_name like %s)
 			{match_conditions}
 		order by

--- a/one_fm/operations/doctype/operations_role/operations_role_list.js
+++ b/one_fm/operations/doctype/operations_role/operations_role_list.js
@@ -1,15 +1,10 @@
 frappe.listview_settings['Operations Role'] = {
+	add_fields: ["is_active"],
 	get_indicator: function(doc) {
-		if(!doc.status) {
-			return [__("Active"), "green", "status,=,Active"];
-		} else if(doc.status == 'Active') {
+		if(doc.is_active == 1) {
 			return [__("Active"), "green", "status,=,Active"]
-		} else if(doc.status == 'Hold') {
-			return [__("Hold"), "orange", "status,=,Hold"]
-		} else if(doc.status == 'Stop') {
-			return [__("Stop"), "red", "status,=,Stop"]
-		} else if(doc.status == 'Cancelled') {
-			return [__("Cancelled"), "grey", "status,=,Cancelled"]
+		} else if(doc.is_active != 1) {
+			return [__("Inactive"), "grey", "status,=,Inactive"]
 		}
 	}
 };


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Operations Role, needs to set active inactive by the user instead of set the status

## Solution description
- Added Active(Check box)
- Standard query updated for operations role
- List view updated with status indicator

## Is there a business logic within a doctype?
    - [x] No

## Output screenshots (optional)
![Screenshot 2023-01-18 at 10 05 50 AM](https://user-images.githubusercontent.com/20554466/213085067-a8171e03-c61a-45a5-99f1-cdd98eda565d.png)

## Areas affected and ensured
- `one_fm/operations/doctype/operations_role/operations_role.js`
-  `one_fm/operations/doctype/operations_role/operations_role_list.js`
-  `one_fm/operations/doctype/operations_role/operations_role.json`
-  `one_fm/operations/doctype/operations_role/operations_role.py`

## Is there any existing behavior change of other features due to this code change?
Yes, User can set active or inactive the Operations Role

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome