### PR TITLE
FEAT: add status field to the operations site

### DIFF
--- a/one_fm/operations/doctype/operations_site/operations_site.json
+++ b/one_fm/operations/doctype/operations_site/operations_site.json
@@ -57,6 +57,12 @@
    "options": "Location"
   },
   {
+    "fieldname": "status",
+    "fieldtype": "Select",
+    "label": "Status",
+    "options": "Active\nInactive"
+   },
+  {
    "fieldname": "column_break_7",
    "fieldtype": "Column Break"
   },

--- a/one_fm/operations/doctype/operations_site/operations_site.json
+++ b/one_fm/operations/doctype/operations_site/operations_site.json
@@ -197,7 +197,20 @@
  "name": "Operations Site",
  "naming_rule": "By fieldname",
  "owner": "Administrator",
- "permissions": [],
+ "permissions": [
+    {
+     "create": 1,
+     "delete": 1,
+     "email": 1,
+     "export": 1,
+     "print": 1,
+     "read": 1,
+     "report": 1,
+     "role": "System Manager",
+     "share": 1,
+     "write": 1
+    }
+   ],
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/one_fm/operations/doctype/operations_site/operations_site.json
+++ b/one_fm/operations/doctype/operations_site/operations_site.json
@@ -11,6 +11,7 @@
   "section_break_4",
   "site_name",
   "site_location",
+  "status",
   "column_break_7",
   "account_supervisor",
   "account_supervisor_name",
@@ -56,12 +57,6 @@
    "label": "Site Location",
    "options": "Location"
   },
-  {
-    "fieldname": "status",
-    "fieldtype": "Select",
-    "label": "Status",
-    "options": "Active\nInactive"
-   },
   {
    "fieldname": "column_break_7",
    "fieldtype": "Column Break"
@@ -187,31 +182,26 @@
    "fieldname": "site_allowance_section",
    "fieldtype": "Section Break",
    "label": "Site Allowance"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Active\nInactive"
   }
  ],
  "links": [],
- "modified": "2021-10-18 14:15:30.537669",
+ "modified": "2023-02-04 11:58:15.336952",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Site",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
+ "permissions": [],
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1,
  "track_seen": 1,
  "track_views": 1

--- a/one_fm/operations/doctype/operations_site/operations_site_list.js
+++ b/one_fm/operations/doctype/operations_site/operations_site_list.js
@@ -1,0 +1,9 @@
+frappe.listview_settings['Operations Shift'] = {
+	get_indicator: function(doc) {
+		if(doc.status == "Active") {
+			return [__("Active"), "green", ];
+		} else if(doc.status == "Inactive") {
+			return [__("Inactive"), "red", ];
+		}
+	}
+};


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
i was to add a status field to detect if the operations site is active or not


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
added a status field, and an indicator on the list view of operations shift

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Operations site

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
