### PR TITLE
chore: Submit salary structure assignment on employee creation

### DIFF
--- a/one_fm/api/doc_methods/salary_structure_assignment.py
+++ b/one_fm/api/doc_methods/salary_structure_assignment.py
@@ -2,25 +2,23 @@ import frappe
 from frappe import _
 
 @frappe.whitelist()
-def fetch_salary_component(salary_structure, base):
+def fetch_salary_component(salary_structure, base=False):
     """This Function Fetches the Salary Components from a given Salary Structure.
-        It further calculates the amount of each component if the component amount is based on 
+        It further calculates the amount of each component if the component amount is based on
         a formula. In that case, it checks if the base amount exists. If notify it throws an error.
-        
+
         If the amount of components is not based on a formula, the item just fetches the given amount.
-        
+
         This action is taken before saving the file.
     Args:
         doc ([doctype]): Salary Structure Assignment.
-    
-    Result: 
+
+    Result:
         Appends the "Salary Structure Component" Table with calculated amount.
     """
-    component = {}
-    
+    component = []
     salary_structure_components = frappe.get_doc("Salary Structure",{"name":salary_structure},['*'])
     if salary_structure_components.earnings:
-        index = 0
         for item in salary_structure_components.earnings:
             if item.amount_based_on_formula == 1 and item.formula:
                 if not base:
@@ -30,13 +28,21 @@ def fetch_salary_component(salary_structure, base):
                     percent = formula.split("*")[1]
                     amount = int(base)*float(percent)
                     if amount != 0 :
-                        component[index] = {"salary_component":item.salary_component,"amount":amount}
+                        component.append({"salary_component":item.salary_component,"amount":amount})
             else:
                 if item.amount != 0:
-                    component[index] = {"salary_component":item.salary_component,"amount":item.amount}
-            index += 1
+                    component.append({"salary_component":item.salary_component,"amount":item.amount})
     return component
-    
+
+def set_salary_components_details_to_salary_structure_assignment(doc, method):
+	if doc.salary_structure:
+		components = fetch_salary_component(doc.salary_structure, doc.base)
+		if components:
+			doc.set('salary_structure_components', [])
+			for component in components:
+				salary_structure_component = doc.append('salary_structure_components')
+				salary_structure_component.salary_component = component['salary_component']
+				salary_structure_component.amount = component['amount']
 
 def calculate_indemnity_amount(doc, method):
     """This function calculates the Indemnity Amount considering the salary component is "included in indemnity"
@@ -44,7 +50,7 @@ def calculate_indemnity_amount(doc, method):
     This action takes place on submit.
     Args:
         doc ([doctype]): Salary Structure Assignment
-    
+
     result: Input calculated "indemnity_amount"
     """
     indemnity_amount = 0

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -399,7 +399,7 @@ def create_salary_structure_assignment(doc, method):
         assignment.company = doc.company
         assignment.from_date = doc.date_of_joining
         assignment.base = doc.one_fm_basic_salary
-        assignment.save(ignore_permissions = True)
+        assignment.submit()
 
 @frappe.whitelist()
 def update_job_offer_from_applicant(jo, status):

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -292,6 +292,9 @@ doc_events = {
 		]
 	},
 	"Salary Structure Assignment": {
+		"validate": [
+			"one_fm.api.doc_methods.salary_structure_assignment.set_salary_components_details_to_salary_structure_assignment",
+		],
 		"before_submit": [
 			"one_fm.api.doc_methods.salary_structure_assignment.calculate_indemnity_amount",
 			"one_fm.api.doc_methods.salary_structure_assignment.calculate_leave_allocation_amount",

--- a/one_fm/one_fm/doctype/salary_component_table/salary_component_table.json
+++ b/one_fm/one_fm/doctype/salary_component_table/salary_component_table.json
@@ -13,37 +13,46 @@
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "salary_component",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Salary Component"
   },
   {
+   "columns": 2,
    "default": "0",
    "fieldname": "include_in_indemnity",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Include in Indemnity"
   },
   {
+   "columns": 2,
    "fieldname": "amount",
    "fieldtype": "Currency",
+   "in_list_view": 1,
    "label": "Amount"
   },
   {
+   "columns": 3,
    "default": "0",
    "fieldname": "include_in_leave_allocation",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Include in Leave Allocation"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-02-06 11:11:30.305064",
+ "modified": "2023-01-31 14:51:05.601559",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Salary Component Table",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/one_fm/public/js/doctype_js/salary_structure_assignment.js
+++ b/one_fm/public/js/doctype_js/salary_structure_assignment.js
@@ -8,22 +8,22 @@ frappe.ui.form.on('Salary Structure Assignment', {
         fetch_salary_component(frm)
     },
 })
- 
+
 function fetch_salary_component(frm){
-    if(frm.doc.base && frm.doc.salary_structure){
+    if(frm.doc.salary_structure){
         return frappe.call({
             method: 'one_fm.api.doc_methods.salary_structure_assignment.fetch_salary_component',
             args:{salary_structure: frm.doc.salary_structure, base:frm.doc.base},
             freeze: true,
             freeze_message: `Processing`,
             callback: function(r) {
-                var component = r.message
+                var components = r.message
                 frm.clear_table('salary_structure_components');
-                for (let c in component){
-                    var sal_com = frm.add_child('salary_structure_components');
-                    sal_com.salary_component = component[c]["salary_component"]
-                    sal_com.amount = component[c]["amount"]  
-                }
+                components.forEach((component, i) => {
+                  var sal_com = frm.add_child('salary_structure_components');
+                  sal_com.salary_component = component["salary_component"]
+                  sal_com.amount = component["amount"]
+                });
                 frm.refresh_fields();
             }
         })


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Submit salary structure assignment on employee creation
- Set salary component table in salary structure assignment properly

## Solution description
- Submit the salary structure assignment instead of save
- Added validation to set salary component details in salary structure assignment, since it was set from the client side.

## Output screenshots (optional)
Before PR
![Screenshot 2023-02-01 at 10 07 48 AM](https://user-images.githubusercontent.com/20554466/215950892-b0c144d9-e362-41ee-974e-8e247aacb769.png)

After PR
![Screenshot 2023-01-31 at 5 53 32 PM](https://user-images.githubusercontent.com/20554466/215950987-ac1321df-7fec-4ace-a9ef-4789aad668de.png)

## Areas affected and ensured
- `one_fm/api/doc_methods/salary_structure_assignment.py`
- `one_fm/hiring/utils.py`
- `one_fm/hooks.py`
- `one_fm/one_fm/doctype/salary_component_table/salary_component_table.json`
- `one_fm/public/js/doctype_js/salary_structure_assignment.js`

## Is there any existing behavior change of other features due to this code change?
 Yes, The salary structure assignment will set the salary components details even if it is created from background

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
