### PR TITLE
feat: Active Repetitive project in OWS

### DIFF
--- a/one_fm/one_fm/custom/project_type.json
+++ b/one_fm/one_fm/custom/project_type.json
@@ -44,7 +44,7 @@
    "name": "Project Type-type",
    "no_copy": 0,
    "non_negative": 0,
-   "options": "\nSCRUM\nPersonal",
+   "options": "\nSCRUM\nPersonal\nActive Repetitive",
    "owner": "Administrator",
    "permlevel": 0,
    "precision": "",

--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -69,13 +69,9 @@
                                                   <div class="widget-subtitle"></div>
                                                 </div>
                                               </div>
-                                            <ul>
-                                            <li><a href="#">Active Repetitive 1</a></li>
-                                            <li><a href="#">Active Repetitive 2</a></li>
-                                            <li><a href="#">Active Repetitive 3</a></li>
-                                            <li><a href="#">Active Repetitive 4</a></li>
-                                            <li><a href="#">Active Repetitive 5</a></li>
-                                            </ul>
+																							<ul>
+	                                                <li v-for="project in active_repetitive_projects"><a href="#" @click.prevent="showTodo(1, project.todo)">[% project.project %]</a></li>
+	                                            </ul>
                                         </div>
                                         <div class="col-md-3 card border-dark scroll-box" id="box3">
 

--- a/one_fm/one_fm/page/ows/ows.js
+++ b/one_fm/one_fm/page/ows/ows.js
@@ -30,6 +30,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 						assigned_todos: [],
 						scrum_projects: [],
 						personal_projects: [],
+						active_repetitive_projects: [],
 						my_todo_filters : new Object,
 						assigned_todo_filters : new Object,
 						doctype_ref:[],
@@ -174,6 +175,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 									me.assigned_todos = res.assigned_todos;
 									me.scrum_projects = res.scrum_projects;
 									me.personal_projects = res.personal_projects;
+									me.active_repetitive_projects = res.active_repetitive_projects;
 									me.doctype_ref = res.filter_references[0]
 									me.user_ref = res.filter_references[1]
 

--- a/one_fm/one_fm/page/ows/ows.py
+++ b/one_fm/one_fm/page/ows/ows.py
@@ -68,8 +68,8 @@ def get_defaults(args=None, has_todo_filter=0, has_assigned_filter=0):
                         """,as_dict=1)
 
     data.scrum_projects = get_to_do_linked_projects("SCRUM")
-
     data.personal_projects = get_to_do_linked_projects("Personal")
+    data.active_repetitive_projects = get_to_do_linked_projects("Active Repetitive")
 
     data.company_objective = get_company_objective()
     data.company_objective_quarter = get_company_objective('Quarterly')
@@ -148,7 +148,7 @@ def get_to_do_linked_projects(type):
         from
             `tabProject` p, `tabToDo` t
         where
-            t.reference_type = "Project" and t.reference_name = p.name and p.project_type = '{0}'
+            t.reference_type = "Project" and t.reference_name = p.name and p.type = '{0}'
             and allocated_to = '{1}'
     '''
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Active Repetitive Project in the OWS dashboard


## Solution description
- Project Type with `Active Repetitive` selection option
- Fetch to ows with respect to the type in project

## Output screenshots (optional)
![Screenshot 2023-05-02 at 1 25 41 PM](https://user-images.githubusercontent.com/20554466/235611251-145a8ac9-bb18-454d-b4f9-f70145c57ea1.png)


## Areas affected and ensured
- `one_fm/one_fm/custom/project_type.json`
- `one_fm/one_fm/page/ows/ows.html`
- `one_fm/one_fm/page/ows/ows.js`
- `one_fm/one_fm/page/ows/ows.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome