### PR TITLE
feat: employee name and id in custom workflow notification details

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -408,7 +408,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
             new_employees = []
             if employees and len(days_off_dict):
                 for i in employees:
-                    if not (i['date'] in days_off_dict.get(i['employee'])):
+                    if not (i.get('date') in days_off_dict.get(i.get('employee'))):
                         new_employees.append(i)
                 if new_employees:
                     employees = new_employees.copy()

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -31,6 +31,7 @@ def sendemail(recipients, subject, header=None, message=None,
 		doc_link = args.get("doc_link")
 		workflow_state = args.get("workflow_state")
 		mandatory_field = args.get("mandatory_field")[0]
+		field_labels = args.get("field_labels")
 
 	if type(recipients) == str:
 		recipients = [recipients]
@@ -57,7 +58,8 @@ def sendemail(recipients, subject, header=None, message=None,
 				pdf_link=pdf_link,
 				doc_link=doc_link,
 				workflow_state=workflow_state,
-				mandatory_field=mandatory_field
+				mandatory_field=mandatory_field,
+				field_labels=field_labels
 			),
 			attachments = attachments,
 			delayed=delayed

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -30,7 +30,7 @@ def sendemail(recipients, subject, header=None, message=None,
 		pdf_link = args.get("pdf_link")
 		doc_link = args.get("doc_link")
 		workflow_state = args.get("workflow_state")
-		mandatory_field = args.get("mandatory_field")[0]
+		mandatory_field = args.get("mandatory_field")
 		field_labels = args.get("field_labels")
 
 	if type(recipients) == str:

--- a/one_fm/templates/emails/default_email_with_workflow.html
+++ b/one_fm/templates/emails/default_email_with_workflow.html
@@ -9,17 +9,17 @@
     }
 </style>
 <div style="background-color: #f9fafa;border-radius: 2vw;padding: 2vh;">
-	<div style="text-align: center;padding: 5px 10px"> 
+	<div style="text-align: center;padding: 5px 10px">
         <img class="brand_logo" src={{logo}}/>
     </div>
     <div style="background-color:white;padding: 3vw;border-radius: 8px;">
-        <div style="padding: 2vh;"> 
-             
-            {% if header is not none %}   
-             <h2 style="text-align: center;"> {{header}} </h2>
-            {% endif %} 
+        <div style="padding: 2vh;">
 
-            {% if actions is not none %} 
+            {% if header is not none %}
+             <h2 style="text-align: center;"> {{header}} </h2>
+            {% endif %}
+
+            {% if actions is not none %}
                 <p>
                     Here is to inform you that the following {{ reference_doctype }} requires your attention/action.<br>
                     {% if mandatory_field is not none %}
@@ -33,9 +33,9 @@
                             </tr>
                         </thead>
                         <tbody>
-                        {% for m in mandatory_field %} 
+                        {% for m in mandatory_field %}
                             <tr>
-                                <td style="padding: 10px;">{{ m }}</td> 
+                                <td style="padding: 10px;">{{ field_labels[m] }}</td>
                                 <td style="padding: 10px;">{{ mandatory_field[m] }}</td>
                             </tr>
                         {% endfor %}
@@ -45,25 +45,25 @@
                     <br>
                     The link to the document is  <a target="_blank" class="underline" href="{{ doc_link }}"> {{reference_name}}</a> <br>
                     Please take your action for document using the action button below.<br>
-                </p>           
-                {% for action in actions %}      
+                </p>
+                {% for action in actions %}
                     <a href="{{ action.action_link }}" class="btn btn-primary btn-action">{{ action.action_name }}</a>
                 {% endfor %}
                 <a href="/" class="btn btn-secondary btn-action">Cancel</a>
-            {% endif %} 
+            {% endif %}
 
-            {% if content is not none %}   
+            {% if content is not none %}
                 {{ content }}
             {% endif %}
         </div>
-       
+
         <div class="email-signature">
             <h5 style="margin-bottom: 0px;">Yours, One Facility Management</h5>
             <a href="mailto:support@one-fm.com">support@one-fm.com</a>
         </div>
         <hr>
         <div >
-            
+
             <div style="display:block;text-align: center;">
                 <div style="color: #454a4a;  ">
                     <h4 style="margin: 0;">Address: 
@@ -79,9 +79,9 @@
                 </div>
             </div>
             <p style="color:#a8b0b0 ;">The content of this email is confidential and intended for the recipient
-            specified in the message only. It is strictly forbidden to share any part of this message 
-            with any third party, without the written consent of the sender. If you received this message by 
-            mistake, please reply to this message and follow with its deletion, so that we can ensure such 
+            specified in the message only. It is strictly forbidden to share any part of this message
+            with any third party, without the written consent of the sender. If you received this message by
+            mistake, please reply to this message and follow with its deletion, so that we can ensure such
             a mistake does not occur in the future.</p>
         </div>
 	</div>


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Employee name and id in custom workflow notification details
- Set  field label instead field name in details to improve the readability of notification

## Solution description
- To set label in the notification details send the labels to the template
- If employee field is in the document then, find employee id and name and set the value to employee field

## Output screenshots (optional)
Before PR(field name)
![Screenshot 2023-05-18 at 12 12 34 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/38c4e78b-0a3a-4781-a2cb-84cd97533314)

After PR(field label)
![Screenshot 2023-05-18 at 12 12 54 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/5e09c845-03ce-4fdd-8988-6dded93cd94f)

Employee details
![Screenshot 2023-05-19 at 10 58 19 AM](https://github.com/ONE-F-M/One-FM/assets/20554466/a000c668-6fe9-4d6e-98dc-04396930c97b)


## Areas affected and ensured
- `one_fm/processor.py`
- `one_fm/templates/emails/default_email_with_workflow.html`
- `one_fm/utils.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
