### PR TITLE
Fix: Dispay of Field and Filter when Form is new.

### DIFF
--- a/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.js
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.js
@@ -12,6 +12,12 @@ frappe.ui.form.on('Google Sheet Data Export', {
 				frappe.model.with_doctype(doctype, () => set_filters_and_field(frm));	
 			}
 		}
+		if(frm.doc.reference_doctype == null){
+			// Clear the field and filter
+			frm.fields_dict.fields_multicheck.$wrapper.empty();
+			frm.fields_dict.filter_list.$wrapper.empty();
+
+		}
 	},
 	onload: (frm) => {
 		frm.set_query("reference_doctype", () => {

--- a/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.json
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.json
@@ -85,6 +85,7 @@
    "label": "Enable Auto Update"
   },
   {
+   "depends_on": "reference_doctype",
    "fieldname": "select_fields_section",
    "fieldtype": "Section Break",
    "label": "Select Fields"
@@ -129,7 +130,7 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2023-01-30 08:02:30.871112",
+ "modified": "2023-02-02 10:46:22.206991",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Google Sheet Data Export",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- the field and filter table is not cleared from the cache when a new google sheet is opened.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
- clear the HTML wrapper.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No

## Is there any existing behavior change of other features due to this code change?
- field and filter section clears up when new.

## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
