### PR TITLE
Fix: valid_till in Work Permit

### DIFF
--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -289,7 +289,8 @@ class WorkPermit(Document):
                 if employee_document.document_name == 'Work Permit':
                     employee_document.attach = work_permit_attachment
                     employee_document.issued_on = today
-                    valid_till.attach = new_expiry_date
+                    employee_document.valid_till = new_expiry_date
+                    # valid_till.attach = new_expiry_date
                     Find = True
                     break
         if not Find:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Valid till raises an error in work permit because it is non existent variable defined in a loop statement.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
