### PR TITLE
Fix: ERF Status 

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.js
+++ b/one_fm/one_fm/doctype/erf/erf.js
@@ -68,6 +68,9 @@ frappe.ui.form.on('ERF', {
 				frm.add_custom_button(__('Close ERF'), () => frm.events.close_erf(frm)).addClass('btn-primary');
 			}
 		}
+		if (!frm.is_new() && frm.doc.docstatus == 0 && frm.doc.amended_from && frm.doc.status == "Cancelled"){
+			frm.set_value('draft_erf_to_hrm', 0);
+		}
 		if (!frm.is_new() && frm.doc.docstatus == 0 && !frm.doc.draft_erf_to_hrm){
 			frm.add_custom_button(__('Submit to HR'), () => frm.events.draft_erf_to_hrm(frm)).addClass('btn-primary');
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- ERF Status is Submitted instead of 'Waiting For Approval'

## Solution description
- If Doc Amended, then change the value 'draft_erf_to_hrm' as 0 when in draft.
- This would help the button appear.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/615445c2-21f9-4791-b476-26c8fd6202de

## Areas affected and ensured
- when the status is cancelled, and doc status is 0, draft_erf_to_hrm is changed to 0.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
