### PR TITLE
Fix: Start Date of Payroll Report

### DIFF
--- a/one_fm/one_fm/report/payroll_report/payroll_report.py
+++ b/one_fm/one_fm/report/payroll_report/payroll_report.py
@@ -221,10 +221,10 @@ def get_payroll_cycle(filters):
 	settings = frappe.get_doc("HR and Payroll Additional Settings")
 	default_date = settings.payroll_date
 
-	start_date = datetime.date(int(filters["year"]), int(filters["month"]), int(default_date))
+	start_date = datetime.date(int(filters["year"]), int(filters["month"])-1, int(default_date))
 	payroll_cycle = {
 		'Other': {
-			'start_date': datetime.date(int(filters["year"]), int(filters["month"]), int(default_date)),
+			'start_date': datetime.date(int(filters["year"]), int(filters["month"])-1, int(default_date)),
 			'end_date': add_days(add_months(datetime.date(int(filters["year"]), int(filters["month"]), int(default_date)), 1), -1)
 			}
 		}
@@ -233,7 +233,7 @@ def get_payroll_cycle(filters):
 		if row.payroll_start_day == 'Month Start':
 			row.payroll_start_day = 1
 		payroll_cycle[row.project] = {
-			'start_date':datetime.date(int(filters["year"]), int(filters["month"]), int(row.payroll_start_day)),
+			'start_date':datetime.date(int(filters["year"]), int(filters["month"])-1, int(row.payroll_start_day)),
 			'end_date':add_days(add_months(datetime.date(int(filters["year"]), int(filters["month"]), int(row.payroll_start_day)), 1), -1)
 		}
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Start Date of give Payroll Report was wrong.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
- Fetch the correct Start Date.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
<img width="400" alt="Screen Shot 2023-04-09 at 11 01 39 AM" src="https://user-images.githubusercontent.com/29017559/230761419-df384196-7c2e-4be2-9e73-720dc7194894.png">
<img width="400" alt="Screen Shot 2023-04-09 at 11 01 58 AM" src="https://user-images.githubusercontent.com/29017559/230761440-af773f36-7678-49b8-bf78-fd9f69b40559.png">


## Areas affected and ensured
- Start Date to fetch Attendance,

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
