### PR TITLE
feat: Shift Permission - Update

### DIFF
--- a/one_fm/operations/doctype/shift_permission/shift_permission.js
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.js
@@ -2,6 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Shift Permission', {
+	refresh: function(frm) {
+		set_options_for_permission_type(frm);
+	},
+	log_type: function(frm) {
+		set_options_for_permission_type(frm);
+	},
 	employee: function(frm) {
 		get_shift_assignment(frm);
 	},
@@ -12,6 +18,20 @@ frappe.ui.form.on('Shift Permission', {
 		get_shift_assignment(frm);
 	},
 });
+
+function set_options_for_permission_type(frm) {
+	if(frm.doc.log_type){
+		if(frm.doc.log_type == 'IN'){
+			frm.set_df_property('permission_type', 'options', ['', 'Arrive Late', 'Forget to Checkin', 'Checkin Issue']);
+		}
+		else{
+			frm.set_df_property('permission_type', 'options', ['', 'Leave Early', 'Forget to Checkout', 'Checkout Issue']);
+		}
+	}
+	else{
+		frm.set_df_property('permission_type', 'options', ['Select Log Type first']);
+	}
+};
 
 function get_shift_assignment(frm){
 	let {employee, emp_name, start_date} = frm.doc;
@@ -25,10 +45,10 @@ function get_shift_assignment(frm){
 				let val = r.message
                 if(val && val.includes(null) != true){
 					let [name, approver, shift, shift_type] = r.message;
-					set_shift_details(frm, name, approver, shift, shift_type);			
+					set_shift_details(frm, name, approver, shift, shift_type);
                 }
 				else{
-					frappe.msgprint(__(`No shift assigned to ${emp_name}. Please check again.`));				
+					frappe.msgprint(__(`No shift assigned to ${emp_name}. Please check again.`));
 					set_shift_details(frm, undefined, undefined, undefined, undefined);
 				}
             }

--- a/one_fm/operations/doctype/shift_permission/shift_permission.json
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.json
@@ -8,9 +8,10 @@
  "field_order": [
   "title",
   "employee",
+  "emp_name",
   "date",
   "column_break_3",
-  "emp_name",
+  "log_type",
   "permission_type",
   "section_break_5",
   "assigned_shift",
@@ -24,6 +25,7 @@
   "arrival_time",
   "leaving_time",
   "latitude",
+  "column_break_20",
   "longitude",
   "section_break_17",
   "reason",
@@ -117,14 +119,16 @@
    "fieldname": "arrival_time",
    "fieldtype": "Time",
    "in_list_view": 1,
-   "label": "Arrival Time"
+   "label": "Arrival Time",
+   "mandatory_depends_on": "eval:doc.permission_type == \"Arrive Late\""
   },
   {
    "depends_on": "eval:doc.permission_type== \"Leave Early\"",
    "fieldname": "leaving_time",
    "fieldtype": "Time",
    "in_list_view": 1,
-   "label": "Leaving Time"
+   "label": "Leaving Time",
+   "mandatory_depends_on": "eval:doc.permission_type== \"Leave Early\""
   },
   {
    "fieldname": "amended_from",
@@ -184,11 +188,22 @@
    "label": "Approver User ID",
    "options": "User",
    "read_only": 1
+  },
+  {
+   "fieldname": "log_type",
+   "fieldtype": "Select",
+   "label": "Log Type",
+   "options": "\nIN\nOUT",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_20",
+   "fieldtype": "Column Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-28 11:58:06.332859",
+ "modified": "2023-01-19 14:50:04.904720",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Shift Permission",

--- a/one_fm/operations/doctype/shift_permission/test_shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/test_shift_permission.py
@@ -3,8 +3,251 @@
 # See license.txt
 from __future__ import unicode_literals
 
-# import frappe
+import frappe
 import unittest
 
+from datetime import timedelta
+from frappe.utils import (
+	add_days, get_year_ending, get_year_start, now_datetime, nowdate
+)
+from one_fm.operations.doctype.shift_permission.shift_permission import (
+	PermissionTypeandLogTypeError,
+	ExistAttendance,
+	ExistCheckin,
+	ShiftDetailsMissing
+)
+from hrms.hr.doctype.attendance.attendance import mark_attendance
+
+shift_permission_record = {
+	"doctype": "Shift Permission",
+	"reason": "Test Reason",
+	"shift_supervisor": "_T-Employee-00001"
+}
+
 class TestShiftPermission(unittest.TestCase):
-	pass
+	def test_shift_permission_type(self):
+		shift_permission = get_shift_permission_record()[0]
+
+		shift_permission.log_type = "IN"
+		shift_permission.permission_type = "Checkout Issue"
+		self.assertRaises(PermissionTypeandLogTypeError, shift_permission.insert)
+		shift_permission.permission_type = "Checkin Issue"
+		self.assertTrue(shift_permission.insert())
+		frappe.db.sql("delete from `tabShift Permission`")
+
+		shift_permission.log_type = "OUT"
+		shift_permission.permission_type = "Checkin Issue"
+		self.assertRaises(PermissionTypeandLogTypeError, shift_permission.insert)
+		frappe.db.sql("delete from `tabShift Permission`")
+		shift_permission.permission_type = "Checkout Issue"
+		self.assertTrue(shift_permission.insert())
+		frappe.db.sql("delete from `tabShift Permission`")
+
+		shift_permission.log_type = "OUT"
+		shift_permission.permission_type = "Leave Early"
+		shift_permission.leaving_time = ''
+		self.assertRaises(frappe.MandatoryError, shift_permission.insert)
+		frappe.db.sql("delete from `tabShift Permission`")
+		shift_permission.leaving_time = '10:10:10'
+		self.assertTrue(shift_permission.insert())
+		frappe.db.sql("delete from `tabShift Permission`")
+
+		shift_permission.log_type = "IN"
+		shift_permission.permission_type = "Arrive Late"
+		shift_permission.arrival_time = ''
+		self.assertRaises(frappe.MandatoryError, shift_permission.insert)
+		frappe.db.sql("delete from `tabShift Permission`")
+		shift_permission.arrival_time = '10:10:10'
+		self.assertTrue(shift_permission.insert())
+		frappe.db.sql("delete from `tabShift Permission`")
+
+	def test_validate_attendance(self):
+		frappe.db.sql("delete from `tabAttendance`")
+		shift_permission, employee = get_shift_permission_record()
+		mark_attendance(employee, nowdate(), "Present")
+
+		shift_permission.log_type = "IN"
+		shift_permission.permission_type = "Checkin Issue"
+		self.assertRaises(ExistAttendance, shift_permission.insert)
+		shift_permission.date = add_days(nowdate(), 1)
+		self.assertTrue(shift_permission.insert())
+		frappe.db.sql("delete from `tabShift Permission`")
+
+	def test_validate_employee_checkin(self):
+		frappe.db.sql("delete from `tabEmployee Checkin`")
+		shift_permission, employee = get_shift_permission_record()
+		employee_checkin = frappe.get_doc(
+			{
+				"doctype": "Employee Checkin",
+				"employee": employee,
+				"time": now_datetime(),
+				"device_id": "device1",
+				"log_type": "IN",
+			}
+		).insert()
+
+		shift_permission.log_type = "IN"
+		shift_permission.permission_type = "Checkin Issue"
+		self.assertRaises(ExistCheckin, shift_permission.insert)
+		shift_permission.date = add_days(nowdate(), 1)
+		self.assertTrue(shift_permission.insert())
+		frappe.db.sql("delete from `tabShift Permission`")
+
+	def test_check_shift_details_value(self):
+		date = nowdate()
+		service_type = make_service_type()
+		operations_shift = make_operations_shift()
+		employee = make_employee("test_employee_@example.com", operations_shift, company="_Test Company")
+		shift_assignment = make_shift_assignment(employee, date)
+
+		shift_permission = frappe.copy_doc(shift_permission_record)
+		shift_permission.employee = employee
+		shift_permission.date = date
+		shift_permission.log_type = "IN"
+		shift_permission.permission_type = "Checkin Issue"
+		self.assertRaises(ShiftDetailsMissing, shift_permission.insert)
+		shift_permission.shift = operations_shift
+		shift_permission.assigned_shift = shift_assignment.name
+		shift_permission.shift_type = shift_assignment.shift_type
+		self.assertTrue(shift_permission.insert())
+		frappe.db.sql("delete from `tabShift Permission`")
+
+def get_shift_permission_record():
+	date = nowdate()
+	service_type = make_service_type()
+	operations_shift = make_operations_shift()
+	employee = make_employee("test_employee_@example.com", operations_shift, company="_Test Company")
+	shift_assignment = make_shift_assignment(employee, date)
+
+	shift_permission = frappe.copy_doc(shift_permission_record)
+	shift_permission.shift = operations_shift
+	shift_permission.date = date
+	shift_permission.assigned_shift = shift_assignment.name
+	shift_permission.shift_type = shift_assignment.shift_type
+	shift_permission.employee = employee
+
+	return shift_permission, employee
+
+def make_service_type():
+	frappe.db.delete("Service Type")
+	service_type = frappe.get_doc(
+		{
+			"doctype": "Service Type",
+			"service_type": "_Test_Service_Type"
+		}
+	).insert()
+	return service_type
+
+def make_operations_shift():
+	operations_shift = frappe.get_doc(
+		{
+			"doctype": "Operations Shift",
+			"service_type": "_Test_Service_Type",
+			"shift_number": "2345"
+		}
+	)
+	operations_shift.insert()
+	return operations_shift.name
+
+def make_employee(user, operations_shift, company=None, **kwargs):
+	frappe.db.delete("Employee")
+	if not frappe.db.get_value("User", user):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": user,
+				"first_name": user,
+				"new_password": "password",
+				"send_welcome_email": 0,
+				"roles": [{"doctype": "Has Role", "role": "Employee"}],
+			}
+		).insert()
+	if not frappe.db.get_value("Employee", {"user_id": user}):
+		employee = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"naming_series": "EMP-",
+				"first_name": user,
+				"last_name": "LN",
+				"employee_name": "Emp Name",
+				"one_fm_first_name_in_arabic": "FNA",
+				"one_fm_last_name_in_arabic": "LNA",
+				"one_fm_basic_salary": "100",
+				"shift": operations_shift,
+				"company": company or erpnext.get_default_company(),
+				"user_id": user,
+				"date_of_birth": "1990-05-08",
+				"date_of_joining": "2013-01-01",
+				"department": frappe.get_all("Department", fields="name")[0].name,
+				"gender": "Female",
+				"company_email": user,
+				"prefered_contact_email": "Company Email",
+				"prefered_email": user,
+				"status": "Active",
+				"employment_type": "Intern",
+			}
+		)
+		if kwargs:
+			employee.update(kwargs)
+		employee.insert()
+		return employee.name
+	else:
+		frappe.db.set_value("Employee", {"user_id": user}, "status", "Active")
+		return frappe.db.get_value("Employee", {"user_id": user})
+
+def make_shift_assignment(employee, start_date, shift_type=None, end_date=None):
+	if not shift_type:
+		shift_type = setup_shift_type().name
+
+	shift_assignment = frappe.get_doc(
+		{
+			"doctype": "Shift Assignment",
+			"shift_type": shift_type,
+			"company": "_Test Company",
+			"employee": employee,
+			"start_date": start_date,
+			"end_date": end_date,
+		}
+	).insert()
+
+	shift_assignment.submit()
+	return shift_assignment
+
+def setup_shift_type(**args):
+	frappe.db.delete("Shift Type")
+	args = frappe._dict(args)
+	date = nowdate()
+
+	shift_type = frappe.get_doc(
+		{
+			"doctype": "Shift Type",
+			"__newname": args.shift_type or "_Test Shift",
+			"start_time": "08:00:00",
+			"end_time": "12:00:00",
+			"enable_auto_attendance": 1,
+			"determine_check_in_and_check_out": "Alternating entries as IN and OUT during the same shift",
+			"working_hours_calculation_based_on": "First Check-in and Last Check-out",
+			"begin_check_in_before_shift_start_time": 60,
+			"allow_check_out_after_shift_end_time": 60,
+			"process_attendance_after": add_days(date, -2),
+			"last_sync_of_checkin": now_datetime() + timedelta(days=1),
+		}
+	)
+
+	holiday_list = "Employee Checkin Test Holiday List"
+	if not frappe.db.exists("Holiday List", "Employee Checkin Test Holiday List"):
+		holiday_list = frappe.get_doc(
+			{
+				"doctype": "Holiday List",
+				"holiday_list_name": "Employee Checkin Test Holiday List",
+				"from_date": get_year_start(date),
+				"to_date": get_year_ending(date),
+			}
+		).insert()
+		holiday_list = holiday_list.name
+
+	shift_type.holiday_list = holiday_list
+	shift_type.update(args)
+	shift_type.save()
+
+	return shift_type


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Streamline Shift Permission

## Solution description
- Add log type(IN/OUT)
- Permission type restricted based on the log type
- Validate attendance and employee checkin record
- Added Test to the shift permission

## Is there a business logic within a doctype?
 - [x] Yes

## Output screenshots (optional)
- Validate Permission Type and Log Type
![Screenshot 2023-01-19 at 5 17 51 PM](https://user-images.githubusercontent.com/20554466/214110494-038cca37-858b-472f-9edf-f990d197a374.png)
![Screenshot 2023-01-19 at 5 19 23 PM](https://user-images.githubusercontent.com/20554466/214110507-848fac93-bea3-4c0a-9341-7b82a80f88a3.png)
- Validate Employee Checkin
![Screenshot 2023-01-20 at 3 44 25 PM](https://user-images.githubusercontent.com/20554466/214110512-50897d71-11a7-44ad-b2e0-4c1940a32caf.png)
- Validate Attendance
![Screenshot 2023-01-20 at 3 46 59 PM](https://user-images.githubusercontent.com/20554466/214110516-9b4d040b-77f9-4196-a7fc-038fd4766fa7.png)
- Test OUT PUT
![Screenshot 2023-01-23 at 10 36 36 PM](https://user-images.githubusercontent.com/20554466/214110522-db332882-3f4b-4f89-9889-8b86ac92b866.png)

## Areas affected and ensured
 - `one_fm/operations/doctype/shift_permission/shift_permission.json`
 - `one_fm/operations/doctype/shift_permission/shift_permission.js`
 - `one_fm/operations/doctype/shift_permission/shift_permission.py`
 - `one_fm/api/v1/shift_permission.py`
 - `one_fm/operations/doctype/shift_permission/test_shift_permission.py`

## Is there any existing behavior change of other features due to this code change?
Yes, Shift Permission validate Attendance and Employee Checkin before creates it.
The API for the create shift permission is having a slight change

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome