### PR TITLE
[184724746] Exclude Exited Employees from OT Roster and FIX SQL ERROR

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -94,34 +94,34 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
             'date': ['between', (start_date, end_date)]
         }
         str_filters = f'es.date between "{start_date}" and "{end_date}"'
-        exited_employee_filters = f"status='Left' and relieving_date between '{start_date}' and '{end_date}'"
+        exited_employee_filters = f"""status='Left' and relieving_date between '{start_date}' and '{end_date}'"""
         if operations_role:
             filters.update({'operations_role': operations_role})
             str_filters +=' and es.operations_role = "{}"'.format(operations_role)
 
         if employee_search_id:
             employee_filters.update({'employee_id': employee_search_id})
-            exited_employee_filters += f" and employee_id = '{employee_search_id}'"
+            exited_employee_filters += f""" and employee_id = "{employee_search_id}" """
         if employee_search_name:
             employee_filters.update({'employee_name': ("like", "%" + employee_search_name + "%")})
-            exited_employee_filters += f" and employee_name LIKE '%{employee_search_name}%' "
+            exited_employee_filters += f""" and employee_name LIKE "%{employee_search_name}%" """
             asa_filters+=f'and asa.employee_name LIKE "%{employee_search_name}%"'
             
         if project:
             employee_filters.update({'project': project})
-            exited_employee_filters += f" and project =  '{project}' "
+            exited_employee_filters += f""" and project =  "{project}" """
             asa_filters+=f' and asa.project = "{project}"'
         if site:
             employee_filters.update({'site': site})
-            exited_employee_filters +=f" and site = '{site}'"
+            exited_employee_filters +=f""" and site = "{site}" """
             asa_filters += f' and asa.site = "{site}"'
         if shift:
             employee_filters.update({'shift': shift})
-            exited_employee_filters += f" and shift = '{shift}'"
+            exited_employee_filters += f""" and shift = "{shift}" """
             asa_filters += f' and asa.shift = "{shift}"'
         if department:
             employee_filters.update({'department': department})
-            exited_employee_filters += f" and department = '{department}'"
+            exited_employee_filters += f""" and department = "{department}" """
 
 
         #--------------------- Fetch Employee list ----------------------------#

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -142,6 +142,8 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
             employees = filter_redundant_employees(employees)
             employee_filters.update({'date': ['between', (start_date, end_date)], 'post_status': 'Planned'})
             employee_filters.pop('employee_availability')
+            employee_filters.pop('employee')
+            
         else:
             employee_filters.update({'status': 'Active'})
             employee_filters.update({'shift_working':'1'})

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -133,6 +133,9 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
         
         if isOt:
             employee_filters.update({'employee_availability' : 'Working'})
+            all_active_employees = frappe.db.sql("SELECT name from `tabEmployee` where status = 'Active'",as_dict =1)
+            all_active_employee_ids = [i.name for i in all_active_employees]
+            employee_filters.update({'employee':['In',all_active_employee_ids]})
             employees = frappe.db.get_list("Employee Schedule", employee_filters, ["distinct employee", "employee_name"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
             master_data.update({'total' : len(employees)})
             employees.extend(exited_employees)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
 Exited Employees appear on the OT Roster

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Modified the fetch query for roster OT to only fetch active employees

## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1400" alt="Screenshot 2023-03-18 at 8 15 17 PM" src="https://user-images.githubusercontent.com/38866184/226131460-241acbeb-304a-436a-a288-dabff586e756.png">


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Page

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [*] Existing Data
- [] New Data

## Was child table created? No
    - [] is attachment required? No
        did you test attachment No
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
