### PR TITLE
fix: Operation Post - Post Schedule - queued

### DIFF
--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -56,46 +56,59 @@ def create_post_schedule_for_operations_post(operations_post):
 	contracts = get_active_contracts_for_project(operations_post.project)
 	if contracts:
 		if contracts.end_date >= getdate():
-			try:
-				owner = frappe.session.user
-				creation = now()
-				query = """
-					Insert Into
-						`tabPost Schedule`
-						(
-							`name`, `post`, `operations_role`, `post_abbrv`, `shift`, `site`, `project`, `date`, `post_status`,
-							`owner`, `modified_by`, `creation`, `modified`, `paid`, `unpaid`
-						)
-					Values
-				"""
-				post_abbrv = frappe.db.get_value("Operations Role", operations_post.post_template, ["post_abbrv"])
-				naming_series = NamingSeries('PS-')
-				ps_name_idx = previous_series = naming_series.get_current_value()
-				today = getdate()
-				start_date = today if contracts.start_date < today else contracts.start_date
-				for date in	pd.date_range(start=start_date, end=contracts.end_date):
-					if not frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": operations_post.name}):
-						ps_name_idx += 1
-						ps_name = 'PS-'+str(ps_name_idx).zfill(5)
-						query += f"""
-							(
-								"{ps_name}", "{operations_post.name}", "{operations_post.post_template}", "{post_abbrv}",
-								"{operations_post.site_shift}", "{operations_post.site}", "{operations_post.project}",
-								'{cstr(date.date())}', 'Planned', "{owner}", "{owner}", "{creation}", "{creation}", '0', '0'
-							),"""
-				if previous_series == ps_name_idx:
-					frappe.msgprint(_("Post is already scheduled."))
-				else:
-					frappe.db.sql(query[:-1], values=[], as_dict=1)
-					frappe.db.commit()
-					naming_series.update_counter(ps_name_idx)
-					frappe.msgprint(_("Post is scheduled as Planned."))
-			except Exception as e:
-				frappe.db.rollback()
-				frappe.log_error('Post Schedule from Operations Post', e)
-				frappe.msgprint(_("Error log is added."), alert=True, indicator='orange')
-				operations_post.reload()
+			today = getdate()
+			start_date = today if contracts.start_date < today else contracts.start_date
+			exists_schedule_in_between = False
+			if frappe.db.exists("Post Schedule", {"date": ['between', (start_date, contracts.end_date)], "post": operations_post.name}):
+				exists_schedule_in_between = True
+				frappe.enqueue(queue_create_post_schedule_for_operations_post, operations_post=operations_post, contracts=contracts, exists_schedule_in_between=exists_schedule_in_between, start_date=start_date, is_async=True, queue="long")
+			else:
+				queue_create_post_schedule_for_operations_post(operations_post, contracts, exists_schedule_in_between, start_date)
 		else:
 			frappe.msgprint(_("End date of the contract referenced in by the project is less than today."))
 	else:
 		frappe.msgprint(_("No active contract found for the project referenced."))
+
+def queue_create_post_schedule_for_operations_post(operations_post, contracts, exists_schedule_in_between, start_date):
+	try:
+		owner = frappe.session.user
+		creation = now()
+		query = """
+			Insert Into
+				`tabPost Schedule`
+				(
+					`name`, `post`, `operations_role`, `post_abbrv`, `shift`, `site`, `project`, `date`, `post_status`,
+					`owner`, `modified_by`, `creation`, `modified`, `paid`, `unpaid`
+				)
+			Values
+		"""
+		post_abbrv = frappe.db.get_value("Operations Role", operations_post.post_template, ["post_abbrv"])
+		naming_series = NamingSeries('PS-')
+		ps_name_idx = previous_series = naming_series.get_current_value()
+
+		for date in	pd.date_range(start=start_date, end=contracts.end_date):
+			schedule_exists = False
+			if exists_schedule_in_between:
+				if not frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": operations_post.name}):
+					schedule_exists = True
+			if not schedule_exists:
+				ps_name_idx += 1
+				ps_name = 'PS-'+str(ps_name_idx).zfill(5)
+				query += f"""
+					(
+						"{ps_name}", "{operations_post.name}", "{operations_post.post_template}", "{post_abbrv}",
+						"{operations_post.site_shift}", "{operations_post.site}", "{operations_post.project}",
+						'{cstr(date.date())}', 'Planned', "{owner}", "{owner}", "{creation}", "{creation}", '0', '0'
+					),"""
+		if previous_series == ps_name_idx:
+			frappe.msgprint(_("Post is already scheduled."))
+		else:
+			frappe.db.sql(query[:-1], values=[], as_dict=1)
+			frappe.db.commit()
+			naming_series.update_counter(ps_name_idx)
+			frappe.msgprint(_("Post is scheduled as Planned."))
+	except Exception as e:
+		frappe.db.rollback()
+		frappe.log_error('Post Schedule from Operations Post', e)
+		frappe.msgprint(_("Error log is added."), alert=True, indicator='orange')
+		operations_post.reload()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Creation of operations post - time out issue 

## Solution description
- Queued the creation method if any post schedule exists in between the date range

## Areas affected and ensured
- `one_fm/operations/doctype/operations_post/operations_post.py`

## Is there any existing behavior change of other features due to this code change?
Yes, if any post schedule exist in between the date range the post schedules will not be created immediately 

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome