### PR TITLE
chore: employee okr - quarterly

### DIFF
--- a/one_fm/one_fm/doctype/objective_key_result/objective_key_result.js
+++ b/one_fm/one_fm/doctype/objective_key_result/objective_key_result.js
@@ -15,6 +15,13 @@ frappe.ui.form.on('Objective Key Result', {
 	},
 	end_date: function(frm){
 		set_objective_link(frm);
+	},
+	employee: function(frm) {
+		if(frm.doc.employee){
+			if(!frm.doc.okr_for || frm.doc.okr_for == 'Yearly'){
+				frm.set_value('okr_for', 'Quarterly');
+			}
+		}
 	}
 });
 

--- a/one_fm/one_fm/doctype/objective_key_result/objective_key_result.json
+++ b/one_fm/one_fm/doctype/objective_key_result/objective_key_result.json
@@ -120,7 +120,8 @@
    "fieldtype": "Select",
    "label": "OKR For",
    "mandatory_depends_on": "eval:!doc.is_company_goal",
-   "options": "\nYearly\nQuarterly"
+   "options": "\nYearly\nQuarterly",
+   "read_only_depends_on": "employee"
   },
   {
    "depends_on": "eval:!doc.is_company_goal && doc.okr_for",
@@ -161,7 +162,7 @@
   }
  ],
  "links": [],
- "modified": "2023-05-02 13:17:08.671416",
+ "modified": "2023-05-09 15:18:51.736389",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Objective Key Result",

--- a/one_fm/one_fm/doctype/objective_key_result/objective_key_result.py
+++ b/one_fm/one_fm/doctype/objective_key_result/objective_key_result.py
@@ -13,8 +13,13 @@ from frappe.utils import getdate
 
 class ObjectiveKeyResult(Document):
 	def validate(self):
+		self.validate_employee_okr()
 		self.validate_company_goal()
 		self.validate_okr_with_same_combination()
+
+	def validate_employee_okr(self):
+		if self.employee and self.okr_for != 'Quarterly':
+			frappe.throw(_("Employee can create OKR for Quarterly only"))
 
 	def validate_company_goal(self):
 		if self.is_company_goal:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Set Employee OKR for Quarterly only and fetch it in the OWS for the Quarter

## Solution description
- Validations and field property updated based on employee selection in OKR
- get_okr_details method updated in OWS

## Areas affected and ensured
- `one_fm/one_fm/doctype/objective_key_result/objective_key_result.json`
- `one_fm/one_fm/doctype/objective_key_result/objective_key_result.js`
- `one_fm/one_fm/doctype/objective_key_result/objective_key_result.py`
- `one_fm/one_fm/page/ows/ows.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome