### PR TITLE
fix: permission on roster employee action

### DIFF
--- a/one_fm/one_fm/doctype/employees_not_rostered/employees_not_rostered.json
+++ b/one_fm/one_fm/doctype/employees_not_rostered/employees_not_rostered.json
@@ -12,6 +12,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
@@ -21,6 +22,7 @@
    "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee Name",
    "read_only": 1
@@ -29,7 +31,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-10-11 14:49:41.013253",
+ "modified": "2023-02-05 10:10:02.594687",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Employees Not Rostered",
@@ -37,5 +39,6 @@
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
@@ -54,6 +54,7 @@
   {
    "fieldname": "supervisor",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Supervisor",
    "options": "Employee",
    "reqd": 1
@@ -75,7 +76,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-10-12 11:54:11.265138",
+ "modified": "2023-02-05 10:08:31.413506",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Roster Employee Actions",
@@ -144,5 +145,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
This allows Roster Employee Action users to use the doctype with no restrictions

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
