### PR TITLE
CHORE: filter supervisor field to show only active employees(shift and site)

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.js
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.js
@@ -164,9 +164,35 @@ frappe.ui.form.on('Operations Shift', {
 				
 				}
 			).addClass('btn-primary');
-	
-		
-		
 		}	
 	},
+	onload: function(frm){
+		frm.set_query("supervisor", function() {
+			return {
+				"filters": {
+					"status": "Active",
+				}
+			};
+
+		});
+	},
+	supervisor: function(frm){
+		frm.trigger("get_employee_status")
+	},
+	get_employee_status: function(frm){
+		frappe.call({
+			method:"frappe.client.get_value",
+			args: {
+				doctype:"Employee",
+				filters: {
+					name:frm.doc.supervisor
+				},
+				fieldname:["status",]
+			}, 
+			callback: function(r) { 
+				frm.toggle_display(["supervisor_name"], r.message.status == "Active")
+
+			}
+		})
+	}
 });

--- a/one_fm/operations/doctype/operations_shift/operations_shift_list.js
+++ b/one_fm/operations/doctype/operations_shift/operations_shift_list.js
@@ -1,6 +1,5 @@
 frappe.listview_settings['Operations Shift'] = {
 	get_indicator: function(doc) {
-        console.log(doc.status)
 		if(doc.status == "Active") {
 			return [__("Active"), "green", ];
 		} else if(doc.status == "Not Active") {

--- a/one_fm/operations/doctype/operations_site/operations_site.js
+++ b/one_fm/operations/doctype/operations_site/operations_site.js
@@ -47,6 +47,35 @@ frappe.ui.form.on('Operations Site', {
 			).addClass('btn-primary');
 		}
 	},
+	onload: function(frm){
+		frm.set_query("account_supervisor", function() {
+			return {
+				"filters": {
+					"status": "Active",
+				}
+			};
+
+		});
+	},
+	account_supervisor: function(frm){
+		frm.trigger("get_employee_status")
+	},
+	get_employee_status: function(frm){
+		frappe.call({
+			method:"frappe.client.get_value",
+			args: {
+				doctype:"Employee",
+				filters: {
+					name:frm.doc.account_supervisor
+				},
+				fieldname:["status",]
+			}, 
+			callback: function(r) { 
+				frm.toggle_display(["account_supervisor_name"], r.message.status == "Active")
+
+			}
+		})
+	}
 })
 
 function quick_entry_shifts_and_posts(frm){


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
filter the supervisor field to display only active employees, upon creation of operations shift and operations site


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
wrote a script that filters the wuery for employees and also toggles the display of the supervisor name based on the status of the employee

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
operations shift
operations site


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
