### PR TITLE
feat: Set site inactive for inactive project

### DIFF
--- a/one_fm/one_fm/project_custom.py
+++ b/one_fm/one_fm/project_custom.py
@@ -40,7 +40,7 @@ def validate_poc_list(doc, method):
         frappe.throw('POC list is mandatory for project type <b>External</b>')
 
 def validate_project(doc, method):
-	if doc.status != 'Open':
+	if doc.status != 'Open' or doc.is_active == "No":
 		set_operation_site_inactive(doc)
 
 def set_operation_site_inactive(doc):

--- a/one_fm/operations/doctype/operations_site/operations_site.py
+++ b/one_fm/operations/doctype/operations_site/operations_site.py
@@ -20,9 +20,14 @@ class OperationsSite(Document):
 		self.validate_project_status()
 
 	def validate_project_status(self):
-		if self.status == "Active" and self.project \
-			and frappe.db.get_value('Project', self.project, 'status') != 'Open':
-			frappe.throw(_("The Project '<b>{0}</b>' selected in the Site '<b>{1}</b>' is <b>Not Open</b>. <br/> To make the Site atcive first make the Project open".format(self.project, self.name)))
+		if self.status == "Active" and self.project:
+			active_open = False
+			if frappe.db.get_value('Project', self.project, 'status') != 'Open':
+				active_open = "Open"
+			elif frappe.db.get_value('Project', self.project, 'is_active') != 'Yes':
+				active_open = "Active"
+			if active_open:
+				frappe.throw(_("The Project '<b>{0}</b>' selected in the Site '<b>{1}</b>' is <b>Not {2}</b>. <br/> To make the Site atcive first make the project {2}".format(self.project, self.name, active_open)))
 
 	def set_operation_shift_inactive(self):
 		operations_shift_list = frappe.get_all('Operations Shift', {'status': 'Active', 'site': self.name})


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Description
- Set site inactive for inactive project
- Validate site activation against inactive project

## Areas affected and ensured
- `one_fm/one_fm/project_custom.py`
- `one_fm/operations/doctype/operations_site/operations_site.py`

## Is there any existing behavior change of other features due to this code change?
Yes, Site will be inactive if the project is set to not active.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome