### PR TITLE
Feat: Create Pending Salary Slip 

### DIFF
--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -627,28 +627,13 @@ def create_salary_slips(doc):
 	doc.check_permission("write")
 	employees = [emp.employee for emp in doc.employees]
 	if employees:
-		args = frappe._dict(
-			{
-				"salary_slip_based_on_timesheet": doc.salary_slip_based_on_timesheet,
-				"payroll_frequency": doc.payroll_frequency,
-				"company": doc.company,
-				"start_date": doc.start_date,
-				"end_date": doc.end_date,
-				"posting_date": doc.posting_date,
-				"deduct_tax_for_unclaimed_employee_benefits": doc.deduct_tax_for_unclaimed_employee_benefits,
-				"deduct_tax_for_unsubmitted_tax_exemption_proof": doc.deduct_tax_for_unsubmitted_tax_exemption_proof,
-				"payroll_entry": doc.name,
-				"exchange_rate": doc.exchange_rate,
-				"currency": doc.currency,
-			}
-		)
 
 		if len(employees) > 30 or frappe.flags.enqueue_payroll_entry:
 			doc.db_set("status", "Queued")
 			frappe.enqueue(
 				create_salary_slips_for_employees,
 				employees=employees,
-				args=args,
+				payroll_entry=doc,
 				publish_progress=False,
 				timeout=6000,
 				queue='long'
@@ -659,7 +644,7 @@ def create_salary_slips(doc):
 				indicator="blue",
 			)
 		else:
-			create_salary_slips_for_employees(employees, args, publish_progress=False)
+			create_salary_slips_for_employees(employees, doc, publish_progress=False)
 			# since this method is called via frm.call this doc needs to be updated manually
 			doc.reload()
 
@@ -680,16 +665,25 @@ def log_payroll_failure(process, payroll_entry, error):
 
 	payroll_entry.db_set({"error_message": error_message, "status": "Failed"})
 
-def create_salary_slips_for_employees(employees, args, publish_progress=True ):
+def create_salary_slips_for_employees(employees, payroll_entry, publish_progress=True ):
 	try:
-		payroll_entry = frappe.get_doc("Payroll Entry", args.payroll_entry)
+		payroll_entry = frappe.get_doc("Payroll Entry", payroll_entry.name)
+		args = frappe._dict(
+			{
+				"salary_slip_based_on_timesheet": payroll_entry.salary_slip_based_on_timesheet,
+				"payroll_frequency": payroll_entry.payroll_frequency,
+				"company": payroll_entry.company,
+				"posting_date": payroll_entry.posting_date,
+				"deduct_tax_for_unclaimed_employee_benefits": payroll_entry.deduct_tax_for_unclaimed_employee_benefits,
+				"deduct_tax_for_unsubmitted_tax_exemption_proof": payroll_entry.deduct_tax_for_unsubmitted_tax_exemption_proof,
+				"exchange_rate": payroll_entry.exchange_rate,
+				"currency": payroll_entry.currency,
+			}
+		)
 		salary_slips_exist_for = get_existing_salary_slips(employees, args)
 		count = 0
-		start_date = args.start_date
-		end_date = args.end_date
-
-		args.pop('start_date')
-		args.pop('end_date')
+		start_date = payroll_entry.start_date
+		end_date = payroll_entry.end_date
 		salary_slip_chunk = []
 		chunk_counter = 0
 
@@ -728,8 +722,6 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True ):
 				frappe.enqueue(create_salary_slip_chunk,slips=salary_slip_chunk, queue="long")
 
 
-		payroll_entry.db_set({"status": "Submitted", "salary_slips_created": 1, "error_message": ""})
-
 		if salary_slips_exist_for:
 			frappe.msgprint(
 				_(
@@ -751,6 +743,47 @@ def create_salary_slip_chunk(slips):
 	for slip in slips:
 		slip.insert()
 		slip.save()
+
+@frappe.whitelist()
+def check_salary_slip_count(doc):
+	payroll_entry = frappe.get_doc("Payroll Entry", doc)
+	salary_count = frappe.db.count("Salary Slip", {"payroll_entry":payroll_entry.name})
+	if salary_count != payroll_entry.number_of_employees:
+		payroll_entry.db_set({"status": "Pending Salary Slip", "salary_slips_created": 0, "error_message": ""})
+		return False
+	payroll_entry.db_set({"status": "Submitted", "salary_slips_created": 1, "error_message": ""})
+	frappe.db.commit()
+	payroll_entry.reload()
+	return True
+
+@frappe.whitelist()
+def create_pending_sal_slip(doc):
+	payroll_entry = frappe.get_doc("Payroll Entry", doc)
+	pe_employees = [emp.employee for emp in payroll_entry.employees]
+	ss_employees = [emp.employee for emp in frappe.get_list("Salary Slip", {"payroll_entry":payroll_entry.name}, ['employee'])]
+	employees = [e for e in pe_employees if e not in ss_employees]
+	
+	if len(employees) > 30 or frappe.flags.enqueue_payroll_entry:
+		payroll_entry.db_set("status", "Queued")
+		frappe.enqueue(
+			create_salary_slips_for_employees,
+			employees=employees,
+			payroll_entry=payroll_entry,
+			publish_progress=False,
+			timeout=6000,
+			queue='long'
+		)
+		frappe.msgprint(
+			_("Salary Slip creation is queued. It may take a few minutes"),
+			alert=True,
+			indicator="blue",
+		)
+	else:
+		create_salary_slips_for_employees(employees, payroll_entry, publish_progress=False)
+		# since this method is called via frm.call this doc needs to be updated manually
+		doc.reload()
+	return True
+
 
 def get_existing_salary_slips(employees, args):
 	return frappe.db.sql_list(

--- a/one_fm/public/js/doctype_js/payroll_entry.js
+++ b/one_fm/public/js/doctype_js/payroll_entry.js
@@ -1,5 +1,16 @@
 frappe.ui.form.on('Payroll Entry', {
+	// onload: function(frm){
+	// 	check_salary_slip_counts(frm)
+	// },
     refresh: function(frm) {
+		if(!frm.is_new() && frm.doc.salary_slips_created == 1){
+			check_salary_slip_counts(frm)
+		}
+		if (frm.doc.status == "Pending Salary Slip"){
+			frm.add_custom_button(__("Create Pending Salary Slip"), function() {
+				frm.trigger("create_pending_salary_slip");
+			}).addClass("btn-warning");
+		}
 		if (frm.doc.salary_slips_created == 1 && frm.doc.bank_account){
 			frm.add_custom_button(__("Download Payroll Bank Export"), function() {
 				let payroll_entry = frm.doc.name
@@ -15,5 +26,36 @@ frappe.ui.form.on('Payroll Entry', {
 					return (doc.justification_needed_on_deduction == 1) ? "orange" : "green";
 				}
 		);
-    }
+    },
+	create_pending_salary_slip: function(frm){
+		create_sal_slip(frm)
+	}
 });
+var check_salary_slip_counts = function(frm){
+	frappe.call({
+		method: 'one_fm.api.doc_methods.payroll_entry.check_salary_slip_count',
+		args: {
+			doc: frm.doc.name
+		},
+		callback: function (r) {
+			if(r.message){
+				console.log(r.message)
+			}
+		},
+	});
+}
+
+var create_sal_slip = function(frm){
+	frappe.call({
+		method: 'one_fm.api.doc_methods.payroll_entry.create_pending_sal_slip',
+		args: {
+			doc: frm.doc.name
+		},
+		callback: function (r) {
+			if(r.message){
+				console.log(r.message)
+				frm.refresh();
+			}
+		},
+	});
+}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
- Have a Button to click and create a pending Salary Slip.

## Solution description
- Check if the no. of the employee in the salary slip is equal to the salary slip created.
- change the status of the salary slip pending.
- Button created if the status is Pending Salary Slip.
- use create_salary_slip_for_employee to create a salary slip.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
<img width="1311" alt="Screen Shot 2023-05-22 at 8 50 35 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/7207cb27-1434-4a5a-b921-63e331e84a19">


## Areas affected and ensured
- A button added.
- A status added.
- Action to create Salary Slip Added.

## Is there any existing behavior change of other features due to this code change?
- No.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
