### PR TITLE
Chore: copy and go to ref button in OWS Page

### DIFF
--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -287,13 +287,13 @@
                             </div>
                         </div>
                         <div class="form-row" :style="">
-                            <div class="col-md-6 mb-3">
+                            <div class="col-md-12" title="View the document">
                                 <label for="validationTooltip01"></label>
-                                <a :href="todo_pane.url" class="btn btn-warning text-center">Go to Ref</a>
+                                <a :href="todo_pane.url" class="btn btn-block btn-warning text-center">Go to Ref</a>
                             </div>
-                            <div class="col-md-6 mb-3">
+                            <div class="col-md-12 mb-3" title="Copy the link to document">
                                 <label for="validationTooltip01"></label>
-                                <a class="btn btn-warning text-center" @click="copyText(todo_pane.url)">Copy</a>
+                                <a class="btn btn-block btn-warning text-center" @click="copyText(todo_pane.url)">Copy Link</a>
                             </div>
                         </div>
                         <div class="form-row">

--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -245,7 +245,7 @@
                         <div class="form-row">
                             <div class="col-md-6 mb-3">
                             <label for="validationTooltip01">Status</label>
-                                <input type="text" class="form-control" :value="todo_pane.status" disabled>
+                                <input type="text" class="form-control" :value="todo_pane.status" ref="message" disabled>
                             </div>
                             <div class="col-md-6 mb-3">
                             <label for="validationTooltip01">Due Date</label>
@@ -287,15 +287,13 @@
                             </div>
                         </div>
                         <div class="form-row" :style="">
-                            <div class="col-md-12 mb-3">
+                            <div class="col-md-6 mb-3">
                                 <label for="validationTooltip01"></label>
-                                <a :href="todo_pane.name" class="btn btn-warning text-center">Go to Ref (Button)</a>
+                                <a :href="todo_pane.url" class="btn btn-warning text-center">Go to Ref</a>
                             </div>
-                        </div>
-                        <div class="form-row">
-                            <div class="col-md-12 mb-3">
-                                <label for="validationTooltip01">Copy link (Button)</label>
-                                <input type="text" class="form-control text-center" value="Mark" disabled>
+                            <div class="col-md-6 mb-3">
+                                <label for="validationTooltip01"></label>
+                                <a class="btn btn-warning text-center" @click="copyText(todo_pane.url)">Copy</a>
                             </div>
                         </div>
                         <div class="form-row">

--- a/one_fm/one_fm/page/ows/ows.js
+++ b/one_fm/one_fm/page/ows/ows.js
@@ -234,6 +234,28 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 							}).datepicker('update', new Date(),
 							);						
 					}
+				},
+				copyText(link_to_copy) {
+					const show_success_alert = () => {
+						frappe.show_alert({
+							indicator: "green",
+							message: __("Copied to clipboard."),
+						});
+					};
+					const show_fail_alert = () => {
+						frappe.show_alert({
+							indicator: "red",
+							message: __("Nothing to Copy."),
+						});
+					};
+					if(link_to_copy == undefined){
+						show_fail_alert();
+					}
+					else {
+							if (navigator.clipboard && window.isSecureContext) {
+								navigator.clipboard.writeText(link_to_copy).then(show_success_alert);
+							} 
+					}
 				}
 			}
 		)

--- a/one_fm/one_fm/page/ows/ows.js
+++ b/one_fm/one_fm/page/ows/ows.js
@@ -190,6 +190,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 							});
 							if (todo.length>0){
 								me.todo_pane = todo[0];
+								me.todo_pane.url = frappe.urllib.get_base_url()+'/app/todo/'+me.todo_pane.name
 							}
 						} else {
 							let todo = me.assigned_todos.filter(function(item){
@@ -197,6 +198,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 							});
 							if (todo.length>0){
 								me.todo_pane = todo[0];
+								me.todo_pane.url = frappe.urllib.get_base_url()+'/app/todo/'+me.todo_pane.name
 							}
 
 						}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
- Copy Button should copy the doc link to the clipboard.
- Go To Ref button should redirect the page to the given doc.

## Solution description
- Add URL in todo_pane dict
- fetch todo_pane.url to copy or direct to the link.
- add success and failure messages for copy button.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
https://user-images.githubusercontent.com/29017559/235428186-b4b60685-4092-45d5-95e0-ba7d877659fd.mov

## Areas affected and ensured
copy and go to ref buttons in ows

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
