### PR TITLE
fix: Project and Site employee validation

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.py
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.py
@@ -66,8 +66,8 @@ class OperationsShift(Document):
 			if employees and len(employees) > 0:
 				msg = "The shift `{0}` is linked with {1} employee(s):<br/>".format(self.name, len(employees))
 				for employee in employees:
-					msg += "<br/>"+employee.name+":"+employee.employee_name
-				msg += '</br></br><a href="{0}/app/employee?shift={1}">click here to view the list</a>'.format(frappe.utils.get_url(), self.name)
+					msg += "<br/>"+"<a href='/app/employee/{0}'>{0}: {1}</a>".format(employee.name, employee.employee_name)
+				msg += '</br></br><a href="/app/employee?status=Active&shift={0}">click here to view the list</a>'.format(self.name)
 				frappe.throw(_("{0}".format(msg)))
 
 	def validate_operations_site_status(self):

--- a/one_fm/operations/doctype/operations_site/operations_site.py
+++ b/one_fm/operations/doctype/operations_site/operations_site.py
@@ -42,14 +42,6 @@ class OperationsSite(Document):
 
 	def update_shift_post_role_status(self):
 		# check if employee in any of the existing site, shift, role, post
-		if self.status=='Active':
-			active_emp_sites = frappe.db.sql(f"""
-				SELECT name FROM tabEmployee WHERE site="{self.name}" AND status='Active'
-			""", as_dict=1)
-			# confirm active employees for site and related shifts
-			if active_emp_sites:
-				frappe.throw(f"There are {len(active_emp_sites)} active employees in site {self.name}")
-			
 		if frappe.db.exists("Operations Shift", {'site':self.name}):
 			frappe.db.sql(f"""
 				UPDATE `tabOperations Shift` set status="{self.status}"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
When project or site is set to inactive, active employees set to both should be validated before disabling. This PR fixes the issue.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
