### PR TITLE
Chore: Validate Salary Structure Assignment  of employees in table while fetching data

### DIFF
--- a/one_fm/grd/doctype/pifss_monthly_deduction/pifss_monthly_deduction.py
+++ b/one_fm/grd/doctype/pifss_monthly_deduction/pifss_monthly_deduction.py
@@ -292,6 +292,7 @@ def import_deduction_data(doc_name):
 	if file_url_1:
 		url_1 = frappe.get_site_path() + file_url_1
 		table_data = []
+		missing_salary_structure_list = []
 		civil_id = ""
 		employee = ""
 		pifss_id_no = ""
@@ -303,6 +304,8 @@ def import_deduction_data(doc_name):
 				pifss_id_no = employee_detail[0]
 				civil_id = employee_detail[1]
 				employee_pk = employee_detail[2]
+				if not frappe.db.exists("Salary Structure Assignment", {"employee": employee_pk}):
+					missing_salary_structure_list.append(employee_pk)
 				table_data.append({
 				'employee': employee_pk, 'pifss_id_no': pifss_id_no, 'civil_id':civil_id, 'employee_name_in_arabic': row[1],
 				'actual_salary': flt(row[2]), 'social_security_salary':flt(row[3]), 'employee_contribution':flt(row[4]),
@@ -316,6 +319,11 @@ def import_deduction_data(doc_name):
 				'actual_salary': flt(row[2]), 'social_security_salary':flt(row[3]), 'employee_contribution':flt(row[4]),
 				'company_contribution':flt(row[5]),'total_contribution':flt(row[6]),
 				})
+		
+		if missing_salary_structure_list:
+			frappe.throw(_("There is no Salary Structure assigned to the following employees:") + '<br><br>'
+				+ '<br>'.join(['<ul><li>{0}</li></ul>'.format(d) for d in missing_salary_structure_list]))
+
 		return table_data,len(table_data)
 
 			# employee_amount = flt(row[1] * (47.730/ 100))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- The error thrown during the approval of PIFSS MOnmtlty Decuction creates an error if SSA is missing. (This is because the doc creates an `Additional Salary` doc). This error should be thrown while GRD Operator fetches the data.

## Solution description
- Validate while fetching the data.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
<img width="500" alt="Screen Shot 2023-02-20 at 12 46 46 PM" src="https://user-images.githubusercontent.com/29017559/220076382-9c1dcafb-fa37-4492-b096-d0cbb3ffb8e2.png">


## Areas affected and ensured
Validate to check if all the employees in the table have SSA

## Is there any existing behavior change of other features due to this code change?
- Validation before head.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
