### PR TITLE
feat: OT Attendance - Additional Salary

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -663,7 +663,6 @@ def issue_penalty(employee, date, penalty_code, shift, issuing_user, penalty_loc
 		"exact_notes": penalty
 	})
 	penalty_issuance.issuing_employee = issuing_employee
-	# penalty_issuance.employee_name = self.lead_name
 	penalty_issuance.flags.ignore_permissions = True
 	penalty_issuance.insert()
 	penalty_issuance.submit()
@@ -1221,34 +1220,185 @@ def generate_site_allowance():
 					for employee in employee_det:
 						#calculate Monthly_site_allowance with the rate of allowance per day.
 						Monthly_site_allowance =  round(int(site.allowance_amount)/no_of_days, 3)*int(employee["count"])
-						create_additional_salary(employee["employee"], Monthly_site_allowance, component_name, end_date, site.name,project=site.project, number_of_days_worked=employee["count"], employee_name=employee["employee_name"])
+						notes = f"Project: {site.project} \nSite: {site.name} \nNumber of days worked: {employee['count']} \n\n"
+						create_additional_salary(employee["employee"], Monthly_site_allowance, component_name, end_date, notes)
 
 #this function creates additional salary for a given component.
-def create_additional_salary(employee, amount, component, end_date, site, project, number_of_days_worked, employee_name):
-	check_add_sal_exists = frappe.db.get_value("Additional Salary", {"employee": employee, "payroll_date": end_date, "salary_component": component}, "name")
-	if check_add_sal_exists:
-		additional_salary = frappe.get_doc("Additional Salary", check_add_sal_exists)
-		additional_salary.amount += amount
-		additional_salary.notes += f"Project -- {project} \n"
-		additional_salary.notes += f"Site -- {site} \n"
-		additional_salary.notes += f"Number of days worked -- {number_of_days_worked} \n\n"
-		additional_salary.flags.ignore_validate_update_after_submit = True
-		additional_salary.save(ignore_permissions=1)
-	else:
-		additional_salary = frappe.new_doc("Additional Salary")
-		additional_salary.employee = employee
-		additional_salary.salary_component = component
-		additional_salary.amount = amount
-		additional_salary.payroll_date = end_date
-		additional_salary.company = erpnext.get_default_company()
-		additional_salary.overwrite_salary_structure_amount = 1
-		additional_salary.notes = f"Project -- {project} \n"
-		additional_salary.notes += f"Site -- {site} \n"
-		additional_salary.notes += f"Number of days worked -- {number_of_days_worked} \n\n"
-		additional_salary.insert()
-		additional_salary.submit()
-	frappe.db.commit()
+def create_additional_salary(employee, amount, component, end_date, notes):
+	try:
+		check_add_sal_exists = frappe.db.exists("Additional Salary", {"employee": employee, "payroll_date": end_date, "salary_component": component})
+		if check_add_sal_exists:
+			additional_salary = frappe.get_doc("Additional Salary", check_add_sal_exists)
+			additional_salary.amount += amount
+			if additional_salary.notes:
+				additional_salary.notes += notes
+			else:
+				additional_salary.notes = notes
+			additional_salary.flags.ignore_validate_update_after_submit = True
+			additional_salary.save(ignore_permissions=1)
+		else:
+			additional_salary = frappe.new_doc("Additional Salary")
+			additional_salary.employee = employee
+			additional_salary.salary_component = component
+			additional_salary.amount = amount
+			additional_salary.payroll_date = end_date
+			additional_salary.company = erpnext.get_default_company()
+			additional_salary.overwrite_salary_structure_amount = 1
+			additional_salary.notes = notes
+			additional_salary.insert()
+			additional_salary.submit()
+		frappe.db.commit()
+	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), 'Additional Salary - {0}'.format(component))
 
+def generate_ot_additional_salary():
+	# Gather the required Date details such as start date, and respective end date.
+	start_date = add_to_date(getdate(), months=-1)
+	end_date = get_end_date(start_date, 'monthly')['end_date']
+
+	# Fetch payroll details from HR and Payroll Additional Settings
+	overtime_component = frappe.db.get_single_value("HR and Payroll Additional Settings", 'overtime_additional_salary_component')
+	working_day_overtime_rate = frappe.db.get_single_value("HR and Payroll Additional Settings", 'working_day_overtime_rate')
+	day_off_overtime_rate = frappe.db.get_single_value("HR and Payroll Additional Settings", 'day_off_overtime_rate')
+	public_holiday_overtime_rate = frappe.db.get_single_value("HR and Payroll Additional Settings", 'public_holiday_overtime_rate')
+
+	# Get the OverTime Attendance for the date range
+	attendance_list = frappe.db.sql("""
+		SELECT
+			*
+		FROM
+			`tabAttendance`
+		WHERE
+			attendance_date between '{start_date}' and '{end_date}'
+			And status = "Present" AND roster_type = "Over-Time"
+		GROUP BY
+			employee, attendance_date
+	""".format(start_date = cstr(start_date), end_date = cstr(end_date)), as_dict=1)
+
+	if attendance_list and len(attendance_list) > 0:
+		for attendance_doc in attendance_list:
+			process_attendance_for_ot_additional_salary(attendance_doc, overtime_component, working_day_overtime_rate, day_off_overtime_rate, public_holiday_overtime_rate, end_date)
+
+def process_attendance_for_ot_additional_salary(attendance_doc, overtime_component, working_day_overtime_rate, day_off_overtime_rate, public_holiday_overtime_rate, end_date):
+	"""
+	This function creates an additional salary document for a given by specifying the salary component for overtime set in the HR and Payroll Additional Settings,
+	by obtaining the details from Attendance where the roster type is set to Over-Time.
+
+	The over time rate is fetched from the project which is linked with the shift the employee was working in.
+	The over time rate is calculated by multiplying the number of hours of the shift with the over time rate for the project.
+
+	In case of no overtime rate is set for the project, overtime rates are fetched from HR and Payroll Additional Settings.
+	Amount is calucated and additional salary is created as:
+	1. If employee has an existing basic schedule on the same day - working day rate is applied
+	2. Working on a holiday of type "weekly off: - day off rate is applied.
+	3. Working on a holiday of type non "weekly off" - public/additional holiday.
+
+	Args:
+		doc: The attendance document
+
+	"""
+	roster_type_basic = "Basic"
+	roster_type_overtime = "Over-Time"
+
+	days_of_week = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+	# Check if attendance is for roster type: Over-Time
+	if attendance_doc.roster_type == roster_type_overtime:
+
+		payroll_date = cstr(attendance_doc.attendance_date)
+
+		# Fetch project and duration of the shift employee worked in operations shift
+		project, overtime_duration = frappe.db.get_value("Operations Shift", attendance_doc.operations_shift, ["project", "duration"])
+
+		# Fetch overtime details from project
+		project_has_overtime_rate, project_overtime_rate = frappe.db.get_value("Project", {'name': project}, ["has_overtime_rate", "overtime_rate"])
+
+		# If project has a specified overtime rate, calculate amount based on overtime rate and create additional salary
+		if project_has_overtime_rate:
+
+			if project_overtime_rate > 0:
+				amount = round(project_overtime_rate * overtime_duration, 3)
+				notes = f"Attendance: {attendance_doc.name} \nProject: {project} \nCalculated based on ot rate set for the project\nProject ot rate: {project_overtime_rate} \n\n"
+				create_additional_salary(attendance_doc.employee, amount, overtime_component, end_date, notes)
+			else:
+				error_msg = _("Overtime rate must be greater than zero for project: {project}".format(project=project))
+				frappe.log_error(error_msg, 'OT Additional Salary - Attendance {0}'.format(attendance_doc.name))
+
+
+		# If no overtime rate is specified, follow labor law => (Basic Hourly Wage * number of worked hours * 1.5)
+		else:
+			# Fetch assigned shift, basic salary  and holiday list for the given employee
+			assigned_shift, holiday_list = frappe.db.get_value("Employee", {'employee': attendance_doc.employee}, ["shift", "holiday_list"])
+			basic_salary = sum(
+				[i.amount for i in frappe.get_last_doc(
+					'Salary Structure Assignment',
+					filters={"employee": attendance_doc.employee, "docstatus":1}
+					).salary_structure_components if i.salary_component=='Basic Salary'
+				]
+			)
+			if assigned_shift:
+				# Fetch duration of the shift employee is assigned to
+				assigned_shift_duration = frappe.db.get_value("Operations Shift", assigned_shift, ["duration"])
+
+				if basic_salary and basic_salary > 0:
+					# Compute hourly wage
+					daily_wage = round(basic_salary/30, 3)
+					hourly_wage = round(daily_wage/assigned_shift_duration, 3)
+
+					# Check if a basic schedule exists for the employee and the attendance date
+					if frappe.db.exists("Employee Schedule", {'employee': attendance_doc.employee, 'date': attendance_doc.attendance_date, 'employee_availability': "Working", 'roster_type': roster_type_basic}):
+
+						if working_day_overtime_rate > 0:
+
+							# Compute amount as per working day rate
+							amount = round(hourly_wage * overtime_duration * working_day_overtime_rate, 3)
+							notes = f"Attendance: {attendance_doc.name} \nCalculated based on working day rate => (Basic hourly wage) * (Duration of worked hours) * {working_day_overtime_rate}(Working day overtime rate) \n\n"
+							create_additional_salary(attendance_doc.employee, amount, overtime_component, end_date, notes)
+						else:
+							error_msg = _("No Wroking Day overtime rate set in HR and Payroll Additional Settings.")
+							frappe.log_error(error_msg, 'OT Additional Salary - Attendance {0}'.format(attendance_doc.name))
+
+					# Check if attendance date falls in a holiday list
+					elif holiday_list:
+
+						# Pass last parameter as "False" to get weekly off days
+						holidays_weekly_off = get_holidays_for_employee(attendance_doc.employee, attendance_doc.attendance_date, attendance_doc.attendance_date, False, False)
+
+						# Pass last paramter as "True" to get non weekly off days, ie, public/additional holidays
+						holidays_public_holiday = get_holidays_for_employee(attendance_doc.employee, attendance_doc.attendance_date, attendance_doc.attendance_date, False, True)
+
+						# Check for weekly off days length and if description of day off is set as one of the weekdays. (By default, description is set to a weekday name)
+						if len(holidays_weekly_off) > 0 and holidays_weekly_off[0].description in days_of_week:
+
+							if day_off_overtime_rate > 0:
+								# Compute amount as per day off rate
+								amount = round(hourly_wage * overtime_duration * day_off_overtime_rate, 3)
+								notes = f"Attendance: {attendance_doc.name} \nCalculated based on day off rate => (Basic hourly wage) * (Duration of worked hours) * {day_off_overtime_rate}(Day off overtime rate) \n\n"
+								create_additional_salary(attendance_doc.employee, amount, overtime_component, end_date, notes)
+							else:
+								error_msg = _("No Day Off overtime rate set in HR and Payroll Additional Settings.")
+								frappe.log_error(error_msg, 'OT Additional Salary - Attendance {0}'.format(attendance_doc.name))
+
+						# Check for weekly off days set to "False", ie, Public/additional holidays in holiday list
+						elif len(holidays_public_holiday) > 0:
+
+							if public_holiday_overtime_rate > 0:
+								# Compute amount as per public holiday rate
+								amount = round(hourly_wage * overtime_duration * public_holiday_overtime_rate, 3)
+								notes = f"Attendance: {attendance_doc.name} \nCalculated based on day off rate => (Basic hourly wage) * (Duration of worked hours) * {public_holiday_overtime_rate}(Public holiday overtime rate) \n\n"
+								create_additional_salary(attendance_doc.employee, amount, overtime_component, end_date, notes)
+							else:
+								error_msg = _("No Public Holiday overtime rate set in HR and Payroll Additional Settings.")
+								frappe.log_error(error_msg, 'OT Additional Salary - Attendance {0}'.format(attendance_doc.name))
+					else:
+						error_msg = _("No basic Employee Schedule or Holiday List found for employee: {employee}".format(employee=attendance_doc.employee))
+						frappe.log_error(error_msg, 'OT Additional Salary - Attendance {0}'.format(attendance_doc.name))
+				else:
+					error_msg = _("Basic Salary not set for employee: {employee} in the employee record.".format(employee=attendance_doc.employee))
+					frappe.log_error(error_msg, 'OT Additional Salary - Attendance {0}'.format(attendance_doc.name))
+			else:
+				error_msg = _("Shift not set for employee: {employee} in the employee record.".format(employee=attendance_doc.employee))
+				frappe.log_error(error_msg, 'OT Additional Salary - Attendance {0}'.format(attendance_doc.name))
 
 def mark_day_attendance():
 	from one_fm.operations.doctype.shift_permission.shift_permission import approve_open_shift_permission

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -605,7 +605,8 @@ scheduler_events = {
 			'one_fm.api.tasks.generate_penalties'
 		],
 		"00 01 24 * *": [
-			'one_fm.api.tasks.generate_site_allowance'
+			'one_fm.api.tasks.generate_site_allowance',
+			'one_fm.api.tasks.generate_ot_additional_salary'
 		],
 		"00 02 24 * *": [
 			'one_fm.api.tasks.generate_payroll'

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -80,22 +80,18 @@ class AttendanceOverride(Attendance):
                 self.operations_shift = shift_assignment.shift
                 self.site = shift_assignment.site
         if self.attendance_request and not self.working_hours and not self.status in [
-            'Holiday', 'Day Off', 'Absent'    
+            'Holiday', 'Day Off', 'Absent'
             ]:
             self.working_hours = frappe.db.get_value("Shift Type", self.shift_type, 'duration')
-    
+
     def on_submit(self):
         self.update_shift_details_in_attendance()
-        try:
-            self.create_additional_salary_for_overtime()
-        except Exception as e:
-            frappe.log_error(frappe.get_traceback(), 'Over-Time Salary')
 
     def validate_duplicate_record(self):
         duplicate = get_duplicate_attendance_record(
 			self.employee, self.attendance_date, self.shift, self.roster_type, self.name
 		)
-        
+
         if duplicate:
             frappe.throw(
 				_("Attendance for employee {0} is already marked for the date {1}: {2} : {3}").format(
@@ -107,12 +103,12 @@ class AttendanceOverride(Attendance):
 				title=_("Duplicate Attendance"),
 				exc=DuplicateAttendanceError,
 			)
-                        
+
     def validate_overlapping_shift_attendance(self):
         attendance = get_overlapping_shift_attendance(
 			self.employee, self.attendance_date, self.shift, self.roster_type, self.name
 		)
-        
+
         if attendance:
             frappe.throw(
 				_("Attendance for employee {0} is already marked for an overlapping shift {1}: {2}").format(
@@ -123,7 +119,7 @@ class AttendanceOverride(Attendance):
 				title=_("Overlapping Shift Attendance"),
 				exc=OverlappingShiftAttendanceError,
 			)
-    
+
     def on_trash(self):
         if frappe.db.exists("Additional Salary", {
             'ref_doctype':self.doctype,
@@ -132,175 +128,6 @@ class AttendanceOverride(Attendance):
             frappe.get_doc("Additional Salary", {
                 'ref_doctype':self.doctype,
                 'ref_docname':self.name}).delete()
-
-
-    def create_additional_salary_for_overtime(self):
-        """
-        This function creates an additional salary document for a given by specifying the salary component for overtime set in the HR and Payroll Additional Settings,
-        by obtaining the details from Attendance where the roster type is set to Over-Time.
-
-        The over time rate is fetched from the project which is linked with the shift the employee was working in.
-        The over time rate is calculated by multiplying the number of hours of the shift with the over time rate for the project.
-
-        In case of no overtime rate is set for the project, overtime rates are fetched from HR and Payroll Additional Settings.
-        Amount is calucated and additional salary is created as:
-        1. If employee has an existing basic schedule on the same day - working day rate is applied
-        2. Working on a holiday of type "weekly off: - day off rate is applied.
-        3. Working on a holiday of type non "weekly off" - public/additional holiday.
-
-        Args:
-            doc: The attendance document
-
-        """
-        roster_type_basic = "Basic"
-        roster_type_overtime = "Over-Time"
-
-        days_of_week = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-
-        # Check if attendance is for roster type: Over-Time
-        if self.roster_type == roster_type_overtime:
-
-            payroll_date = cstr(self.attendance_date)
-
-            # Fetch payroll details from HR and Payroll Additional Settings
-            overtime_component = frappe.db.get_single_value("HR and Payroll Additional Settings", 'overtime_additional_salary_component')
-            working_day_overtime_rate = frappe.db.get_single_value("HR and Payroll Additional Settings", 'working_day_overtime_rate')
-            day_off_overtime_rate = frappe.db.get_single_value("HR and Payroll Additional Settings", 'day_off_overtime_rate')
-            public_holiday_overtime_rate = frappe.db.get_single_value("HR and Payroll Additional Settings", 'public_holiday_overtime_rate')
-
-            # Fetch project and duration of the shift employee worked in operations shift
-            project, overtime_duration = frappe.db.get_value("Operations Shift", self.operations_shift, ["project", "duration"])
-
-            # Fetch overtime details from project
-            project_has_overtime_rate, project_overtime_rate = frappe.db.get_value("Project", {'name': project}, ["has_overtime_rate", "overtime_rate"])
-
-            # If project has a specified overtime rate, calculate amount based on overtime rate and create additional salary
-            if project_has_overtime_rate:
-
-                if project_overtime_rate > 0:
-                    amount = round(project_overtime_rate * overtime_duration, 3)
-                    notes = "Calculated based on overtime rate set for the project: {project}".format(project=project)
-
-                    self.create_additional_salary(amount, overtime_component, notes)
-
-                else:
-                    frappe.throw(_("Overtime rate must be greater than zero for project: {project}".format(project=project)))
-
-            # If no overtime rate is specified, follow labor law => (Basic Hourly Wage * number of worked hours * 1.5)
-            else:
-                # Fetch assigned shift, basic salary  and holiday list for the given employee
-                assigned_shift, holiday_list = frappe.db.get_value("Employee", {'employee': self.employee}, ["shift", "holiday_list"])
-                basic_salary = sum(
-                    [i.amount for i in frappe.get_last_doc(
-                        'Salary Structure Assignment', 
-                        filters={"employee": self.employee, "docstatus":1}
-                        ).salary_structure_components if i.salary_component=='Basic Salary'
-                    ]
-                )
-                if assigned_shift:
-                    # Fetch duration of the shift employee is assigned to
-                    assigned_shift_duration = frappe.db.get_value("Operations Shift", assigned_shift, ["duration"])
-
-                    if basic_salary and basic_salary > 0:
-                        # Compute hourly wage
-                        daily_wage = round(basic_salary/30, 3)
-                        hourly_wage = round(daily_wage/assigned_shift_duration, 3)
-
-                        # Check if a basic schedule exists for the employee and the attendance date
-                        if frappe.db.exists("Employee Schedule", {'employee': self.employee, 'date': self.attendance_date, 'employee_availability': "Working", 'roster_type': roster_type_basic}):
-
-                            if working_day_overtime_rate > 0:
-
-                                # Compute amount as per working day rate
-                                amount = round(hourly_wage * overtime_duration * working_day_overtime_rate, 3)
-                                notes = "Calculated based on working day rate => (Basic hourly wage) * (Duration of worked hours) * {working_day_overtime_rate}".format(working_day_overtime_rate=working_day_overtime_rate)
-
-                                self.create_additional_salary(amount, overtime_component, notes)
-
-                            else:
-                                frappe.throw(_("No Wroking Day overtime rate set in HR and Payroll Additional Settings."))
-
-                        # Check if attendance date falls in a holiday list
-                        elif holiday_list:
-
-                            # Pass last parameter as "False" to get weekly off days
-                            holidays_weekly_off = get_holidays_for_employee(self.employee, self.attendance_date, self.attendance_date, False, False)
-
-                            # Pass last paramter as "True" to get non weekly off days, ie, public/additional holidays
-                            holidays_public_holiday = get_holidays_for_employee(self.employee, self.attendance_date, self.attendance_date, False, True)
-
-                            # Check for weekly off days length and if description of day off is set as one of the weekdays. (By default, description is set to a weekday name)
-                            if len(holidays_weekly_off) > 0 and holidays_weekly_off[0].description in days_of_week:
-
-                                if day_off_overtime_rate > 0:
-
-                                    # Compute amount as per day off rate
-                                    amount = round(hourly_wage * overtime_duration * day_off_overtime_rate, 3)
-                                    notes = "Calculated based on day off rate => (Basic hourly wage) * (Duration of worked hours) * {day_off_overtime_rate}".format(day_off_overtime_rate=day_off_overtime_rate)
-
-                                    self.create_additional_salary(amount, overtime_component, notes)
-
-                                else:
-                                    frappe.throw(_("No Day Off overtime rate set in HR and Payroll Additional Settings."))
-
-                            # Check for weekly off days set to "False", ie, Public/additional holidays in holiday list
-                            elif len(holidays_public_holiday) > 0:
-
-                                if public_holiday_overtime_rate > 0:
-
-                                    # Compute amount as per public holiday rate
-                                    amount = round(hourly_wage * overtime_duration * public_holiday_overtime_rate, 3)
-                                    notes = "Calculated based on day off rate => (Basic hourly wage) * (Duration of worked hours) * {public_holiday_overtime_rate}".format(public_holiday_overtime_rate=public_holiday_overtime_rate)
-
-                                    self.create_additional_salary(amount, overtime_component, notes)
-
-                                else:
-                                    frappe.throw(_("No Public Holiday overtime rate set in HR and Payroll Additional Settings."))
-                        else:
-                            frappe.throw(_("No basic Employee Schedule or Holiday List found for employee: {employee}".format(employee=self.employee)))
-
-                    else:
-                        frappe.throw(_("Basic Salary not set for employee: {employee} in the employee record.".format(employee=self.employee)))
-
-                else:
-                    frappe.throw(_("Shift not set for employee: {employee} in the employee record.".format(employee=self.employee)))
-
-    def create_additional_salary(self, amount, component, notes):
-        """
-        This function creates a document in the Additonal Salary doctype.
-
-        Args:
-            employee: employee code (eg: HR-EMP-0001)
-            amount: amount to be considered in the additional salary
-            component: type of component
-            payroll_date: date that falls in the range during which this additional salary must be considered for payroll
-            notes: Any additional notes
-
-        Raises:
-            exception e: Any internal server error
-        """
-
-        try:
-            if not frappe.db.exists("Additional Assignment", {
-                    'ref_doctype':self.doctype,
-                    'ref_docname':self.name
-                }):
-                additional_salary = frappe.new_doc("Additional Salary")
-                additional_salary.employee = self.employee
-                additional_salary.salary_component = component
-                additional_salary.amount = amount
-                additional_salary.payroll_date = self.attendance_date
-                additional_salary.company = erpnext.get_default_company()
-                additional_salary.overwrite_salary_structure_amount = 1
-                additional_salary.notes = notes
-                additional_salary.ref_doctype = self.doctype
-                additional_salary.ref_docname = self.name
-                additional_salary.insert()
-                additional_salary.submit()
-
-        except Exception as e:
-            frappe.log_error(frappe.get_traceback(), 'Additional Salary')
-            frappe.throw(_(str(e)))
 
     def update_shift_details_in_attendance(doc):
         # condition = ''
@@ -341,7 +168,7 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
         'docstatus':1
         }):
         open_leaves = frappe.db.sql(f"""
-            SELECT name, employee FROM `tabLeave Application` 
+            SELECT name, employee FROM `tabLeave Application`
             WHERE employee='{emp}' AND status='Open' AND '{att_date}' BETWEEN from_date AND to_date;
         """, as_dict=1)
         if not open_leaves: # continue if no open leaves
@@ -364,7 +191,7 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
                         })
                     )
                     return
-                
+
             if holiday_today.get(employee.holiday_list):
                 status = "Holiday"
                 comment = "Holiday - " +str(holiday_today.get(employee.holiday_list))
@@ -378,10 +205,10 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
                 )
                 return
             elif employee_schedule:
-                if employee_schedule.employee_availability == 'Working':                  
+                if employee_schedule.employee_availability == 'Working':
                     # continue to mark attendance if checkin exists
                     mark_for_shift_assignment(employee, att_date)
-            
+
             # check for shift assignment
             else:
                 mark_for_shift_assignment(employee, att_date)
@@ -411,12 +238,12 @@ def mark_for_shift_assignment(employee, att_date, roster_type='Basic'):
         checkin = ''
         checkout = ''
 
-        in_checkins = frappe.db.get_list("Employee Checkin", filters={"shift_assignment": shift_assignment.name, 'log_type': 'IN'}, 
+        in_checkins = frappe.db.get_list("Employee Checkin", filters={"shift_assignment": shift_assignment.name, 'log_type': 'IN'},
             fields="name, owner, creation, modified, modified_by, docstatus, idx, employee, employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance, shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type, shift_permission, actual_time, MIN(time) as time",
             order_by="employee ASC", group_by="shift_assignment"
         )
         in_checkins = in_checkins[0] if in_checkins else frappe._dict({})
-        out_checkins = frappe.db.get_list("Employee Checkin", filters={"shift_assignment": shift_assignment.name, 'log_type': 'OUT'}, 
+        out_checkins = frappe.db.get_list("Employee Checkin", filters={"shift_assignment": shift_assignment.name, 'log_type': 'OUT'},
             fields="name, owner, creation, modified, modified_by, docstatus, idx, employee, employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance, shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type, shift_permission, actual_time, MAX(time) as time",
             order_by="employee ASC", group_by="shift_assignment"
         )
@@ -437,7 +264,7 @@ def mark_for_shift_assignment(employee, att_date, roster_type='Basic'):
                 comment = ""
                 checkin = in_checkins
                 checkout = out_checkins
-            
+
         create_single_attendance_record(frappe._dict({
             'status': status,
             'comment': comment,
@@ -450,7 +277,7 @@ def mark_for_shift_assignment(employee, att_date, roster_type='Basic'):
             'roster_type': roster_type
             })
         )
-        
+
 
         # working_hours = (out_time - in_time).total_seconds() / (60 * 60)
 
@@ -464,7 +291,7 @@ def create_single_attendance_record(record):
         }):
         # clear absent
         frappe.db.sql(f"""
-            DELETE FROM `tabAttendance` WHERE employee="{record.employee.name}" AND 
+            DELETE FROM `tabAttendance` WHERE employee="{record.employee.name}" AND
             attendance_date="{record.attendance_date}" AND roster_type="{record.roster_type}"
             AND status="Absent"
         """)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Stop creating individual/multiple additional salary on attendance marked for OT
- Overtime attendance to efficiently create additional salary so information could be easily identified

## Solution description
- Remove the code for creating individual additional salary for ot attendance
- Cron will run for generate ot additional salary(one for one employee) for the period of payroll on payroll date
![Screenshot 2023-03-31 at 3 55 42 PM](https://user-images.githubusercontent.com/20554466/229419946-64174856-2e91-422b-9207-d22f94f928e0.png)


## Areas affected and ensured
- `one_fm/api/tasks.py`
- `one_fm/hooks.py`
- `one_fm/overrides/attendance.py`

## Is there any existing behavior change of other features due to this code change?
Yes, only create an ot additional salary for an employee in a payroll period against multiple attendance

## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
