### PR TITLE
Feat: Make Routine Tasks, Active Repetitive, Personal and Scrum Projects clickable and linked to the document

### DIFF
--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -145,16 +145,16 @@
                                                     <div class="control-value like-disabled-input" > <a href="#" @click.prevent="showTodo(todo.name)">[% todo.name %]</a> </div>
                                                  </div>
                                                 <div class="col-md-2 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p @click.prevent="showTodo(todo.date)">[% todo.date %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p>[% todo.date %]</p></div>
                                                  </div>
                                                  <div class="col-md-3 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(todo.reference_type)">[% todo.reference_type %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p>[% todo.reference_type %]</p></div>
                                                  </div>
                                                  <div class="col-md-2 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(todo.priority)">[% todo.priority %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p>[% todo.priority %]</p></div>
                                                  </div>
                                                  <div class="col-md-3 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(todo.assigned_by)">[% todo.assigned_by %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p>[% todo.assigned_by %]</p></div>
                                                  </div>
 
                                                  <hr>
@@ -202,22 +202,22 @@
                                                         <div class="control-value like-disabled-input" > <a href="#" @click.prevent="showTodo(todo.name)">[% todo.name %]</a></div>
                                                      </div>
                                                     <div class="col-md-2 mb-3 text-center">
-                                                        <div class="control-value like-disabled-input" > <p @click.prevent="showTodo(todo.date)">[% todo.date %]</p></div>
+                                                        <div class="control-value like-disabled-input" > <p>[% todo.date %]</p></div>
 
                                                      </div>
                                                      <div class="col-md-3 mb-3 text-center">
                                                         <div class="control-value like-disabled-input" >
-                                                        <p @click.prevent="showTodo(todo.reference_type)">[% todo.reference_type %]</p>
+                                                        <p>[% todo.reference_type %]</p>
                                                         </div>
                                                      </div>
                                                      <div class="col-md-2 mb-3 text-center">
                                                         <div class="control-value like-disabled-input" >
-                                                        <p @click.prevent="showTodo(todo.priority)">[% todo.priority %]</p>
+                                                        <p>[% todo.priority %]</p>
                                                         </div>
                                                      </div>
                                                      <div class="col-md-3 mb-3 text-center">
                                                         <div class="control-value like-disabled-input" >
-                                                        <p @click.prevent="showTodo(todo.allocated_to)">[% todo.allocated_to %]</p>
+                                                        <p>[% todo.allocated_to %]</p>
                                                         </div>
                                                      </div>
                                                      <hr>

--- a/one_fm/one_fm/page/ows/ows.html
+++ b/one_fm/one_fm/page/ows/ows.html
@@ -41,9 +41,12 @@
                                                       <div class="widget-subtitle"></div>
                                                     </div>
                                                   </div>
-																									<ul>
-			                                                <li v-for="task in routine_tasks"><a href="#" @click.prevent="showTodo(1, task.todo)">[% task.task %]</a></li>
-			                                            </ul>
+                                                  <div v-for="task in routine_tasks">
+                                                    <div class="control-value like-disabled-input" >
+                                                        <a href="#" @click.prevent="showTodo(task.todo)">[% task.task %]</a>
+                                                    </div>
+                                                   
+                                                </div>
                                         </div>
                                         <div class="col-md-3 card border-dark scroll-box" id="box2">
 
@@ -53,9 +56,11 @@
                                                   <div class="widget-subtitle"></div>
                                                 </div>
                                               </div>
-																							<ul>
-	                                                <li v-for="project in active_repetitive_projects"><a href="#" @click.prevent="showTodo(1, project.todo)">[% project.project %]</a></li>
-	                                            </ul>
+													<div v-for="project in active_repetitive_projects">
+                                                        <div class="control-value like-disabled-input">
+                                                            <a href="#" @click.prevent="showTodo(project.todo)">[% project.project %]</a>
+                                                        </div>
+                                                    </div>
                                         </div>
                                         <div class="col-md-3 card border-dark scroll-box" id="box3">
 
@@ -69,9 +74,11 @@
                                                   <div class="widget-subtitle"></div>
                                                 </div>
                                               </div>
-                                            <ul>
-                                                <li v-for="project in personal_projects"><a href="#" @click.prevent="showTodo(1, project.todo)">[% project.project %]</a></li>
-                                            </ul>
+                                            <div v-for="project in personal_projects">
+                                                <div class="control-value like-disabled-input">
+                                                    <a href="#" @click.prevent="showTodo(project.todo)">[% project.project %]</a>
+                                                </div>
+                                            </div>
                                         </div>
                                         <div class="col-md-3 card border-dark scroll-box" id="box4">
 
@@ -81,9 +88,11 @@
                                                   <div class="widget-subtitle"></div>
                                                 </div>
                                               </div>
-                                            <ul>
-                                                <li v-for="project in scrum_projects"><a href="#" @click.prevent="showTodo(1, project.todo)">[% project.project %]</a></li>
-                                            </ul>
+                                            <div v-for="project in scrum_projects">
+                                                <div class="control-value like-disabled-input">
+                                                    <a href="#" @click.prevent="showTodo(project.todo)">[% project.project %]</a>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
 
@@ -133,19 +142,19 @@
 
                                             <div class="form-row" v-for="todo in my_todos">
                                                 <div class="col-md-2 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <a href="#" @click.prevent="showTodo(1, todo.name)">[% todo.name %]</a> </div>
+                                                    <div class="control-value like-disabled-input" > <a href="#" @click.prevent="showTodo(todo.name)">[% todo.name %]</a> </div>
                                                  </div>
                                                 <div class="col-md-2 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p @click.prevent="showTodo(1, todo.date)">[% todo.date %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p @click.prevent="showTodo(todo.date)">[% todo.date %]</p></div>
                                                  </div>
                                                  <div class="col-md-3 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(1, todo.reference_type)">[% todo.reference_type %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(todo.reference_type)">[% todo.reference_type %]</p></div>
                                                  </div>
                                                  <div class="col-md-2 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(1, todo.priority)">[% todo.priority %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(todo.priority)">[% todo.priority %]</p></div>
                                                  </div>
                                                  <div class="col-md-3 mb-3 text-center">
-                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(1, todo.assigned_by)">[% todo.assigned_by %]</p></div>
+                                                    <div class="control-value like-disabled-input" > <p  @click.prevent="showTodo(todo.assigned_by)">[% todo.assigned_by %]</p></div>
                                                  </div>
 
                                                  <hr>
@@ -190,25 +199,25 @@
                                             <!-- <ul> -->
                                                 <div class="form-row" v-for="todo in assigned_todos">
                                                     <div class="col-md-2 mb-3 text-center">
-                                                        <div class="control-value like-disabled-input" > <a href="#" @click.prevent="showTodo(0, todo.name)">[% todo.name %]</a></div>
+                                                        <div class="control-value like-disabled-input" > <a href="#" @click.prevent="showTodo(todo.name)">[% todo.name %]</a></div>
                                                      </div>
                                                     <div class="col-md-2 mb-3 text-center">
-                                                        <div class="control-value like-disabled-input" > <p @click.prevent="showTodo(0, todo.date)">[% todo.date %]</p></div>
+                                                        <div class="control-value like-disabled-input" > <p @click.prevent="showTodo(todo.date)">[% todo.date %]</p></div>
 
                                                      </div>
                                                      <div class="col-md-3 mb-3 text-center">
                                                         <div class="control-value like-disabled-input" >
-                                                        <p @click.prevent="showTodo(0, todo.reference_type)">[% todo.reference_type %]</p>
+                                                        <p @click.prevent="showTodo(todo.reference_type)">[% todo.reference_type %]</p>
                                                         </div>
                                                      </div>
                                                      <div class="col-md-2 mb-3 text-center">
                                                         <div class="control-value like-disabled-input" >
-                                                        <p @click.prevent="showTodo(0, todo.priority)">[% todo.priority %]</p>
+                                                        <p @click.prevent="showTodo(todo.priority)">[% todo.priority %]</p>
                                                         </div>
                                                      </div>
                                                      <div class="col-md-3 mb-3 text-center">
                                                         <div class="control-value like-disabled-input" >
-                                                        <p @click.prevent="showTodo(0, todo.allocated_to)">[% todo.allocated_to %]</p>
+                                                        <p @click.prevent="showTodo(todo.allocated_to)">[% todo.allocated_to %]</p>
                                                         </div>
                                                      </div>
                                                      <hr>

--- a/one_fm/one_fm/page/ows/ows.js
+++ b/one_fm/one_fm/page/ows/ows.js
@@ -26,6 +26,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 						todo_pane: {
 							name: ''
 						},
+						all_todos: [],
 						my_todos: [],
 						assigned_todos: [],
 						scrum_projects: [],
@@ -251,24 +252,14 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 					showTodo(todoType, todoName){
 						// 1 = mytodo, 0 = assigned_todo
 						let me = this;
-						if (todoType==1){
-							let todo = me.my_todos.filter(function(item){
-							 return item.name==todoName;
-							});
-							if (todo.length>0){
-								me.todo_pane = todo[0];
-								me.todo_pane.url = frappe.urllib.get_base_url()+'/app/todo/'+me.todo_pane.name
-							}
-						} else {
-							let todo = me.assigned_todos.filter(function(item){
+						let todo = me.all_todos.filter(function(item){
 							return item.name==todoName;
-							});
-							if (todo.length>0){
-								me.todo_pane = todo[0];
-								me.todo_pane.url = frappe.urllib.get_base_url()+'/app/todo/'+me.todo_pane.name
-							}
-
+						});
+						if (todo.length>0){
+							me.todo_pane = todo[0];
+							me.todo_pane.url = frappe.urllib.get_base_url()+'/app/todo/'+me.todo_pane.name
 						}
+					
 					},
 					loadSpinner(state){
 						if (state==0){

--- a/one_fm/one_fm/page/ows/ows.js
+++ b/one_fm/one_fm/page/ows/ows.js
@@ -212,6 +212,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 									me.company_objective =  res.company_objective ? res.company_objective.name : '';
 									me.company_objective_quarter =  res.company_objective_quarter ? res.company_objective_quarter.name : '';
 									me.my_objective =  res.my_objective ? res.my_objective.name : '';
+									me.all_todos = res.all_todos;
 									me.my_todos = res.my_todos;
 									me.assigned_todos = res.assigned_todos;
 									me.scrum_projects = res.scrum_projects;
@@ -249,7 +250,7 @@ frappe.pages['ows'].on_page_load = function(wrapper) {
 						})
 						$('#okr_quarter').prop('disabled', 'disabled');
 					},
-					showTodo(todoType, todoName){
+					showTodo(todoName){
 						// 1 = mytodo, 0 = assigned_todo
 						let me = this;
 						let todo = me.all_todos.filter(function(item){


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Make Routine Tasks, Active Repetitive tasks, and Personal and scrum Projects to clickable and linked to the document.



## Solution description
- remove listing.
- fetch all todos 
- correct the showTodo function.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)

https://user-images.githubusercontent.com/29017559/236676348-869ee658-02fa-4c12-8370-147af728eb2d.mov



## Areas affected and ensured
- all links are clickable.
- all data fetched correctly.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
