### PR TITLE
Fix: local variable 'workflow_state' referenced before assignment

### DIFF
--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -11,8 +11,9 @@ def sendemail(recipients, subject, header=None, message=None,
 	sender=None, cc=None , attachments=None, delayed=False, args=None, template=None):
 	logo = "https://one-fm.com/files/ONEFM_Identity.png"
 	template = "default_email"
-	actions=pdf_link=""
+	actions=pdf_link=workflow_state=""
 	doc_link = "#"
+	mandatory_field=None
 
 	head = header[0] if header else ""
 	if not message:

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -14,7 +14,7 @@ def sendemail(recipients, subject, header=None, message=None,
 	actions=pdf_link=workflow_state=""
 	doc_link = "#"
 	mandatory_field=None
-
+	print("inMail")
 	head = header[0] if header else ""
 	if not message:
 		message = " "
@@ -30,7 +30,7 @@ def sendemail(recipients, subject, header=None, message=None,
 		pdf_link = args.get("pdf_link")
 		doc_link = args.get("doc_link")
 		workflow_state = args.get("workflow_state")
-		mandatory_field = args.get("mandatory_field")
+		mandatory_field = args.get("mandatory_field")[0]
 
 	if type(recipients) == str:
 		recipients = [recipients]
@@ -57,7 +57,7 @@ def sendemail(recipients, subject, header=None, message=None,
 				pdf_link=pdf_link,
 				doc_link=doc_link,
 				workflow_state=workflow_state,
-				mandatory_field=mandatory_field[0]
+				mandatory_field=mandatory_field
 			),
 			attachments = attachments,
 			delayed=delayed


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- local variable 'workflow_state' referenced before the assignment
- Variable workflow_state, mandatory field needs to be defined.

## Solution description
- Define the variable.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Areas affected and ensured
- Email sent fine. 

## Is there any existing behavior change of other features due to this code change?
- no

## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
