### PR TITLE
fix: Leave Application Approved but still Open

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -642,7 +642,7 @@ scheduler_events = {
 		'one_fm.api.doc_methods.payroll_entry.notify_for_open_leave_application'
 		],
 		"45 23 23 * *": [ #approve all the open leave application
-		'one_fm.api.doc_methods.payroll_entry.close_all_leave_application '
+		'one_fm.api.doc_methods.payroll_entry.close_all_leave_application'
 		]
 	}
 }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -31,3 +31,4 @@ one_fm.patches.v14_0.reassign_reshare_leaves
 one_fm.patches.v14_0.set_leave_ref_fields_in_paid_sick_leave_additional_salary
 one_fm.patches.v14_0.remove_leave_application_field_from_additional_salary
 one_fm.patches.v14_0.fix_leave_application_attachments
+one_fm.patches.v14_0.update_leave_application_status_to_approved

--- a/one_fm/patches/v14_0/update_leave_application_status_to_approved.py
+++ b/one_fm/patches/v14_0/update_leave_application_status_to_approved.py
@@ -1,0 +1,12 @@
+import frappe
+
+def execute():
+	query = '''
+		update
+			`tabLeave Application`
+		set
+			status = 'Approved'
+		where
+			workflow_state = 'Approved' and status = 'Open'
+	'''
+	frappe.db.sql(query)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Approved leave applications status are in Open

## Solution description
- Auto leave approval process are just update the workflow state, now we updates the record.

## Output screenshots (optional)
Before PR 
![Screenshot 2023-04-16 at 11 07 36 AM](https://user-images.githubusercontent.com/20554466/232490271-bf31e163-762c-4bfc-a2ae-5b5e052a5e51.png)
Patch
![Screenshot 2023-04-17 at 6 18 47 PM](https://user-images.githubusercontent.com/20554466/232490353-47d0e6ff-6f22-418b-8215-aae02d7cbafd.png)

## Areas affected and ensured
- `one_fm/api/doc_methods/payroll_entry.py`
- `one_fm/hooks.py`
- `one_fm/overrides/leave_application.py`
- `one_fm/patches.txt`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes
    ## Was the patch test? Yes

## Which browser(s) did you use for testing?
- [x] Chrome
