### PR TITLE
feat: override frappe send_workflow_action_email

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -27,10 +27,12 @@ from hrms.overrides.employee_master import EmployeeMaster,validate_onboarding_pr
 from one_fm.overrides.employee import EmployeeOverride
 from frappe.email.doctype.email_queue.email_queue import QueueBuilder,SendMailContext
 from one_fm.overrides.email_queue import prepare_email_content as email_content,get_unsubscribe_str_
+from frappe.workflow.doctype.workflow_action import workflow_action
+from one_fm.utils import override_frappe_send_workflow_action_email
 
 __version__ = '14.3.0'
 
-
+workflow_action.send_workflow_action_email = override_frappe_send_workflow_action_email
 SendMailContext.get_unsubscribe_str = get_unsubscribe_str_
 QueueBuilder.prepare_email_content  = email_content
 EmployeeMaster.validate = EmployeeOverride.validate

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -13,7 +13,8 @@ def sendemail(recipients, subject, header=None, message=None,
 	template = "default_email"
 	actions=pdf_link=workflow_state=""
 	doc_link = "#"
-	mandatory_field=None
+	mandatory_field = None
+	field_labels = None
 	print("inMail")
 	head = header[0] if header else ""
 	if not message:

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2501,6 +2501,13 @@ def get_users_next_action_data(transitions, doc, recipients):
 			)
 	return user_data_map
 
+def override_frappe_send_workflow_action_email(users_data, doc):
+	recipients = []
+	for d in users_data:
+		recipients.append(d.get("email"))
+	if recipients:
+		send_workflow_action_email(doc, recipients)
+
 @frappe.whitelist()
 def send_workflow_action_email(doc, recipients):
     queue_send_workflow_action_email(doc=doc, recipients=recipients)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Override frappe send_workflow_action_email to make a standard between the custom and core workflow notification
- Issue fix in send email method - field_labels referenced before assignment

## Solution description
- Override the method in init
`from frappe.workflow.doctype.workflow_action import workflow_action
from one_fm.utils import override_frappe_send_workflow_action_email`
`workflow_action.send_workflow_action_email = override_frappe_send_workflow_action_email`

## Areas affected and ensured
- `one_fm/__init__.py`
- `one_fm/utils.py`
- `one_fm/processor.py`


## Is there any existing behavior change of other features due to this code change?
Yes, workflow notifications are standardised with respect to onefm custom workflow notification.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome