### PR TITLE
feat: RFP - Workflow Update

### DIFF
--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -5233,7 +5233,7 @@
   "doctype": "Workflow",
   "document_type": "Contracts",
   "is_active": 1,
-  "modified": "2023-05-22 08:14:42.898973",
+  "modified": "2023-05-25 07:45:57.383215",
   "name": "Contracts",
   "override_status": 0,
   "send_email_alert": 0,
@@ -6016,107 +6016,6 @@
    }
   ],
   "workflow_name": "Employee Checkin Issue",
-  "workflow_state_field": "workflow_state"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow",
-  "document_type": "Request for Purchase",
-  "is_active": 1,
-  "modified": "2023-05-22 14:42:02.493687",
-  "name": "RFP",
-  "override_status": 0,
-  "send_email_alert": 0,
-  "states": [
-   {
-    "allow_edit": "Warehouse Supervisor",
-    "doc_status": "1",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": null,
-    "parent": "RFP",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Submit to Purchase Officer",
-    "update_field": "",
-    "update_value": ""
-   },
-   {
-    "allow_edit": "Purchase Officer",
-    "doc_status": "1",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": null,
-    "parent": "RFP",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Pending Approval",
-    "update_field": "",
-    "update_value": ""
-   },
-   {
-    "allow_edit": "Purchase Manager",
-    "doc_status": "1",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": null,
-    "parent": "RFP",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Approved",
-    "update_field": "status",
-    "update_value": "Approved"
-   },
-   {
-    "allow_edit": "Purchase Manager",
-    "doc_status": "2",
-    "is_optional_state": 0,
-    "message": null,
-    "next_action_email_template": null,
-    "parent": "RFP",
-    "parentfield": "states",
-    "parenttype": "Workflow",
-    "state": "Rejected",
-    "update_field": "status",
-    "update_value": "Rjected"
-   }
-  ],
-  "transitions": [
-   {
-    "action": "Submit for Approval",
-    "allow_self_approval": 1,
-    "allowed": "Purchase Officer",
-    "condition": null,
-    "next_state": "Pending Approval",
-    "parent": "RFP",
-    "parentfield": "transitions",
-    "parenttype": "Workflow",
-    "state": "Submit to Purchase Officer"
-   },
-   {
-    "action": "Approve",
-    "allow_self_approval": 1,
-    "allowed": "Purchase Manager",
-    "condition": null,
-    "next_state": "Approved",
-    "parent": "RFP",
-    "parentfield": "transitions",
-    "parenttype": "Workflow",
-    "state": "Pending Approval"
-   },
-   {
-    "action": "Reject",
-    "allow_self_approval": 1,
-    "allowed": "Purchase Manager",
-    "condition": null,
-    "next_state": "Rejected",
-    "parent": "RFP",
-    "parentfield": "transitions",
-    "parenttype": "Workflow",
-    "state": "Pending Approval"
-   }
-  ],
-  "workflow_name": "RFP",
   "workflow_state_field": "workflow_state"
  }
 ]

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -699,13 +699,6 @@ scheduler_events = {
 
 fixtures = [
 	{
-		# "dt": "Custom Field",
-		# 'filters': [['dt', 'in', ['Shift Request', 'Shift Permission', 'Employee', 'Project', 'Location', 'Employee Checkin', 'Shift Assignment', 'Shift Type', 'Operations Site']]]
-	},
-	{
-		"dt": "Property Setter"
-	},
-	{
 		"dt": "Workflow State"
 	},
 	{
@@ -715,21 +708,9 @@ fixtures = [
 		"dt": "Workflow"
 	},
 	{
-		"dt": "Client Script",
-		'filters': [['dt', 'in', ['Stock Entry', 'Warehouse',
-		'Payment Entry', 'Payment Request', 'Purchase Receipt', 'Purchase Order']]]
-	},
-	{
-		"dt": "Print Format"
-	},
-	{
 		"dt": "Role",
 		"filters": [["name", "in",["Operations Manager", "Shift Supervisor", "Site Supervisor", "Projects Manager"]]]
 	},
-	# {
-	# 	"dt": "Custom DocPerm",
-	# 	"filters": [["role", "in",["Operations Manager", "Shift Supervisor", "Site Supervisor", "Projects Manager"]]]
-	# },
 	{
 		"dt": "Email Template"
 	},

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -34,3 +34,4 @@ one_fm.patches.v14_0.fix_leave_application_attachments
 one_fm.patches.v14_0.approve_all_time_sheets
 one_fm.patches.v14_0.update_leave_application_status_to_approved
 #one_fm.patches.v14_0.update_operations_status
+one_fm.patches.v14_0.remove_rfp_workflow

--- a/one_fm/patches/v14_0/remove_rfp_workflow.py
+++ b/one_fm/patches/v14_0/remove_rfp_workflow.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+	if frappe.db.exists('Workflow', {'name': 'RFP', 'document_type': 'Request for Purchase'}):
+		frappe.delete_doc("Workflow", 'RFP')

--- a/one_fm/purchase/doctype/purchase_settings/purchase_settings.json
+++ b/one_fm/purchase/doctype/purchase_settings/purchase_settings.json
@@ -7,10 +7,7 @@
  "field_order": [
   "request_for_material_section",
   "request_for_material_accepter",
-  "request_for_material_approver",
-  "request_for_purchase_section",
-  "request_for_purchase_accepter",
-  "request_for_purchase_approver"
+  "request_for_material_approver"
  ],
  "fields": [
   {
@@ -22,7 +19,7 @@
    "fieldname": "request_for_material_approver",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Request for Material Approver",
+   "label": "Default RFM Approver",
    "options": "User",
    "reqd": 1
   },
@@ -30,33 +27,14 @@
    "fieldname": "request_for_material_accepter",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Request for Material Accepter",
-   "options": "User",
-   "reqd": 1
-  },
-  {
-   "fieldname": "request_for_purchase_section",
-   "fieldtype": "Section Break",
-   "label": "Request for Purchase"
-  },
-  {
-   "fieldname": "request_for_purchase_accepter",
-   "fieldtype": "Link",
-   "label": "Request for Purchase Accepter",
-   "options": "User",
-   "reqd": 1
-  },
-  {
-   "fieldname": "request_for_purchase_approver",
-   "fieldtype": "Link",
-   "label": "Request for Purchase Approver",
+   "label": "Default RFM Accepter",
    "options": "User",
    "reqd": 1
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-05-14 08:16:36.618318",
+ "modified": "2023-05-25 07:20:12.938845",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Purchase Settings",

--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js
@@ -2,46 +2,29 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Request for Purchase', {
-	before_workflow_action: function(frm){
-		if(frm.doc.workflow_state == 'Submit to Purchase Officer' && frm.doc.items_to_order.length <= 0){
-			frm.scroll_to_field('items_to_order');
-		}
-	},
 	refresh: function(frm) {
 		set_intro_related_to_status(frm);
 		frm.events.make_custom_buttons(frm);
-		if(!frm.doc.approver || (frm.doc.approver != frm.doc.__onload.approver)){
-			frm.set_value('approver', frm.doc.__onload.approver);
-		}
-		if(!frm.doc.accepter || (frm.doc.accepter != frm.doc.__onload.accepter)){
-			frm.set_value('accepter', frm.doc.__onload.accepter);
-		}
-	},
-	status: function(frm) {
-		if(frm.doc.status && frm.doc.status == 'Rejected'){
-			frm.set_df_property('reason_for_rejection', 'reqd', true);
-		}
-		else{
-			frm.set_df_property('reason_for_rejection', 'reqd', false);
-		}
 	},
 	make_custom_buttons: function(frm) {
-		if (frm.doc.docstatus == 1){
-			if(frm.doc.status == 'Draft') {
-				if(frm.doc.items.length > frm.doc.items_to_order.length && !frm.doc.notified_the_rfm_requester){
-					frm.add_custom_button(__("Notify the Requester"),
-						() => frm.events.notify_the_rfm_requester(frm));
-				}
-				frm.add_custom_button(__("Request for Quotation"),
-					() => frm.events.make_request_for_quotation(frm), __('Create'));
+		if (frm.doc.docstatus == 1 && frappe.user.has_role('Purchase Officer')){
+			if(frm.doc.items.length > frm.doc.items_to_order.length && !frm.doc.notified_the_rfm_requester){
+				frm.add_custom_button(__("Notify the Requester"),
+					() => frm.events.notify_the_rfm_requester(frm));
+			}
 
+			frm.add_custom_button(__("Create Request for Quotation"),
+				() => frm.events.make_request_for_quotation(frm), __('Actions'));
+
+			if(frm.doc.__onload.exists_qfs){
 				frm.add_custom_button(__("Compare Quotations"),
-					() => frm.events.make_quotation_comparison_sheet(frm));
+					() => frm.events.make_quotation_comparison_sheet(frm), __('Actions'));
 			}
-			if(frm.doc.status == 'Approved'){
-				frm.add_custom_button(__("Purchase Order"),
-					() => frm.events.make_purchase_order(frm), __('Create'));
-			}
+
+			frm.add_custom_button(__("Create Purchase Order"),
+				() => frm.events.make_purchase_order(frm), __('Actions'));
+
+			frm.page.set_inner_btn_group_as_primary(__('Actions'));
 		}
 	},
 	make_request_for_quotation: function(frm) {
@@ -94,11 +77,15 @@ frappe.ui.form.on('Request for Purchase', {
 		if(frm.is_dirty()){
 			frappe.throw(__('Please Save the Document and Continue .!'))
 		}
-		var zero_rate_item_in_items_to_order = frm.doc.items_to_order.filter(items_to_order => items_to_order.rate <= 0);
-		var zero_rate_item_idx_in_items_to_order = zero_rate_item_in_items_to_order.map(pt => {return pt.idx}).join(', ');
-		if(zero_rate_item_idx_in_items_to_order && zero_rate_item_idx_in_items_to_order.length > 0) {
+		if(frm.doc.items_to_order.length <= 0){
 			frm.scroll_to_field('items_to_order');
-			frappe.throw(__("Not able to create PO, because the rates are not set in the `Items to Order` table for rows {0}", [zero_rate_item_idx_in_items_to_order]))
+			frappe.throw(__("Fill Items to Order to Create Purchase Order"))
+		}
+		var mandatory_fields_not_set_for_po = frm.doc.items_to_order.filter(items_to_order => (items_to_order.rate <= 0 || !items_to_order.item_code || !items_to_order.supplier));
+		var idx_mandatory_fields_not_set_for_po = mandatory_fields_not_set_for_po.map(pt => {return pt.idx}).join(', ');
+		if(idx_mandatory_fields_not_set_for_po && idx_mandatory_fields_not_set_for_po.length > 0) {
+			frm.scroll_to_field('items_to_order');
+			frappe.throw(__("Not able to create PO, Set Item Code/Supplier/Rate in <b>Items to Order</b> rows {0}", [idx_mandatory_fields_not_set_for_po]))
 		}
 
 		var stock_item_in_items_to_order = frm.doc.items_to_order.filter(items_to_order => items_to_order.is_stock_item === 1 && !items_to_order.t_warehouse);
@@ -140,34 +127,14 @@ frappe.ui.form.on('Request for Purchase', {
 });
 
 var set_intro_related_to_status = function(frm) {
-	if(frm.doc.docstatus == 0){
-		frm.set_intro("")
-		frm.set_intro(__("Submit the document to confirm and notify the Purchase Manager"), 'blue');
-	}
 	if (frm.doc.docstatus == 1){
-		if(frm.doc.status == 'Draft') {
-			frm.set_intro(__("Create Request for Quotation (Optional)."), 'yellow');
-			frm.set_intro(__("Compare Quotations if Quotaiton Available (Optional)."), 'yellow');
-			if((frm.doc.items_to_order && frm.doc.items_to_order.length == 0) || !frm.doc.items_to_order){
-				frm.set_intro(__("Fill Items to Order - Check Supplier and Item Code set Correctly."), 'yellow');
-			}
-			frm.set_intro(__("Click `Confirm Item Details and Send for Approval` Button"), 'yellow');
-			frm.set_intro(__("On Approval, Requester can create PO from the create dropdown button"), 'yellow');
+		frm.set_intro(__("Create Request for Quotation (Optional) from the Actions dropdown"), 'yellow');
+		frm.set_intro(__("Create Quotation from Supplier (Optional) from the Request for Quotation"), 'yellow');
+		frm.set_intro(__("Compare Quotations if Quotaiton Available (Optional) from the Actions dropdown"), 'yellow');
+		if((frm.doc.items_to_order && frm.doc.items_to_order.length == 0) || !frm.doc.items_to_order){
+			frm.set_intro(__("Fill Items to Order - Check Supplier, Item Code and Rate set Correctly."), 'yellow');
 		}
-		if(frm.doc.status == "Draft Request"){
-			frm.set_intro(__("On Accept notify Approver"), 'yellow');
-			frm.set_intro(__("On Approval, Requester can create PO from the create dropdown button"), 'yellow');
-		}
-		if(frm.doc.status == "Accepted"){
-			frm.set_intro(__("On Approval, Requester can create PO from the create dropdown button"), 'yellow');
-		}
-		if(frm.doc.status == 'Approved'){
-			frappe.db.get_value("Purchase Order", {"one_fm_request_for_purchase": frm.doc.name}, "name", function(r) {
-				if(!r || !r.name){
-					frm.set_intro(__("Requester can create PO"), 'yellow');
-				}
-			})
-		}
+		frm.set_intro(__("Purchase Officer can Create Purchase Order from the Actions dropdown"), 'yellow');
 	}
 };
 

--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.json
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.json
@@ -17,8 +17,6 @@
   "request_for_material",
   "notified_the_rfm_requester",
   "type",
-  "accepter",
-  "approver",
   "section_break_5",
   "requested_by",
   "employee",
@@ -230,23 +228,6 @@
   },
   {
    "allow_on_submit": 1,
-   "fieldname": "accepter",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Accepter",
-   "options": "User",
-   "read_only": 1
-  },
-  {
-   "allow_on_submit": 1,
-   "fieldname": "approver",
-   "fieldtype": "Link",
-   "label": "Approver",
-   "options": "User",
-   "read_only": 1
-  },
-  {
-   "allow_on_submit": 1,
    "depends_on": "eval:doc.docstatus == 1",
    "fieldname": "supplier",
    "fieldtype": "Link",
@@ -280,7 +261,7 @@
  "icon": "fa fa-shopping-cart",
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-14 08:28:11.632485",
+ "modified": "2023-05-25 07:18:24.470556",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Request for Purchase",

--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
@@ -13,38 +13,16 @@ from frappe.utils.user import get_users_with_role
 from frappe.permissions import has_permission
 from one_fm.api.doc_events import get_employee_user_id
 from frappe.desk.form.assign_to import add as add_assignment, DuplicateToDoError
-from one_fm.utils import send_workflow_action_email, get_users_with_role_permitted_to_doctype
+from one_fm.utils import get_users_with_role_permitted_to_doctype
 
 class RequestforPurchase(Document):
 	def onload(self):
-		self.get_accepter_and_approver()
-
-	def validate(self):
-		accepter, approver = self.get_accepter_and_approver()
-		if not self.approver:
-			self.approver = approver
-		if not self.accepter:
-			self.accepter = accepter
-
-	def get_accepter_and_approver(self):
-		accepter = frappe.db.get_value('Purchase Settings', None, 'request_for_purchase_accepter')
-		approver = frappe.db.get_value('Purchase Settings', None, 'request_for_purchase_approver')
-		reports_to = False
-		if self.type == 'Project' and self.project:
-			reports_to = frappe.db.get_value('Project', self.project, 'account_manager')
-		elif self.employee:
-			reports_to = frappe.db.get_value('Employee', self.employee, 'reports_to')
-		if reports_to:
-			approver = get_employee_user_id(reports_to)
-			if approver:
-				accepter = approver
-		self.set_onload('accepter', accepter)
-		self.set_onload('approver', approver)
-		return accepter, approver
+		self.set_onload('exists_qfs', False)
+		if frappe.db.get_value('Quotation from Supplier', {'request_for_purchase': self.name}, 'name'):
+			self.set_onload('exists_qfs', True)
 
 	def on_submit(self):
-		if self.workflow_state == 'Submit to Purchase Officer':
-			self.assign_purchase_officer()
+		self.assign_purchase_officer()
 
 	def assign_purchase_officer(self):
 		purchase_officers = get_users_with_role_permitted_to_doctype('Purchase Officer', self.doctype)
@@ -64,45 +42,16 @@ class RequestforPurchase(Document):
 				)
 			})
 
-	def on_update_after_submit(self):
-		if self.workflow_state == 'Pending Approval':
-			self.validate_items_to_order()
-			purchase_managers = get_users_with_role_permitted_to_doctype('Purchase Manager', self.doctype)
-			if purchase_managers:
-				send_workflow_action_email(self, purchase_managers)
-			else:
-				self.add_comment("Comment", _("Not able to send workflow action to Purchase Manager, because there is no user with role <b>Purchase Manager</b>"))
-
-		if self.workflow_state in ['Approved', 'Rejected']:
-			self.notify_purchase_officer()
-
-	def notify_purchase_officer(self):
-		if 'Purchase Officer' not in frappe.get_roles(frappe.session.user):
-			purchase_officers = get_users_with_role_permitted_to_doctype('Purchase Officer', self.doctype)
-			if purchase_officers:
-				page_link = get_url(self.get_url())
-				message = """
-					Dear Purchase Officer,
-					<br/>
-					<p>
-						The Request for Purchase <a href='{0}'>{1}</a> is {2} by {3}.
-						Now you can initiate the Purchase Order
-					</p>
-				""".format(page_link, self.name, self.workflow_state, get_fullname(frappe.session.user))
-				subject = '{0} Request for Purchase by {1}'.format(self.workflow_state, get_fullname(self.requested_by))
-				sendemail(recipients=purchase_officers, subject=subject, message=message, reference_doctype=self.doctype, reference_name=self.name)
-				create_notification_log(subject, message, purchase_officers, self)
-				frappe.msgprint(_("Notification sent to Purchase Officer"))
-
 	def validate_items_to_order(self):
 		if not self.items_to_order:
-			frappe.throw(_("Fill Items to Order to Submit for Approval"))
+			frappe.throw(_("Fill Items to Order!"))
 		no_item_code_in_items_to_order = [item.idx for item in self.items_to_order if (not item.item_code or not item.supplier)]
 		if no_item_code_in_items_to_order and len(no_item_code_in_items_to_order) > 0:
 			frappe.throw(_("Set Item Code/Supplier in <b>Items to Order</b> rows {0}".format(no_item_code_in_items_to_order)))
 
 	@frappe.whitelist()
 	def make_purchase_order_for_quotation(self, warehouse=None):
+		self.validate_items_to_order()
 		if self.items_to_order:
 			wh = warehouse if warehouse else self.warehouse
 			for item in self.items_to_order:
@@ -187,39 +136,6 @@ def make_quotation_comparison_sheet(source_name, target_doc=None):
 	doclist.request_for_quotation = rfq if rfq else ''
 	return doclist
 
-@frappe.whitelist()
-def make_purchase_order(source_name, target_doc=None):
-	def set_missing_values(source, target):
-		target.ignore_pricing_rule = 1
-		target.run_method("set_missing_values")
-		target.run_method("get_schedule_dates")
-		target.run_method("calculate_taxes_and_totals")
-
-	def update_item(obj, target, source_parent):
-		target.stock_qty = obj.qty # flt(obj.qty) * flt(obj.conversion_factor)
-
-	doclist = get_mapped_doc("Request for Purchase", source_name,		{
-		"Request for Purchase": {
-			"doctype": "Purchase Order",
-			"validation": {
-				"docstatus": ["=", 1],
-			}
-		},
-		"Request for Purchase Quotation Item": {
-			"doctype": "Purchase Order Item",
-			"field_map": [
-				["quotation_item", "supplier_quotation_item"],
-				["quotation", "supplier_quotation"],
-				["request_for_material", "request_for_material"],
-				["request_for_material_item", "request_for_material_item"],
-				["sales_order", "sales_order"]
-			],
-			"postprocess": update_item
-		}
-	}, target_doc, set_missing_values)
-
-	return doclist
-
 def create_purchase_order(**args):
 	args = frappe._dict(args)
 	po_id = frappe.db.exists('Purchase Order',
@@ -232,11 +148,8 @@ def create_purchase_order(**args):
 		po.transaction_date = nowdate()
 		po.set_warehouse = args.warehouse
 		po.quotation = args.quotation
-		# po.schedule_date = add_days(nowdate(), 1)
-		# po.company = args.company
 		po.supplier = args.supplier
 		po.is_subcontracted = args.is_subcontracted or "No"
-		# po.currency = args.currency or frappe.get_cached_value('Company',  po.company,  "default_currency")
 		po.conversion_factor = args.conversion_factor or 1
 		po.supplier_warehouse = args.supplier_warehouse or None
 		po.one_fm_request_for_purchase = args.request_for_purchase


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Workflow update - Remove approval workflow in RFP

## Solution description
- Remove workflow and bring all validations in the actions of creating related records from RFP
- Remove - approver fields from RFP
- Remove rfp workflow

## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/20554466/8686e4e5-6975-4108-9bf5-134ce833e427


https://github.com/ONE-F-M/One-FM/assets/20554466/5cc84e7f-281e-427a-be54-d3d0f929a260



## Areas affected and ensured
- `one_fm/fixtures/workflow.json`
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py`
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.json`
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js`
- `one_fm/purchase/doctype/purchase_settings/purchase_settings.json`
- `one_fm/patches.txt`
- `one_fm/hooks.py`

## Is there any existing behavior change of other features due to this code change?
Yes, there is no approval workflow in RFP after this PR

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes
    ## Was the patch test? Yes
![Screenshot 2023-05-25 at 10 46 01 AM](https://github.com/ONE-F-M/One-FM/assets/20554466/b35b38a8-014a-4d47-a3ca-33d437dd34ae)


## Which browser(s) did you use for testing?
- [x] Chrome
