### PR TITLE
[CHORE] Made contract items table compulsory

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -200,7 +200,8 @@
    "fieldname": "items",
    "fieldtype": "Table",
    "label": "Items",
-   "options": "Contract Item"
+   "options": "Contract Item",
+   "reqd": 1
   },
   {
    "collapsible": 1,
@@ -482,7 +483,7 @@
   }
  ],
  "links": [],
- "modified": "2023-02-14 23:33:59.030912",
+ "modified": "2023-05-28 09:50:41.365007",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To make the contracts items child table in the Contracts doctype


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Used the doctype core to set the contracts item to mandatory

## Is there a business logic within a doctype?
    - [] Yes
    - []x No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2023-05-24 10-33-10](https://github.com/ONE-F-M/One-FM/assets/99317649/f553e409-6679-490f-9f72-0bfd07114be4)


## Areas affected and ensured
List out the areas affected by your code changes.
Contracts Doctype


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
