### PR TITLE
fix: create post schedule from operations post

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -970,3 +970,10 @@ def get_delivery_note(contracts, date):
 		AND dn.customer="{contracts.client}" AND posting_date
 		BETWEEN '{first_day}' AND '{last_day}' AND dn.status='To Bill';
 	;""", as_dict=1)
+
+
+def get_active_contracts_for_project(project):
+	contracts_exists = frappe.db.exists('Contracts', {'project': project, 'workflow_state': 'Active'})
+	if contracts_exists:
+		return frappe.get_doc('Contracts', contracts_exists)
+	return False


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Get active contracts for project
- Post schedule creation background job failing from operations post due to time out

## Solution description
- Post schedules are created by direct sql injection
- Update post schedule naming series
- Log error and db rollback on exception happens while sql injection
- Proper messages set for the user

## Output screenshots

https://user-images.githubusercontent.com/20554466/217062920-48118841-7b92-438b-b849-47d470d71912.mov

https://user-images.githubusercontent.com/20554466/217062971-4ff78368-ec5b-4294-aedb-22925916bc9d.mov

## Areas affected and ensured
- `one_fm/operations/doctype/contracts/contracts.py`
- `one_fm/operations/doctype/operations_post/operations_post.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome