### PR TITLE
Fix: Checkin after insert method.

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -88,32 +88,33 @@ def after_insert_background(self):
 	try:
 		# update shift if not exists
 		curr_shift = get_shift_from_checkin(self)
-		shift_type = frappe.db.sql(f"""SELECT * FROM `tabShift Type` WHERE name='{curr_shift.shift_type}' """, as_dict=1)[0]
-		# calculate entry
-		early_exit = 0
-		late_entry = 0
-		actual_time = str(self.time)
-		if not '.' in actual_time:
-			actual_time += '.000000'
+		if curr_shift:
+			shift_type = frappe.db.sql(f"""SELECT * FROM `tabShift Type` WHERE name='{curr_shift.shift_type}' """, as_dict=1)[0]
+			# calculate entry
+			early_exit = 0
+			late_entry = 0
+			actual_time = str(self.time)
+			if not '.' in actual_time:
+				actual_time += '.000000'
 
-		if self.log_type=='IN':
-			if (datetime.strptime(actual_time, '%Y-%m-%d %H:%M:%S.%f') - timedelta(minutes=shift_type.late_entry_grace_period)) > curr_shift.start_datetime:
-				late_entry = 1
-		if self.log_type=='OUT':
-			if (datetime.strptime(actual_time, '%Y-%m-%d %H:%M:%S.%f') + timedelta(minutes=shift_type.early_exit_grace_period)) < curr_shift.end_datetime:
-				early_exit = 1
+			if self.log_type=='IN':
+				if (datetime.strptime(actual_time, '%Y-%m-%d %H:%M:%S.%f') - timedelta(minutes=shift_type.late_entry_grace_period)) > curr_shift.start_datetime:
+					late_entry = 1
+			if self.log_type=='OUT':
+				if (datetime.strptime(actual_time, '%Y-%m-%d %H:%M:%S.%f') + timedelta(minutes=shift_type.early_exit_grace_period)) < curr_shift.end_datetime:
+					early_exit = 1
 
-		query = f"""
-			UPDATE `tabEmployee Checkin` SET
-			shift_assignment="{curr_shift.name}", operations_shift="{curr_shift.shift}", shift_type='{curr_shift.shift_type}',
-			shift='{curr_shift.shift_type}', shift_actual_start="{curr_shift.start_datetime}", shift_actual_end="{curr_shift.end_datetime}",
-			shift_start="{curr_shift.start_datetime.date()}", shift_end="{curr_shift.end_datetime.date()}", early_exit={early_exit},
-			late_entry={late_entry}, date='{curr_shift.start_date if self.log_type=='IN' else curr_shift.end_datetime}', 
-			roster_type='{curr_shift.roster_type}'
-			WHERE name="{self.name}"
-		"""
-		frappe.db.sql(query, values=[], as_dict=1)
-		frappe.db.commit()
+			query = f"""
+				UPDATE `tabEmployee Checkin` SET
+				shift_assignment="{curr_shift.name}", operations_shift="{curr_shift.shift}", shift_type='{curr_shift.shift_type}',
+				shift='{curr_shift.shift_type}', shift_actual_start="{curr_shift.start_datetime}", shift_actual_end="{curr_shift.end_datetime}",
+				shift_start="{curr_shift.start_datetime.date()}", shift_end="{curr_shift.end_datetime.date()}", early_exit={early_exit},
+				late_entry={late_entry}, date='{curr_shift.start_date if self.log_type=='IN' else curr_shift.end_datetime}', 
+				roster_type='{curr_shift.roster_type}'
+				WHERE name="{self.name}"
+			"""
+			frappe.db.sql(query, values=[], as_dict=1)
+			frappe.db.commit()
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), 'Employee Checkin')
 	
@@ -226,7 +227,6 @@ def get_shift_from_checkin(checkin):
 	for s in shifts:
 		if ((s.start_datetime + timedelta(minutes=-70)) <= checkin.time <= (s.end_datetime + timedelta(minutes=60))):
 			return s
-	return False
 
 
 def notify_supervisor_about_late_entry(checkin):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- The method get_shift_from_checkin returned False, but expected to be a dict. 

## Solution description
- Return None instead of False in get_shift_from_checkin
- Check if anyvalue is returned before using it as a dict.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
When return None:
<img width="400" alt="Screen Shot 2023-03-30 at 12 04 07 PM" src="https://user-images.githubusercontent.com/29017559/228787238-9c6335ea-3b2a-43ae-aad1-a0632347dd57.png">
When Return as a dict:
<img width="400" alt="Screen Shot 2023-03-30 at 12 09 53 PM" src="https://user-images.githubusercontent.com/29017559/228787712-26e03b43-3165-4781-a48e-685224f4c076.png">

## Areas affected and ensured
- Shift Assignment Field in check-in log is left blank. 

## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
