### PR TITLE
hot fix: rfm approver for type department

### DIFF
--- a/one_fm/purchase/doctype/request_for_material/request_for_material.py
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.py
@@ -181,6 +181,9 @@ class RequestforMaterial(BuyingController):
 					'description': _('{0}: Request for Material by {1}'.format(self.workflow_state, get_fullname(self.request_for_material_approver)))
 				})
 				self.add_comment("Comment", _("Assign to Warehouse Supervisor {0} to process the request".format(filtered_users[0])))
+			else:
+				frappe.msgprint(_("Not able to find user with role Warehouse Supervisor to assign this RFM"), alert=True)
+				self.add_comment("Comment", _("On Approval, not able to find user with role Warehouse Supervisor to assign this RFM"))
 		except DuplicateToDoError:
 			frappe.message_log.pop()
 			pass

--- a/one_fm/purchase/doctype/request_for_material/request_for_material.py
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.py
@@ -122,7 +122,7 @@ class RequestforMaterial(BuyingController):
 			approver = False
 			if self.type == 'Project' and self.project:
 				approver = frappe.db.get_value('Project', self.project, 'account_manager')
-			elif self.type == 'Individual' and self.employee:
+			elif self.type in ['Individual', 'Department'] and self.employee:
 				approver = frappe.db.get_value('Employee', self.employee, 'reports_to')
 			elif self.type == 'Onboarding':
 				employee = frappe.db.exists("Employee", {'user_id': self.owner})


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- RFM is not fetching approver as reports to for type Department
- RFM is not showing any notification to the user about the warehouse supervisor assignment 

## Solution description
- Type Department add to the condition for fetching the reports to
- Add comments and message to the user about the assignment

## Output screenshots (optional)
![Screenshot 2023-05-19 at 1 47 25 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/8e6b91c3-ed4b-4d25-80a9-d9a663decd4f)
![Screenshot 2023-05-19 at 1 51 02 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/9f31b23d-f41c-4ba9-bedd-94ae0f03d0db)

## Areas affected and ensured
- `one_fm/purchase/doctype/request_for_material/request_for_material.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome