### PR TITLE
hotfix: get_leave_details - unknown column

### DIFF
--- a/one_fm/overrides/leave_policy_assignment.py
+++ b/one_fm/overrides/leave_policy_assignment.py
@@ -51,7 +51,7 @@ def get_leave_type_detail():
 			"is_lwp",
 			"is_earned_leave",
 			"is_compensatory",
-			"based_on_date_of_joining",
+			"allocate_on_day",
 			"is_carry_forward",
 			"expire_carry_forwarded_leaves_after_days",
 			"earned_leave_frequency",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
-
![Screenshot 2023-02-13 at 4 28 44 PM](https://user-images.githubusercontent.com/20554466/218440868-a2dd858f-f133-4dac-bf8d-aa1ff53c5ceb.png)

## Solution description
- Updated the override method

## Areas affected and ensured
- `one_fm/overrides/leave_policy_assignment.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome