### PR TITLE
fix: fixed datetime and int error in checkin (late arrival notif)

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -1,4 +1,5 @@
 from datetime import timedelta, datetime
+from dateutil.parser import parse
 import frappe
 from frappe import _
 from frappe.utils import cint, get_datetime, cstr, getdate, now_datetime, add_days, now
@@ -250,7 +251,7 @@ def notify_supervisor_about_late_entry(checkin):
 		if last_shift_assignment and not shift_permission:
 			if checkin.time.time() > datetime.strptime(str(shift_late_minutes["start_time"] + timedelta(minutes=shift_late_minutes['supervisor_reminder_shift_start'])), "%H:%M:%S").time():
 				time_diff = calculate_time_diffrence_for_checkin(shift_late_minutes["start_time"], checkin.time)
-				time_of_arrival = datetime.strptime(str(checkin.time), '%Y-%m-%d %H:%M:%S' ).time()
+				time_of_arrival = parse(str(checkin.time)).time()
 				get_reports_to = frappe.db.get_value("Employee", {"name": checkin.employee}, ['reports_to'], as_dict=1)
 				if get_reports_to:
 					return send_push_notification_for_late_entry(get_reports_to["reports_to"], checkin.employee_name, roster_type=the_roster_type if the_roster_type else "Basic", time_difference=time_diff, shift=op_shift, time_of_arrival=time_of_arrival)
@@ -287,5 +288,5 @@ def calculate_time_diffrence_for_checkin(shift_time, checkin_time):
 	time_diff_in_minutes = (checkin_time - datetime_shift).seconds // 60
 	the_diff = divmod(time_diff_in_minutes, 60) 
 	if the_diff[0] < 1:
-		return list(the_diff[1])
+		return [the_diff[1]]
 	return list(the_diff)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
the int was not an iterable and the list function was called on it, and also the post decimal figures in a date time object, made the strptime redundant and buggy


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
i used the parse function instead of the strptime function on the datetime object, and used square braces around the int, instead of calling the list method


## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Employee Checkin


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
