### PR TITLE
Fix: Date Issue in Salary Slip generation

### DIFF
--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -178,9 +178,6 @@ def set_bank_details(self, employee_details):
 			SELECT employee from `tabEmployee` E
 			WHERE E.status = 'Active'
 			AND E.employment_type != 'Subcontractor'
-			AND E.name IN (
-				{0}
-			)
 			AND E.name NOT IN (
 				SELECT employee from `tabSalary Structure Assignment` SE
 			)
@@ -763,8 +760,8 @@ def seperate_salary_slip(employees, start_date, end_date):
 		if len(salary_structure_assignment) > 0:
 			mid_date = ""
 			for ssa in salary_structure_assignment:
-				start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
-				end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+				start_date = datetime.strptime(start_date, '%Y-%m-%d').date() if isinstance(start_date, 'str') else start_date
+				end_date = datetime.strptime(end_date, '%Y-%m-%d').date() if isinstance(end_date, 'str') else end_date
 
 				if ssa.from_date > start_date and ssa.from_date < end_date:
 					mid_date = ssa.from_date


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- The date in production is of type DateTime. but, str in local. 

## Solution description
- check if the given variable is a string using isinstance()

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Areas affected and ensured
- fetching employees, checking for missing Salary Structure Assignment
- salary slip generation

## Is there any existing behavior change of other features due to this code change?
- no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
