### PR TITLE
Feat:  payroll to calculate two Salary Structures on the same Payroll Cycle.

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -6,10 +6,10 @@ from hrms.payroll.doctype.salary_slip.salary_slip import SalarySlip
 from erpnext.stock.doctype.item_price.item_price import ItemPrice
 from one_fm.api.doc_methods.shift_request import shift_request_submit, validate_approver, shift_request_cancel, validate_default_shift
 from one_fm.api.doc_methods.payroll_entry import (
-	validate_employee_attendance, get_count_holidays_of_employee, get_count_employee_attendance, fill_employee_details
+	validate_employee_attendance, get_count_holidays_of_employee, get_count_employee_attendance, fill_employee_details, create_salary_slips
 )
 from one_fm.api.doc_methods.salary_slip import (
-	get_working_days_details, get_unmarked_days_based_on_doj_or_relieving, get_unmarked_days
+	get_working_days_details, get_unmarked_days_based_on_doj_or_relieving, get_unmarked_days, get_data_for_eval
 )
 from one_fm.api.doc_methods.item_price import validate,check_duplicates
 from hrms.hr.doctype.leave_application.leave_application import LeaveApplication
@@ -33,10 +33,12 @@ PayrollEntry.validate_employee_attendance = validate_employee_attendance
 PayrollEntry.get_count_holidays_of_employee = get_count_holidays_of_employee
 PayrollEntry.get_count_employee_attendance = get_count_employee_attendance
 PayrollEntry.fill_employee_details = fill_employee_details
+PayrollEntry.create_salary_slips = create_salary_slips
 SalarySlip.get_working_days_details = get_working_days_details
 SalarySlip.get_unmarked_days_based_on_doj_or_relieving = get_unmarked_days_based_on_doj_or_relieving
 SalarySlip.get_unmarked_days = get_unmarked_days
 SalarySlip.add_tax_components = add_tax_components
+SalarySlip.get_data_for_eval = get_data_for_eval
 ItemPrice.validate = validate
 ItemPrice.check_duplicates = check_duplicates
 LeaveApplication.notify_leave_approver = notify_leave_approver

--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -2,14 +2,14 @@ import frappe, erpnext, json
 from dateutil.relativedelta import relativedelta
 from frappe.utils import (
 	cint, cstr, flt, nowdate, add_days, getdate, fmt_money, add_to_date, DATE_FORMAT, date_diff,
-	get_first_day, get_last_day
+	get_first_day, get_last_day, get_link_to_form
 )
 from frappe import _
 from frappe.utils.pdf import get_pdf
 import openpyxl as xl
 import time
 import datetime
-from datetime import datetime
+from datetime import datetime, timedelta
 from copy import copy
 from pathlib import Path
 from hrms.payroll.doctype.payroll_entry.payroll_entry import (
@@ -515,7 +515,7 @@ def export_nbk(doc, template_path):
 
 		end = time.time()
 
-		print("Total Execution Time: ", end-start)
+		# print("Total Execution Time: ", end-start)
 
 	except Exception as e:
 		frappe.throw(e)
@@ -573,5 +573,143 @@ def email_missing_payment_information(recipients):
 		Send missing salary payment information
 		as an email.
 	"""
-	print(frappe.session.data)
-	print(recipients, '\n\n\n')
+	# print(frappe.session.data)
+	# print(recipients, '\n\n\n')
+
+@frappe.whitelist()
+def create_salary_slips(doc):
+	"""
+	Creates salary slip for selected employees if already not created
+	"""
+	doc.check_permission("write")
+	employees = [emp.employee for emp in doc.employees]
+	if employees:
+		args = frappe._dict(
+			{
+				"salary_slip_based_on_timesheet": doc.salary_slip_based_on_timesheet,
+				"payroll_frequency": doc.payroll_frequency,
+				"company": doc.company,
+				"posting_date": doc.posting_date,
+				"deduct_tax_for_unclaimed_employee_benefits": doc.deduct_tax_for_unclaimed_employee_benefits,
+				"deduct_tax_for_unsubmitted_tax_exemption_proof": doc.deduct_tax_for_unsubmitted_tax_exemption_proof,
+				"payroll_entry": doc.name,
+				"exchange_rate": doc.exchange_rate,
+				"currency": doc.currency,
+			}
+		)
+
+		if len(employees) > 30 or frappe.flags.enqueue_payroll_entry:
+			doc.db_set("status", "Queued")
+			frappe.enqueue(
+				create_salary_slips_for_employees,
+				timeout=600,
+				employees=employees,
+				args=args,
+				start_date=doc.start_date,
+				end_date=doc.end_date,
+				publish_progress=False,
+			)
+			frappe.msgprint(
+				_("Salary Slip creation is queued. It may take a few minutes"),
+				alert=True,
+				indicator="blue",
+			)
+		else:
+			create_salary_slips_for_employees(employees, args, start_date=doc.start_date, end_date=doc.end_date, publish_progress=False)
+			# since this method is called via frm.call this doc needs to be updated manually
+			doc.reload()
+
+def log_payroll_failure(process, payroll_entry, error):
+	error_log = frappe.log_error(
+		title=_("Salary Slip {0} failed for Payroll Entry {1}").format(process, payroll_entry.name)
+	)
+	message_log = frappe.message_log.pop() if frappe.message_log else str(error)
+
+	try:
+		error_message = json.loads(message_log).get("message")
+	except Exception:
+		error_message = message_log
+
+	error_message += "\n" + _("Check Error Log {0} for more details.").format(
+		get_link_to_form("Error Log", error_log.name)
+	)
+
+	payroll_entry.db_set({"error_message": error_message, "status": "Failed"})
+
+def create_salary_slips_for_employees(employees, args, start_date, end_date, publish_progress=True ):
+	try:
+		payroll_entry = frappe.get_doc("Payroll Entry", args.payroll_entry)
+		salary_slips_exist_for = get_existing_salary_slips(employees, args)
+		count = 0
+
+		employees_list = seperate_salary_slip(employees, start_date, end_date)
+
+		for emp in employees_list:
+			if emp['employee'] not in salary_slips_exist_for:
+				args.update({"doctype": "Salary Slip"})
+				args.update(emp)
+				
+				frappe.get_doc(args).insert()
+
+				count += 1
+				if publish_progress:
+					frappe.publish_progress(
+						count * 100 / len(set(employees) - set(salary_slips_exist_for)),
+						title=_("Creating Salary Slips..."),
+					)
+
+		payroll_entry.db_set({"status": "Submitted", "salary_slips_created": 1, "error_message": ""})
+
+		if salary_slips_exist_for:
+			frappe.msgprint(
+				_(
+					"Salary Slips already exist for employees {}, and will not be processed by this payroll."
+				).format(frappe.bold(", ".join(emp for emp in salary_slips_exist_for))),
+				title=_("Message"),
+				indicator="orange",
+			)
+
+	except Exception as e:
+		frappe.db.rollback()
+		log_payroll_failure("creation", payroll_entry, e)
+
+	finally:
+		frappe.db.commit()  # nosemgrep
+		frappe.publish_realtime("completed_salary_slip_creation")
+
+def get_existing_salary_slips(employees, args):
+	return frappe.db.sql_list(
+		"""
+		select distinct employee from `tabSalary Slip`
+		where docstatus!= 2 and company = %s and payroll_entry = %s
+			and start_date >= %s and end_date <= %s
+			and employee in (%s)
+	"""
+		% ("%s", "%s", "%s", "%s", ", ".join(["%s"] * len(employees))),
+		[args.company, args.payroll_entry, args.start_date, args.end_date] + employees,
+	)
+
+def seperate_salary_slip(employees, start_date, end_date):
+	parm = []
+	for emp in employees:
+		salary_structure_assignment = frappe.get_all("Salary Structure Assignment", {"employee":emp, "from_date":["between",(start_date, end_date)]},["*"])
+
+		if len(salary_structure_assignment) > 0:
+			mid_date = ""
+			for ssa in salary_structure_assignment:
+				start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+				end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+
+				if ssa.from_date > start_date and ssa.from_date < end_date:
+					mid_date = ssa.from_date
+			if mid_date:
+				parm.append({"employee": emp, "start_date":start_date, "end_date":mid_date - timedelta(days=1)})
+				parm.append({"employee": emp, "start_date":mid_date , "end_date":end_date})
+		else:
+			parm.append({"employee": emp, "start_date":start_date , "end_date":end_date})
+		
+	return parm
+
+				
+
+				


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Create a Separate salary Slip to calculate for different salary structure assignments in the same Payroll.

## Solution description
- Override create a salary slip method to separate the payroll date. 

## Is there a business logic within a doctype?
    - [ ] Yes
    - [n] No


## Output screenshots (optional)
<img width="838" alt="Screen Shot 2023-01-31 at 8 11 46 AM" src="https://user-images.githubusercontent.com/29017559/215671298-d3cb6107-20db-4fb6-8d6b-87b85e24cc4b.png">


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
