### PR TITLE
Feat: Input Sheet in order of column selected

### DIFF
--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -182,14 +182,15 @@ class DataExporter:
 		# build list of valid docfields
 		tablecolumns = []
 		table_name = "tab" + dt
-		for f in frappe.db.get_table_columns_description(table_name):
-			field = meta.get_field(f.name)
-			if field and (
-				(self.select_columns and f.name in self.select_columns[dt]) or not self.select_columns
-			):
+		print(self.select_columns)
+
+		fields = [ sub['name'] for sub in frappe.db.get_table_columns_description(table_name) ]
+		for f in self.select_columns[dt]:
+			field = meta.get_field(f)
+			if field:
 				tablecolumns.append(field)
 
-		tablecolumns.sort(key=lambda a: int(a.idx))
+		# tablecolumns.sort(key=lambda a: int(a.idx))
 
 		_column_start_end = frappe._dict(start=0)
 
@@ -209,8 +210,7 @@ class DataExporter:
 							"reqd": 1,
 							"info": _("Parent is the name of the document to which the data will get added to."),
 						}
-					),
-					True,
+					)
 				)
 
 			_column_start_end = frappe._dict(start=0)
@@ -220,24 +220,16 @@ class DataExporter:
 			if self.with_data:
 				self._append_name_column(dt)
 
-		for docfield in tablecolumns:
-			self.append_field_column(docfield, True)
 
-		# all non mandatory fields
 		for docfield in tablecolumns:
-			self.append_field_column(docfield, False)
-
+			self.append_field_column(docfield)
 
 		_column_start_end.end = len(self.columns) + 1
 
 		self.column_start_end[(dt, parentfield)] = _column_start_end
 
-	def append_field_column(self, docfield, for_mandatory):
+	def append_field_column(self, docfield):
 		if not docfield:
-			return
-		if for_mandatory and not docfield.reqd:
-			return
-		if not for_mandatory and docfield.reqd:
 			return
 		if docfield.fieldname in ("parenttype", "trash_reason"):
 			return
@@ -249,6 +241,8 @@ class DataExporter:
 			and docfield.fieldname != "name"
 		):
 			return
+		print(docfield.fieldname)
+		print(self.fieldrow)
 
 		self.fieldrow.append(docfield.fieldname)
 		self.labelrow.append(_(docfield.label))
@@ -295,8 +289,7 @@ class DataExporter:
 					"fieldtype": "Data",
 					"reqd": 1,
 				}
-			),
-			True,
+			)
 		)
 
 	def create(self):

--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -182,7 +182,6 @@ class DataExporter:
 		# build list of valid docfields
 		tablecolumns = []
 		table_name = "tab" + dt
-		print(self.select_columns)
 
 		fields = [ sub['name'] for sub in frappe.db.get_table_columns_description(table_name) ]
 		for f in self.select_columns[dt]:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- As a Data Exporter, data columns need to be uploaded in the order of selection of fields.

## Solution description
- Disable sorting of fields as per index.
- Select the column list appended in order of selection

## Output screenshots (optional)
https://user-images.githubusercontent.com/29017559/218302333-edf48428-a89b-41ea-b3ac-12b48cc8d0a9.mov

## Areas affected and ensured
- All columns uploaded.
- sorting of column disabled.

## Is there any existing behavior change of other features due to this code change?
- Column uploaded in order of selection

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
