### PR TITLE
hot fix: Work Permit - Submit

### DIFF
--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -873,7 +873,7 @@
    "label": "Payment Details Section"
   },
   {
-   "depends_on": "eval:frappe.session.user == doc.grd_operator",
+   "depends_on": "eval: !doc.__islocal",
    "fieldname": "work_permit_information_section",
    "fieldtype": "Section Break",
    "label": "Work Permit Information"
@@ -885,7 +885,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-02-05 15:56:10.611873",
+ "modified": "2023-03-11 12:10:09.583298",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Giving an error on submit of Work Permit, the error says, set values for two fields, but fields are not visible
- On submit of Work Permit it saves the employee doc of non existing document name(Work Permit)
![Screenshot 2023-03-11 at 5 07 45 PM](https://user-images.githubusercontent.com/20554466/224614243-64c636aa-0b06-4870-9a1e-ff5a32aa8f1f.png)


## Solution description
- Set field visible if it is not new doc
- Mandatory field messages are optimised
![Screenshot 2023-03-11 at 5 04 46 PM](https://user-images.githubusercontent.com/20554466/224614286-1101c053-0c1c-4f19-ade8-5dec9c60a801.png)
- Create a document record name if it is not exist

## Areas affected and ensured
- `one_fm/grd/doctype/work_permit/work_permit.json`
- `one_fm/grd/doctype/work_permit/work_permit.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome