### PR TITLE
Fix: Datetime in shift assignment

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -772,11 +772,11 @@ def create_shift_assignment(roster, date, time):
 		fields=['name', 'shift_type', 'start_time', 'end_time'])
 	shift_types_dict = {}
 	for i in shift_types:
-		i.start_datetime = f"{date} {i.start_time}"
+		i.start_datetime = f"{date} {(datetime.datetime.min + i.start_time).time()}"
 		if i.end_time.total_seconds() < i.start_time.total_seconds():
-			i.end_datetime = f"{add_days(date, 1)} {i.end_time}"
+			i.end_datetime = f"{add_days(date, 1)} {(datetime.datetime.min + i.end_time).time()}"
 		else:
-			i.end_datetime = f"{date} {i.end_time}"
+			i.end_datetime = f"{date} {(datetime.datetime.min + i.end_time).time()}"
 		shift_types_dict[i.name] = i
 	default_shift = frappe.get_doc("Shift Type", '"Standard|Morning|08:00:00-17:00:00|9 hours"').as_dict()
 

--- a/one_fm/tasks/erpnext/shift_assignment.py
+++ b/one_fm/tasks/erpnext/shift_assignment.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.utils import add_days
+import datetime
 
 def before_insert(doc, events):
     """
@@ -9,12 +10,11 @@ def before_insert(doc, events):
         frappe.throw(f"{doc.employee} - {doc.employee_name} is not active and cannot be assigned to a shift")
     if doc.shift_type:
         shift = frappe.get_doc("Shift Type", doc.shift_type)
-        doc.start_datetime = f"{doc.start_date} {shift.start_time}"
+        doc.start_datetime = f"{doc.start_date} {(datetime.datetime.min + shift.start_time).time()}"
         if shift.end_time.total_seconds() < shift.start_time.total_seconds():
-            doc.end_datetime = f"{add_days(doc.start_date, 1)} {shift.end_time}"
+            doc.end_datetime = f"{add_days(doc.start_date, 1)} {(datetime.datetime.min + shift.end_time).time()}"
         else:
-            doc.end_datetime = f"{doc.start_date} {shift.end_time}"
-
+            doc.end_datetime = f"{doc.start_date} {(datetime.datetime.min + shift.end_time).time()}"
 
 def validate(doc, events):
     pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Shift assignment fetched wrong start_datetime and End_datetime when shift starts or ends at 00:00:00.

## Solution description
Since the time from shift assignment is dateTime.timestamp, it is valued at 0:00:00. When converting it to string, it fetched the last value from the previous string. 
The solution was to fetch the time from the timestamp and then convert it to string.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="400" alt="Screen Shot 2023-02-05 at 10 49 18 AM" src="https://user-images.githubusercontent.com/29017559/216807752-d00ef193-e5c2-4976-af13-908b0409e9c5.png">


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
