### PR TITLE
hot fix: shift permission and eci - set employee

### DIFF
--- a/one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.js
+++ b/one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.js
@@ -18,7 +18,7 @@ frappe.ui.form.on('Employee Checkin Issue', {
 });
 
 function set_employee_from_the_session_user(frm) {
-	if(frappe.session.user != 'Administrator'){
+	if(frappe.session.user != 'Administrator' && frm.is_new()){
 		frappe.db.get_value('Employee', {'user_id': frappe.session.user} , 'name', function(r) {
 			if(r && r.name){
 				frm.set_value('employee', r.name);

--- a/one_fm/operations/doctype/shift_permission/shift_permission.js
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.js
@@ -23,7 +23,7 @@ frappe.ui.form.on('Shift Permission', {
 });
 
 function set_employee_from_the_session_user(frm) {
-	if(frappe.session.user != 'Administrator'){
+	if(frappe.session.user != 'Administrator' && frm.is_new()){
 		frappe.db.get_value('Employee', {'user_id': frappe.session.user} , 'name', function(r) {
 			if(r && r.name){
 				frm.set_value('employee', r.name);


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Shift permission and eci set employee value upon opening the document

## Solution description
- set employee from the session user only if it is a new document

## Areas affected and ensured
- `one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.js`
- `one_fm/operations/doctype/shift_permission/shift_permission.js`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome