### PR TITLE
fix: v1 Shift Permission

### DIFF
--- a/one_fm/api/v1/shift_permission.py
+++ b/one_fm/api/v1/shift_permission.py
@@ -33,9 +33,6 @@ def create_shift_permission(employee_id: str = None, log_type: str = None, permi
     if not employee_id:
         return response("Bad Request", 400, None, "employee_id required.")
 
-    if not log_type:
-        return response("Bad Request", 400, None, "log_type required.")
-
     if not permission_type:
         return response("Bad Request", 400, None, "permission_type required.")
 
@@ -45,13 +42,21 @@ def create_shift_permission(employee_id: str = None, log_type: str = None, permi
     if not reason:
         return response("Bad Request", 400, None, "reason required.")
 
+    if not log_type:
+        if permission_type in ['Arrive Late', 'Forget to Checkin', 'Checkin Issue']:
+            log_type='IN'
+        elif permission_type in ['Leave Early', 'Forget to Checkout', 'Checkout Issue']:
+            log_type='OUT'
+        else:
+            return response("Bad Request", 400, None, "log_type required.")
+
     if log_type == "IN" and permission_type not in ['Arrive Late', 'Forget to Checkin', 'Checkin Issue']:
         return response("Bad Request", 400, None, _('Permission Type cannot be {0}. It should be one of \
-            "Arrive Late", "Forget to Checkin", "Checkin Issue" for Log Type "IN"'.format(permission_type))
+            "Arrive Late", "Forget to Checkin", "Checkin Issue" for Log Type "IN"'.format(permission_type)))
 
     if log_type == "OUT" and permission_type not in ['Leave Early', 'Forget to Checkout', 'Checkout Issue']:
         return response("Bad Request", 400, None, _('Permission Type cannot be {0}. It should be one of \
-            "Leave Early", "Forget to Checkout", "Checkout Issue" for Log Type "OUT"'.format(permission_type))
+            "Leave Early", "Forget to Checkout", "Checkout Issue" for Log Type "OUT"'.format(permission_type)))
 
     if permission_type == "Arrive Late" and not arrival_time:
         return response("Bad Request", 400, None, "Arrival time required for late arrival shift permission.")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
V1 shift permission in the mobile app is not updated with log_type, we auto add the log_type based on input from permission_type 

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
