### PR TITLE
[BUG] [184626845] Update Roster to Show exited staff

### DIFF
--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -156,14 +156,14 @@ class CreateMap():
             self.schedule_query  = f"""SELECT  es.employee, es.employee_name, es.date, es.operations_role, es.post_abbrv, \
             es.shift, es.roster_type, es.employee_availability, es.day_off_ot, es.project from `tabEmployee Schedule`es  where \
                 es.employee in  ('{employees[0].employee}') and {self.str_filter} order by es.employee """
-            self.attendance_query = f"SELECT at.status,at.leave_application, at.attendance_date,at.employee,at.employee_name from `tabAttendance`at  where at.employee in ('{employees[0].employee}')  and at.attendance_date between '{self.start}' and '{self.end}' and docstatus = 1 AND roster_type='{self.roster_type}' order by at.employee """
-            self.employee_query = f"SELECT name, employee_id, employee_name,day_off_category,number_of_days_off from `tabEmployee` where name in ('{employees[0].employee}') order by employee_name"
+            self.attendance_query = f"SELECT at.status,at.leave_application,  at.attendance_date,at.employee,at.employee_name from `tabAttendance`at where at.employee in ('{employees[0].employee}')  and at.attendance_date between '{self.start}' and '{self.end}' and at.docstatus = 1 AND at.roster_type='{self.roster_type}' order by at.employee """
+            self.employee_query = f"SELECT name,employee_id,relieving_date, employee_name,day_off_category,number_of_days_off from `tabEmployee` where name in ('{employees[0].employee}') order by employee_name"
         else:
             self.schedule_query  = f"SELECT  es.employee, es.employee_name, es.date, es.operations_role, es.post_abbrv, \
                 es.shift, es.roster_type, es.employee_availability, es.day_off_ot, es.project from `tabEmployee Schedule`es  where \
                     es.employee in {self.employees} and {self.str_filter} order by es.employee "
-            self.attendance_query = f"SELECT at.status,at.leave_type,at.leave_application, at.attendance_date,at.employee,at.employee_name from `tabAttendance`at  where at.employee in {self.employees}  and at.attendance_date between '{self.start}' and '{self.end}' and docstatus = 1 AND roster_type='{self.roster_type}' order by at.employee """
-            self.employee_query = f"SELECT name,  employee_id, employee_name,day_off_category,number_of_days_off from `tabEmployee` where name in {self.employees} order by employee_name"
+            self.attendance_query = f"SELECT at.status,at.leave_type,at.leave_application, at.attendance_date,at.employee,at.employee_name from `tabAttendance`at where at.employee in {self.employees}  and at.attendance_date between '{self.start}' and '{self.end}' and at.docstatus = 1 AND at.roster_type='{self.roster_type}' order by at.employee """
+            self.employee_query = f"SELECT name, employee_id,relieving_date, employee_name,day_off_category,number_of_days_off from `tabEmployee` where name in {self.employees} order by employee_name"
 
         
         self.schedule_set = frappe.db.sql(self.schedule_query,as_dict=1) if self.employees else []
@@ -207,6 +207,7 @@ class CreateMap():
                     'employee_id':self.employee_period_details[key]['employee_id'],
                     'employee_name':self.employee_period_details[key]['employee_name'],
                     'date':self.cur_date,
+                    'relieving_date':self.employee_period_details[key]['relieving_date'],
                     'day_off_category': self.employee_period_details[key]['day_off_category'],
                     'number_of_days_off': self.employee_period_details[key]['number_of_days_off']
                 }
@@ -267,10 +268,12 @@ class CreateMap():
                     'leave_application': one.leave_application,
                     'leave_type':one.leave_type,
                     'date': one.attendance_date,
+                    'relieving_date':self.employee_period_details[row[1]].get('relieving_date'),
                     'attendance': one.status,
                     'employee_availability':one.status if one.status == "Day Off" else "",
                     'day_off_category': self.employee_period_details[row[1]].get('day_off_category'),
                     'number_of_days_off': self.employee_period_details[row[1]].get('number_of_days_off'),
+                    
                     'employee_id': self.employee_period_details[row[1]].get('employee_id')
                 })
         except Exception as e:

--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -555,6 +555,12 @@
                             </div>
                             <div class="col-sm-12 col-md-4 custompageselecttype mb10">
                                 <div class="d-flex">
+                                    <div class="legendboxview darkblackox"></div>
+                                    <div class="pl10 font16 cardtitlecolor">Exited in Roster Month</div>
+                                </div>
+                            </div>
+                            <div class="col-sm-12 col-md-4 custompageselecttype mb10">
+                                <div class="d-flex">
                                     <div class="legendboxview purplebox"></div>
                                     <div class="pl10 font16 cardtitlecolor">Leave</div>
                                 </div>

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -406,13 +406,13 @@ function load_js(page) {
 					primary_action_label: 'Submit',
 					primary_action(values) {
 						$('#cover-spin').show(0);
-						console.log({ posts, values })
+						
 						frappe.call({
 							// method: 'one_fm.one_fm.page.roster.roster.edit_post',
 							method: 'one_fm.api.v2.flutter.roster.edit_post',
 							args: { posts, values },
 							callback: function (r) {
-								console.log(r);
+								
 								d.hide();
 								$('#cover-spin').hide();
 								let element = get_wrapper_element().slice(1);
@@ -1088,6 +1088,7 @@ function get_roster_data(page, isOt) {
 	let { project, site, shift, department, operations_role, designation } = page.filters;
 	let { limit_start, limit_page_length } = page.pagination;
 	if (project || site || shift || department || operations_role || designation){
+		
 		$('#cover-spin').show(0);
 		frappe.call({
 			method: "one_fm.one_fm.page.roster.roster.get_roster_view", //dotted path to server method
@@ -1125,13 +1126,15 @@ let attendancemap = {
 	'Absent': 'redboxcolor',
 	'Work From Home': 'greenboxcolor',
 	'Half Day': 'greenboxcolor',
-	'On Leave': 'purplebox'
+	'On Leave': 'purplebox',
+	
 };
 let attendance_abbr_map = {
 	'Present': 'P',
 	'Absent': 'A',
 	'Work From Home': 'WFH',
 	'Half Day': 'HD',
+	
 	'On Leave': 'OL'
 };
 // Renders on get_roster_data function
@@ -1231,8 +1234,11 @@ function render_roster(res, page, isOt) {
 		while (day <= end_date) {
 			// for(let day = start_date; day <= end_date; start_date.add(1, 'days')){
 			let sch = ``;
-			let { employee, employee_name, date, operations_role, post_abbrv, employee_availability, shift, actual_shift, roster_type, attendance, asa, day_off_ot,leave_type,leave_application } = employees_data[employee_key][i];
+			
+			
+			let { employee, employee_name, date, operations_role, post_abbrv, employee_availability, shift, actual_shift, roster_type, attendance, asa, day_off_ot,leave_type,leave_application,relieving_date } = employees_data[employee_key][i];
 			//OT schedule view
+			
 			
 			if (isOt) {
 				if ((actual_shift && shift) && (actual_shift!=shift) && roster_type == 'Over-Time' && day_off_ot==0) {
@@ -1290,13 +1296,17 @@ function render_roster(res, page, isOt) {
 			}
 			//Basic schedule view
 			else {
+				
 			 	if ((actual_shift && shift) && (actual_shift!=shift) && day_off_ot==0) {
+				
+				
 				sch = `
 				<td>
 					<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
 						data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 				</td>`;
 				} else if (post_abbrv && roster_type == 'Basic' && !asa && day_off_ot==0) {
+					
 					j++;
 					sch = `
 					<td>
@@ -1304,6 +1314,7 @@ function render_roster(res, page, isOt) {
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 					</td>`;
 				} else if(post_abbrv && roster_type == 'Basic' && asa && day_off_ot==0){
+					
 					j++;
 					sch = `
 					<td>
@@ -1311,6 +1322,7 @@ function render_roster(res, page, isOt) {
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${"<strong>Scheduled:</strong> <br>" + shift + "<br>" + "<strong>Assigned:</strong> <br>" + asa}</span></div>
 					</td>`;
 				}else if(post_abbrv && roster_type == 'Basic' && day_off_ot==1){
+					
 					j++;
 					sch = `
 					<td>
@@ -1319,12 +1331,14 @@ function render_roster(res, page, isOt) {
 					</td>`;
 				}
 				else if (employee_availability && !post_abbrv) {
+					
 					sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so"
 							data-selectid="${employee + "|" + date + "|" + employee_availability}">${leavemap[employee_availability]}</div>
 					</td>`;
 				} else if (attendance && !employee_availability) {
+					
 					if (attendance == 'Present') { j++; }
 					sch = `
 					<td>
@@ -1332,11 +1346,23 @@ function render_roster(res, page, isOt) {
 							data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application+'|'+leave_type}</span></div>
 					</td>`;
 				} else {
+					
+					if(moment(date)>=moment(relieving_date)){
+						
+						sch = `
+					<td>
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkblackox d-flex justify-content-center align-items-center text-white so customtooltip"
+							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">EX<span class="customtooltiptext">Exited</span></div>
+					</td>`;
+					}
+					else{
+						
 					sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
 							data-selectid="${employee + "|" + date}"></div>
 					</td>`;
+					}
 				}
 				i++;
 				start_date.add(1, 'days');
@@ -1370,7 +1396,7 @@ function get_roster_week_data(page, isOt) {
 	let { start_date, end_date } = page;
 	let { project, site, shift, department, operations_role } = page.filters;
 	let { limit_start, limit_page_length } = page.pagination;
-	// console.log(limit_start, limit_page_length);
+	
 
 	frappe.xcall('one_fm.one_fm.page.roster.roster.get_roster_view', { start_date, end_date, employee_search_name, project, site, shift, department, operations_role, isOt, limit_start, limit_page_length })
 		.then(res => {
@@ -1406,7 +1432,7 @@ function get_roster_week_data(page, isOt) {
 				while (day <= end_date) {
 					// for(let day = start_date; day <= end_date; start_date.add(1, 'days')){
 					let { date, operations_role, count, highlight } = operations_roles_data[operations_role_name][i];
-					// console.log(count, typeof (count));
+					
 					let pt_count = `
 				<td class="${highlight}">
 					<div class="text-center" data-selectid="${operations_role + "|" + date}">${count}</div>
@@ -1523,7 +1549,7 @@ function get_post_data(page) {
 	let { limit_start, limit_page_length } = page.pagination;
 	if (project || site || shift || department || operations_role){
 		$('#cover-spin').show(0);
-		// console.log(start_date, end_date, project, site, shift, operations_role,limit_start, limit_page_length);
+		
 		frappe.xcall('one_fm.one_fm.page.roster.roster.get_post_view', { start_date, end_date, project, site, shift, operations_role, limit_start, limit_page_length })
 			.then(res => {
 				$('#cover-spin').hide();

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -14,1063 +14,1072 @@ from one_fm.utils import query_db_list
 
 @frappe.whitelist(allow_guest=True)
 def get_staff(assigned=1, employee_id=None, employee_name=None, company=None, project=None, site=None, shift=None, department=None, designation=None):
-	date = cstr(add_to_date(nowdate(), days=1))
-	conds = ""
+    date = cstr(add_to_date(nowdate(), days=1))
+    conds = ""
 
-	if employee_name:
-		conds += 'and emp.employee_name="{name}" '.format(name=employee_name)
-	if department:
-		conds += 'and emp.department="{department}" '.format(department=department)
-	if designation:
-		conds += 'and emp.designation="{designation}" '.format(designation=designation)
-	if company:
-		conds += 'and emp.company="{company}" '.format(company=company)
+    if employee_name:
+        conds += 'and emp.employee_name="{name}" '.format(name=employee_name)
+    if department:
+        conds += 'and emp.department="{department}" '.format(department=department)
+    if designation:
+        conds += 'and emp.designation="{designation}" '.format(designation=designation)
+    if company:
+        conds += 'and emp.company="{company}" '.format(company=company)
 
-	if project:
-		conds += 'and emp.project="{project}" '.format(project=project)
-	if site:
-		conds += 'and emp.site="{site}" '.format(site=site)
-	if shift:
-		conds += 'and emp.name="{shift}" '.format(shift=shift)
+    if project:
+        conds += 'and emp.project="{project}" '.format(project=project)
+    if site:
+        conds += 'and emp.site="{site}" '.format(site=site)
+    if shift:
+        conds += 'and emp.name="{shift}" '.format(shift=shift)
 
-	if not cint(assigned):
-		data = frappe.db.sql("""
-			select
-				distinct emp.name, emp.employee_id, emp.employee_name, emp.image, emp.one_fm_nationality as nationality, usr.mobile_no, usr.name as email, emp.designation, emp.department, emp.project
-			from `tabEmployee` as emp, `tabUser` as usr
-			where
-			emp.project is NULL
-			and emp.site is NULL
-			and emp.shift is NULL
-			and emp.user_id=usr.name
-			{conds}
-		""".format(date=date, conds=conds), as_dict=1)
-		return data
+    if not cint(assigned):
+        data = frappe.db.sql("""
+            select
+                distinct emp.name, emp.employee_id, emp.employee_name, emp.image, emp.one_fm_nationality as nationality, usr.mobile_no, usr.name as email, emp.designation, emp.department, emp.project
+            from `tabEmployee` as emp, `tabUser` as usr
+            where
+            emp.project is NULL
+            and emp.site is NULL
+            and emp.shift is NULL
+            and emp.user_id=usr.name
+            {conds}
+        """.format(date=date, conds=conds), as_dict=1)
+        return data
 
-	data = frappe.db.sql("""
-		select
-			distinct emp.name, emp.employee_id, emp.employee_name, emp.image, emp.one_fm_nationality as nationality, 
-   		usr.mobile_no, usr.name as email, emp.designation, emp.department, emp.shift, emp.site,
-     	emp.project,opsite.account_supervisor_name as site_supervisor,opshift.supervisor_name as shift_supervisor
-		from `tabEmployee` as emp, `tabUser` as usr,`tabOperations Shift` as opshift,`tabOperations Site` as opsite
-		where
-		emp.project is not NULL
-		and emp.site is not NULL
-		and emp.shift is not NULL
-		and emp.user_id=usr.name
-		and emp.shift = opshift.name
-		and emp.site = opsite.name
-		{conds}
-	""".format(date=date, conds=conds), as_dict=1)
-	return data
+    data = frappe.db.sql("""
+        select
+            distinct emp.name, emp.employee_id, emp.employee_name, emp.image, emp.one_fm_nationality as nationality, 
+           usr.mobile_no, usr.name as email, emp.designation, emp.department, emp.shift, emp.site,
+         emp.project,opsite.account_supervisor_name as site_supervisor,opshift.supervisor_name as shift_supervisor
+        from `tabEmployee` as emp, `tabUser` as usr,`tabOperations Shift` as opshift,`tabOperations Site` as opsite
+        where
+        emp.project is not NULL
+        and emp.site is not NULL
+        and emp.shift is not NULL
+        and emp.user_id=usr.name
+        and emp.shift = opshift.name
+        and emp.site = opsite.name
+        {conds}
+    """.format(date=date, conds=conds), as_dict=1)
+    return data
 
 @frappe.whitelist(allow_guest=True)
 def get_staff_filters_data():
-	company = frappe.get_list("Company", limit_page_length=9999, order_by="name asc")
-	projects = frappe.get_list("Project", limit_page_length=9999, order_by="name asc")
-	sites = frappe.get_list("Operations Site", limit_page_length=9999, order_by="name asc")
-	shifts = frappe.get_list("Operations Shift", limit_page_length=9999, order_by="name asc")
-	departments = frappe.get_list("Department", limit_page_length=9999, order_by="name asc")
-	designations = frappe.get_list("Designation", limit_page_length=9999, order_by="name asc")
+    company = frappe.get_list("Company", limit_page_length=9999, order_by="name asc")
+    projects = frappe.get_list("Project", limit_page_length=9999, order_by="name asc")
+    sites = frappe.get_list("Operations Site", limit_page_length=9999, order_by="name asc")
+    shifts = frappe.get_list("Operations Shift", limit_page_length=9999, order_by="name asc")
+    departments = frappe.get_list("Department", limit_page_length=9999, order_by="name asc")
+    designations = frappe.get_list("Designation", limit_page_length=9999, order_by="name asc")
 
-	return {
-		"company": company,
-		"projects": projects,
-		"sites": sites,
-		"shifts": shifts,
-		"departments": departments,
-		"designations": designations
-	}
+    return {
+        "company": company,
+        "projects": projects,
+        "sites": sites,
+        "shifts": shifts,
+        "departments": departments,
+        "designations": designations
+    }
 
 
 @frappe.whitelist()
 def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_search_id=None, employee_search_name=None, project=None, site=None, shift=None, department=None, operations_role=None, designation=None, isOt=None, limit_start=0, limit_page_length=9999):
-	try:
-		master_data, formatted_employee_data, post_count_data, employee_filters, additional_assignment_filters={}, {}, {}, {}, {}
-		operations_roles_list = []
-		employees = []
-		
-		filters = {
-			'date': ['between', (start_date, end_date)]
-		}
-		str_filters = f'es.date between "{start_date}" and "{end_date}"'
+    try:
+        master_data, formatted_employee_data, post_count_data, employee_filters= {}, {}, {}, {}
+        operations_roles_list = []
+        employees = []
+        asa_filters = "em.status = 'Active' "
+        filters = {
+            'date': ['between', (start_date, end_date)]
+        }
+        str_filters = f'es.date between "{start_date}" and "{end_date}"'
 
-		if operations_role:
-			filters.update({'operations_role': operations_role})
-			str_filters +=' and es.operations_role = "{}"'.format(operations_role)
+        if operations_role:
+            filters.update({'operations_role': operations_role})
+            str_filters +=' and es.operations_role = "{}"'.format(operations_role)
 
-		if employee_search_id:
-			employee_filters.update({'employee_id': employee_search_id})
+        if employee_search_id:
+            employee_filters.update({'employee_id': employee_search_id})
 
-		if employee_search_name:
-			employee_filters.update({'employee_name': ("like", "%" + employee_search_name + "%")})
-			additional_assignment_filters.update({'employee_name': ("like", "%" + employee_search_name + "%")})
-		if project:
-			employee_filters.update({'project': project})
-			additional_assignment_filters.update({'project': project})
-		if site:
-			employee_filters.update({'site': site})
-			additional_assignment_filters.update({'site': site})
-		if shift:
-			employee_filters.update({'shift': shift})
-			additional_assignment_filters.update({'shift': shift})
-		if department:
-			employee_filters.update({'department': department})
+        if employee_search_name:
+            employee_filters.update({'employee_name': ("like", "%" + employee_search_name + "%")})
+            
+            asa_filters+=f'and asa.employee_name LIKE "%{employee_search_name}%"'
+            
+        if project:
+            employee_filters.update({'project': project})
+            
+            asa_filters+=f' and asa.project = "{project}"'
+        if site:
+            employee_filters.update({'site': site})
+           
+            asa_filters += f' and asa.site = "{site}"'
+        if shift:
+            employee_filters.update({'shift': shift})
+            
+            asa_filters += f' and asa.shift = "{shift}"'
+        if department:
+            employee_filters.update({'department': department})
 
 
-		#--------------------- Fetch Employee list ----------------------------#
-		if isOt:
-			employee_filters.update({'employee_availability' : 'Working'})
-			employees = frappe.db.get_list("Employee Schedule", employee_filters, ["distinct employee", "employee_name"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
-			master_data.update({'total' : len(employees)})
-			employee_filters.update({'date': ['between', (start_date, end_date)], 'post_status': 'Planned'})
-			employee_filters.pop('employee_availability')
-		else:
-			employee_filters.update({'status': 'Active'})
-			employee_filters.update({'shift_working':'1'})
-			if designation:
-				employee_filters.update({'designation' : designation})
-			employees = frappe.db.get_list("Employee", employee_filters, ["employee", "employee_name", "day_off_category", "number_of_days_off"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
-			employees_asa = frappe.db.get_list("Additional Shift Assignment", additional_assignment_filters, ["distinct employee", "employee_name"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
-			if len(employees_asa) > 0:
-				employees.extend(employees_asa)
-				employees = filter_redundant_employees(employees)
-			master_data.update({'total': len(employees)})
-			employee_filters.pop('status', None)
-			employee_filters.pop('shift_working', None)
-			employee_filters.update({'date': ['between', (start_date, end_date)], 'post_status': 'Planned'})
+        #--------------------- Fetch Employee list ----------------------------#
+        if isOt:
+            employee_filters.update({'employee_availability' : 'Working'})
+            employees = frappe.db.get_list("Employee Schedule", employee_filters, ["distinct employee", "employee_name"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
+            master_data.update({'total' : len(employees)})
+            employee_filters.update({'date': ['between', (start_date, end_date)], 'post_status': 'Planned'})
+            employee_filters.pop('employee_availability')
+        else:
+            employee_filters.update({'status': 'Active'})
+            employee_filters.update({'shift_working':'1'})
+            if designation:
+                employee_filters.update({'designation' : designation})
+            employees = frappe.db.get_list("Employee", employee_filters, ["employee", "employee_name", "day_off_category", "number_of_days_off"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
+            
+            employees_asa_q = f"""SELECT distinct asa.employee as employee, asa.employee_name  as employee_name from `tabAdditional Shift Assignment` asa JOIN `tabEmployee`em on em.name =asa.employee where {asa_filters}"""
+            #Conditional to ensure that the proceeding code block does not run unless Project,shift or site is queried
+            if employee_search_name or shift or site or project:
+                employees_asa = frappe.db.sql(employees_asa_q,as_dict=1)
+                if len(employees_asa) > 0:
+                    employees.extend(employees_asa)
+                    employees = filter_redundant_employees(employees)
+            master_data.update({'total': len(employees)})
+            employee_filters.pop('status', None)
+            employee_filters.pop('shift_working', None)
+            employee_filters.update({'date': ['between', (start_date, end_date)], 'post_status': 'Planned'})
 
-		if employee_search_name:
-			employee_filters.pop('employee_name')
-		if employee_search_id:
-			employee_filters.pop('employee_id')
-		if department:
-			employee_filters.pop('department', None)
-		if operations_role:
-			employee_filters.update({'operations_role': operations_role})
-		if designation:
-			employee_filters.pop('designation', None)
+        if employee_search_name:
+            employee_filters.pop('employee_name')
+        if employee_search_id:
+            employee_filters.pop('employee_id')
+        if department:
+            employee_filters.pop('department', None)
+        if operations_role:
+            employee_filters.update({'operations_role': operations_role})
+        if designation:
+            employee_filters.pop('designation', None)
 
-		#------------------- Fetch Operations Roles ------------------------#
-		operations_roles_list = frappe.db.get_list("Post Schedule", employee_filters, ["distinct operations_role", "post_abbrv"], ignore_permissions=True)
-		if operations_role:
-			employee_filters.pop('operations_role', None)
-		employee_filters.pop('date')
-		employee_filters.pop('post_status')
+        #------------------- Fetch Operations Roles ------------------------#
+        operations_roles_list = frappe.db.get_list("Post Schedule", employee_filters, ["distinct operations_role", "post_abbrv"], ignore_permissions=True)
+        if operations_role:
+            employee_filters.pop('operations_role', None)
+        employee_filters.pop('date')
+        employee_filters.pop('post_status')
 
-		#------------------- Fetch Employee Schedule --------------------#
-		#The following section creates a iterable that uses the employee name and id as keys and groups  the  employee data fetched in previous queries
+        #------------------- Fetch Employee Schedule --------------------#
+        #The following section creates a iterable that uses the employee name and id as keys and groups  the  employee data fetched in previous queries
 
-		new_map=CreateMap(start=start_date,end=end_date,employees=employees,filters=str_filters,isOt=isOt)
-		master_data.update({'employees_data': new_map.formated_rs})
+        new_map=CreateMap(start=start_date,end=end_date,employees=employees,filters=str_filters,isOt=isOt)
+        master_data.update({'employees_data': new_map.formated_rs})
 
-		#----------------- Get Operations Role count and check fill status -------------------#
-		post_map = PostMap(start=start_date,end=end_date,operations_roles_list=operations_roles_list,filters=employee_filters)
-		master_data.update({'operations_roles_data': post_map.template})
-		response("Success", 200, master_data)
-	except Exception as e:
-		print(frappe.get_traceback())
-		return response("Server Error", 500, None, str(frappe.get_traceback()))
+        #----------------- Get Operations Role count and check fill status -------------------#
+        post_map = PostMap(start=start_date,end=end_date,operations_roles_list=operations_roles_list,filters=employee_filters)
+        master_data.update({'operations_roles_data': post_map.template})
+        response("Success", 200, master_data)
+    except Exception as e:
+        print(frappe.get_traceback())
+        return response("Server Error", 500, None, str(frappe.get_traceback()))
 
 def get_active_employees(start_date, end_date, master_data):
-	employees = [i.name for i in frappe.db.get_list('Employee', filters={'status': ['!=', 'Left']})]
-	employees += [i.name for i in frappe.db.sql("""
-		SELECT name FROM `tabEmployee`
-		WHERE status='Left' AND relieving_date BETWEEN '{start_date}' AND '{end_date}'""".format(
-		start_date=start_date, end_date=end_date), as_dict=1
-	)]
-	new_employees = {}
-	employees_data = master_data.get('employees_data')
-	for k, v in employees_data.items():
-		if v[0]['employee'] in employees:
-			new_employees[k] = v
-	master_data['total'] = len(new_employees)
-	master_data['employees_data'] = new_employees
+    employees = [i.name for i in frappe.db.get_list('Employee', filters={'status': ['!=', 'Left']})]
+    employees += [i.name for i in frappe.db.sql("""
+        SELECT name FROM `tabEmployee`
+        WHERE status='Left' AND relieving_date BETWEEN '{start_date}' AND '{end_date}'""".format(
+        start_date=start_date, end_date=end_date), as_dict=1
+    )]
+    new_employees = {}
+    employees_data = master_data.get('employees_data')
+    for k, v in employees_data.items():
+        if v[0]['employee'] in employees:
+            new_employees[k] = v
+    master_data['total'] = len(new_employees)
+    master_data['employees_data'] = new_employees
 
-	return master_data
+    return master_data
 
 
 def filter_redundant_employees(employees):
-	return list({employee['employee']:employee for employee in employees}.values())
+    return list({employee['employee']:employee for employee in employees}.values())
 
 @frappe.whitelist(allow_guest=True)
 def get_post_view(start_date, end_date,  project=None, site=None, shift=None, operations_role=None, active_posts=1, limit_start=0, limit_page_length=100):
 
-	user, user_roles, user_employee = get_current_user_details()
-	if "Operations Manager" not in user_roles and "Projects Manager" not in user_roles and "Site Supervisor" not in user_roles:
-		frappe.throw(_("Insufficient permissions for Post View."))
+    user, user_roles, user_employee = get_current_user_details()
+    if "Operations Manager" not in user_roles and "Projects Manager" not in user_roles and "Site Supervisor" not in user_roles:
+        frappe.throw(_("Insufficient permissions for Post View."))
 
-	filters, master_data, post_data = {}, {}, {}
-	if project:
-		filters.update({'project': project})
-	if site:
-		filters.update({'site': site})
-	if shift:
-		filters.update({'site_shift': shift})
-	if operations_role:
-		filters.update({'post_template': operations_role})
-	post_total = len(frappe.db.get_list("Operations Post", filters))
-	post_list = frappe.db.get_list("Operations Post", filters, "name", order_by="name asc", limit_start=limit_start, limit_page_length=limit_page_length)
-	fields = ['name', 'post', 'operations_role','date', 'post_status', 'site', 'shift', 'project']
+    filters, master_data, post_data = {}, {}, {}
+    if project:
+        filters.update({'project': project})
+    if site:
+        filters.update({'site': site})
+    if shift:
+        filters.update({'site_shift': shift})
+    if operations_role:
+        filters.update({'post_template': operations_role})
+    post_total = len(frappe.db.get_list("Operations Post", filters))
+    post_list = frappe.db.get_list("Operations Post", filters, "name", order_by="name asc", limit_start=limit_start, limit_page_length=limit_page_length)
+    fields = ['name', 'post', 'operations_role','date', 'post_status', 'site', 'shift', 'project']
 
-	filters.pop('post_template', None)
-	filters.pop('site_shift', None)
-	if operations_role:
-		filters.update({'operations_role': operations_role})
-	if shift:
-		filters.update({'shift': shift})
-	for key, group in itertools.groupby(post_list, key=lambda x: (x['name'])):
-		schedule_list = []
-		filters.update({'date': ['between', (start_date, end_date)], 'post': key})
-		schedules = frappe.db.get_list("Post Schedule", filters, fields, order_by="date asc, post asc")
-		for date in	pd.date_range(start=start_date, end=end_date):
-			if not any(cstr(schedule.date) == cstr(date).split(" ")[0] for schedule in schedules):
-				schedule = {
-				'post': key,
-				'date': cstr(date).split(" ")[0]
-				}
-			else:
-				schedule = next((sch for sch in schedules if cstr(sch.date) == cstr(date).split(" ")[0]), {})
-			schedule_list.append(schedule)
-		post_data.update({key: schedule_list})
+    filters.pop('post_template', None)
+    filters.pop('site_shift', None)
+    if operations_role:
+        filters.update({'operations_role': operations_role})
+    if shift:
+        filters.update({'shift': shift})
+    for key, group in itertools.groupby(post_list, key=lambda x: (x['name'])):
+        schedule_list = []
+        filters.update({'date': ['between', (start_date, end_date)], 'post': key})
+        schedules = frappe.db.get_list("Post Schedule", filters, fields, order_by="date asc, post asc")
+        for date in	pd.date_range(start=start_date, end=end_date):
+            if not any(cstr(schedule.date) == cstr(date).split(" ")[0] for schedule in schedules):
+                schedule = {
+                'post': key,
+                'date': cstr(date).split(" ")[0]
+                }
+            else:
+                schedule = next((sch for sch in schedules if cstr(sch.date) == cstr(date).split(" ")[0]), {})
+            schedule_list.append(schedule)
+        post_data.update({key: schedule_list})
 
-	master_data.update({"post_data": post_data, "total": post_total})
-	return master_data
+    master_data.update({"post_data": post_data, "total": post_total})
+    return master_data
 
 @frappe.whitelist()
 def get_filtered_operations_role(doctype, txt, searchfield, start, page_len, filters):
-	shift = filters.get('shift')
-	return frappe.db.sql("""
-		select distinct name
-		from `tabOperations Role`
-		where shift="{shift}"
-	""".format(shift=shift))
+    shift = filters.get('shift')
+    return frappe.db.sql("""
+        select distinct name
+        from `tabOperations Role`
+        where shift="{shift}"
+    """.format(shift=shift))
 
 
 def get_current_user_details():
-	user = frappe.session.user
-	user_roles = frappe.get_roles(user)
-	user_employee = frappe.get_value("Employee", {"user_id": user}, ["name", "employee_id", "employee_name", "image", "enrolled", "designation"], as_dict=1)
-	return user, user_roles, user_employee
+    user = frappe.session.user
+    user_roles = frappe.get_roles(user)
+    user_employee = frappe.get_value("Employee", {"user_id": user}, ["name", "employee_id", "employee_name", "image", "enrolled", "designation"], as_dict=1)
+    return user, user_roles, user_employee
 
 
 @frappe.whitelist()
 def schedule_staff(employees, shift, operations_role, otRoster, start_date, project_end_date, keep_days_off=0, request_employee_schedule=0, day_off_ot=None, end_date=None):
-	try:
-		_start_date = getdate(start_date)
-		validation_logs = []
-		user, user_roles, user_employee = get_current_user_details()
-		employees = json.loads(employees)
-		if not employees:
-			frappe.throw("Employees must be selected.")
-		
-		employees = [i for i in employees if getdate(i['date']) >= _start_date]
-		employee_list = []
-		for i in employees:
-			if not i['employee'] in employee_list:
-				employee_list.append(i['employee'])
-		
-		if cint(project_end_date) and not end_date:
-			project = frappe.db.get_value("Operations Shift", shift, ["project"])
-			if frappe.db.exists("Contracts", {'project': project}):
-				contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-				if not end_date:
-					validation_logs.append("Please set contract end date for contract: {contract}".format(contract=contract))
-			else:
-				validation_logs.append("No contract linked with project {project}".format(project=project))
+    try:
+        _start_date = getdate(start_date)
+        validation_logs = []
+        user, user_roles, user_employee = get_current_user_details()
+        employees = json.loads(employees)
+        if not employees:
+            frappe.throw("Employees must be selected.")
+        
+        employees = [i for i in employees if getdate(i['date']) >= _start_date]
+        employee_list = []
+        for i in employees:
+            if not i['employee'] in employee_list:
+                employee_list.append(i['employee'])
+        
+        if cint(project_end_date) and not end_date:
+            project = frappe.db.get_value("Operations Shift", shift, ["project"])
+            if frappe.db.exists("Contracts", {'project': project}):
+                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                if not end_date:
+                    validation_logs.append("Please set contract end date for contract: {contract}".format(contract=contract))
+            else:
+                validation_logs.append("No contract linked with project {project}".format(project=project))
 
-		elif end_date and not cint(project_end_date):
-			end_date = end_date
+        elif end_date and not cint(project_end_date):
+            end_date = end_date
 
-		elif not cint(project_end_date) and not end_date:
-			validation_logs.append("Please set an end date for scheduling the staff.")
+        elif not cint(project_end_date) and not end_date:
+            validation_logs.append("Please set an end date for scheduling the staff.")
 
-		elif cint(project_end_date) and end_date:
-			validation_logs.append("Please select either the project end date or set a custom date. You cannot set both!")
+        elif cint(project_end_date) and end_date:
+            validation_logs.append("Please select either the project end date or set a custom date. You cannot set both!")
 
-		emp_tuple = str(employee_list).replace('[', '(').replace(']',')')
-		# date_range = pd.date_range(start=start_date, end=end_date)
+        emp_tuple = str(employee_list).replace('[', '(').replace(']',')')
+        # date_range = pd.date_range(start=start_date, end=end_date)
 
-		if not cint(request_employee_schedule) and "Projects Manager" not in user_roles and "Operations Manager" not in user_roles:
-			all_employee_shift_query = frappe.db.sql("""
-				SELECT DISTINCT es.shift, s.supervisor
-				FROM `tabEmployee Schedule` es JOIN `tabOperations Shift` s ON es.shift = s.name
-				WHERE
-				es.date BETWEEN '{start_date}' AND '{end_date}'
-				AND es.employee_availability='Working' AND es.employee IN {emp_tuple}
-				GROUP BY es.shift
-			""".format(start_date=start_date, end_date=end_date, emp_tuple=emp_tuple), as_dict=1)
+        if not cint(request_employee_schedule) and "Projects Manager" not in user_roles and "Operations Manager" not in user_roles:
+            all_employee_shift_query = frappe.db.sql("""
+                SELECT DISTINCT es.shift, s.supervisor
+                FROM `tabEmployee Schedule` es JOIN `tabOperations Shift` s ON es.shift = s.name
+                WHERE
+                es.date BETWEEN '{start_date}' AND '{end_date}'
+                AND es.employee_availability='Working' AND es.employee IN {emp_tuple}
+                GROUP BY es.shift
+            """.format(start_date=start_date, end_date=end_date, emp_tuple=emp_tuple), as_dict=1)
 
-			for i in all_employee_shift_query:
-				if user_employee.name != i.supervisor:
-					validation_logs.append("You are not authorized to change this schedule. Please check the Request Employee Schedule option to place a request.")
-					break
+            for i in all_employee_shift_query:
+                if user_employee.name != i.supervisor:
+                    validation_logs.append("You are not authorized to change this schedule. Please check the Request Employee Schedule option to place a request.")
+                    break
 
-		if len(validation_logs) > 0:
-			frappe.log_error(str(validation_logs), 'Roster Schedule')
-			frappe.throw(str(validation_logs))
-		else:
-			# extreme schedule
-			extreme_schedule(employees=employees, start_date=start_date, end_date=end_date, shift=shift,
-				operations_role=operations_role, otRoster=otRoster, keep_days_off=keep_days_off, day_off_ot=day_off_ot,
-				request_employee_schedule=request_employee_schedule, employee_list=employee_list
-			)
-			# employees_list = frappe.db.get_list("Employee", filters={"name": ["IN", employees]}, fields=["name", "employee_id", "employee_name"])
-			update_roster(key="roster_view")
-			response("success", 200, {'message':'Successfully rostered employees'})
-	except Exception as e:
-		frappe.log_error(frappe.get_traceback(), "Schedule Roster")
-		response("error", 200, None, str(e))
+        if len(validation_logs) > 0:
+            frappe.log_error(str(validation_logs), 'Roster Schedule')
+            frappe.throw(str(validation_logs))
+        else:
+            # extreme schedule
+            extreme_schedule(employees=employees, start_date=start_date, end_date=end_date, shift=shift,
+                operations_role=operations_role, otRoster=otRoster, keep_days_off=keep_days_off, day_off_ot=day_off_ot,
+                request_employee_schedule=request_employee_schedule, employee_list=employee_list
+            )
+            # employees_list = frappe.db.get_list("Employee", filters={"name": ["IN", employees]}, fields=["name", "employee_id", "employee_name"])
+            update_roster(key="roster_view")
+            response("success", 200, {'message':'Successfully rostered employees'})
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "Schedule Roster")
+        response("error", 200, None, str(e))
 
 def update_roster(key):
-	frappe.publish_realtime(key, "Success")
+    frappe.publish_realtime(key, "Success")
 
 
 def extreme_schedule(employees, shift, operations_role, otRoster, start_date, end_date, keep_days_off, day_off_ot, 
-	request_employee_schedule, employee_list):
-	if not employees:
-		frappe.msgprint("Please select employees before rostering")
-		return
-	creation = now()
-	owner = frappe.session.user
-	# date_range = [i.date() for i in pd.date_range(start=start_date, end=end_date)]
-	operations_shift = frappe.get_doc("Operations Shift", shift, ignore_permissions=True)
-	operations_role = frappe.get_doc("Operations Role", operations_role, ignore_permissions=True)
-	day_off_ot = cint(day_off_ot)
-	if otRoster == 'false':
-		roster_type = 'Basic'
-	elif otRoster == 'true' or day_off_ot == 1:
-		roster_type = 'Over-Time'
+    request_employee_schedule, employee_list):
+    if not employees:
+        frappe.msgprint("Please select employees before rostering")
+        return
+    creation = now()
+    owner = frappe.session.user
+    # date_range = [i.date() for i in pd.date_range(start=start_date, end=end_date)]
+    operations_shift = frappe.get_doc("Operations Shift", shift, ignore_permissions=True)
+    operations_role = frappe.get_doc("Operations Role", operations_role, ignore_permissions=True)
+    day_off_ot = cint(day_off_ot)
+    if otRoster == 'false':
+        roster_type = 'Basic'
+    elif otRoster == 'true' or day_off_ot == 1:
+        roster_type = 'Over-Time'
 
-	# check for end date
-	if end_date:
-		end_date = getdate(end_date)
-		new_employees = []
-		for i in employees:
-			if getdate(i['date']) <= end_date:
-				new_employees.append(i)
-		if new_employees:
-			employees = new_employees.copy()
-	# check keep days_off
-	if keep_days_off:
-		days_off_list = frappe.db.get_list("Employee Schedule", filters={
-			'employee':['IN', [i['employee'] for i in employees]],
-			'date': ['IN', [i['date'] for i in employees]],
-			'employee_availability': 'Day Off'
-		}, fields=['name', 'employee', 'date'])
-		days_off_dict = {}
-		if days_off_list:
-			# build a dict in the form {'hr-emp-0002:['2023-01-01,]} 
-			for i in days_off_list:
-				if days_off_dict.get(i.employee):
-					days_off_dict[i.employee].append(str(i.date))
-				else:
-					days_off_dict[i.employee] = [str(i.date)]
-			# remove records from employees
-			new_employees = []
-			for i in employees:
-				if not (i['date'] in days_off_dict.get(i['employee'])):
-					new_employees.append(i)
-			if new_employees:
-				employees = new_employees.copy()
-	
-	# # get and structure employee dictionary for easy hashing
-	employees_list = frappe.db.get_list("Employee", filters={'employee': ['IN', employee_list]}, fields=['name', 'employee_name', 'department'], ignore_permissions=True)
-	employees_dict = {}
-	for i in employees_list:
-		employees_dict[i.name] = i
-	
-	if not cint(request_employee_schedule):
-	# 	"""
-	# 		USE DIRECT SQL TO CREATE ROSTER SCHEDULE.
-	# 	"""
-		query = """
-			INSERT INTO `tabEmployee Schedule` (`name`, `employee`, `employee_name`, `department`, `date`, `shift`, `site`, `project`, `shift_type`, `employee_availability`, 
-			`operations_role`, `post_abbrv`, `roster_type`, `day_off_ot`, `owner`, `modified_by`, `creation`, `modified`)
-			VALUES 
-		"""
-		if not cint(keep_days_off):
-			id_list = [] #store for schedules list
-			for employee in employees:
-				employee_doc = employees_dict.get(employee['employee'])
-				name = f"{employee['date']}_{employee['employee']}_{roster_type}"
-				id_list.append(name)
-				query += f"""
-					(
-						"{name}", "{employee['employee']}", "{employee_doc.employee_name}", "{employee_doc.department}", "{employee['date']}", "{operations_shift.name}", 
-						"{operations_shift.site}", "{operations_shift.project}", '{operations_shift.shift_type}', "Working", 
-						"{operations_role.name}", "{operations_role.post_abbrv}", "{roster_type}", 
-						{day_off_ot}, "{owner}", "{owner}", "{creation}", "{creation}"
-					),"""
+    # check for end date
+    if end_date:
+        end_date = getdate(end_date)
+        new_employees = []
+        for i in employees:
+            if getdate(i['date']) <= end_date:
+                new_employees.append(i)
+        if new_employees:
+            employees = new_employees.copy()
+    # check keep days_off
+    if keep_days_off:
+        days_off_list = frappe.db.get_list("Employee Schedule", filters={
+            'employee':['IN', [i['employee'] for i in employees]],
+            'date': ['IN', [i['date'] for i in employees]],
+            'employee_availability': 'Day Off'
+        }, fields=['name', 'employee', 'date'])
+        days_off_dict = {}
+        if days_off_list:
+            # build a dict in the form {'hr-emp-0002:['2023-01-01,]} 
+            for i in days_off_list:
+                if days_off_dict.get(i.employee):
+                    days_off_dict[i.employee].append(str(i.date))
+                else:
+                    days_off_dict[i.employee] = [str(i.date)]
+            # remove records from employees
+            new_employees = []
+            for i in employees:
+                if not (i['date'] in days_off_dict.get(i['employee'])):
+                    new_employees.append(i)
+            if new_employees:
+                employees = new_employees.copy()
+    
+    # # get and structure employee dictionary for easy hashing
+    employees_list = frappe.db.get_list("Employee", filters={'employee': ['IN', employee_list]}, fields=['name', 'employee_name', 'department'], ignore_permissions=True)
+    employees_dict = {}
+    for i in employees_list:
+        employees_dict[i.name] = i
+    
+    if not cint(request_employee_schedule):
+    # 	"""
+    # 		USE DIRECT SQL TO CREATE ROSTER SCHEDULE.
+    # 	"""
+        query = """
+            INSERT INTO `tabEmployee Schedule` (`name`, `employee`, `employee_name`, `department`, `date`, `shift`, `site`, `project`, `shift_type`, `employee_availability`, 
+            `operations_role`, `post_abbrv`, `roster_type`, `day_off_ot`, `owner`, `modified_by`, `creation`, `modified`)
+            VALUES 
+        """
+        if not cint(keep_days_off):
+            id_list = [] #store for schedules list
+            for employee in employees:
+                employee_doc = employees_dict.get(employee['employee'])
+                name = f"{employee['date']}_{employee['employee']}_{roster_type}"
+                id_list.append(name)
+                query += f"""
+                    (
+                        "{name}", "{employee['employee']}", "{employee_doc.employee_name}", "{employee_doc.department}", "{employee['date']}", "{operations_shift.name}", 
+                        "{operations_shift.site}", "{operations_shift.project}", '{operations_shift.shift_type}', "Working", 
+                        "{operations_role.name}", "{operations_role.post_abbrv}", "{roster_type}", 
+                        {day_off_ot}, "{owner}", "{owner}", "{creation}", "{creation}"
+                    ),"""
 
-			query = query[:-1]
+            query = query[:-1]
 
-			query += f"""
-				ON DUPLICATE KEY UPDATE
-				modified_by = VALUES(modified_by),
-				modified = "{creation}",
-				operations_role = VALUES(operations_role),
-				post_abbrv = VALUES(post_abbrv),
-				roster_type = VALUES(roster_type),
-				shift = VALUES(shift),
-				project = VALUES(project),
-				site = VALUES(site),
-				shift_type = VALUES(shift_type),
-				day_off_ot = VALUES(day_off_ot),
-				employee_availability = "Working"
-			"""
-			frappe.db.sql(query, values=[], as_dict=1)
-			frappe.db.commit()
-		else:
-			id_list = [] #store for schedules list
-			for employee in employees:
-				employee_doc = employees_dict.get(employee['employee'])
-				name = f"{employee['date']}_{employee['employee']}_{roster_type}"
-				id_list.append(name)
-				query += f"""
-					(
-						"{name}", "{employee['employee']}", "{employee_doc.employee_name}", "{employee_doc.department}", "{employee['date']}", "{operations_shift.name}", 
-						"{operations_shift.site}", "{operations_shift.project}", '{operations_shift.shift_type}', "Working", 
-						"{operations_role.name}", "{operations_role.post_abbrv}", "{roster_type}", 
-						{day_off_ot}, "{owner}", "{owner}", "{creation}", "{creation}"
-					),"""
+            query += f"""
+                ON DUPLICATE KEY UPDATE
+                modified_by = VALUES(modified_by),
+                modified = "{creation}",
+                operations_role = VALUES(operations_role),
+                post_abbrv = VALUES(post_abbrv),
+                roster_type = VALUES(roster_type),
+                shift = VALUES(shift),
+                project = VALUES(project),
+                site = VALUES(site),
+                shift_type = VALUES(shift_type),
+                day_off_ot = VALUES(day_off_ot),
+                employee_availability = "Working"
+            """
+            frappe.db.sql(query, values=[], as_dict=1)
+            frappe.db.commit()
+        else:
+            id_list = [] #store for schedules list
+            for employee in employees:
+                employee_doc = employees_dict.get(employee['employee'])
+                name = f"{employee['date']}_{employee['employee']}_{roster_type}"
+                id_list.append(name)
+                query += f"""
+                    (
+                        "{name}", "{employee['employee']}", "{employee_doc.employee_name}", "{employee_doc.department}", "{employee['date']}", "{operations_shift.name}", 
+                        "{operations_shift.site}", "{operations_shift.project}", '{operations_shift.shift_type}', "Working", 
+                        "{operations_role.name}", "{operations_role.post_abbrv}", "{roster_type}", 
+                        {day_off_ot}, "{owner}", "{owner}", "{creation}", "{creation}"
+                    ),"""
 
-			query = query[:-1]
+            query = query[:-1]
 
-			query += f"""
-				ON DUPLICATE KEY UPDATE
-				modified_by = VALUES(modified_by),
-				modified = "{creation}",
-				operations_role = VALUES(operations_role),
-				post_abbrv = VALUES(post_abbrv),
-				roster_type = VALUES(roster_type),
-				shift = VALUES(shift),
-				project = VALUES(project),
-				site = VALUES(site),
-				shift_type = VALUES(shift_type),
-				day_off_ot = VALUES(day_off_ot),
-				employee_availability = "Working"
-			"""
-			frappe.db.sql(query, values=[], as_dict=1)
-			frappe.db.commit()
-	else:
-		"""
-			Handle request employee schedule
-		"""
-		from_schedule = frappe.db.get_list(
-			"Employee Schedule",
-			filters={
-				"shift": shift,
-				"date": ["BETWEEN", [start_date, end_date]],
-				"employee": ["IN", employee_list]
-			},
-			fields=["shift", "site", "project", "employee", "employee_name", "operations_role"],
-			group_by="employee DESC"
-		)
-		if len(from_schedule):
-			if otRoster == 'false':
-				roster_type = 'Basic'
-			elif otRoster == 'true':
-				roster_type = 'Over-Time'
-			
-			requester, requester_name = frappe.db.get_value("Employee", {"user_id":frappe.session.user}, ["name", "employee_name"])
-			# get required shift supervisors and make as dict for easy hashing
-			shifts_dataset = frappe.db.get_list("Operations Shift", filters={"name": ["IN", [i.shift for i in from_schedule]]}, fields=["name", "supervisor", "supervisor_name"], order_by="name ASC")
-			shift_datadict = {}
-			for i in shifts_dataset:
-				shift_datadict[i.name] = i
-			
-			for emp in from_schedule:			
-				req_es_doc = frappe.new_doc("Request Employee Schedule")
-				req_es_doc.employee = emp.employee
-				req_es_doc.from_shift = emp.shift
-				req_es_doc.from_operations_role = emp.operations_role
-				req_es_doc.to_shift = shift
-				req_es_doc.to_operations_role = operations_role.name
-				req_es_doc.start_date = start_date
-				req_es_doc.end_date = end_date
-				req_es_doc.roster_type = roster_type
-				req_es_doc.save(ignore_permissions=True)
-			frappe.db.commit()
-			frappe.msgprint("Request Employee Schedule created successfully")
+            query += f"""
+                ON DUPLICATE KEY UPDATE
+                modified_by = VALUES(modified_by),
+                modified = "{creation}",
+                operations_role = VALUES(operations_role),
+                post_abbrv = VALUES(post_abbrv),
+                roster_type = VALUES(roster_type),
+                shift = VALUES(shift),
+                project = VALUES(project),
+                site = VALUES(site),
+                shift_type = VALUES(shift_type),
+                day_off_ot = VALUES(day_off_ot),
+                employee_availability = "Working"
+            """
+            frappe.db.sql(query, values=[], as_dict=1)
+            frappe.db.commit()
+    else:
+        """
+            Handle request employee schedule
+        """
+        from_schedule = frappe.db.get_list(
+            "Employee Schedule",
+            filters={
+                "shift": shift,
+                "date": ["BETWEEN", [start_date, end_date]],
+                "employee": ["IN", employee_list]
+            },
+            fields=["shift", "site", "project", "employee", "employee_name", "operations_role"],
+            group_by="employee DESC"
+        )
+        if len(from_schedule):
+            if otRoster == 'false':
+                roster_type = 'Basic'
+            elif otRoster == 'true':
+                roster_type = 'Over-Time'
+            
+            requester, requester_name = frappe.db.get_value("Employee", {"user_id":frappe.session.user}, ["name", "employee_name"])
+            # get required shift supervisors and make as dict for easy hashing
+            shifts_dataset = frappe.db.get_list("Operations Shift", filters={"name": ["IN", [i.shift for i in from_schedule]]}, fields=["name", "supervisor", "supervisor_name"], order_by="name ASC")
+            shift_datadict = {}
+            for i in shifts_dataset:
+                shift_datadict[i.name] = i
+            
+            for emp in from_schedule:			
+                req_es_doc = frappe.new_doc("Request Employee Schedule")
+                req_es_doc.employee = emp.employee
+                req_es_doc.from_shift = emp.shift
+                req_es_doc.from_operations_role = emp.operations_role
+                req_es_doc.to_shift = shift
+                req_es_doc.to_operations_role = operations_role.name
+                req_es_doc.start_date = start_date
+                req_es_doc.end_date = end_date
+                req_es_doc.roster_type = roster_type
+                req_es_doc.save(ignore_permissions=True)
+            frappe.db.commit()
+            frappe.msgprint("Request Employee Schedule created successfully")
 
-	# update employee additional records
-	frappe.enqueue(update_employee_shift, employees=employees, shift=shift, owner=owner, creation=creation)
+    # update employee additional records
+    frappe.enqueue(update_employee_shift, employees=employees, shift=shift, owner=owner, creation=creation)
 
 
 def update_employee_shift(employees, shift, owner, creation):
-	"""Update employee assignment"""
+    """Update employee assignment"""
 
-	site, project = frappe.get_value("Operations Shift", shift, ["site", "project"])
-	# structure employee record
-	# filter and sort, check if employee site and project match retrieved
-	employees_data = frappe.db.get_list("Employee", filters={"name": ["IN", employees]}, fields=["name", "employee_name", "employee_id", "project", "site", "shift"])
-	unmatched_record = {}
-	matched_record = []
-	no_shift_assigned = []
-	for emp in employees_data:
-		if emp.project and emp.project != project or emp.site and emp.site != site or emp.shift and emp.shift != shift:
-			unmatched_record[emp.name] = emp
-		elif emp.project == project and emp.site == site and emp.shift == shift:
-			matched_record.append(emp.name)
-		else:
-			no_shift_assigned.append(emp.name)
+    site, project = frappe.get_value("Operations Shift", shift, ["site", "project"])
+    # structure employee record
+    # filter and sort, check if employee site and project match retrieved
+    employees_data = frappe.db.get_list("Employee", filters={"name": ["IN", employees]}, fields=["name", "employee_name", "employee_id", "project", "site", "shift"])
+    unmatched_record = {}
+    matched_record = []
+    no_shift_assigned = []
+    for emp in employees_data:
+        if emp.project and emp.project != project or emp.site and emp.site != site or emp.shift and emp.shift != shift:
+            unmatched_record[emp.name] = emp
+        elif emp.project == project and emp.site == site and emp.shift == shift:
+            matched_record.append(emp.name)
+        else:
+            no_shift_assigned.append(emp.name)
 
 
-	# start with unmatched
-	if unmatched_record:
-		query = """
-			INSERT INTO `tabAdditional Shift Assignment` (`name`, `employee`, `employee_name`, `employee_id`, `site`, `shift`, `project`, `owner`, `modified_by`, `creation`, `modified`)
-			VALUES 
-		"""
-		for k, emp in unmatched_record.items():
-			query += f"""(
-					"{emp.name}|{shift}", "{emp.name}", "{emp.employee_name}", "{emp.employee_id}", "{site}", "{shift}", 
-					"{project}", "{owner}", "{owner}", "{creation}", "{creation}"
-			),"""
-		query = query.replace(", None", '')
-		query = query[:-1]
-		query += """
-			ON DUPLICATE KEY UPDATE
-			project = VALUES(project),
-			site = VALUES(site),
-			shift = VALUES(shift),
-			modified_by = VALUES(modified_by),
-			modified = VALUES(modified)
-		"""
-		frappe.db.sql(query)
+    # start with unmatched
+    if unmatched_record:
+        query = """
+            INSERT INTO `tabAdditional Shift Assignment` (`name`, `employee`, `employee_name`, `employee_id`, `site`, `shift`, `project`, `owner`, `modified_by`, `creation`, `modified`)
+            VALUES 
+        """
+        for k, emp in unmatched_record.items():
+            query += f"""(
+                    "{emp.name}|{shift}", "{emp.name}", "{emp.employee_name}", "{emp.employee_id}", "{site}", "{shift}", 
+                    "{project}", "{owner}", "{owner}", "{creation}", "{creation}"
+            ),"""
+        query = query.replace(", None", '')
+        query = query[:-1]
+        query += """
+            ON DUPLICATE KEY UPDATE
+            project = VALUES(project),
+            site = VALUES(site),
+            shift = VALUES(shift),
+            modified_by = VALUES(modified_by),
+            modified = VALUES(modified)
+        """
+        frappe.db.sql(query)
 
-	if matched_record:
-		frappe.db.delete("Additional Shift Assignment", {
-			"employee": ["IN", matched_record]
-		})
+    if matched_record:
+        frappe.db.delete("Additional Shift Assignment", {
+            "employee": ["IN", matched_record]
+        })
 
-	if no_shift_assigned:
-		for employee in no_shift_assigned:
-			""" This function updates the employee project, site and shift in the employee doctype """
-			frappe.db.set_value("Employee", employee, {"project":project, "site":site, "shift":shift})
+    if no_shift_assigned:
+        for employee in no_shift_assigned:
+            """ This function updates the employee project, site and shift in the employee doctype """
+            frappe.db.set_value("Employee", employee, {"project":project, "site":site, "shift":shift})
 
-	frappe.db.commit()
+    frappe.db.commit()
 
 
 def update_employee_assignment(employee, project, site, shift):
-	""" This function updates the employee project, site and shift in the employee doctype """
-	frappe.db.set_value("Employee", employee, "project", val=project)
-	frappe.db.set_value("Employee", employee, "site", val=site)
-	frappe.db.set_value("Employee", employee, "shift", val=shift)
+    """ This function updates the employee project, site and shift in the employee doctype """
+    frappe.db.set_value("Employee", employee, "project", val=project)
+    frappe.db.set_value("Employee", employee, "site", val=site)
+    frappe.db.set_value("Employee", employee, "shift", val=shift)
 
 
 @frappe.whitelist()
 def schedule_leave(employees, leave_type, start_date, end_date):
-	try:
-		for employee in json.loads(employees):
-			for date in	pd.date_range(start=start_date, end=end_date):
-				if frappe.db.exists("Employee Schedule", {"employee": employee["employee"], "date": cstr(date.date())}):
-					roster = frappe.get_doc("Employee Schedule", {"employee": employee["employee"], "date": cstr(date.date())})
-					roster.shift = None
-					roster.shift_type = None
-					roster.project = None
-					roster.site = None
-				else:
-					roster = frappe.new_doc("Employee Schedule")
-					roster.employee = employee["employee"]
-					roster.date = cstr(date.date())
-				roster.employee_availability = leave_type
-				roster.save(ignore_permissions=True)
-	except Exception as e:
-		return frappe.utils.response.report_error(e.http_status_code)
+    try:
+        for employee in json.loads(employees):
+            for date in	pd.date_range(start=start_date, end=end_date):
+                if frappe.db.exists("Employee Schedule", {"employee": employee["employee"], "date": cstr(date.date())}):
+                    roster = frappe.get_doc("Employee Schedule", {"employee": employee["employee"], "date": cstr(date.date())})
+                    roster.shift = None
+                    roster.shift_type = None
+                    roster.project = None
+                    roster.site = None
+                else:
+                    roster = frappe.new_doc("Employee Schedule")
+                    roster.employee = employee["employee"]
+                    roster.date = cstr(date.date())
+                roster.employee_availability = leave_type
+                roster.save(ignore_permissions=True)
+    except Exception as e:
+        return frappe.utils.response.report_error(e.http_status_code)
 
 @frappe.whitelist(allow_guest=True)
 def unschedule_staff(employees, start_date, end_date=None, never_end=0):
-	try:
-		_start_date = getdate(start_date)
-		if end_date:
-			stop_date = getdate(end_date)
-		else: stop_date = None
-		delete_list = []
-		employees = json.loads(employees)
-		if not employees:
-			response("Error", 400, None, {'message':'Employees must be selected.'})
-		employees = [i for i in employees if getdate(i['date'])>=_start_date]
+    try:
+        _start_date = getdate(start_date)
+        if end_date:
+            stop_date = getdate(end_date)
+        else: stop_date = None
+        delete_list = []
+        employees = json.loads(employees)
+        if not employees:
+            response("Error", 400, None, {'message':'Employees must be selected.'})
+        employees = [i for i in employees if getdate(i['date'])>=_start_date]
 
-		if end_date:
-			employees = [i for i in employees if getdate(i['date'])<=stop_date]
+        if end_date:
+            employees = [i for i in employees if getdate(i['date'])<=stop_date]
 
-		# check if no end date
-		if cint(never_end) == 1:
-			employees_to_delete = []
-			for i in employees:
-				if not i['employee'] in employees_to_delete:
-					employees_to_delete.append(i['employee'])
-			# delete all schedules greater than start date
-			employees_to_delete=str(tuple(employees_to_delete)).replace(',)', ')')
-			frappe.db.sql(f"""
-				DELETE FROM `tabEmployee Schedule` WHERE employee IN {employees_to_delete} and date>='{start_date}'
-			""")
-		else:
-			for i in employees:
-				frappe.db.sql(f"""
-					DELETE FROM `tabEmployee Schedule` WHERE employee='{i['employee']}' and date='{i['date']}'
-				""")
-		response("Success", 200, {'message':'Staff(s) unscheduled successfully'})
-	except Exception as e:
-		frappe.throw(str(e))
-		response("Error", 200, None, str(e))
+        # check if no end date
+        if cint(never_end) == 1:
+            employees_to_delete = []
+            for i in employees:
+                if not i['employee'] in employees_to_delete:
+                    employees_to_delete.append(i['employee'])
+            # delete all schedules greater than start date
+            employees_to_delete=str(tuple(employees_to_delete)).replace(',)', ')')
+            frappe.db.sql(f"""
+                DELETE FROM `tabEmployee Schedule` WHERE employee IN {employees_to_delete} and date>='{start_date}'
+            """)
+        else:
+            for i in employees:
+                frappe.db.sql(f"""
+                    DELETE FROM `tabEmployee Schedule` WHERE employee='{i['employee']}' and date='{i['date']}'
+                """)
+        response("Success", 200, {'message':'Staff(s) unscheduled successfully'})
+    except Exception as e:
+        frappe.throw(str(e))
+        response("Error", 200, None, str(e))
 
 @frappe.whitelist()
 def edit_post(posts, values):
 
-	user, user_roles, user_employee = get_current_user_details()
+    user, user_roles, user_employee = get_current_user_details()
 
-	if "Operations Manager" not in user_roles and "Projects Manager" not in user_roles:
-		frappe.throw(_("Insufficient permissions to Edit Post."))
-	
-	args = frappe._dict(json.loads(values))
+    if "Operations Manager" not in user_roles and "Projects Manager" not in user_roles:
+        frappe.throw(_("Insufficient permissions to Edit Post."))
+    
+    args = frappe._dict(json.loads(values))
 
-	if args.post_status == "Plan Post":
-		if args.plan_end_date and cint(args.project_end_date):
-			frappe.throw(_("Cannot set both project end date and custom end date!"))
+    if args.post_status == "Plan Post":
+        if args.plan_end_date and cint(args.project_end_date):
+            frappe.throw(_("Cannot set both project end date and custom end date!"))
 
-		if not args.plan_end_date and not cint(args.project_end_date):
-			frappe.throw(_("Please set an end date!"))
+        if not args.plan_end_date and not cint(args.project_end_date):
+            frappe.throw(_("Please set an end date!"))
 
-		frappe.enqueue(plan_post, posts=posts, args=args, is_async=True, queue='long')
-
-
-	elif args.post_status == "Cancel Post":
-		if args.cancel_end_date and cint(args.project_end_date):
-			frappe.throw(_("Cannot set both project end date and custom end date!"))
-
-		if not args.cancel_end_date and not cint(args.project_end_date):
-			frappe.throw(_("Please set an end date!"))
-
-		frappe.enqueue(cancel_post,posts=posts, args=args, is_async=True, queue='long')
+        frappe.enqueue(plan_post, posts=posts, args=args, is_async=True, queue='long')
 
 
-	elif args.post_status == "Suspend Post":
-		if args.suspend_to_date and cint(args.project_end_date):
-			frappe.throw(_("Cannot set both project end date and custom end date!"))
+    elif args.post_status == "Cancel Post":
+        if args.cancel_end_date and cint(args.project_end_date):
+            frappe.throw(_("Cannot set both project end date and custom end date!"))
 
-		if not args.suspend_to_date and not cint(args.project_end_date):
-			frappe.throw(_("Please set an end date!"))
+        if not args.cancel_end_date and not cint(args.project_end_date):
+            frappe.throw(_("Please set an end date!"))
 
-		frappe.enqueue(suspend_post, posts=posts, args=args, is_async=True, queue='long')
+        frappe.enqueue(cancel_post,posts=posts, args=args, is_async=True, queue='long')
 
 
-	elif args.post_status == "Post Off":
-		if args.repeat_till and cint(args.project_end_date):
-			frappe.throw(_("Cannot set both project end date and custom end date!"))
+    elif args.post_status == "Suspend Post":
+        if args.suspend_to_date and cint(args.project_end_date):
+            frappe.throw(_("Cannot set both project end date and custom end date!"))
 
-		if not args.repeat_till and not cint(args.project_end_date):
-			frappe.throw(_("Please set an end date!"))
+        if not args.suspend_to_date and not cint(args.project_end_date):
+            frappe.throw(_("Please set an end date!"))
 
-		if args.repeat == "Does not repeat" and cint(args.project_end_date):
-			frappe.throw(_("Cannot set both project end date and choose 'Does not repeat' option!"))
+        frappe.enqueue(suspend_post, posts=posts, args=args, is_async=True, queue='long')
 
-		frappe.enqueue(post_off, posts=posts, args=args, is_async=True, queue='long')
 
-	frappe.enqueue(update_roster, key="staff_view", is_async=True, queue='long')
+    elif args.post_status == "Post Off":
+        if args.repeat_till and cint(args.project_end_date):
+            frappe.throw(_("Cannot set both project end date and custom end date!"))
+
+        if not args.repeat_till and not cint(args.project_end_date):
+            frappe.throw(_("Please set an end date!"))
+
+        if args.repeat == "Does not repeat" and cint(args.project_end_date):
+            frappe.throw(_("Cannot set both project end date and choose 'Does not repeat' option!"))
+
+        frappe.enqueue(post_off, posts=posts, args=args, is_async=True, queue='long')
+
+    frappe.enqueue(update_roster, key="staff_view", is_async=True, queue='long')
 
 def plan_post(posts, args):
-	""" This function sets the post status to planned provided a post, start date and an end date """
+    """ This function sets the post status to planned provided a post, start date and an end date """
 
-	end_date = None
+    end_date = None
 
-	if args.plan_end_date and not cint(args.project_end_date):
-		end_date = args.plan_end_date
+    if args.plan_end_date and not cint(args.project_end_date):
+        end_date = args.plan_end_date
 
-	for post in json.loads(posts):
-		if cint(args.project_end_date) and not args.plan_end_date:
-			project = frappe.db.get_value("Operations Post", post["post"], ["project"])
-			if frappe.db.exists("Contracts", {'project': project}):
-				contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-				if not end_date:
-					frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-			else:
-				frappe.throw(_("No contract linked with project {project}".format(project=project)))
+    for post in json.loads(posts):
+        if cint(args.project_end_date) and not args.plan_end_date:
+            project = frappe.db.get_value("Operations Post", post["post"], ["project"])
+            if frappe.db.exists("Contracts", {'project': project}):
+                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                if not end_date:
+                    frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+            else:
+                frappe.throw(_("No contract linked with project {project}".format(project=project)))
 
-		for date in pd.date_range(start=args.plan_from_date, end=end_date):
-			if frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": post["post"]}):
-				doc = frappe.get_doc("Post Schedule", {"date": cstr(date.date()), "post": post["post"]})
-			else:
-				doc = frappe.new_doc("Post Schedule")
-				doc.post = post["post"]
-				doc.date = cstr(date.date())
-			doc.post_status = "Planned"
-			doc.save()
-		frappe.db.commit()
+        for date in pd.date_range(start=args.plan_from_date, end=end_date):
+            if frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": post["post"]}):
+                doc = frappe.get_doc("Post Schedule", {"date": cstr(date.date()), "post": post["post"]})
+            else:
+                doc = frappe.new_doc("Post Schedule")
+                doc.post = post["post"]
+                doc.date = cstr(date.date())
+            doc.post_status = "Planned"
+            doc.save()
+        frappe.db.commit()
 
 def cancel_post(posts, args):
-	end_date = None
+    end_date = None
 
-	if args.cancel_end_date and not cint(args.project_end_date):
-		end_date = args.plan_end_date
+    if args.cancel_end_date and not cint(args.project_end_date):
+        end_date = args.plan_end_date
 
-	for post in json.loads(posts):
-		if cint(args.project_end_date) and not args.cancel_end_date:
-			project = frappe.db.get_value("Operations Post", post["post"], ["project"])
-			if frappe.db.exists("Contracts", {'project': project}):
-				contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-				if not end_date:
-					frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-			else:
-				frappe.throw(_("No contract linked with project {project}".format(project=project)))
+    for post in json.loads(posts):
+        if cint(args.project_end_date) and not args.cancel_end_date:
+            project = frappe.db.get_value("Operations Post", post["post"], ["project"])
+            if frappe.db.exists("Contracts", {'project': project}):
+                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                if not end_date:
+                    frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+            else:
+                frappe.throw(_("No contract linked with project {project}".format(project=project)))
 
-		for date in	pd.date_range(start=args.cancel_from_date, end=end_date):
-			if frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": post["post"]}):
-				doc = frappe.get_doc("Post Schedule", {"date": cstr(date.date()), "post": post["post"]})
-			else:
-				doc = frappe.new_doc("Post Schedule")
-				doc.post = post["post"]
-				doc.date = cstr(date.date())
-			doc.paid = args.suspend_paid
-			doc.unpaid = args.suspend_unpaid
-			doc.post_status = "Cancelled"
-			doc.save()
-	frappe.db.commit()
+        for date in	pd.date_range(start=args.cancel_from_date, end=end_date):
+            if frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": post["post"]}):
+                doc = frappe.get_doc("Post Schedule", {"date": cstr(date.date()), "post": post["post"]})
+            else:
+                doc = frappe.new_doc("Post Schedule")
+                doc.post = post["post"]
+                doc.date = cstr(date.date())
+            doc.paid = args.suspend_paid
+            doc.unpaid = args.suspend_unpaid
+            doc.post_status = "Cancelled"
+            doc.save()
+    frappe.db.commit()
 
 def suspend_post(posts, args):
-	end_date = None
+    end_date = None
 
-	if args.suspend_to_date and not cint(args.project_end_date):
-		end_date = args.suspend_to_date
+    if args.suspend_to_date and not cint(args.project_end_date):
+        end_date = args.suspend_to_date
 
-	for post in json.loads(posts):
-		if cint(args.project_end_date) and not args.suspend_to_date:
-			project = frappe.db.get_value("Operations Post", post["post"], ["project"])
-			if frappe.db.exists("Contracts", {'project': project}):
-				contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-				if not end_date:
-					frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-			else:
-				frappe.throw(_("No contract linked with project {project}".format(project=project)))
+    for post in json.loads(posts):
+        if cint(args.project_end_date) and not args.suspend_to_date:
+            project = frappe.db.get_value("Operations Post", post["post"], ["project"])
+            if frappe.db.exists("Contracts", {'project': project}):
+                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                if not end_date:
+                    frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+            else:
+                frappe.throw(_("No contract linked with project {project}".format(project=project)))
 
-		for date in	pd.date_range(start=args.suspend_from_date, end=end_date):
-			if frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": post["post"]}):
-				doc = frappe.get_doc("Post Schedule", {"date": cstr(date.date()), "post": post["post"]})
-			else:
-				doc = frappe.new_doc("Post Schedule")
-				doc.post = post["post"]
-				doc.date = cstr(date.date())
-			doc.paid = args.suspend_paid
-			doc.unpaid = args.suspend_unpaid
-			doc.post_status = "Suspended"
-			doc.save()
-	frappe.db.commit()
+        for date in	pd.date_range(start=args.suspend_from_date, end=end_date):
+            if frappe.db.exists("Post Schedule", {"date": cstr(date.date()), "post": post["post"]}):
+                doc = frappe.get_doc("Post Schedule", {"date": cstr(date.date()), "post": post["post"]})
+            else:
+                doc = frappe.new_doc("Post Schedule")
+                doc.post = post["post"]
+                doc.date = cstr(date.date())
+            doc.paid = args.suspend_paid
+            doc.unpaid = args.suspend_unpaid
+            doc.post_status = "Suspended"
+            doc.save()
+    frappe.db.commit()
 
 def post_off(posts, args):
-	from one_fm.api.mobile.roster import month_range
-	post_off_paid = args.post_off_paid
-	post_off_unpaid = args.post_off_unpaid
+    from one_fm.api.mobile.roster import month_range
+    post_off_paid = args.post_off_paid
+    post_off_unpaid = args.post_off_unpaid
 
-	if args.repeat == "Does not repeat":
-		for post in json.loads(posts):
-			set_post_off(post["post"], post["date"], post_off_paid, post_off_unpaid)
-	else:
-		if args.repeat and args.repeat in ["Daily", "Weekly", "Monthly", "Yearly"]:
-			end_date = None
+    if args.repeat == "Does not repeat":
+        for post in json.loads(posts):
+            set_post_off(post["post"], post["date"], post_off_paid, post_off_unpaid)
+    else:
+        if args.repeat and args.repeat in ["Daily", "Weekly", "Monthly", "Yearly"]:
+            end_date = None
 
-			if args.repeat_till and not cint(args.project_end_date):
-				end_date = args.repeat_till
+            if args.repeat_till and not cint(args.project_end_date):
+                end_date = args.repeat_till
 
-			if args.repeat == "Daily":
-				for post in json.loads(posts):
-					if cint(args.project_end_date) and not args.repeat_till:
-						project = frappe.db.get_value("Operations Post", post["post"], ["project"])
-						if frappe.db.exists("Contracts", {'project': project}):
-							contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-							if not end_date:
-								frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-						else:
-							frappe.throw(_("No contract linked with project {project}".format(project=project)))
+            if args.repeat == "Daily":
+                for post in json.loads(posts):
+                    if cint(args.project_end_date) and not args.repeat_till:
+                        project = frappe.db.get_value("Operations Post", post["post"], ["project"])
+                        if frappe.db.exists("Contracts", {'project': project}):
+                            contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                            if not end_date:
+                                frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                        else:
+                            frappe.throw(_("No contract linked with project {project}".format(project=project)))
 
-					for date in	pd.date_range(start=post["date"], end=end_date):
-						set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
+                    for date in	pd.date_range(start=post["date"], end=end_date):
+                        set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
 
-			elif args.repeat == "Weekly":
-				week_days = []
-				if args.sunday: week_days.append("Sunday")
-				if args.monday: week_days.append("Monday")
-				if args.tuesday: week_days.append("Tuesday")
-				if args.wednesday: week_days.append("Wednesday")
-				if args.thursday: week_days.append("Thursday")
-				if args.friday: week_days.append("Friday")
-				if args.saturday: week_days.append("Saturday")
-				for post in json.loads(posts):
-					if cint(args.project_end_date) and not args.repeat_till:
-						project = frappe.db.get_value("Operations Post", post["post"], ["project"])
-						if frappe.db.exists("Contracts", {'project': project}):
-							contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-							if not end_date:
-								frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-						else:
-							frappe.throw(_("No contract linked with project {project}".format(project=project)))
+            elif args.repeat == "Weekly":
+                week_days = []
+                if args.sunday: week_days.append("Sunday")
+                if args.monday: week_days.append("Monday")
+                if args.tuesday: week_days.append("Tuesday")
+                if args.wednesday: week_days.append("Wednesday")
+                if args.thursday: week_days.append("Thursday")
+                if args.friday: week_days.append("Friday")
+                if args.saturday: week_days.append("Saturday")
+                for post in json.loads(posts):
+                    if cint(args.project_end_date) and not args.repeat_till:
+                        project = frappe.db.get_value("Operations Post", post["post"], ["project"])
+                        if frappe.db.exists("Contracts", {'project': project}):
+                            contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                            if not end_date:
+                                frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                        else:
+                            frappe.throw(_("No contract linked with project {project}".format(project=project)))
 
-					for date in	pd.date_range(start=post["date"], end=end_date):
-						if getdate(date).strftime('%A') in week_days:
-							set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
+                    for date in	pd.date_range(start=post["date"], end=end_date):
+                        if getdate(date).strftime('%A') in week_days:
+                            set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
 
-			elif args.repeat == "Monthly":
-				for post in json.loads(posts):
-					if cint(args.project_end_date) and not args.repeat_till:
-						project = frappe.db.get_value("Operations Post", post["post"], ["project"])
-						if frappe.db.exists("Contracts", {'project': project}):
-							contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-							if not end_date:
-								frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-						else:
-							frappe.throw(_("No contract linked with project {project}".format(project=project)))
+            elif args.repeat == "Monthly":
+                for post in json.loads(posts):
+                    if cint(args.project_end_date) and not args.repeat_till:
+                        project = frappe.db.get_value("Operations Post", post["post"], ["project"])
+                        if frappe.db.exists("Contracts", {'project': project}):
+                            contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                            if not end_date:
+                                frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                        else:
+                            frappe.throw(_("No contract linked with project {project}".format(project=project)))
 
-					for date in	month_range(post["date"], end_date):
-						set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
+                    for date in	month_range(post["date"], end_date):
+                        set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
 
-			elif args.repeat == "Yearly":
-				for post in json.loads(posts):
-					if cint(args.project_end_date) and not args.repeat_till:
-						project = frappe.db.get_value("Operations Post", post["post"], ["project"])
-						if frappe.db.exists("Contracts", {'project': project}):
-							contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-							if not end_date:
-								frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-						else:
-							frappe.throw(_("No contract linked with project {project}".format(project=project)))
+            elif args.repeat == "Yearly":
+                for post in json.loads(posts):
+                    if cint(args.project_end_date) and not args.repeat_till:
+                        project = frappe.db.get_value("Operations Post", post["post"], ["project"])
+                        if frappe.db.exists("Contracts", {'project': project}):
+                            contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                            if not end_date:
+                                frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                        else:
+                            frappe.throw(_("No contract linked with project {project}".format(project=project)))
 
-					for date in	pd.date_range(start=post["date"], end=end_date, freq=pd.DateOffset(years=1)):
-						set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
-	frappe.db.commit()
+                    for date in	pd.date_range(start=post["date"], end=end_date, freq=pd.DateOffset(years=1)):
+                        set_post_off(post["post"], cstr(date.date()), post_off_paid, post_off_unpaid)
+    frappe.db.commit()
 
 def set_post_off(post, date, post_off_paid, post_off_unpaid):
-	if frappe.db.exists("Post Schedule", {"date": date, "post": post}):
-		doc = frappe.get_doc("Post Schedule", {"date": date, "post": post})
-	else:
-		doc = frappe.new_doc("Post Schedule")
-		doc.post = post
-		doc.date = date
-	doc.paid = post_off_paid
-	doc.unpaid = post_off_unpaid
-	doc.post_status = "Post Off"
-	doc.save()
+    if frappe.db.exists("Post Schedule", {"date": date, "post": post}):
+        doc = frappe.get_doc("Post Schedule", {"date": date, "post": post})
+    else:
+        doc = frappe.new_doc("Post Schedule")
+        doc.post = post
+        doc.date = date
+    doc.paid = post_off_paid
+    doc.unpaid = post_off_unpaid
+    doc.post_status = "Post Off"
+    doc.save()
 
 
 
 @frappe.whitelist()
 def dayoff(employees, selected_dates=0, repeat=0, repeat_freq=None, week_days=[], repeat_till=None, project_end_date=None):
-	"""
-		Set days of done with sql query for instant response
-	"""
-	try:
-		creation = now()
-		owner = frappe.session.user
-		roster_type = "Basic"
-		id_list = []
-		query = """
-			INSERT INTO `tabEmployee Schedule` (`name`, `employee`, `date`, `shift`, `site`, `project`, `shift_type`, `employee_availability`, 
-			`operations_role`, `post_abbrv`, `roster_type`, `day_off_ot`, `owner`, `modified_by`, `creation`, `modified`)
-			VALUES 
-		"""
-		querycontent = """"""
+    """
+        Set days of done with sql query for instant response
+    """
+    try:
+        creation = now()
+        owner = frappe.session.user
+        roster_type = "Basic"
+        id_list = []
+        query = """
+            INSERT INTO `tabEmployee Schedule` (`name`, `employee`, `date`, `shift`, `site`, `project`, `shift_type`, `employee_availability`, 
+            `operations_role`, `post_abbrv`, `roster_type`, `day_off_ot`, `owner`, `modified_by`, `creation`, `modified`)
+            VALUES 
+        """
+        querycontent = """"""
 
 
-		if not repeat_till and not cint(project_end_date) and not selected_dates:
-			frappe.throw(_("Please select either a repeat till date or check the project end date option."))
+        if not repeat_till and not cint(project_end_date) and not selected_dates:
+            frappe.throw(_("Please select either a repeat till date or check the project end date option."))
 
-		from one_fm.api.mobile.roster import month_range
-		if cint(selected_dates):
-			for employee in json.loads(employees):
-				date = employee['date']
-				name = f"{date}_{employee['employee']}_{roster_type}"
-				id_list.append(name)
-				querycontent += f"""(
-					"{name}", "{employee["employee"]}", "{date}", "", "", "", 
-					'', "Day Off", "", "", "Basic", 
-					0, "{owner}", "{owner}", "{creation}", "{creation}"
-				),"""
-		else:
-			if repeat and repeat_freq in ["Daily", "Weekly", "Monthly", "Yearly"]:
-				end_date = None
-				if repeat_till and not cint(project_end_date):
-					end_date = repeat_till
+        from one_fm.api.mobile.roster import month_range
+        if cint(selected_dates):
+            for employee in json.loads(employees):
+                date = employee['date']
+                name = f"{date}_{employee['employee']}_{roster_type}"
+                id_list.append(name)
+                querycontent += f"""(
+                    "{name}", "{employee["employee"]}", "{date}", "", "", "", 
+                    '', "Day Off", "", "", "Basic", 
+                    0, "{owner}", "{owner}", "{creation}", "{creation}"
+                ),"""
+        else:
+            if repeat and repeat_freq in ["Daily", "Weekly", "Monthly", "Yearly"]:
+                end_date = None
+                if repeat_till and not cint(project_end_date):
+                    end_date = repeat_till
 
-				if repeat_freq == "Daily":
-					for employee in json.loads(employees):
-						if cint(project_end_date):
-							project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
-							if frappe.db.exists("Contracts", {'project': project}):
-								contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-								if not end_date:
-									frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-							else:
-								frappe.throw(_("No contract linked with project {project}".format(project=project)))
-						for date in	pd.date_range(start=employee["date"], end=end_date):
-							name = f"{date.date()}_{employee['employee']}_{roster_type}"
-							id_list.append(name)
-							querycontent += f"""(
-								"{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
-								'', "Day Off", "", "", "Basic", 
-								0, "{owner}", "{owner}", "{creation}", "{creation}"
-							),"""
+                if repeat_freq == "Daily":
+                    for employee in json.loads(employees):
+                        if cint(project_end_date):
+                            project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
+                            if frappe.db.exists("Contracts", {'project': project}):
+                                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                                if not end_date:
+                                    frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                            else:
+                                frappe.throw(_("No contract linked with project {project}".format(project=project)))
+                        for date in	pd.date_range(start=employee["date"], end=end_date):
+                            name = f"{date.date()}_{employee['employee']}_{roster_type}"
+                            id_list.append(name)
+                            querycontent += f"""(
+                                "{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
+                                '', "Day Off", "", "", "Basic", 
+                                0, "{owner}", "{owner}", "{creation}", "{creation}"
+                            ),"""
 
-				elif repeat_freq == "Weekly":
-					for employee in json.loads(employees):
-						if cint(project_end_date):
-							project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
-							if frappe.db.exists("Contracts", {'project': project}):
-								contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-								if not end_date:
-									frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-							else:
-								frappe.throw(_("No contract linked with project {project}".format(project=project)))
-						for date in	pd.date_range(start=employee["date"], end=end_date):
-							if getdate(date).strftime('%A') in week_days:
-								name = f"{date.date()}_{employee['employee']}_{roster_type}"
-								id_list.append(name)
-								querycontent += f"""(
-									"{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
-									'', "Day Off", "", "", "Basic", 
-									0, "{owner}", "{owner}", "{creation}", "{creation}"
-								),"""
+                elif repeat_freq == "Weekly":
+                    for employee in json.loads(employees):
+                        if cint(project_end_date):
+                            project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
+                            if frappe.db.exists("Contracts", {'project': project}):
+                                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                                if not end_date:
+                                    frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                            else:
+                                frappe.throw(_("No contract linked with project {project}".format(project=project)))
+                        for date in	pd.date_range(start=employee["date"], end=end_date):
+                            if getdate(date).strftime('%A') in week_days:
+                                name = f"{date.date()}_{employee['employee']}_{roster_type}"
+                                id_list.append(name)
+                                querycontent += f"""(
+                                    "{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
+                                    '', "Day Off", "", "", "Basic", 
+                                    0, "{owner}", "{owner}", "{creation}", "{creation}"
+                                ),"""
 
-				elif repeat_freq == "Monthly":
-					for employee in json.loads(employees):
-						if cint(project_end_date):
-							project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
-							if frappe.db.exists("Contracts", {'project': project}):
-								contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-								if not end_date:
-									frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-							else:
-								frappe.throw(_("No contract linked with project {project}".format(project=project)))
-						for date in	month_range(employee["date"], end_date):
-							name = f"{date.date()}_{employee['employee']}_{roster_type}"
-							id_list.append(name)
-							querycontent += f"""(
-								"{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
-								'', "Day Off", "", "", "Basic", 
-								0, "{owner}", "{owner}", "{creation}", "{creation}"
-							),"""
+                elif repeat_freq == "Monthly":
+                    for employee in json.loads(employees):
+                        if cint(project_end_date):
+                            project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
+                            if frappe.db.exists("Contracts", {'project': project}):
+                                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                                if not end_date:
+                                    frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                            else:
+                                frappe.throw(_("No contract linked with project {project}".format(project=project)))
+                        for date in	month_range(employee["date"], end_date):
+                            name = f"{date.date()}_{employee['employee']}_{roster_type}"
+                            id_list.append(name)
+                            querycontent += f"""(
+                                "{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
+                                '', "Day Off", "", "", "Basic", 
+                                0, "{owner}", "{owner}", "{creation}", "{creation}"
+                            ),"""
 
-				elif repeat_freq == "Yearly":
-					for employee in json.loads(employees):
-						if cint(project_end_date):
-							project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
-							if frappe.db.exists("Contracts", {'project': project}):
-								contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
-								if not end_date:
-									frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
-							else:
-								frappe.throw(_("No contract linked with project {project}".format(project=project)))
-						for date in	pd.date_range(start=employee["date"], end=end_date, freq=pd.DateOffset(years=1)):
-							name = f"{date.date()}_{employee['employee']}_{roster_type}"
-							id_list.append(name)
-							querycontent += f"""(
-								"{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
-								'', "Day Off", "", "", "Basic", 
-								0, "{owner}", "{owner}", "{creation}", "{creation}"
-							),"""
+                elif repeat_freq == "Yearly":
+                    for employee in json.loads(employees):
+                        if cint(project_end_date):
+                            project = frappe.db.get_value("Employee", {'employee': employee["employee"]}, ["project"])
+                            if frappe.db.exists("Contracts", {'project': project}):
+                                contract, end_date = frappe.db.get_value("Contracts", {'project': project}, ["name", "end_date"])
+                                if not end_date:
+                                    frappe.throw(_("No end date set for contract {contract}".format(contract=contract)))
+                            else:
+                                frappe.throw(_("No contract linked with project {project}".format(project=project)))
+                        for date in	pd.date_range(start=employee["date"], end=end_date, freq=pd.DateOffset(years=1)):
+                            name = f"{date.date()}_{employee['employee']}_{roster_type}"
+                            id_list.append(name)
+                            querycontent += f"""(
+                                "{name}", "{employee["employee"]}", "{date.date()}", "", "", "", 
+                                '', "Day Off", "", "", "Basic", 
+                                0, "{owner}", "{owner}", "{creation}", "{creation}"
+                            ),"""
 
-		if querycontent:
-			querycontent = querycontent[:-1]
-			query += querycontent
-			query += f"""
-				ON DUPLICATE KEY UPDATE
-				modified_by = VALUES(modified_by),
-				modified = "{creation}",
-				operations_role = "",
-				post_abbrv = "",
-				roster_type = "",
-				shift = "",
-				project = "",
-				site = "",
-				shift_type = "",
-				day_off_ot = 0,
-				roster_type = "Basic",
-				employee_availability = "Day Off"
-			"""
-			frappe.db.sql(query, values=[], as_dict=1)
-			frappe.db.commit()
-		response("success", 200, {'message':'Days Off set successfully.'})
-	except Exception as e:
-		response("error", 200, None, str(e))
+        if querycontent:
+            querycontent = querycontent[:-1]
+            query += querycontent
+            query += f"""
+                ON DUPLICATE KEY UPDATE
+                modified_by = VALUES(modified_by),
+                modified = "{creation}",
+                operations_role = "",
+                post_abbrv = "",
+                roster_type = "",
+                shift = "",
+                project = "",
+                site = "",
+                shift_type = "",
+                day_off_ot = 0,
+                roster_type = "Basic",
+                employee_availability = "Day Off"
+            """
+            frappe.db.sql(query, values=[], as_dict=1)
+            frappe.db.commit()
+        response("success", 200, {'message':'Days Off set successfully.'})
+    except Exception as e:
+        response("error", 200, None, str(e))
 
 
 @frappe.whitelist()
 def assign_staff(employees, shift, request_employee_assignment):
-	if not employees:
-		frappe.throw("Please select employees first")
-	validation_logs = []
-	user, user_roles, user_employee = get_current_user_details()
-	shift, site, project = frappe.db.get_value("Operations Shift", shift, ['name', 'site', 'project'])
-	if not cint(request_employee_assignment):
-		for emp in json.loads(employees):
-			emp_project, emp_site, emp_shift = frappe.db.get_value("Employee", emp, ["project", "site", "shift"])
-			supervisor = frappe.db.get_value("Operations Shift", emp_shift, ["supervisor"])
-			# if user_employee.name != supervisor:
-			# 	validation_logs.append("You are not authorized to change assignment for employee {emp}. Please check the Request Employee Assignment option to place a request.".format(emp=emp))
+    if not employees:
+        frappe.throw("Please select employees first")
+    validation_logs = []
+    user, user_roles, user_employee = get_current_user_details()
+    shift, site, project = frappe.db.get_value("Operations Shift", shift, ['name', 'site', 'project'])
+    if not cint(request_employee_assignment):
+        for emp in json.loads(employees):
+            emp_project, emp_site, emp_shift = frappe.db.get_value("Employee", emp, ["project", "site", "shift"])
+            supervisor = frappe.db.get_value("Operations Shift", emp_shift, ["supervisor"])
+            # if user_employee.name != supervisor:
+            # 	validation_logs.append("You are not authorized to change assignment for employee {emp}. Please check the Request Employee Assignment option to place a request.".format(emp=emp))
 
-	if len(validation_logs) > 0:
-		frappe.throw(str(validation_logs))
-		frappe.log_error(str(validation_logs))
-	else:
-		try:
-			start = time.time()
-			for employee in json.loads(employees):
-				if not cint(request_employee_assignment):
-					frappe.enqueue(assign_job, employee=employee, shift=shift, site=site, project=project, is_async=True, queue="long")
-				else:
-					emp_project, emp_site, emp_shift = frappe.db.get_value("Employee", employee, ["project", "site", "shift"])
-					site, project = frappe.get_value("Operations Shift", shift, ["site", "project"])
-					if emp_project != project or emp_site != site or emp_shift != shift:
-						frappe.enqueue(create_request_employee_assignment, employee=employee, from_shift=emp_shift, to_shift=shift, is_async=True, queue="long")
-			frappe.enqueue(update_roster, key="staff_view", is_async=True, queue="long")
-			end = time.time()
+    if len(validation_logs) > 0:
+        frappe.throw(str(validation_logs))
+        frappe.log_error(str(validation_logs))
+    else:
+        try:
+            start = time.time()
+            for employee in json.loads(employees):
+                if not cint(request_employee_assignment):
+                    frappe.enqueue(assign_job, employee=employee, shift=shift, site=site, project=project, is_async=True, queue="long")
+                else:
+                    emp_project, emp_site, emp_shift = frappe.db.get_value("Employee", employee, ["project", "site", "shift"])
+                    site, project = frappe.get_value("Operations Shift", shift, ["site", "project"])
+                    if emp_project != project or emp_site != site or emp_shift != shift:
+                        frappe.enqueue(create_request_employee_assignment, employee=employee, from_shift=emp_shift, to_shift=shift, is_async=True, queue="long")
+            frappe.enqueue(update_roster, key="staff_view", is_async=True, queue="long")
+            end = time.time()
 
-			return True
+            return True
 
-		except Exception as e:
-			frappe.log_error(str(e))
-			frappe.throw(_(str(e)))
+        except Exception as e:
+            frappe.log_error(str(e))
+            frappe.throw(_(str(e)))
 
 def create_request_employee_assignment(employee, from_shift, to_shift):
-	req_ea_doc = frappe.new_doc("Request Employee Assignment")
-	req_ea_doc.employee = employee
-	req_ea_doc.from_shift = from_shift
-	req_ea_doc.to_shift = to_shift
-	req_ea_doc.save(ignore_permissions=True)
+    req_ea_doc = frappe.new_doc("Request Employee Assignment")
+    req_ea_doc.employee = employee
+    req_ea_doc.from_shift = from_shift
+    req_ea_doc.to_shift = to_shift
+    req_ea_doc.save(ignore_permissions=True)
 
 
 def assign_job(employee, shift, site, project):
-	start = time.time()
-	frappe.set_value("Employee", employee, "shift", shift)
-	frappe.set_value("Employee", employee, "site", site)
-	frappe.set_value("Employee", employee, "project", project)
+    start = time.time()
+    frappe.set_value("Employee", employee, "shift", shift)
+    frappe.set_value("Employee", employee, "site", site)
+    frappe.set_value("Employee", employee, "project", project)
 
 
 @frappe.whitelist(allow_guest=True)
 def search_staff(key, search_term):
-	conds = ""
-	if key == "customer" and search_term:
-		conds += 'and prj.customer like "%{customer}%" and emp.project=prj.name'.format(customer=search_term)
-	elif key == "employee_id" and search_term:
-		conds += 'and emp.employee_id like "%{employee_id}%" '.format(employee_id=search_term)
-	elif key == "project" and search_term:
-		conds += 'and emp.project like "%{project}%" '.format(project=search_term)
-	elif key == "site" and search_term:
-		conds += 'and emp.site like "%{site}%" '.format(site=search_term)
-	elif key == "employee_name" and search_term:
-		conds += 'and emp.employee_name like "%{name}%" '.format(name=search_term)
+    conds = ""
+    if key == "customer" and search_term:
+        conds += 'and prj.customer like "%{customer}%" and emp.project=prj.name'.format(customer=search_term)
+    elif key == "employee_id" and search_term:
+        conds += 'and emp.employee_id like "%{employee_id}%" '.format(employee_id=search_term)
+    elif key == "project" and search_term:
+        conds += 'and emp.project like "%{project}%" '.format(project=search_term)
+    elif key == "site" and search_term:
+        conds += 'and emp.site like "%{site}%" '.format(site=search_term)
+    elif key == "employee_name" and search_term:
+        conds += 'and emp.employee_name like "%{name}%" '.format(name=search_term)
 
-	data = frappe.db.sql("""
-		select
-			distinct emp.name, emp.employee_id, emp.employee_name, emp.image, emp.one_fm_nationality as nationality, usr.mobile_no, usr.name as email, emp.designation, emp.department, emp.shift, emp.site, emp.project
-		from `tabEmployee` as emp, `tabUser` as usr, `tabProject` as prj
-		where
-		emp.user_id=usr.name
-		{conds}
-	""".format(conds=conds), as_dict=1)
-	return data
+    data = frappe.db.sql("""
+        select
+            distinct emp.name, emp.employee_id, emp.employee_name, emp.image, emp.one_fm_nationality as nationality, usr.mobile_no, usr.name as email, emp.designation, emp.department, emp.shift, emp.site, emp.project
+        from `tabEmployee` as emp, `tabUser` as usr, `tabProject` as prj
+        where
+        emp.user_id=usr.name
+        {conds}
+    """.format(conds=conds), as_dict=1)
+    return data
 
 @frappe.whitelist()
 def get_employee_detail(employee_pk):
-	if employee_pk:
-		pk, employee_id, employee_name, enrolled, cell_number = frappe.db.get_value("Employee", employee_pk, ["name", "employee_id", "employee_name", "enrolled", "cell_number"])
-		return {'pk':pk, 'employee_id': employee_id, 'employee_name': employee_name, 'enrolled': enrolled, "cell_number": cell_number}
+    if employee_pk:
+        pk, employee_id, employee_name, enrolled, cell_number = frappe.db.get_value("Employee", employee_pk, ["name", "employee_id", "employee_name", "enrolled", "cell_number"])
+        return {'pk':pk, 'employee_id': employee_id, 'employee_name': employee_name, 'enrolled': enrolled, "cell_number": cell_number}

--- a/one_fm/www/css/site.css
+++ b/one_fm/www/css/site.css
@@ -1025,6 +1025,7 @@ body[data-route="roster"] .lightgreenboxcolor {
 body[data-route="roster"] .pinkboxcolor {
   background: #ff05d5;
 }
+
 body[data-route="roster"] .redboxcolor {
   background: #ff0000;
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
Disabled employees were appearing in the roster page by means of additional shift assignment doctype

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Update the Roster script to only include staff that exited in the current month

## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1405" alt="Screenshot 2023-03-12 at 5 00 55 PM" src="https://user-images.githubusercontent.com/38866184/224557641-d3f9a7d6-1abe-47c8-bd04-85c58fa95572.png">
<img width="1405" alt="Screenshot 2023-03-12 at 5 01 17 PM" src="https://user-images.githubusercontent.com/38866184/224557646-b7b22c28-f67f-4765-821b-842ea792cb72.png">


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Page

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Exited staff schedule will now render in black

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? No
    - [] is attachment required? No
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
