### PR TITLE
feat: generate sick leave deduction

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1408,17 +1408,17 @@ def generate_sick_leave_deduction():
 	# Get the OverTime Attendance for the date range
 	leave_list = frappe.db.sql("""
 		select
-			*
+			la.name, la.employee, la.leave_type, la.total_leave_days, lt.one_fm_paid_sick_leave_deduction_salary_component
 		from
 			`tabLeave Application` la, `tabLeave Type` lt
 		where
 			(
-				la.start_date between '{start_date}' and '{end_date}'
+				la.from_date between '{start_date}' and '{end_date}'
 				or
-				la.end_date between '{start_date}' and '{end_date}'
+				la.to_date between '{start_date}' and '{end_date}'
 				or
 				(
-					la.start_date < '{start_date}' and la.end_date > '{end_date}'
+					la.from_date < '{start_date}' and la.to_date > '{end_date}'
 				)
 			)
 			and
@@ -1428,7 +1428,7 @@ def generate_sick_leave_deduction():
 			and
 				la.status = 'Approved'
  		group by
-			employee, start_date
+			employee, from_date
 	""".format(start_date = cstr(start_date), end_date = cstr(end_date)), as_dict=1)
 
 	if leave_list and len(leave_list) > 0:
@@ -1482,8 +1482,8 @@ def create_additional_salary_for_paid_sick_leave(doc, daily_rate, salary, paymen
 			Daily Rate: <b>{2}</b><br>
 			Deduction Days Number: <b>{3}</b><br>
 			Deduction Percent: <b>{4}%</b><br/>
-			Deduct Amount: <b>{5}</b><br>
-		""".format(salary, daily_rate, payment_days, deduction_percentage*100, doc.name, amount)
+			Deduct Amount: <b>{5}</b><br/><br/>
+		""".format(doc.name, salary, daily_rate, payment_days, deduction_percentage*100, amount)
 		create_additional_salary(doc.employee, amount, salary_component, end_date, deduction_notes)
 
 def mark_day_attendance():

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -606,7 +606,8 @@ scheduler_events = {
 		],
 		"00 01 24 * *": [
 			'one_fm.api.tasks.generate_site_allowance',
-			'one_fm.api.tasks.generate_ot_additional_salary'
+			'one_fm.api.tasks.generate_ot_additional_salary',
+			'one_fm.api.tasks.generate_sick_leave_deduction'
 		],
 		"00 02 24 * *": [
 			'one_fm.api.tasks.generate_payroll'

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -544,7 +544,6 @@ def create_gp_letter_request():
 @frappe.whitelist(allow_guest=True)
 def leave_appillication_on_submit(doc, method):
     if doc.status == "Approved":
-        leave_appillication_paid_sick_leave(doc, method)
         update_employee_hajj_status(doc, method)
         
 
@@ -559,88 +558,9 @@ def notify_employee(doc, method):
         message = "Hello, Your "+doc.leave_type+" Application "+date+" has been "+doc.workflow_state
         push_notification_rest_api_for_leave_application(doc.employee,"Leave Application", message, doc.name)
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def leave_appillication_on_cancel(doc, method):
     update_employee_hajj_status(doc, method)
-    leave_appillication_paid_sick_leave(doc, method)
-
-@frappe.whitelist(allow_guest=True)
-def leave_appillication_paid_sick_leave(doc, method):
-	if doc.leave_type and frappe.db.get_value("Leave Type", doc.leave_type, 'one_fm_is_paid_sick_leave') == 1:
-		if method == 'on_submit':
-			salary = get_salary_amount(doc.employee)
-			if salary:
-				create_additional_salary_for_paid_sick_leave(doc, salary)
-		elif method == 'on_cancel':
-			cancel_additional_salary_for_paid_sick_leave(doc.name)
-
-def cancel_additional_salary_for_paid_sick_leave(leave_application):
-	additional_salary_exists = frappe.db.exists('Additional Salary', {
-		'ref_doctype': 'Leave Application',
-		'ref_docname': leave_application
-	})
-	if additional_salary_exists:
-		additional_salary = frappe.get_doc('Additional Salary', additional_salary_exists)
-		if additional_salary.docstatus == 1:
-			additional_salary.cancel()
-		else:
-			additional_salary.delete()
-
-def create_additional_salary_for_paid_sick_leave(doc, salary):
-    daily_rate = salary/30
-    from hrms.hr.doctype.leave_application.leave_application import get_leave_details
-    leave_details = get_leave_details(doc.employee, nowdate())
-    curr_year_applied_days = 0
-    if doc.leave_type in leave_details['leave_allocation'] and leave_details['leave_allocation'][doc.leave_type]:
-        curr_year_applied_days = leave_details['leave_allocation'][doc.leave_type]['leaves_taken']
-    if curr_year_applied_days == 0:
-        curr_year_applied_days = doc.total_leave_days
-
-    leave_payment_breakdown = get_leave_payment_breakdown(doc.leave_type)
-
-    total_payment_days = 0
-    if leave_payment_breakdown:
-        threshold_days = 0
-        for payment_breakdown in leave_payment_breakdown:
-            payment_days = 0
-            threshold_days += payment_breakdown.threshold_days
-            if total_payment_days < doc.total_leave_days:
-                if curr_year_applied_days >= threshold_days and (curr_year_applied_days - doc.total_leave_days) < threshold_days:
-                    payment_days = threshold_days - (curr_year_applied_days-doc.total_leave_days) - total_payment_days
-                elif curr_year_applied_days <= threshold_days: # Gives true this also doc.total_leave_days <= threshold_days:
-                    payment_days = doc.total_leave_days - total_payment_days
-                create_additional_salary(salary, daily_rate, payment_days, doc, payment_breakdown)
-                total_payment_days += payment_days
-
-    if total_payment_days < doc.total_leave_days and doc.total_leave_days-total_payment_days > 0:
-        create_additional_salary(salary, daily_rate, doc.total_leave_days-total_payment_days, doc)
-
-def create_additional_salary(salary, daily_rate, payment_days, leave_application, payment_breakdown=False):
-    if payment_days > 0:
-        deduction_percentage = 1
-        salary_component = frappe.db.get_value("Leave Type", leave_application.leave_type, "one_fm_paid_sick_leave_deduction_salary_component")
-        if payment_breakdown:
-            deduction_percentage = payment_breakdown.salary_deduction_percentage/100
-            salary_component = payment_breakdown.salary_component
-        deduction_notes = """
-            Employee Salary: <b>{0}</b><br>
-            Daily Rate: <b>{1}</b><br>
-            Deduction Days Number: <b>{2}</b><br>
-            Deduction Percent: <b>{3}%</b>
-        """.format(salary, daily_rate, payment_days, deduction_percentage*100)
-
-        additional_salary = frappe.get_doc({
-            "doctype":"Additional Salary",
-            "employee": leave_application.employee,
-            "salary_component": salary_component,
-            "payroll_date": leave_application.from_date,
-            "leave_application": leave_application.name,
-            "notes": deduction_notes,
-            "amount": payment_days*daily_rate*deduction_percentage,
-			"ref_doctype": leave_application.doctype,
-			"ref_docname": leave_application.name
-        }).insert(ignore_permissions=True)
-        additional_salary.submit()
 
 def get_leave_payment_breakdown(leave_type):
     leave_type_doc = frappe.get_doc("Leave Type", leave_type)
@@ -2955,7 +2875,7 @@ def get_today_leaves(cur_date):
 
 def get_approver(employee):
     """
-        Get document approver for employee by 
+        Get document approver for employee by
         reports_to, shift_approver, site_approver
     """
     operations_site, operations_shift = '', ''
@@ -2976,7 +2896,7 @@ def get_approver(employee):
 
 def get_approver_for_many_employees(supervisor=None):
     """
-        Get document approver for employee by 
+        Get document approver for employee by
         reports_to, shift_approver, site_approver
     """
     if not supervisor:
@@ -2990,8 +2910,8 @@ def get_approver_for_many_employees(supervisor=None):
     if operations_site:
         employees += [i.name for i in frappe.db.get_list('Employee', {'site':['IN', operations_site]}, "name", ignore_permissions=True) if not i.name in employees]
     operations_shift = [i.name for i in frappe.db.get_list('Operations Shift', {'supervisor':supervisor}, "name", ignore_permissions=True)]
-    if operations_shift:    
-        employees += [i.name for i in frappe.db.get_list('Employee', {'shift':['IN', operations_shift]}, "name", ignore_permissions=True) if not i.name in employees]    
+    if operations_shift:
+        employees += [i.name for i in frappe.db.get_list('Employee', {'shift':['IN', operations_shift]}, "name", ignore_permissions=True) if not i.name in employees]
     employees.append(supervisor)
     return employees
 
@@ -3032,7 +2952,7 @@ def post_login(self):
             {
             'doctype':'Administrator Auto Log',
             'ip': session.session_ip,
-            'login_time': session.last_updated, 
+            'login_time': session.last_updated,
             'session_expiry': session.session_expiry,
             'device': session.device,
             'session_country': json.dumps(session.session_country),


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Stop creating individual/multiple additional salary on sick leave deduction
- Generate sick leave deduction on the payroll cycle for each employee only once

## Solution description
- Remove the code for creating individual additional salary for sick leave
- Crone will run for generate sick leave deduction as additional salary(one for one employee) for the period of payroll on payroll date
![Screenshot 2023-04-01 at 1 08 37 PM](https://user-images.githubusercontent.com/20554466/229427137-6a5897ea-c1a0-435d-8de6-df522733d43e.png)

## Areas affected and ensured
- `one_fm/api/tasks.py`
- `one_fm/hooks.py`
- `one_fm/utils.py`

## Is there any existing behavior change of other features due to this code change?
Yes, only create an additional salary for an employee in a payroll period against multiple sick leave

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
