### PR TITLE
chore: headers to Show Stock Level in RFM items

### DIFF
--- a/one_fm/purchase/doctype/request_for_material/request_for_material.js
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.js
@@ -816,50 +816,63 @@ frappe.ui.form.on("Request for Material Item", {
 					if(r.message && r.message.length > 0){
 						var data = r.message;
 						var $wrapper = dialog.fields_dict.stock_level_html.$wrapper;
-						var template = `{% for d in data %}
-							<div class="dashboard-list-item">
-								<div class="row">
-									<div class="col-sm-3" style="margin-top: 8px;">
-										<a data-type="warehouse" data-name="{{ d.warehouse }}">{{ d.warehouse }}</a>
-									</div>
-									<div class="col-sm-3" style="margin-top: 8px;">
-										{% if show_item %}
-											<a data-type="item"
-												data-name="{{ d.item_code }}">{{ d.item_code }}
-												{% if d.item_name != d.item_code %}({{ d.item_name }}){% endif %}
-											</a>
-										{% endif %}
-									</div>
-									<div class="col-sm-4">
-										<span class="inline-graph">
-											<span class="inline-graph-half" title="{{ __("Reserved Qty") }}">
-												<span class="inline-graph-count">{{ d.total_reserved }}</span>
-												<span class="inline-graph-bar">
-													<span class="inline-graph-bar-inner"
-														style="width: {{ cint(Math.abs(d.total_reserved)/max_count * 100) || 5 }}%">
-													</span>
-												</span>
-											</span>
-											<span class="inline-graph-half" title="{{ __("Actual Qty {0} / Waiting Qty {1}", [d.actual_qty, d.pending_qty]) }}">
-												<span class="inline-graph-count">
-													{{ d.actual_qty }} {{ (d.pending_qty > 0) ? ("(" + d.pending_qty+ ")") : "" }}
-												</span>
-												<span class="inline-graph-bar">
-													<span class="inline-graph-bar-inner dark"
-														style="width: {{ cint(d.actual_qty/max_count * 100) }}%">
-													</span>
-													{% if d.pending_qty > 0 %}
-													<span class="inline-graph-bar-inner" title="{{ __("Projected Qty") }}"
-														style="width: {{ cint(d.pending_qty/max_count * 100) }}%">
-													</span>
-													{% endif %}
-												</span>
-											</span>
-										</span>
-									</div>
+						var template = `
+							<div class="row">
+								<div class="col-sm-3" style="margin-top: 1px;">
+									<b>Warehouse</b>
+								</div>
+								<div class="col-sm-3" style="margin-top: 1px;">
+									<b>Item</b>
+								</div>
+								<div class="col-sm-4" style="margin-top: 1px; text-align: center;">
+									<b>Stock Level</b>
 								</div>
 							</div>
-						{% endfor %}
+							<hr/>
+							{% for d in data %}
+								<div class="dashboard-list-item">
+									<div class="row">
+										<div class="col-sm-3" style="margin-top: 8px;">
+											<a data-type="warehouse" data-name="{{ d.warehouse }}">{{ d.warehouse }}</a>
+										</div>
+										<div class="col-sm-3" style="margin-top: 8px;">
+											{% if show_item %}
+												<a data-type="item"
+													data-name="{{ d.item_code }}">{{ d.item_code }}
+													{% if d.item_name != d.item_code %}({{ d.item_name }}){% endif %}
+												</a>
+											{% endif %}
+										</div>
+										<div class="col-sm-4">
+											<span class="inline-graph">
+												<span class="inline-graph-half" title="{{ __("Reserved Qty") }}">
+													<span class="inline-graph-count">{{ d.total_reserved }}</span>
+													<span class="inline-graph-bar">
+														<span class="inline-graph-bar-inner"
+															style="width: {{ cint(Math.abs(d.total_reserved)/max_count * 100) || 5 }}%">
+														</span>
+													</span>
+												</span>
+												<span class="inline-graph-half" title="{{ __("Actual Qty {0} / Waiting Qty {1}", [d.actual_qty, d.pending_qty]) }}">
+													<span class="inline-graph-count">
+														{{ d.actual_qty }} {{ (d.pending_qty > 0) ? ("(" + d.pending_qty+ ")") : "" }}
+													</span>
+													<span class="inline-graph-bar">
+														<span class="inline-graph-bar-inner dark"
+															style="width: {{ cint(d.actual_qty/max_count * 100) }}%">
+														</span>
+														{% if d.pending_qty > 0 %}
+														<span class="inline-graph-bar-inner" title="{{ __("Projected Qty") }}"
+															style="width: {{ cint(d.pending_qty/max_count * 100) }}%">
+														</span>
+														{% endif %}
+													</span>
+												</span>
+											</span>
+										</div>
+									</div>
+								</div>
+							{% endfor %}
 						`;
 
 						var max_count = 0;


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Headers to Show Stock Level in RFM items

## Solution description
Before the PR
![Screenshot 2023-05-10 at 2 13 09 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/329e78ba-58c5-485b-80e9-76e6860c7ad7)

After the PR
![Screenshot 2023-05-10 at 2 15 30 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/6511f5a3-3e04-42ea-bae4-01bb5b679cb5)

## Areas affected and ensured
-`one_fm/purchase/doctype/request_for_material/request_for_material.js`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome

Let me know, the description help you or not!