### PR TITLE
fix: Operations Post - Timeout issue

### DIFF
--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -44,10 +44,10 @@ class OperationsPost(Document):
 		if self.status == "Active":
 			check_list = frappe.db.get_list("Post Schedule", filters={"post":self.name, "date": [">", getdate()]})
 			if len(check_list) < 1 :
-				return frappe.enqueue(set_post_schedule(doc=self), is_async=True, queue="long")
+				frappe.enqueue(set_post_schedule, doc=self, is_async=True, queue="long")
 
 		elif self.status == "Inactive":
-			return frappe.enqueue(delete_schedule(doc=self), is_async=True, queue="long")
+			frappe.enqueue(delete_schedule, doc=self, is_async=True, queue="long")
 
 def set_post_schedule(doc):
 	project = frappe.get_doc("Project", doc.project)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Operations Post save getting timeout

## Solution description
- On update of Operations Post it is creating and Post Schedules and returns. Post Schedule creation is in a queue and it is taking time to complete and the system wait to return the result. We removed the return and works fine

## Areas affected and ensured
- `one_fm/operations/doctype/operations_post/operations_post.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome