### PR TITLE
feat: Close ERF by Senior Recruiter

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.js
+++ b/one_fm/one_fm/doctype/erf/erf.js
@@ -63,7 +63,8 @@ frappe.ui.form.on('ERF', {
 			}
 		}
 		if (frm.doc.docstatus == 1 && frm.doc.status == "Accepted"){
-			if(frappe.session.user==frm.doc.erf_requested_by || frappe.session.user==frm.doc.recruiter_assigned || frappe.session.user==frm.doc.secondary_recruiter_assigned){
+			const is_senior_recruiter = frappe.user.has_role('Senior Recruiter');
+			if (is_senior_recruiter || [frm.doc.erf_requested_by, frm.doc.recruiter_assigned, frm.doc.secondary_recruiter_assigned].includes(frappe.session.user)) {
 				frm.add_custom_button(__('Close ERF'), () => frm.events.close_erf(frm)).addClass('btn-primary');
 			}
 		}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Senior Recruiter needs to close the ERF on behalf of the  Recruiter assigned to the ERF. So that  the ERF can be closed if the assigned recruiter has left the company or on leave.

## Solution description
- check for the role `Senior Recruiter` and allow the action to close ERF

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.js`

## Is there any existing behavior change of other features due to this code change?
Yes, Senior Recruiter can close the ERF.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome