### PR TITLE
[184828932] Add Site Supervisor field to Roster Post Action Page

### DIFF
--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.json
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.json
@@ -10,9 +10,13 @@
   "end_date",
   "actions_section",
   "status",
-  "action_type",
   "supervisor",
   "supervisor_name",
+  "column_break_9",
+  "action_type",
+  "site_supervisor",
+  "site_supervisor_name",
+  "section_break_12",
   "operations_roles_not_filled"
  ],
  "fields": [
@@ -28,7 +32,8 @@
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
    "in_list_view": 1,
-   "label": "Supervisor",
+   "in_standard_filter": 1,
+   "label": "Shift Supervisor",
    "options": "Employee",
    "reqd": 1
   },
@@ -73,13 +78,37 @@
    "fieldtype": "Data",
    "ignore_user_permissions": 1,
    "in_list_view": 1,
-   "label": "Supervisor Name",
+   "label": "Shift Supervisor Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "site_supervisor",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Site Supervisor",
+   "options": "Employee"
+  },
+  {
+   "fetch_from": "site_supervisor.employee_name",
+   "fieldname": "site_supervisor_name",
+   "fieldtype": "Data",
+   "label": "Site Supervisor Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_12",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-16 01:20:00.139929",
+ "modified": "2023-04-20 18:34:00.628526",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Roster Post Actions",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [*] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As a Roster Post Action User I would to have Site Supervisor Listed Field and Site Supervisor Name


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
As a Roster Post Action User I would to have Site Supervisor Listed Field and Site Supervisor Name

## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Post Action Doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [*] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
