### PR TITLE
fix: Recipients: before_save - Shift Request notification

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -360,7 +360,6 @@ doc_events = {
 	},
 	"Shift Request":{
 		"before_save":[
-			"one_fm.api.doc_methods.shift_request.send_workflow_action_email",
 			"one_fm.api.doc_methods.shift_request.fill_to_date",
 		],
 		"on_update_after_submit":[


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Invalid email address Sender: Notifications , Recipients: before_save, 

## Solution description
- Shift Request doc event(before_save) triggering the `send_workflow_action_email`, removed before save doc event. 

## Areas affected and ensured
- `one_fm/hooks.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome