### PR TITLE
fix: RFP - Purchase manager notification loop

### DIFF
--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
@@ -44,13 +44,11 @@ class RequestforPurchase(Document):
 		for user in users:
 			if has_permission(doctype=self.doctype, user=user):
 				filtered_users.append(user)
-			if filtered_users and len(filtered_users) > 0:
-				message = "Dear Purchase Manager, <br/> <p>Please Review the Request for Purchase <a href='{0}'>{1}</a> Submitted by {2}.</p>".format(page_link, self.name, self.requested_by)
-				subject = '{0} Request for Purchase by {1}'.format(self.status, self.requested_by)
-				send_email(self, filtered_users, message, subject)
-				create_notification_log(subject, message, [self.accepter], self)
-				notified = True
-		if notified:
+		if filtered_users and len(filtered_users) > 0:
+			message = "Dear Purchase Manager, <br/> <p>Please Review the Request for Purchase <a href='{0}'>{1}</a> Submitted by {2}.</p>".format(page_link, self.name, self.requested_by)
+			subject = '{0} Request for Purchase by {1}'.format(self.status, self.requested_by)
+			send_email(self, filtered_users, message, subject)
+			create_notification_log(subject, message, filtered_users, self)
 			frappe.msgprint(_("Notification sent to Purchase Manager"))
 		self.reload()
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Purchase Manager user getting the same RFP notification multiple times

## Solution description
- Identified that the notification sending from a loop and it is fixed

## Areas affected and ensured
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
No

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome