### PR TITLE
fix: Shift Permission and ECI - Validate attendance and employee checkin

### DIFF
--- a/one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.py
+++ b/one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.py
@@ -22,11 +22,12 @@ class ShiftDetailsMissing(frappe.ValidationError):
 
 class EmployeeCheckinIssue(Document):
 	def validate(self):
-		self.validate_attendance()
-		self.validate_employee_checkin()
 		self.check_shift_details_value()
 		self.validate_date()
 		self.validate_duplicate_record()
+		if self.workflow_state in ['Pending', 'Approved']:
+			self.validate_attendance()
+			self.validate_employee_checkin()
 
 	def validate_attendance(self):
 		attendance = frappe.db.exists('Attendance',{'attendance_date': self.date, 'employee': self.employee, 'docstatus': 1})

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -28,11 +28,12 @@ class ShiftDetailsMissing(frappe.ValidationError):
 class ShiftPermission(Document):
 	def validate(self):
 		self.validate_permission_type()
-		self.validate_attendance()
-		self.validate_employee_checkin()
 		self.check_shift_details_value()
 		self.validate_date()
 		self.validate_record()
+		if self.workflow_state in ['Pending', 'Approved']:
+			self.validate_attendance()
+			self.validate_employee_checkin()
 		if not self.title:
 			self.title = self.emp_name
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Shift Permission and ECI not able to reject, if an checkin or attendance exist for the employee

## Solution description
- Validate attendance and employee checkin existence if the state is in pending or approved 

## Areas affected and ensured
- `one_fm/operations/doctype/employee_checkin_issue/employee_checkin_issue.py`
- `one_fm/operations/doctype/shift_permission/shift_permission.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome