### PR TITLE
feat: filter yearly and quarterly OKR in OWS

### DIFF
--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -12,24 +12,16 @@
                                     <table class="table table-bordered">
                                     <tbody>
                                         <tr class="table-primary">
-                                            <td>The Goal:
-																							<input class="form-control" type="text" :value="company_goal">
-																						</td>
+                                            <td>The Goal: <b>[% company_goal %]</b></td>
                                         </tr>
                                         <tr class="table-success">
-                                            <td>Company Objective:
-																							<input class="form-control" type="text" :value="company_objective">
-																						</td>
+                                            <td>Company Objective: <b>[% company_objective %]</b></td>
                                         </tr>
                                         <tr class="table-warning">
-                                            <td>Company Objective Quarter:
-																							<input class="form-control" type="text" :value="company_objective_quarter">
-																						</td>
+                                            <td>Company Objective Quarter: <b>[% company_objective_quarter %]</b></td>
                                         </tr>
                                         <tr class="table-danger">
-                                            <td>My Objective:
-																							<input class="form-control" type="text" :value="my_objective">
-																						</td>
+                                            <td>My Objective: <b>[% my_objective %]</b></td>
                                         </tr>
                                     </tbody>
                                     </table>

--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -230,11 +230,13 @@
                 <div class="card-body">
                     <div class="form-row">
                         <div class="awesomplete col-md-6 mb-3">
+														<label class="control-label" style="padding-right: 0px;">Year</label>
                             <select class="input-with-feedback form-control" id = "okr_year" name = "okr_year">
 																<option>Select Year</option>
 														</select>
                         </div>
 												<div class="awesomplete col-md-6 mb-3">
+														<label class="control-label" style="padding-right: 0px;">Quarter</label>
                             <select class="input-with-feedback form-control" id = "okr_quarter" name = "okr_quarter">
 																<option>Select Quarter</option>
 														</select>

--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -229,11 +229,15 @@
             <div class="card border-dark mb-3">
                 <div class="card-body">
                     <div class="form-row">
-                        <div class="col-md-6 mb-3">
-                            <input type="text" class="form-control text-center" placeholder="Year (1)" value="Mark " >
+                        <div class="awesomplete col-md-6 mb-3">
+                            <select class="input-with-feedback form-control" id = "okr_year" name = "okr_year">
+																<option>Select Year</option>
+														</select>
                         </div>
-                        <div class="col-md-6 mb-3">
-                            <input type="text" class="form-control text-center" placeholder="Quarter (2)" value="Mark" disabled>
+												<div class="awesomplete col-md-6 mb-3">
+                            <select class="input-with-feedback form-control" id = "okr_quarter" name = "okr_quarter">
+																<option>Select Quarter</option>
+														</select>
                         </div>
                     </div>
                 </div>

--- a/one_fm/one_fm/page/ows/ows.js
+++ b/one_fm/one_fm/page/ows/ows.js
@@ -37,7 +37,9 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 						user_ref:[],
 						company_objective: '',
 						company_objective_quarter: '',
-						my_objective: ''
+						my_objective: '',
+						okr_year: '',
+						okr_quarter: ''
 					}
 				},
 				mounted(){
@@ -74,12 +76,13 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 					},
 					fetchOKR(){
 						let me = this;
-
+						me.okr_year = $('#okr_year').val();
+						me.okr_quarter = $('#okr_quarter').val();
 						frappe.call({
 							method: "one_fm.one_fm.page.ows.ows.get_okr_details",
 							args: {
-								okr_year : $('#okr_year').val(),
-								okr_quarter : $('#okr_quarter').val()
+								okr_year: me.okr_year,
+								okr_quarter: me.okr_quarter
 							},
 							callback: function(r) {
 								if (r.message){
@@ -96,7 +99,14 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 						let me = this
 
 						$('#okr_year').change(function(){
-							me.fetchOKR()
+							me.fetchOKR();
+							if(me.okr_year){
+								$('#okr_quarter').prop('disabled', false);
+							}
+							else{
+								$('#okr_quarter').prop('disabled', 'disabled');
+								$("#okr_quarter").val("Default");
+							}
 						})
 
 						$('#okr_quarter').change(function(){
@@ -223,19 +233,20 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 					setOKRYearQuarter(okr_year_data){
 						$('#okr_year').empty()
 						$('#okr_year').select2({
-							data:[{ 'id': '', 'text': 'Select Year' }].concat(okr_year_data)
+							data:[{ 'id': '', 'text': 'Default' }].concat(okr_year_data)
 						})
 
 						$('#okr_quarter').empty()
 						$('#okr_quarter').select2({
 							data:[
-								{ 'id': '', 'text': 'Select Quarter' },
+								{ 'id': '', 'text': 'Default' },
 								{ 'id': 'Q1', 'text': 'Q1' },
 								{ 'id': 'Q2', 'text': 'Q2' },
 								{ 'id': 'Q3', 'text': 'Q3' },
 								{ 'id': 'Q4', 'text': 'Q4' },
 							]
 						})
+						$('#okr_quarter').prop('disabled', 'disabled');
 					},
 					showTodo(todoType, todoName){
 						// 1 = mytodo, 0 = assigned_todo

--- a/one_fm/one_fm/page/ows/ows.js
+++ b/one_fm/one_fm/page/ows/ows.js
@@ -72,8 +72,36 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 						this.getDefault()
 
 					},
+					fetchOKR(){
+						let me = this;
+
+						frappe.call({
+							method: "one_fm.one_fm.page.ows.ows.get_okr_details",
+							args: {
+								okr_year : $('#okr_year').val(),
+								okr_quarter : $('#okr_quarter').val()
+							},
+							callback: function(r) {
+								if (r.message){
+									let data = r.message;
+									me.company_goal =  data.company_goal;
+									me.company_objective =  data.company_objective ? data.company_objective.name : '';
+									me.company_objective_quarter =  data.company_objective_quarter ? data.company_objective_quarter.name : '';
+									me.my_objective =  data.my_objective ? data.my_objective.name : '';
+								}
+							}
+						});
+					},
 					setupTriggers(){
 						let me = this
+
+						$('#okr_year').change(function(){
+							me.fetchOKR()
+						})
+
+						$('#okr_quarter').change(function(){
+							me.fetchOKR()
+						})
 
 						$('#my_todos_id').change(function(){
 							me.getAllFilters()
@@ -115,6 +143,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 											{ 'id': 'High', 'text': 'High' }]
 						reference_data = reference_data.concat(me.doctype_ref)
 						assigned_data = assigned_data.concat(me.user_ref)
+
 						if(is_my_todo){
 
 							$('#my_todos_ref_type').empty()
@@ -169,9 +198,9 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 								if (r.message){
 									let res = r.message;
 									me.company_goal =  res.company_goal;
-									me.company_objective =  res.company_objective;
-									me.company_objective_quarter =  res.company_objective_quarter;
-									me.my_objective =  res.my_objective;
+									me.company_objective =  res.company_objective ? res.company_objective.name : '';
+									me.company_objective_quarter =  res.company_objective_quarter ? res.company_objective_quarter.name : '';
+									me.my_objective =  res.my_objective ? res.my_objective.name : '';
 									me.my_todos = res.my_todos;
 									me.assigned_todos = res.assigned_todos;
 									me.scrum_projects = res.scrum_projects;
@@ -186,9 +215,27 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 										me.setupFilters(0)
 									}
 
+									me.setOKRYearQuarter(res.okr_year)
 								}
 							}
 						});
+					},
+					setOKRYearQuarter(okr_year_data){
+						$('#okr_year').empty()
+						$('#okr_year').select2({
+							data:[{ 'id': '', 'text': 'Select Year' }].concat(okr_year_data)
+						})
+
+						$('#okr_quarter').empty()
+						$('#okr_quarter').select2({
+							data:[
+								{ 'id': '', 'text': 'Select Quarter' },
+								{ 'id': 'Q1', 'text': 'Q1' },
+								{ 'id': 'Q2', 'text': 'Q2' },
+								{ 'id': 'Q3', 'text': 'Q3' },
+								{ 'id': 'Q4', 'text': 'Q4' },
+							]
+						})
 					},
 					showTodo(todoType, todoName){
 						// 1 = mytodo, 0 = assigned_todo

--- a/one_fm/one_fm/page/ows/ows.py
+++ b/one_fm/one_fm/page/ows/ows.py
@@ -85,32 +85,63 @@ def get_defaults(args=None, has_todo_filter=0, has_assigned_filter=0):
     data.filter_references = get_reference_and_users()
     if not any([bool(mytodo_cond),bool(myassigned_cond)]):
         data.reset_filters = 1
+
+    data.okr_year = get_fiscal_year()
     return data
 
-def get_company_objective(okr_for='Yearly'):
+@frappe.whitelist()
+def get_okr_details(okr_year, okr_quarter):
+	data = frappe._dict({})
+	data.company_objective = get_company_objective(okr_year=okr_year)
+	data.company_objective_quarter = get_company_objective('Quarterly', okr_year, okr_quarter)
+	data.my_objective = get_my_objective(okr_year)
+	data.company_goal = get_company_goal()
+	return data
+
+def get_fiscal_year():
 	query = '''
 		select
-			*
+			name as id, name as text
+		from
+			`tabFiscal Year`
+		where
+			disabled != 1
+	'''
+	return frappe.db.sql(query, as_dict=True)
+
+def get_company_objective(okr_for='Yearly', okr_year=False, okr_quarter=False):
+	query = '''
+		select
+			name, okr_title, employee, description, year, quarter, okr_for, start_date, end_date
 		from
 			`tabObjective Key Result`
 		where
-			'{0}' between start_date and end_date
-			and
 			company_objective = 1
 			and
-			okr_for = '{1}'
-	'''
-	result = frappe.db.sql(query.format(getdate(today()), okr_for), as_dict=True)
-	if result:
-		if okr_for == 'Yearly':
-			return result[0].name
+			okr_for = '{0}'
+	'''.format(okr_for)
+
+	if okr_year:
+		if okr_for == 'Quarterly' and not okr_quarter:
+			return False
+		query += " and year = '{0}'".format(okr_year)
+		if okr_quarter:
+			query += " and quarter = '{0}'".format(okr_quarter)
+	else:
+		query += " and '{0}' between start_date and end_date".format(getdate(today()))
+
+	results = frappe.db.sql(query, as_dict=True)
+	if results:
+		if okr_year or okr_for == 'Yearly':
+			return results[0]
 		elif okr_for == 'Quarterly':
-			quarter = get_the_quarter(result[0].start_date, result[0].end_date)
+			quarter = get_the_quarter(results[0].start_date, results[0].end_date)
 			if quarter:
-				for res in result:
-					if res.quarter == quarter:
-						return res.name
-	return ''
+				for result in results:
+					if result.quarter == quarter:
+						return result
+
+	return False
 
 def get_the_quarter(start_date, end_date, date=today()):
 	months_in_qtr = month_diff(end_date, start_date)/4
@@ -127,7 +158,7 @@ def get_the_quarter(start_date, end_date, date=today()):
 def get_company_goal():
 	query = '''
 		select
-			*
+			name, okr_title, employee, description, year, quarter, okr_for, start_date, end_date
 		from
 			`tabObjective Key Result`
 		where
@@ -138,25 +169,27 @@ def get_company_goal():
 		return result[0].name
 	return ""
 
-def get_my_objective():
+def get_my_objective(year=False):
 	employee = frappe.db.get_value('Employee', {'user_id': frappe.session.user})
 	if employee:
 		query = '''
 			select
-				*
+				name, okr_title, employee, description, year, quarter, okr_for, start_date, end_date
 			from
 				`tabObjective Key Result`
 			where
-				'{0}' between start_date and end_date
-				and
-				employee = '{1}'
+				employee = '{0}'
 				and
 				okr_for = "Yearly"
-		'''
-		result = frappe.db.sql(query.format(getdate(today()), employee), as_dict=True)
+		'''.format(employee)
+		if year:
+			query += " and year = '{0}'".format(year)
+		else:
+			query += " and '{0}' between start_date and end_date".format(getdate(today()))
+		result = frappe.db.sql(query, as_dict=True)
 		if result:
-			return result[0].name
-	return ''
+			return result[0]
+	return False
 
 def get_to_do_linked_routine_task():
 	query = '''


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Filter yearly and quarterly OKR that will populate the page header of OWS

## Solution description
- Apply filters to the okr details API
- UI updated with the filter

## Output screenshots (optional)
![Screenshot 2023-05-07 at 12 04 48 AM](https://user-images.githubusercontent.com/20554466/236641348-00be94a6-cc0f-40f5-888a-615fbb9cc973.png)
![Screenshot 2023-05-07 at 12 11 08 AM](https://user-images.githubusercontent.com/20554466/236641382-5b7bd2e1-5bcc-4b44-84a4-f1364fcf77f4.png)
![Screenshot 2023-05-07 at 12 11 22 AM](https://user-images.githubusercontent.com/20554466/236641384-67419605-449d-44a3-880f-4f0a5404aa3d.png)
![Screenshot 2023-05-07 at 12 11 39 AM](https://user-images.githubusercontent.com/20554466/236641386-58f483ec-8b88-4a93-bbaf-15ff916a7d7b.png)

## Areas affected and ensured
- `one_fm/one_fm/page/ows/ows.html`
- `one_fm/one_fm/page/ows/ows.js`
- `one_fm/one_fm/page/ows/ows.py`

## Is there any existing behavior change of other features due to this code change?
Yes, filter for year and quarter applied in OWS

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome