### PR TITLE
feat: roster employee actions - site supervisor and permission

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -168,7 +168,9 @@ permission_query_conditions = {
 	"Penalty Issuance": "one_fm.legal.doctype.penalty_issuance.penalty_issuance.get_permission_query_conditions",
 	"Issue": "one_fm.utils.get_issue_permission_query_conditions",
     "Leave Application": "one_fm.permissions.leave_application_list",
+	"Roster Employee Actions": "one_fm.one_fm.doctype.roster_employee_actions.roster_employee_actions.get_permission_query_conditions"
 }
+
 has_permission = {
  	"Penalty": "one_fm.legal.doctype.penalty.penalty.has_permission",
  	"Penalty Issuance": "one_fm.legal.doctype.penalty_issuance.penalty_issuance.has_permission",

--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
@@ -10,9 +10,15 @@
   "end_date",
   "actions",
   "status",
+  "column_break_bi2pf",
   "action_type",
+  "section_break_t1lpn",
   "supervisor",
   "supervisor_name",
+  "column_break_yxhnr",
+  "site_supervisor",
+  "site_supervisor_name",
+  "section_break_h7sd9",
   "employees_not_rostered"
  ],
  "fields": [
@@ -58,7 +64,7 @@
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
    "in_standard_filter": 1,
-   "label": "Supervisor",
+   "label": "Shift  Supervisor",
    "options": "Employee",
    "reqd": 1
   },
@@ -74,13 +80,45 @@
    "fieldtype": "Data",
    "ignore_user_permissions": 1,
    "in_list_view": 1,
-   "label": "Supervisor Name",
+   "label": "Shift  Supervisor Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_bi2pf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_h7sd9",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_t1lpn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_yxhnr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "site_supervisor.employee_name",
+   "fieldname": "site_supervisor_name",
+   "fieldtype": "Data",
+   "ignore_user_permissions": 1,
+   "label": "Site Supervisor Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "site_supervisor",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_standard_filter": 1,
+   "label": "Site Supervisor",
+   "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-16 01:18:58.950452",
+ "modified": "2023-04-25 08:24:30.276897",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Roster Employee Actions",

--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import nowdate, add_to_date, cstr, cint, getdate, get_link_to_form
 from one_fm.processor import sendemail
+from frappe.permissions import get_doctype_roles
 
 class RosterEmployeeActions(Document):
 	def autoname(self):
@@ -22,3 +23,35 @@ class RosterEmployeeActions(Document):
 				Please review the employees assigned to you, take necessary actions and update the status.<br>
 				Link: {link}""".format(link=link))
 			sendemail([user_id], subject=subject, message=message, reference_doctype=self.doctype, reference_name=self.name)
+
+@frappe.whitelist()
+def get_permission_query_conditions(user):
+	"""
+		Method used to set the permission to get the list of docs (Example: list view query)
+		Called from the permission_query_conditions of hooks for the DocType Roster Employee Actions
+		args:
+			user: name of User object or current user
+		return conditions query
+	"""
+	if not user: user = frappe.session.user
+
+	if user == "Administrator":
+		return ""
+
+	# Fetch all the roles associated with the current user
+	user_roles = frappe.get_roles(user)
+
+	if "System Manager" in user_roles:
+		return ""
+
+	# Get roles allowed to Roster Employee Actions doctype
+	doctype_roles = get_doctype_roles('Roster Employee Actions')
+	# If doctype roles is in user roles, then user permitted
+	role_exist = [role in doctype_roles for role in user_roles]
+
+	if role_exist and len(role_exist) > 0 and True in role_exist:
+		employee = frappe.get_value("Employee", {"user_id": user}, ["name"])
+		if "Shift Supervisor" in user_roles or "Site Supervisor" in user_roles:
+			return '(`tabRoster Employee Actions`.`supervisor`="{employee}" or `tabRoster Employee Actions`.`site_supervisor`="{employee}")'.format(employee = employee)
+
+	return ""

--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions_list.js
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions_list.js
@@ -1,19 +1,13 @@
 frappe.listview_settings['Roster Employee Actions'] = {
-
     // set default filters
-    filters: {
-
-    },
     onload(listview){
         if (!frappe.user.has_role('Operation Admin')){
             frappe.db.get_value('Employee', {'user_id':frappe.session.user}, 'name').then(res=>{
-                console.log(res.message.name)
                 $('input[data-fieldname="supervisor"]')[0].value = res.message.name;
                 $('button[data-original-title="Refresh"')[0].click();
-                $('input[data-fieldname="supervisor"]')[0].disabled=1;
+                // $('input[data-fieldname="supervisor"]')[0].disabled=1;
             })
-        } 
-        
+        }
     },
     before_render(listview) {
     },

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1804,7 +1804,7 @@ def create_roster_employee_actions():
         employees = employees + emp
 
     # fetch supervisors and list of employees(not rostered) under them
-    result = frappe.db.sql("""select sv.employee, group_concat(e.employee)
+    result = frappe.db.sql("""select sv.employee, sv.site, group_concat(e.employee)
             from `tabEmployee` e
             join `tabOperations Shift` sh on sh.name = e.shift
             join `tabEmployee` sv on sh.supervisor=sv.employee
@@ -1814,7 +1814,8 @@ def create_roster_employee_actions():
     # for each supervisor, create a roster action
     for res in result:
         supervisor = res[0]
-        employees = res[1].split(",")
+        site_supervisor = frappe.get_value('Operations Site', res[1], 'account_supervisor')
+        employees = res[2].split(",")
 
         roster_employee_actions_doc = frappe.new_doc("Roster Employee Actions")
         roster_employee_actions_doc.start_date = start_date
@@ -1822,6 +1823,7 @@ def create_roster_employee_actions():
         roster_employee_actions_doc.status = "Pending"
         roster_employee_actions_doc.action_type = "Roster Employee"
         roster_employee_actions_doc.supervisor = supervisor
+        roster_employee_actions_doc.site_supervisor = site_supervisor
 
         for emp in employees:
             roster_employee_actions_doc.append('employees_not_rostered', {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Add site supervisor field with the site supervisor's name So Site supervisor can access and take action on `roster employee action`

## Solution description
- Organise the form and add site supervisor to the doctype
- Set site supervisor value on auto creation of roster employee actions
- Set permission query for site supervisor and shift supervisor

## Output screenshots (optional)
Before the PR
![Screenshot 2023-04-24 at 1 23 52 PM](https://user-images.githubusercontent.com/20554466/234255740-ebd4b62b-36df-4ec9-850a-227f26a18208.png)

After the PR
![Screenshot 2023-04-24 at 1 27 47 PM](https://user-images.githubusercontent.com/20554466/234255785-7780c021-a737-4e77-b3de-0bef954277f6.png)

## Areas affected and ensured
- `one_fm/hooks.py`
- `one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json`
- `one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py`
- `one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions_list.js`
- `one_fm/utils.py`


## Is there any existing behavior change of other features due to this code change?
Yes, Site supervisor added to the roster employee actions and permissions are updated accordingly

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome