### PR TITLE
feat: Checkin notification and default values in ECI and Shift permission

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -8,7 +8,7 @@ import frappe, erpnext
 from frappe import _
 from frappe.model.workflow import apply_workflow
 from frappe.utils import (
-	now_datetime,nowtime, cstr, getdate, get_datetime, cint, add_to_date, 
+	now_datetime,nowtime, cstr, getdate, get_datetime, cint, add_to_date,
 	datetime, today, add_days, now
 )
 from one_fm.api.doc_events import get_employee_user_id
@@ -155,18 +155,13 @@ def notify_checkin_checkout_final_reminder(recipients, log_type, notification_ti
 
 	checkin_message_body = """
 					<a class="btn btn-success" href="/app/face-recognition">Check In</a>&nbsp;
-					<br>
-					Submit a Shift Permission if you are planing to arrive late
-					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
-					<br>
-					Submit an Attendance Request if you forgot to checkin
-					<a class="btn btn-secondary" href="/app/attendance-request/new-attendance-request-1">Submit Attendance Request</a>&nbsp;
-					<br>
+					<br/>
+					Submit a Shift Permission if you are planing to arrive late or forgot to checkin
+					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1?log_type=IN&&permission_type=Arrive Late">Submit Shift Permission</a>&nbsp;
+					<br/>
 					Submit a Employee Checkin Issue if there are issues in checkin
 					<a class="btn btn-secondary" href="/app/employee-checkin-issue/new-employee-checkin-issue-1?log_type=IN">Submit Employee Checkin Issue</a>&nbsp;
-					<br>
-					Submit a Shift Request if you are trying to checkin from another site location
-					<a class="btn btn-info" href="/app/shift-request/new-shift-request-1">Submit Shift Request</a>&nbsp;
+					<br/>
 					<h3>{0}</h3>
 					"""
 	checkin_message = _(checkin_message_body.format("DON'T FORGET TO CHECKIN"))
@@ -176,9 +171,10 @@ def notify_checkin_checkout_final_reminder(recipients, log_type, notification_ti
 
 	checkout_message = _("""
 		<a class="btn btn-danger" href="/app/face-recognition">Check Out</a>
-		Submit a Shift Permission if you are planing to leave early or is there any issue in checkout or forget to checkout
-		<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
-		<br>
+		<br/>
+		Submit a Shift Permission if you are planing to leave early or forget to checkout
+		<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1?log_type=OUT&&permission_type=Leave Early"">Submit Shift Permission</a>&nbsp;
+		<br/>
 		Submit a Employee Checkin Issue if there are issues in checkout
 		<a class="btn btn-secondary" href="/app/employee-checkin-issue/new-employee-checkin-issue-1?log_type=OUT">Submit Employee Checkin Issue</a>&nbsp;
 		""")
@@ -271,7 +267,7 @@ def supervisor_reminder(shift, today_datetime, now_time):
 
 		if len(recipients) > 0:
 			for recipient in recipients:
-				
+
 				action_user, Role = get_action_user(recipient.name,recipient.shift)
 				#for_user = get_employee_user_id(recipient.reports_to) if get_employee_user_id(recipient.reports_to) else get_notification_user(op_shift)
 				subject = _('{employee} has not checked out yet.'.format(employee=recipient.employee_name))
@@ -842,7 +838,7 @@ def create_shift_assignment(roster, date, time):
 						query += """, '', '', ''),"""
 				else:
 					has_rostered.append(r.employee_name)
-					
+
 
 			query = query[:-1]
 			query += f"""
@@ -879,7 +875,7 @@ def create_shift_assignment(roster, date, time):
 		recipient = frappe.get_value("Email Account", {"name":"Support"}, ["email_id"])
 		msg = frappe.render_template('one_fm/templates/emails/missing_shift_assignment.html', context={"rosters": roster})
 		sendemail(sender=sender, recipients= recipient, content=msg, subject="Shift Assignment Failed", delay=False)
-		
+
 
 def validate_am_shift_assignment():
 	date = cstr(getdate())
@@ -919,7 +915,7 @@ def validate_am_shift_assignment():
 		sender = frappe.get_value("Email Account", filters = {"default_outgoing": 1}, fieldname = "email_id") or None
 		recipient = frappe.get_value("Email Account", {"name":"Support"}, ["email_id"])
 		msg = frappe.render_template('one_fm/templates/emails/missing_shift_assignment.html', context={"rosters": roster})
-		     
+
 		sendemail(sender=sender, recipients= recipient, content=msg, subject="Missed Shift Assignments List", delay=False)
 		frappe.enqueue(create_shift_assignment, roster = roster, date = date, time='AM', is_async=True, queue='long')
 
@@ -951,16 +947,16 @@ def validate_pm_shift_assignment():
 				E.name = ES.employee
 				AND E.status = "Left")
 	""".format(date=cstr(date)), as_dict=1)
-	
+
 	non_shift = fetch_non_shift(date, "PM")
 	if non_shift:
 		roster.extend(non_shift)
-	
+
 	if len(roster)>0:
 		sender = frappe.get_value("Email Account", filters = {"default_outgoing": 1}, fieldname = "email_id") or None
 		recipient = frappe.get_value("Email Account", {"name":"Support"}, ["email_id"])
 		msg = frappe.render_template('one_fm/templates/emails/missing_shift_assignment.html', context={"rosters": roster})
-		     
+
 		sendemail(sender=sender, recipients= recipient, content=msg, subject="Missed Shift Assignments List", delay=False)
 		frappe.enqueue(create_shift_assignment, roster = roster, date = date, time='PM', is_async=True, queue='long')
 
@@ -1558,16 +1554,16 @@ def get_current_schedules(employee, log_type=None):
 			}
 		):
 		return False
-	
+
 	# check holiday
 	if get_holiday_today(start_date).get(employee_doc.holiday_list):
 		return False
-	
+
 	if curr_shift:
 		# check for leaves
 		if frappe.db.sql(f"""
-				SELECT name, employee FROM `tabLeave Application` 
-				WHERE employee='{employee}' AND status IN ('Open', 'Approved') 
+				SELECT name, employee FROM `tabLeave Application`
+				WHERE employee='{employee}' AND status IN ('Open', 'Approved')
 				AND '{start_date}' BETWEEN from_date AND to_date;
 			""", as_dict=1):
 			return False
@@ -1581,15 +1577,15 @@ def get_current_schedules(employee, log_type=None):
 
 		# check for shift request:
 		if frappe.db.sql(f"""
-				SELECT name, employee FROM `tabShift Request` 
-				WHERE employee='{employee}' AND docstatus=1 
+				SELECT name, employee FROM `tabShift Request`
+				WHERE employee='{employee}' AND docstatus=1
 				AND '{start_date}' BETWEEN from_date AND to_date;
 			""", as_dict=1):
 			return False
 		# check attendance request
 		if frappe.db.sql(f"""
-				SELECT name, employee FROM `tabAttendance Request` 
-				WHERE employee='{employee}' AND docstatus=1 
+				SELECT name, employee FROM `tabAttendance Request`
+				WHERE employee='{employee}' AND docstatus=1
 				AND '{start_date}' BETWEEN from_date AND to_date;
 			""", as_dict=1):
 			return False
@@ -1611,7 +1607,7 @@ def get_current_schedules(employee, log_type=None):
 def fetch_employees_not_in_checkin():
 	"""
 	This method fetch list of employees yet to checkin or have shift permission,
-	attendance request, shift request, leave application based on log_type and 
+	attendance request, shift request, leave application based on log_type and
 	if their shift start or end falls withing the current hour
 	"""
 	if not production_domain():
@@ -1629,24 +1625,24 @@ def fetch_employees_not_in_checkin():
 		# capture current minute
 		if log_type=='IN':
 			reminder_minutes = [i.minute for i in frappe.db.sql("""
-				SELECT notification_reminder_after_shift_start as minute FROM `tabShift Type` 
-				WHERE notification_reminder_after_shift_start>0  
+				SELECT notification_reminder_after_shift_start as minute FROM `tabShift Type`
+				WHERE notification_reminder_after_shift_start>0
 				GROUP BY notification_reminder_after_shift_start;
 			""", as_dict=1)]
 			supervisor_reminder_minutes = [i.minute for i in frappe.db.sql("""
-				SELECT supervisor_reminder_shift_start as minute FROM `tabShift Type` 
-				WHERE supervisor_reminder_shift_start>0  
+				SELECT supervisor_reminder_shift_start as minute FROM `tabShift Type`
+				WHERE supervisor_reminder_shift_start>0
 				GROUP BY supervisor_reminder_shift_start;
 			""", as_dict=1)]
 		else:
 			reminder_minutes = [i.minute for i in frappe.db.sql("""
-				SELECT notification_reminder_after_shift_end as minute FROM `tabShift Type` 
-				WHERE notification_reminder_after_shift_end>0  
+				SELECT notification_reminder_after_shift_end as minute FROM `tabShift Type`
+				WHERE notification_reminder_after_shift_end>0
 				GROUP BY notification_reminder_after_shift_end;
 			""", as_dict=1)]
 			supervisor_reminder_minutes = [i.minute for i in frappe.db.sql("""
-				SELECT supervisor_reminder_start_ends as minute FROM `tabShift Type` 
-				WHERE supervisor_reminder_start_ends>0  
+				SELECT supervisor_reminder_start_ends as minute FROM `tabShift Type`
+				WHERE supervisor_reminder_start_ends>0
 				GROUP BY supervisor_reminder_start_ends;
 			""", as_dict=1)]
 
@@ -1656,7 +1652,7 @@ def fetch_employees_not_in_checkin():
 			SELECT DISTINCT sa.employee, sa.shift_type, sa.start_datetime, sa.end_datetime,
 			sa.shift as operations_shift, st.notification_reminder_after_shift_start,
 			st.notification_reminder_after_shift_end, st.supervisor_reminder_shift_start,
-			st.supervisor_reminder_start_ends, os.supervisor as shift_supervisor, 
+			st.supervisor_reminder_start_ends, os.supervisor as shift_supervisor,
 			osi.account_supervisor as site_supervisor
 
 			FROM `tabShift Assignment` sa RIGHT JOIN `tabShift Type` st ON sa.shift_type=st.name
@@ -1695,8 +1691,8 @@ def fetch_employees_not_in_checkin():
 		employees_yet_to_checkin = [i for i in employees_yet_to_checkin if not i in shift_permissions]
 		# attendance request
 		attendance_request = [i.employee for i in frappe.db.sql(f"""
-			SELECT employee FROM `tabAttendance Request` 
-			WHERE  docstatus=1 
+			SELECT employee FROM `tabAttendance Request`
+			WHERE  docstatus=1
 			AND '{cur_date}' BETWEEN from_date AND to_date
 			AND employee IN {shift_assignments_employees_tuple}
 			GROUP BY employee
@@ -1704,8 +1700,8 @@ def fetch_employees_not_in_checkin():
 		employees_yet_to_checkin = [i for i in employees_yet_to_checkin if not i in attendance_request]
 		# leave application
 		leave_application = [i.employee for i in frappe.db.sql(f"""
-			SELECT employee FROM `tabLeave Application` 
-			WHERE status IN ('Open', 'Approved') 
+			SELECT employee FROM `tabLeave Application`
+			WHERE status IN ('Open', 'Approved')
 			AND '{cur_date}' BETWEEN from_date AND to_date
 			AND employee IN {shift_assignments_employees_tuple}
 		""", as_dict=1)]
@@ -1713,7 +1709,7 @@ def fetch_employees_not_in_checkin():
 
 		# shift request
 		shift_request = [i.employee for i in frappe.db.sql(f"""
-			SELECT employee FROM `tabShift Request` 
+			SELECT employee FROM `tabShift Request`
 			WHERE  docstatus=1 AND '{cur_date}' BETWEEN from_date AND to_date
 			AND employee IN {shift_assignments_employees_tuple}
 		""", as_dict=1)]
@@ -1727,24 +1723,24 @@ def fetch_employees_not_in_checkin():
 			'holiday_list': ['IN', employees_yet_to_checkin]
 		})]
 		employees_yet_to_checkin = [i for i in employees_yet_to_checkin if not i in holiday_list_employees]
-		
+
 		employee_details = frappe.db.get_list("Employee", filters={
 			'name': ['IN', employees_yet_to_checkin]},
-			fields=['name', 'employee_id', 'employee_name', 'user_id', 'prefered_contact_email', 
+			fields=['name', 'employee_id', 'employee_name', 'user_id', 'prefered_contact_email',
 			'prefered_email', 'reports_to']
 		)
 
-		
+
 		if log_type=='IN':
 			for i in employee_details:
 				if shift_assignments_employees_dict.get(i.name):
 					i = {**i, **shift_assignments_employees_dict.get(i.name), **{'log_type':'IN'}}
 					del i['name']
 					# check if is_after_grace_period
-					if minute in reminder_minutes:i['is_after_grace_checkin'] = True				
+					if minute in reminder_minutes:i['is_after_grace_checkin'] = True
 					else:i['is_after_grace_checkin'] = False
 					# check if supervisor reminder
-					if minute in supervisor_reminder_minutes:i['is_supervisor_checkin_reminder'] = True				
+					if minute in supervisor_reminder_minutes:i['is_supervisor_checkin_reminder'] = True
 					else:i['is_supervisor_checkin_reminder'] = False
 					# check initial
 					if (minute==i['start_datetime'].minute and hour==i['start_datetime'].hour):i['initial_checkin_reminder']=True
@@ -1756,10 +1752,10 @@ def fetch_employees_not_in_checkin():
 					i = {**i, **shift_assignments_employees_dict.get(i.name), **{'log_type':'OUT'}}
 					del i['name']
 					# check if is_after_grace_period
-					if minute in reminder_minutes:i['is_after_grace_checkout'] = True				
+					if minute in reminder_minutes:i['is_after_grace_checkout'] = True
 					else:i['is_after_grace_checkout'] = False
 					# check if supervisor reminder
-					if minute in supervisor_reminder_minutes:i['is_supervisor_checkout_reminder'] = True				
+					if minute in supervisor_reminder_minutes:i['is_supervisor_checkout_reminder'] = True
 					else:i['is_supervisor_checkout_reminder'] = False
 					# check initial
 					if (minute==i['end_datetime'].minute and hour==i['end_datetime'].hour):i['initial_checkout_reminder']=True
@@ -1767,12 +1763,12 @@ def fetch_employees_not_in_checkin():
 					return_data.append(frappe._dict(i))
 
 	return frappe._dict({
-		'employees':return_data, 
+		'employees':return_data,
 		# 'reminder_minutes':reminder_minutes,
 		# 'supervisor_reminder_minutes': supervisor_reminder_minutes,
 		'minute':minute, 'date':cur_date, 'total':len(return_data)
 	})
-	
+
 
 def has_checkin_record(employee, log_type, date):
 	if frappe.db.exists('Employee Checkin', {
@@ -1862,11 +1858,11 @@ def initiate_checkin_notification(res):
 				user_roles = frappe.get_roles(recipient.user_id)
 				if "Head Office Employee" in user_roles:
 					push_notification_rest_api_for_checkin(
-						recipient.employee, notification_title, notification_subject, 
+						recipient.employee, notification_title, notification_subject,
 						checkin=True, arriveLate=True, checkout=False)
 				else:
 					push_notification_rest_api_for_checkin(
-						recipient.employee, notification_title, notification_subject, 
+						recipient.employee, notification_title, notification_subject,
 						checkin=True,arriveLate=False,checkout=False)
 		send_notification(
 			notification_title, notification_subject, checkin_message,
@@ -1887,17 +1883,17 @@ def initiate_checkin_notification(res):
 				user_roles = frappe.get_roles(recipient.user_id)
 				if "Head Office Employee" in user_roles:
 					push_notification_rest_api_for_checkin(
-						recipient.employee, notification_title, notification_subject, 
+						recipient.employee, notification_title, notification_subject,
 						checkin=True, arriveLate=True, checkout=False)
 				else:
 					push_notification_rest_api_for_checkin(
-						recipient.employee, notification_title, notification_subject, 
+						recipient.employee, notification_title, notification_subject,
 						checkin=True,arriveLate=False,checkout=False)
 		send_notification(
 			notification_title, notification_subject, checkin_message_after_grace,
 			notification_category, checkin_reminder_id_list
 		)
-	
+
 	# process supervisor checkin reminder
 	if supervisor_checkin_reminder:
 		title = "Checkin Report"
@@ -1936,18 +1932,18 @@ def initiate_checkin_notification(res):
 				user_roles = frappe.get_roles(recipient.user_id)
 				if "Head Office Employee" in user_roles:
 					push_notification_rest_api_for_checkin(
-						recipient.employee, notification_title, notification_subject, 
+						recipient.employee, notification_title, notification_subject,
 						checkin=False, arriveLate=False, checkout=True)
 				else:
 					push_notification_rest_api_for_checkin(
-						recipient.employee, notification_title, notification_subject, 
+						recipient.employee, notification_title, notification_subject,
 						checkin=False,arriveLate=False,checkout=True)
 		send_notification(
 			notification_title, notification_subject, checkout_message,
 			notification_category, checkout_reminder_id_list
 		)
 
-	
+
 	# process supervisor checkout reminder
 	if supervisor_checkout_reminder:
 		title = "Checkout Report"

--- a/one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.js
+++ b/one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.js
@@ -9,10 +9,29 @@ frappe.ui.form.on('Employee Checkin Issue', {
 			}).addClass('btn-primary');
 		}
 	},
+	onload: function(frm) {
+		set_employee_from_the_session_user(frm);
+	},
 	employee: function(frm) {
 		get_shift_assignment(frm);
 	}
 });
+
+function set_employee_from_the_session_user(frm) {
+	if(frappe.session.user != 'Administrator'){
+		frappe.db.get_value('Employee', {'user_id': frappe.session.user} , 'name', function(r) {
+			if(r && r.name){
+				frm.set_value('employee', r.name);
+			}
+			else{
+				frappe.show_alert({
+					message: __('Not find employee record for the user <b>{0}</b>', [frappe.session.user]),
+					indicator: 'yellow'
+				});
+			}
+		});
+	}
+};
 
 function create_issue(frm) {
 	frappe.call({

--- a/one_fm/operations/doctype/shift_permission/shift_permission.js
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Shift Permission', {
+	onload: function(frm) {
+		set_employee_from_the_session_user(frm);
+	},
 	refresh: function(frm) {
 		set_options_for_permission_type(frm);
 	},
@@ -18,6 +21,22 @@ frappe.ui.form.on('Shift Permission', {
 		get_shift_assignment(frm);
 	},
 });
+
+function set_employee_from_the_session_user(frm) {
+	if(frappe.session.user != 'Administrator'){
+		frappe.db.get_value('Employee', {'user_id': frappe.session.user} , 'name', function(r) {
+			if(r && r.name){
+				frm.set_value('employee', r.name);
+			}
+			else{
+				frappe.show_alert({
+					message: __('Not find employee record for the user <b>{0}</b>', [frappe.session.user]),
+					indicator: 'yellow'
+				});
+			}
+		});
+	}
+};
 
 function set_options_for_permission_type(frm) {
 	if(frm.doc.log_type){

--- a/one_fm/operations/doctype/shift_permission/shift_permission.json
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.json
@@ -52,6 +52,7 @@
    "label": "Shift Details"
   },
   {
+   "default": "Today",
    "fieldname": "date",
    "fieldtype": "Date",
    "in_list_view": 1,
@@ -115,6 +116,7 @@
    "reqd": 1
   },
   {
+   "default": "Now",
    "depends_on": "eval:doc.permission_type == \"Arrive Late\"",
    "fieldname": "arrival_time",
    "fieldtype": "Time",
@@ -123,6 +125,7 @@
    "mandatory_depends_on": "eval:doc.permission_type == \"Arrive Late\""
   },
   {
+   "default": "Now",
    "depends_on": "eval:doc.permission_type== \"Leave Early\"",
    "fieldname": "leaving_time",
    "fieldtype": "Time",
@@ -203,7 +206,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-01-19 14:50:04.904720",
+ "modified": "2023-02-16 09:03:03.466801",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Shift Permission",

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -59,10 +59,15 @@ class ShiftPermission(Document):
 				exc = PermissionTypeandLogTypeError)
 		if self.permission_type == "Arrive Late":
 			field_list = [{'Arrival Time':'arrival_time'}]
+			self.leaving_time = ''
 			self.set_mandatory_fields(field_list)
 		if self.permission_type == "Leave Early":
 			field_list = [{'Leaving Time':'leaving_time'}]
+			self.arrival_time = ''
 			self.set_mandatory_fields(field_list)
+		if self.permission_type not in ['Arrive Late', 'Leave Early']:
+			self.arrival_time = ''
+			self.leaving_time = ''
 
 	# This method validates the shift details availability for employee
 	def check_shift_details_value(self):
@@ -78,7 +83,7 @@ class ShiftPermission(Document):
 	def validate_record(self):
 		date = getdate(self.date).strftime('%d-%m-%Y')
 		if self.docstatus==0 and frappe.db.exists("Shift Permission", {
-			"employee": self.employee, "date":self.date, "assigned_shift": self.assigned_shift, 
+			"employee": self.employee, "date":self.date, "assigned_shift": self.assigned_shift,
 			"permission_type": self.permission_type, "workflow_state":"Pending", 'name':['!=', self.name]
 			}):
 			frappe.throw(_("{employee} has already applied for permission to {type} on {date}.".format(employee=self.emp_name, type=self.permission_type.lower(), date=date)))
@@ -154,9 +159,9 @@ def fetch_approver(employee):
 def approve_open_shift_permission(start_date, end_date):
 	try:
 		shift_permissions = frappe.db.sql(f"""
-			SELECT sp.name FROM `tabShift Permission` sp JOIN `tabShift Assignment` sa 
+			SELECT sp.name FROM `tabShift Permission` sp JOIN `tabShift Assignment` sa
 			ON sa.name=sp.assigned_shift
-			WHERE sa.start_date='{start_date}' and sa.end_date='{end_date}' 
+			WHERE sa.start_date='{start_date}' and sa.end_date='{end_date}'
 			AND sp.workflow_state='Pending' AND sp.docstatus=0
 		""", as_dict=1)
 		# apply workflow


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Set current user employee in ECI onload
- Set default values in Shift Permission
- Checkin notification links update

## Solution description
- Set session-user employee in ECI and Shift Permission
- Set default values in Shift Permission like time and date
- Links in the checkin notification massage updated with parameters

## Output screenshots (optional)
![Screenshot 2023-02-21 at 2 30 11 AM](https://user-images.githubusercontent.com/20554466/220199133-b33f2d67-104f-4205-8a89-f94effa61e17.png)

## Areas affected and ensured
- `one_fm/api/tasks.py`
- `one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.js`
- `one_fm/operations/doctype/shift_permission/shift_permission.js`
- `one_fm/operations/doctype/shift_permission/shift_permission.json`
- `one_fm/operations/doctype/shift_permission/shift_permission.py`

## Is there any existing behavior change of other features due to this code change?
Yes, Default values are updated

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome