### PR TITLE
Fix: Shift Request Action with Shift Assignment

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -771,7 +771,8 @@ def create_shift_assignment(roster, date, time):
 	shift_request = frappe.db.get_list("Shift Request", filters={
 		'employee': ['IN', [i.employee for i in roster]],
 		'from_date': ['<=', date],
-		'to_date': ['>=', date]
+		'to_date': ['>=', date],
+		'workflow_state': 'Approved'
 		},
 		fields=['name', 'employee', 'check_in_site', 'check_out_site']
 	)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- When New Shift Request is approved, it should create a shift assignment if from date is today.
- When Cancelled, It should cancel shift assignments, and then create a new shift assignment for today if the schedule exists.

## Solution description
- date comparison is fixed.
- Creation of Shift assignment if schedule exists for the day.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
https://user-images.githubusercontent.com/29017559/215735503-cb6d131b-ab45-4f04-8465-38d1ef6da9b8.mov



## Areas affected and ensured
- If Condition to create shift assignment
- Check schedule for creation of shift assignment

## Is there any existing behavior change of other features due to this code change?
-no.

## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
