### PR TITLE
HOTFIX [184681472] Leave Application Assignment fix

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -53,9 +53,7 @@ def is_app_user(emp):
 
 
 class LeaveApplicationOverride(LeaveApplication):
-    def after_insert(self):
-        self.assign_to_leave_approver()
-
+    
     def notify_employee(self):
         template = frappe.db.get_single_value("HR Settings", "leave_status_notification_template")
         if not template:
@@ -87,6 +85,7 @@ class LeaveApplicationOverride(LeaveApplication):
         validate_active_employee(self.employee)
         set_employee_name(self)
         self.validate_dates()
+        self.update_attachment_name()
         self.validate_balance_leaves()
         self.validate_leave_overlap()
         self.validate_max_days()
@@ -100,6 +99,10 @@ class LeaveApplicationOverride(LeaveApplication):
         self.validate_applicable_after()
 
     def after_insert(self):
+        self.assign_to_leave_approver()
+        self.update_attachment_name()
+        
+    def update_attachment_name(self):
         if self.proof_documents:
             for each in self.proof_documents:
                 if each.attachments:

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -27,3 +27,4 @@ one_fm.patches.v14_0.fix_sick__leaves
 one_fm.patches.v14_0.update_route_for_wiki_page
 one_fm.patches.v14_0.update_cancelled_leave_application_workflow_state
 one_fm.patches.v14_0.allocate_leave_allocation
+one_fm.patches.v14_0.reassign_reshare_leaves

--- a/one_fm/patches/v14_0/reassign_reshare_leaves.py
+++ b/one_fm/patches/v14_0/reassign_reshare_leaves.py
@@ -1,0 +1,13 @@
+import frappe
+from hrms.hr.utils import share_doc_with_approver
+def execute():
+    #Reshare and Reassign all draft leave applications
+    all_leaves = frappe.get_all("Leave Application",{"docstatus":0})
+    for each in all_leaves:
+        try:
+            leave_doc = frappe.get_doc("Leave Application",each.name)
+            leave_doc.assign_to_leave_approver()
+            share_doc_with_approver(leave_doc, leave_doc.leave_approver)
+        except:
+            frappe.log_error("An Error Occured while closing {}".format(each.name))
+            continue


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
Leave Application documents were not being assigned or shared correctly with the leave approver because of a duplicate after insert hook


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
* I removed the duplicate after insert hook
* I modified the refactored the method for renaming attachments
* I Created a patch to reassign already leave applications in draft 

## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Leave Application

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Leave Applications will be assigned correctly

## Did you test with the following dataset?
- [*] Existing Data
- [*] New Data

## Was child table created? No
    - [] is attachment required? No
        did you test attachment 
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [*] Yes
- [] No
    ## Was the patch test? Yes


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
