### PR TITLE
Fix: Payroll Fetch Employee as per Payroll Cycle

### DIFF
--- a/one_fm/api/doc_methods/templates/payroll/bank_issue.html
+++ b/one_fm/api/doc_methods/templates/payroll/bank_issue.html
@@ -15,8 +15,6 @@
         <tr>
           <th>#</th>
           <th>Employee</th>
-          <th>Name</th>
-          <th>Department</th>
           <th>Issue</th>
         </tr>
       </thead>
@@ -24,9 +22,7 @@
         {% for i in employees %}
             <tr>
               <th>{{loop.index}}</th>
-              <td>{{i.employee.employee}}</td>
-              <td>{{i.employee.employee_name}}</td>
-              <td>{{i.employee.department}}</td>
+              <td>{{i.employee}}</td>
               <td>{{i.issue}}</td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Fetch Employees in Payroll Cycle as per Payroll Cycle.
- Validate Missing Salary Structure Assignment before fetching Employee.

## Solution description
- Get the Project List as per the given Payroll start and end date.
- Filter list of employees as per Project. 
- But, before all that Validate if the Salary Structure assignment is missing.

## Output screenshots (optional)
<img width="754" alt="Screen Shot 2023-03-20 at 9 36 07 PM" src="https://user-images.githubusercontent.com/29017559/226447791-33655efb-93fd-4024-9e2e-55a97880f67b.png">


## Areas affected and ensured
- Generate_payroll Cron method
- Get employee details to check for missing SSA

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
