### PR TITLE
fix: compensatory leave request from attendance

### DIFF
--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -304,7 +304,8 @@ def manage_attendance_on_holiday(doc, method):
 
             if not is_site_allowance_exist_for_this_employee(doc.employee, doc.attendance_date):
                 create_additional_salary_from_attendance(doc, salary_component, remark)
-            create_compensatory_leave_request_from_attendance(doc, leave_type, remark)
+            if doc.status == "Present":
+                create_compensatory_leave_request_from_attendance(doc, leave_type, remark)
 
         # cancel additional salary and compensatory leave request on attendance cancel
         if method == "on_cancel":
@@ -486,6 +487,3 @@ def attach_abbreviation_to_roles():
                 role.post_abbrv = post_abbrv
             role.save(ignore_permissions=True)
             frappe.db.commit()
-
-
-


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Not allowing to submit attendance on holiday with DayOff status

## Analysis and design (optional)
Asper the Core feature, an employee can have a compensatory leave request for an present attendance on holiday
https://github.com/frappe/hrms/blob/77d51ab9ca6ebe50003cefb7848356e878d09d63/hrms/hr/doctype/compensatory_leave_request/compensatory_leave_request.py#L37

Here the user submit an attendance with status `Day Off` and on submit of the attendance it is creating the Compensatory Leave Request. 

## Solution description
- Create compensatory leave request on holiday attendance if the attendance status is Present

## Areas affected and ensured
- `one_fm/one_fm/utils.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome