### PR TITLE
Filter Out Subcontractor from no Salary Structure Assignment validation

### DIFF
--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -171,7 +171,8 @@ def set_bank_details(self, employee_details):
 	employee_list = ', '.join(['"{}"'.format(employee.employee) for employee in employee_details])
 	missing_ssa = frappe.db.sql(""" 
 		SELECT employee from `tabEmployee` E
-		WHERE E.status = "Active"
+		WHERE E.status = 'Active'
+		AND E.employment_type != 'Subcontractor'
 		AND E.name IN ({0})
 		""".format(employee_list), as_dict=True)
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
- Since Subcontractor has no salary, They can be ignored from the salary structure assignment policy.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
- add employeement_type!= "Subcontractor" condition
