### PR TITLE
hot fix: job applicant issue

### DIFF
--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -936,10 +936,15 @@ def get_employee_record_exists_for_job_offer_or_job_applicant(job_offer=False, j
 def change_applicant_erf(job_applicant, old_erf, new_erf):
 	job_applicant_obj = frappe.get_doc("Job Applicant", job_applicant)
 	if job_applicant_obj.one_fm_erf == old_erf and frappe.db.exists("ERF", new_erf):
+		new_erf_obj = frappe.get_doc("ERF", new_erf)
 		job_applicant_obj.one_fm_erf = new_erf
 		job_applicant_obj.job_title = frappe.db.get_value("Job Opening", {'one_fm_erf': new_erf})
+		job_applicant_obj.designation = frappe.db.get_value("Job Opening", job_applicant_obj.job_title, "designation")
+		job_applicant_obj.department = new_erf_obj.department
+		job_applicant_obj.project = new_erf_obj.project
+		job_applicant_obj.one_fm_hiring_method = new_erf_obj.hiring_method
+		job_applicant_obj.interview_round = new_erf_obj.interview_round
 		job_applicant_obj.save(ignore_permissions=True)
-
 
 @frappe.whitelist()
 def send_magic_link_to_applicant_based_on_link_for(name, link_for):

--- a/one_fm/templates/pages/applicant_docs.html
+++ b/one_fm/templates/pages/applicant_docs.html
@@ -290,7 +290,12 @@
                                     </div>
                                     <div class="form-group col-md-4">
                                         <label class="form-label" for="Birth_Place">Place of Birth *</label>
-                                        <input class="form-control input2" type="text" id="Birth_Place" name="birth_place" size="50" {% if job_applicant.one_fm_place_of_birth != None %} value="{{ job_applicant.one_fm_place_of_birth }}" {% endif %}>
+                                        <select class="form-control input2" id="Birth_Place" name="birth_place" aria-placeholder="Select Your Birth Place">
+																					<option value="select" selected disabled>Select Your Birth Place</option>
+																					{% if job_applicant.one_fm_nationality != None %}
+																							<option value="{{ job_applicant.one_fm_place_of_birth }}" selected>{{ job_applicant.one_fm_place_of_birth }}</option>
+																					{% endif %}>
+                                        </select>
                                     </div>
 
                                 </div>

--- a/one_fm/templates/pages/applicant_docs.js
+++ b/one_fm/templates/pages/applicant_docs.js
@@ -138,10 +138,13 @@ function populate_country(){
     method: "one_fm.templates.pages.applicant_docs.populate_country",
     callback: function(r) {
       langArray = r.message;
+
       if(langArray){
         var place_of_issue = document.getElementById("Passport_Place_of_Issue");
+        var place_of_birth = document.getElementById("Birth_Place");
         for (let i=0; i<=langArray.length;i++) {
           place_of_issue.options[place_of_issue.options.length] = new Option(langArray[i], langArray[i]);
+          place_of_birth.options[place_of_birth.options.length] = new Option(langArray[i], langArray[i]);
         }
       }
     }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Changing the erf on the job application, does not change the designation and captures the interview round of that new erf
- Place of birth field in Job Applicant is link to country were as it is a text field in the job applicant portal page

## Solution description
- Update the fields value in job applicant from erf on Change ERF
- Set Place of Birth as select tag and set country in options for the portal applicant doc
Place of birth in job applicant doctype
![Screenshot 2023-03-25 at 3 31 33 PM](https://user-images.githubusercontent.com/20554466/227711329-3db5c757-ce0c-41ad-9ab5-ada2a5e9d68a.png)

Place of birth in job applicant doc - Before PR
![Screenshot 2023-03-25 at 3 32 57 PM](https://user-images.githubusercontent.com/20554466/227711348-6f2240a9-3695-44ab-992f-345c1de128f5.png)

Place of birth in job applicant doc - After PR
![Screenshot 2023-03-25 at 3 41 30 PM](https://user-images.githubusercontent.com/20554466/227711364-ecc5a09e-79ac-4815-b7bd-1ac44f6a8f18.png)

## Areas affected and ensured
- `one_fm/hiring/utils.py`
- `one_fm/templates/pages/applicant_docs.html`
- `one_fm/templates/pages/applicant_docs.js`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome