### PR TITLE
fix: Employee name in timesheet Absent attendance

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1470,7 +1470,7 @@ def mark_daily_attendance(start_date, end_date):
 		for i in timesheet_employees_data:
 			try:
 				if not timesheet_dict.get(i.employee):
-					emp = employees_data.get(i.employee)
+					emp = timesheet_employees_data.get(i.employee)
 					employee_attendance[i.employee] = frappe._dict({
 						'name':f"HR-ATT-{start_date}-{i.employee}", 'employee':i.employee, 'employee_name':emp.employee_name,
 						'working_hours':0, 'status':'Absent', 'shift':'', 'in_time':'00:00:00', 'out_time':'00:00:00',


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Employee name is not setting the absent attendance record

## Areas affected and ensured
- `one_fm/api/tasks.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome