### PR TITLE
feat: validate item assigned before create rfp from rfm

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -408,7 +408,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
             new_employees = []
             if employees and len(days_off_dict):
                 for i in employees:
-                    if not (i['date'] in days_off_dict.get(i['employee'])):
+                    if not (i.get('date') in days_off_dict.get(i.get('employee'))):
                         new_employees.append(i)
                 if new_employees:
                     employees = new_employees.copy()

--- a/one_fm/purchase/doctype/request_for_material/request_for_material.py
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.py
@@ -543,6 +543,9 @@ def make_request_for_purchase(source_name, target_doc=None):
 	def update_item(obj, target, source_parent):
 		qty = obj.pur_qty
 		target.qty = qty
+		if not obj.item_code:
+			frappe.throw(_("Please specify the Item Code in each line before you create RFP"))
+
 	doclist = get_mapped_doc("Request for Material", source_name, 	{
 		"Request for Material": {
 			"doctype": "Request for Purchase",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Validate if item is selected in the rfm item lines before creating the rfp

## Solution description
- Add a validation in the rfp creation from rfm

## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/20554466/e5e6437b-f049-4038-b73a-5706ec77a356

## Areas affected and ensured
- `one_fm/purchase/doctype/request_for_material/request_for_material.py`

## Is there any existing behavior change of other features due to this code change?
Yes, RFP can be created from RFM if the item selected in the item lines

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome