### PR TITLE
hotfix: ows - list index out of range

### DIFF
--- a/one_fm/one_fm/page/ows/ows.py
+++ b/one_fm/one_fm/page/ows/ows.py
@@ -197,11 +197,12 @@ def get_my_objective(year=False, quarter=False):
 		else:
 			query += " and '{0}' between start_date and end_date".format(getdate(today()))
 			results = frappe.db.sql(query, as_dict=True)
-			quarter = get_the_quarter(results[0].start_date, results[0].end_date)
-			if quarter:
-				for result in results:
-					if result.quarter == quarter:
-						return result
+			if results:
+				quarter = get_the_quarter(results[0].start_date, results[0].end_date)
+				if quarter:
+					for result in results:
+						if result.quarter == quarter:
+							return result
 
 		return False
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- OWS page is showing list index out of range issue
<img width="1435" alt="Screen Shot 2023-05-10 at 3 49 41 PM" src="https://github.com/ONE-F-M/One-FM/assets/20554466/7c538c20-b637-48da-9c5c-cb3114fe1d2a">

## Areas affected and ensured
- `one_fm/one_fm/page/ows/ows.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome