### PR TITLE
FEAT: On project update(is_active = False && project_type = "External) , related post, shift , site, role should be inactive

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -264,7 +264,8 @@ doc_events = {
 	},
 	"Project": {
 		"validate": "one_fm.one_fm.project_custom.validate_poc_list",
-		"onload": "one_fm.one_fm.project_custom.get_depreciation_expense_amount"
+		"onload": "one_fm.one_fm.project_custom.get_depreciation_expense_amount",
+		"on_update": "one_fm.one_fm.utils.switch_shift_site_post_to_inactive"
 	# 	"on_update": "one_fm.api.doc_events.project_on_update"
 	},
 	"Attendance": {

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -489,3 +489,32 @@ def attach_abbreviation_to_roles():
 
 
 
+def switch_shift_site_post_to_inactive(doc, method):
+    if doc.is_active == "No" and  doc.project_type == "External":
+        list_of_shift = frappe.db.sql(f""" select name from `tabOperations Shift` where project = "{doc.name}" """)
+        if list_of_shift:
+            for shift in list_of_shift[0]:
+                frappe.db.set_value("Operations Shift", shift, {
+                    "status": "Not Active"
+                })
+
+        list_of_role = frappe.db.sql(f""" select name from `tabOperations Role` where project = "{doc.name}" """)
+        if list_of_role:
+            for role in list_of_role[0]:
+                frappe.db.set_value("Operations Role", role, {
+                    "is_active": False
+                })
+
+        list_of_post = frappe.db.sql(f""" select name from `tabOperations Post` where project = "{doc.name}" """)
+        if list_of_post:
+            for post in list_of_post[0]:
+                frappe.db.set_value("Operations Post", post, {
+                    "status": "Inactive"
+                })
+
+        list_of_sites = frappe.db.sql(f""" select name from `tabOperations Site` where project = "{doc.name}" """)
+        if list_of_sites:
+            for site in list_of_sites[0]:
+                frappe.db.set_value("Operations Site", site, {
+                    "status": "Inactive"
+                })


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
whenever a project's project type is external and the is_active field is set to no, all related operations post, operations role, operations shift and operations site, should be set to inactive

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
added an update function that carries out the task feature

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Projects, Operations Role, Operations Shift, Operations SIte, Operations Post


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
