### PR TITLE
fix: Cancel leave application by workflow

### DIFF
--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -5240,7 +5240,7 @@
   "doctype": "Workflow",
   "document_type": "Leave Application",
   "is_active": 1,
-  "modified": "2022-12-12 21:41:08.855158",
+  "modified": "2023-02-28 09:19:46.222086",
   "name": "Leave Application",
   "override_status": 0,
   "send_email_alert": 0,
@@ -5320,6 +5320,28 @@
     "parentfield": "transitions",
     "parenttype": "Workflow",
     "state": "Open"
+   },
+   {
+    "action": "Cancel",
+    "allow_self_approval": 1,
+    "allowed": "Leave Approver",
+    "condition": null,
+    "next_state": "Cancelled",
+    "parent": "Leave Application",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Approved"
+   },
+   {
+    "action": "Cancel",
+    "allow_self_approval": 1,
+    "allowed": "Leave Approver",
+    "condition": null,
+    "next_state": "Cancelled",
+    "parent": "Leave Application",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Rejected"
    }
   ],
   "workflow_name": "Leave Application",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -24,3 +24,4 @@ one_fm.patches.v14_0.patch_contract_items
 one_fm.patches.v14_0.update_place_of_birth
 one_fm.patches.v14_0.update_working_hours_threshold_for_absent_in_shift_type
 one_fm.patches.v14_0.fix_sick__leaves
+one_fm.patches.v14_0.update_cancelled_leave_application_workflow_state

--- a/one_fm/patches/v14_0/update_cancelled_leave_application_workflow_state.py
+++ b/one_fm/patches/v14_0/update_cancelled_leave_application_workflow_state.py
@@ -1,0 +1,12 @@
+import frappe
+
+def execute():
+	query = '''
+		update
+			`tabLeave Application`
+		set
+			workflow_state = 'Cancelled'
+		where
+			workflow_state = 'Approved' and status = 'Cancelled'
+	'''
+	frappe.db.sql(query)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Cancel leave application by workflow
- Patch to set workflow state as cancelled  for cancelled leave application 

## Solution description
- Added cancel workflow transaction for leave application
- Patch to set workflow state as cancelled  for cancelled leave application 
![Screenshot 2023-02-21 at 2 36 17 PM](https://user-images.githubusercontent.com/20554466/221771500-aa40948e-3959-4299-8b58-6d087bb1503a.png)

## Areas affected and ensured
- `one_fm/fixtures/workflow.json`
- `one_fm/patches.txt`

## Is there any existing behavior change of other features due to this code change?
Yes, Cancelled leave application will show Cancelled indicator
Leave application can be cancelled by the workflow

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes
    ## Was the patch test? Yes
![Screenshot 2023-02-28 at 11 47 47 AM](https://user-images.githubusercontent.com/20554466/221771904-b4842fe0-0f69-4266-b6d2-e1125dab8906.png)


## Which browser(s) did you use for testing?
- [x] Chrome
