### PR TITLE
Feat: HR User, single additional salary for site allowance is created per payroll

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1193,6 +1193,11 @@ def generate_site_allowance():
 	#get list of all site that includes Site Allowance.
 	operations_site = frappe.get_all("Operations Site", {"include_site_allowance":"1"},["name","allowance_amount"])
 
+	component_name = frappe.db.get_single_value('HR and Payroll Additional Settings', 'site_allowance_additional_salary_component')
+	if not component_name:
+		component_name = "Site Allowance"
+
+
 	#Gather the required Date details such as start date, and respective end date. Get current year and month to get the no. of days in the current month.
 	start_date = add_to_date(getdate(), months=-1)
 	end_date = get_end_date(start_date, 'monthly')['end_date']
@@ -1216,21 +1221,28 @@ def generate_site_allowance():
 					for employee in employee_det:
 						#calculate Monthly_site_allowance with the rate of allowance per day.
 						Monthly_site_allowance =  round(int(site.allowance_amount)/no_of_days, 3)*int(employee[1])
-						create_additional_salary(employee[0], Monthly_site_allowance, "Site Allowance", end_date)
+						create_additional_salary(employee[0], Monthly_site_allowance, component_name, end_date, site.name)
 
 #this function creates additional salary for a given component.
-def create_additional_salary(employee, amount, component, end_date):
-	additional_salary = frappe.new_doc("Additional Salary")
-	additional_salary.employee = employee
-	additional_salary.salary_component = component
-	additional_salary.amount = amount
-	additional_salary.payroll_date = end_date
-	additional_salary.company = erpnext.get_default_company()
-	additional_salary.overwrite_salary_structure_amount = 1
-	additional_salary.notes = "Site Allowance"
-	additional_salary.insert()
-	additional_salary.submit()
-
+def create_additional_salary(employee, amount, component, end_date, site):
+	check_add_sal_exists = frappe.db.get_value("Additional Salary", {"employee": employee, "payroll_date": end_date, "salary_component": component}, "name")
+	if check_add_sal_exists:
+		additional_salary = frappe.get_doc("Additional Salary", check_add_sal_exists)
+		additional_salary.amount += amount
+		additional_salary.note += f" , {site}"
+		additional_salary.flags.ignore_validate_update_after_submit = True
+		additional_salary.save(ignore_permissions=1)
+	else:	
+		additional_salary = frappe.new_doc("Additional Salary")
+		additional_salary.employee = employee
+		additional_salary.salary_component = component
+		additional_salary.amount = amount
+		additional_salary.payroll_date = end_date
+		additional_salary.company = erpnext.get_default_company()
+		additional_salary.overwrite_salary_structure_amount = 1
+		additional_salary.notes = f"Site Allowance for {site}"
+		additional_salary.insert()
+		additional_salary.submit()
 
 
 def mark_day_attendance():

--- a/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
+++ b/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.json
@@ -30,6 +30,8 @@
   "col_br_1",
   "day_off_overtime_rate",
   "public_holiday_overtime_rate",
+  "site_allowance_additional_salary_settings_section",
+  "site_allowance_additional_salary_component",
   "hr_notification_settings_section",
   "remind_employee_checkin_checkout",
   "column_break_17",
@@ -253,12 +255,25 @@
    "fieldname": "enable_export",
    "fieldtype": "Check",
    "label": "Enable Export"
+  },
+  {
+   "fieldname": "site_allowance_additional_salary_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Site Allowance Additional Salary Settings"
+  },
+  {
+   "fieldname": "site_allowance_additional_salary_component",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Site Allowance Additional Salary Component",
+   "options": "Salary Component",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-01-05 16:12:17.217621",
+ "modified": "2023-03-20 18:18:57.559006",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "HR and Payroll Additional Settings",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Normally, if there are two different site allowance only one would be used in the salary slip calculation, so the feat was to make i that, additional salary of the same component and the payroll date are summed up together


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
added a check that checks if there is an additional salary instance of the same salary component and same payroll date, the amount would be summed up together, and during the calculation of the salary slip, it owuld be taken into account properly. All these are subject to the tasks that runs every 24th of the month in payroll calculation

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Additional Salary


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
