### PR TITLE
HotFix: Payroll Report Not showing

### DIFF
--- a/one_fm/one_fm/report/payroll_report/payroll_report.py
+++ b/one_fm/one_fm/report/payroll_report/payroll_report.py
@@ -174,7 +174,7 @@ def get_data(filters):
 			JOIN `tabPayroll Employee Detail` ped ON e.name=ped.employee
 			JOIN `tabPayroll Entry` pe ON pe.name=ped.parent
 			JOIN `tabAttendance` at ON at.employee=e.name
-		WHERE ssa.docstatus=1 AND pe.posting_date BETWEEN '{first_day_of_month}' and '{last_day_of_month}'
+		WHERE ssa.docstatus=1 AND pe.end_date BETWEEN '{first_day_of_month}' and '{last_day_of_month}'
 			AND pe.docstatus=1
 			AND at.attendance_date BETWEEN pe.start_date AND pe.end_date
 			AND at.roster_type='Basic'


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- The payroll report was empty even though the salary slip exists for the given month.

## Solution description
- the query fetched payroll as per the posting date but should have been the ending date.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
<img width="400" alt="Screen Shot 2023-02-16 at 12 33 53 PM" src="https://user-images.githubusercontent.com/29017559/219326055-d97c7f40-a7f2-4c93-ad0e-a451adeac683.png">


## Areas affected and ensured
- payroll report fetch data query

## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
