### PR TITLE
feat: Rate set before creating the PO in RFP

### DIFF
--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js
@@ -125,6 +125,9 @@ frappe.ui.form.on('Request for Purchase', {
 						message: "Purchase Order Created",
 						indicator: "green"
 					});
+					frappe.set_route('List', 'Purchase Order', {
+						one_fm_request_for_purchase: frm.doc.name
+					})
 				}
 			},
 			freeze: true,
@@ -132,6 +135,16 @@ frappe.ui.form.on('Request for Purchase', {
 		})
 	},
 	make_purchase_order: function(frm) {
+		if(frm.is_dirty()){
+			frappe.throw(__('Please Save the Document and Continue .!'))
+		}
+		var zero_rate_item_in_items_to_order = frm.doc.items_to_order.filter(items_to_order => items_to_order.rate <= 0);
+		var zero_rate_item_idx_in_items_to_order = zero_rate_item_in_items_to_order.map(pt => {return pt.idx}).join(', ');
+		if(zero_rate_item_idx_in_items_to_order && zero_rate_item_idx_in_items_to_order.length > 0) {
+			frm.scroll_to_field('items_to_order');
+			frappe.throw(__("Not able to create PO, because the rates are not set in the `Items to Order` table for rows {0}", [zero_rate_item_idx_in_items_to_order]))
+		}
+
 		var stock_item_in_items_to_order = frm.doc.items_to_order.filter(items_to_order => items_to_order.is_stock_item === 1 && !items_to_order.t_warehouse);
 		var stock_item_code_in_items_to_order = stock_item_in_items_to_order.map(pt => {return pt.item_code}).join(', ');
 		if(stock_item_in_items_to_order && stock_item_in_items_to_order.length > 0 && !frm.doc.warehouse) {

--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
@@ -109,7 +109,7 @@ class RequestforPurchase(Document):
 					wh = item.t_warehouse
 				create_purchase_order(supplier=item.supplier, request_for_purchase=self.name, item_code=item.item_code,
 					qty=item.qty, rate=item.rate, delivery_date=item.delivery_date, uom=item.uom, description=item.description,
-					warehouse=wh, quotation=item.quotation)
+					warehouse=wh, quotation=item.quotation, do_not_submit=True)
 
 	@frappe.whitelist()
 	def accept_approve_reject_request_for_purchase(self, status, approver, accepter, reason_for_rejection=None):
@@ -296,7 +296,5 @@ def create_purchase_order(**args):
 	})
 	if not args.do_not_save:
 		po.save(ignore_permissions=True)
-		# if not args.do_not_submit:
-		# 	po.submit()
-
-	return po
+		if not args.do_not_submit:
+			po.submit()

--- a/one_fm/purchase/doctype/request_for_purchase_quotation_item/request_for_purchase_quotation_item.json
+++ b/one_fm/purchase/doctype/request_for_purchase_quotation_item/request_for_purchase_quotation_item.json
@@ -120,7 +120,6 @@
    "allow_on_submit": 1,
    "fieldname": "quotation",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Quotation",
    "options": "Quotation From Supplier"
   },
@@ -151,8 +150,9 @@
    "allow_on_submit": 1,
    "fieldname": "rate",
    "fieldtype": "Currency",
+   "in_list_view": 1,
    "label": "Rate",
-   "read_only": 1
+   "read_only_depends_on": "quotation"
   },
   {
    "allow_on_submit": 1,
@@ -172,7 +172,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-10-24 14:19:03.611667",
+ "modified": "2023-05-15 19:32:38.049118",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Request for Purchase Quotation Item",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Allow to create PO from RFP only if the rates are set in the items to order

## Solution description
- Client side validations and optimisations

## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/20554466/63965ed1-d41f-4bea-9610-7c59b68eee65

## Areas affected and ensured
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js`
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py`
- `one_fm/purchase/doctype/request_for_purchase_quotation_item/request_for_purchase_quotation_item.json`

## Is there any existing behavior change of other features due to this code change?
Yes, User can create PO from RFP only if rates are set in the Items to order

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome

Let me know, the description help you or not!