### PR TITLE
HotFix: Salary Slip End Date Issue.

### DIFF
--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -178,6 +178,9 @@ def set_bank_details(self, employee_details):
 			SELECT employee from `tabEmployee` E
 			WHERE E.status = 'Active'
 			AND E.employment_type != 'Subcontractor'
+			AND E.name IN (
+				{0}
+			)
 			AND E.name NOT IN (
 				SELECT employee from `tabSalary Structure Assignment` SE
 			)
@@ -675,7 +678,7 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True ):
 		salary_slips_exist_for = get_existing_salary_slips(employees, args)
 		count = 0
 		start_date = args.start_date
-		end_date = args.start_date
+		end_date = args.end_date
 
 		args.pop('start_date')
 		args.pop('end_date')


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Both start and end dates in the Salary slip were the same causing issues in the calculation
<img width="300" alt="Screen Shot 2023-03-22 at 12 02 47 PM" src="https://user-images.githubusercontent.com/29017559/226852742-f432fe11-dc61-4d71-84cc-39e7bee208ad.png">

- Also, fixed SSA validation.

## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No

## Output screenshots (optional)
<img width="400" alt="Screen Shot 2023-03-22 at 12 03 15 PM" src="https://user-images.githubusercontent.com/29017559/226852872-1a6fc69e-43f2-4de5-8361-3fe94115f333.png">


## Areas affected and ensured
- Salary Slip Creation

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
