### PR TITLE
[FEATURE] Made purchase receipt button visible to specific users only

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -270,6 +270,7 @@ doc_events = {
 	"Purchase Receipt": {
 		"before_submit": "one_fm.purchase.utils.before_submit_purchase_receipt",
 		"on_submit": "one_fm.one_fm.doctype.customer_asset.customer_asset.on_purchase_receipt_submit",
+		"validate": "one_fm.purchase.utils.validate_store_keeper_project_supervisor"
 	},
 	"Contact": {
 		"on_update": "one_fm.accommodation.doctype.accommodation.accommodation.accommodation_contact_update"

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -487,3 +487,22 @@ def attach_abbreviation_to_roles():
                 role.post_abbrv = post_abbrv
             role.save(ignore_permissions=True)
             frappe.db.commit()
+
+
+
+def validate_store_keeper_project_supervisor_roles(doc):
+    user = frappe.session.user
+    user_emp = frappe.db.get_value("Employee", {"user_id": user}, "name")
+    if doc.doctype == "Purchase Order":
+        if doc.set_warehouse:
+            warehouse_manager = frappe.db.get_value("Warehouse", doc.set_warehouse, "one_fm_store_keeper")
+            if warehouse_manager:
+                emp = frappe.db.get_value("Employee", warehouse_manager, "name")
+                return bool(emp == user_emp)
+            
+        elif False:
+            pass
+        
+        store_keepers = frappe.db.get_list("Warehouse", pluck="one_fm_store_keeper")
+        return bool(user_emp in store_keepers)
+    return False

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -502,14 +502,14 @@ def validate_store_keeper_project_supervisor_roles(doc):
                     warehouse_manager = frappe.db.get_value("Warehouse", doc["set_warehouse"], "one_fm_store_keeper")
                     if warehouse_manager:
                         emp = frappe.db.get_value("Employee", warehouse_manager, "name")
-                        return any((emp == user_emp, roles_check))
+                        return emp == user_emp
                     
             if "project" in doc.keys():
                 if doc["project"]:
                     project_manager = frappe.db.get_value("Project", doc["project"], "account_manager")
                     if project_manager:
-                        return any((project_manager == user_emp, roles_check))
-                    
+                        return project_manager == user_emp
+                       
             return roles_check
         return False
     except Exception as e:

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -489,13 +489,15 @@ def attach_abbreviation_to_roles():
             frappe.db.commit()
 
 
-
+@frappe.whitelist()
 def validate_store_keeper_project_supervisor_roles(doc):
+    doc = json.loads(doc)
+    print(doc.values())
     user = frappe.session.user
     user_emp = frappe.db.get_value("Employee", {"user_id": user}, "name")
-    if doc.doctype == "Purchase Order":
-        if doc.set_warehouse:
-            warehouse_manager = frappe.db.get_value("Warehouse", doc.set_warehouse, "one_fm_store_keeper")
+    if doc["doctype"] == "Purchase Order":
+        if doc["set_warehouse"]:
+            warehouse_manager = frappe.db.get_value("Warehouse", doc["set_warehouse"], "one_fm_store_keeper")
             if warehouse_manager:
                 emp = frappe.db.get_value("Employee", warehouse_manager, "name")
                 return bool(emp == user_emp)

--- a/one_fm/public/js/doctype_js/purchase_order.js
+++ b/one_fm/public/js/doctype_js/purchase_order.js
@@ -96,3 +96,192 @@ frappe.ui.form.on('Payment Schedule', {
 		}
 	}
 })
+
+
+// class MyPurchaseOrderController extends erpnext.buying.PurchaseOrderController {
+// 	constructor(frm) {
+// 	  super(frm);
+// 	  this.frm = frm;
+// 	}
+  
+// 	refresh() {
+// 	  super.refresh(this.frm.doc);
+  
+// 	  console.log(333333333)
+// 	  this.frm.page.set_inner_btn_group_as_primary(__('Create'));
+// 	  this.frm.remove_custom_button('Purchase Receipt');
+// 	//   this.frm.page.clear_inner_toolbar();
+	  
+// 	}
+//   }
+
+//   frappe.ui.form.on('Purchase Order', {
+// 	refresh: function(frm) {
+// 		frm.controller = new MyPurchaseOrderController(frm);
+// 		frm.controller.refresh();
+// 	}
+// });
+
+
+
+
+
+
+// frappe.provide("erpnext.buying");
+
+// erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends erpnext.buying.BuyingController {
+// 	setup() {
+// 		this.frm.custom_make_buttons = {
+// 			'Purchase Receipt': 'Purchase Receipt',
+// 			'Purchase Invoice': 'Purchase Invoice',
+// 			'Payment Entry': 'Payment',
+// 			'Subcontracting Order': 'Subcontracting Order',
+// 			'Stock Entry': 'Material to Supplier'
+// 		}
+
+// 		super.setup();
+// 	}
+
+// 	refresh(doc, cdt, cdn) {
+// 		var me = this;
+// 		super.refresh();
+// 		var allow_receipt = false;
+// 		var is_drop_ship = false;
+
+// 		for (var i in cur_frm.doc.items) {
+// 			var item = cur_frm.doc.items[i];
+// 			if(item.delivered_by_supplier !== 1) {
+// 				allow_receipt = true;
+// 			} else {
+// 				is_drop_ship = true;
+// 			}
+
+// 			if(is_drop_ship && allow_receipt) {
+// 				break;
+// 			}
+// 		}
+
+// 		this.frm.set_df_property("drop_ship", "hidden", !is_drop_ship);
+
+// 		if(doc.docstatus == 1) {
+// 			this.frm.fields_dict.items_section.wrapper.addClass("hide-border");
+// 			if(!this.frm.doc.set_warehouse) {
+// 				this.frm.fields_dict.items_section.wrapper.removeClass("hide-border");
+// 			}
+
+// 			if(!in_list(["Closed", "Delivered"], doc.status)) {
+// 				if(this.frm.doc.status !== 'Closed' && flt(this.frm.doc.per_received) < 100 && flt(this.frm.doc.per_billed) < 100) {
+// 					// Don't add Update Items button if the PO is following the new subcontracting flow.
+// 					if (!(this.frm.doc.is_subcontracted && !this.frm.doc.is_old_subcontracting_flow)) {
+// 						this.frm.add_custom_button(__('Update Items'), () => {
+// 							erpnext.utils.update_child_items({
+// 								frm: this.frm,
+// 								child_docname: "items",
+// 								child_doctype: "Purchase Order Detail",
+// 								cannot_add_row: false,
+// 							})
+// 						});
+// 					}
+// 				}
+// 				if (this.frm.has_perm("submit")) {
+// 					if(flt(doc.per_billed, 6) < 100 || flt(doc.per_received, 6) < 100) {
+// 						if (doc.status != "On Hold") {
+// 							this.frm.add_custom_button(__('Hold'), () => this.hold_purchase_order(), __("Status"));
+// 						} else{
+// 							this.frm.add_custom_button(__('Resume'), () => this.unhold_purchase_order(), __("Status"));
+// 						}
+// 						this.frm.add_custom_button(__('Close'), () => this.close_purchase_order(), __("Status"));
+// 					}
+// 				}
+
+// 				if(is_drop_ship && doc.status!="Delivered") {
+// 					this.frm.add_custom_button(__('Delivered'),
+// 						this.delivered_by_supplier, __("Status"));
+
+// 					this.frm.page.set_inner_btn_group_as_primary(__("Status"));
+// 				}
+// 			} else if(in_list(["Closed", "Delivered"], doc.status)) {
+// 				if (this.frm.has_perm("submit")) {
+// 					this.frm.add_custom_button(__('Re-open'), () => this.unclose_purchase_order(), __("Status"));
+// 				}
+// 			}
+// 			if(doc.status != "Closed") {
+// 				if (doc.status != "On Hold") {
+// 					if(flt(doc.per_received) < 100 && allow_receipt) {
+// 						// cur_frm.add_custom_button(__('Purchase Receipt'), this.make_purchase_receipt, __('Create'));
+// 						if (doc.is_subcontracted) {
+// 							if (doc.is_old_subcontracting_flow) {
+// 								if (me.has_unsupplied_items()) {
+// 									cur_frm.add_custom_button(__('Material to Supplier'), function() { me.make_stock_entry(); }, __("Transfer"));
+// 								}
+// 							}
+// 							else {
+// 								cur_frm.add_custom_button(__('Subcontracting Order'), this.make_subcontracting_order, __('Create'));
+// 							}
+// 						}
+// 					}
+// 					if(flt(doc.per_billed) < 100)
+// 						cur_frm.add_custom_button(__('Purchase Invoice'),
+// 							this.make_purchase_invoice, __('Create'));
+
+// 					if(flt(doc.per_billed) < 100 && doc.status != "Delivered") {
+// 						cur_frm.add_custom_button(__('Payment'), cur_frm.cscript.make_payment_entry, __('Create'));
+// 					}
+
+// 					if(flt(doc.per_billed) < 100) {
+// 						this.frm.add_custom_button(__('Payment Request'),
+// 							function() { me.make_payment_request() }, __('Create'));
+// 					}
+
+// 					if(!doc.auto_repeat) {
+// 						cur_frm.add_custom_button(__('Subscription'), function() {
+// 							erpnext.utils.make_subscription(doc.doctype, doc.name)
+// 						}, __('Create'))
+// 					}
+
+// 					if (doc.docstatus === 1 && !doc.inter_company_order_reference) {
+// 						let me = this;
+// 						let internal = me.frm.doc.is_internal_supplier;
+// 						if (internal) {
+// 							let button_label = (me.frm.doc.company === me.frm.doc.represents_company) ? "Internal Sales Order" :
+// 								"Inter Company Sales Order";
+
+// 							me.frm.add_custom_button(button_label, function() {
+// 								me.make_inter_company_order(me.frm);
+// 							}, __('Create'));
+// 						}
+
+// 					}
+// 				}
+
+// 				cur_frm.page.set_inner_btn_group_as_primary(__('Create'));
+// 			}
+// 		} else if(doc.docstatus===0) {
+// 			cur_frm.cscript.add_from_mappers();
+// 		}
+// 	}
+	
+//     // ...
+
+//     make_packing_slip() {
+//         // ...
+//     }
+
+// 	make_purchase_receipt() {
+// 		console.log("44444444444444444444444444");
+// 		frappe.model.open_mapped_doc({
+// 			method: "erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_receipt",
+// 			frm: cur_frm,
+// 			freeze_message: __("Creating Purchase Receipt ...")
+// 		})
+// 	}
+
+//     // ...
+
+//     make_payment_request() {
+//         // ...
+//     }
+// }
+
+$.extend(cur_frm.cscript, new erpnext.buying.PurchaseOrderController({frm: cur_frm}));
+

--- a/one_fm/public/js/doctype_js/purchase_order.js
+++ b/one_fm/public/js/doctype_js/purchase_order.js
@@ -18,7 +18,7 @@ frappe.ui.form.on('Purchase Order', {
 			method: "one_fm.one_fm.utils.validate_store_keeper_project_supervisor_roles",
 			args: {"doc": frm.doc},
 			callback: function(r){
-				if (r.message){
+				if (!r.message){
 					frm.remove_custom_button("Purchase Receipt", 'Create');
 				}
 			}

--- a/one_fm/public/js/doctype_js/purchase_order.js
+++ b/one_fm/public/js/doctype_js/purchase_order.js
@@ -13,6 +13,18 @@ frappe.ui.form.on('Purchase Order', {
 		set_field_property_for_documents(frm);
 		set_field_property_for_other_documents(frm);
 	},
+	onload_post_render: function(frm){
+		frappe.call({
+			method: "one_fm.one_fm.utils.validate_store_keeper_project_supervisor_roles",
+			args: {"doc": frm.doc},
+			callback: function(r){
+				if (r.message){
+					frm.remove_custom_button("Purchase Receipt", 'Create');
+				}
+			}
+		});
+
+	},
 
 	set_warehouse: function(frm){
 		if(frm.doc.set_warehouse){
@@ -96,192 +108,4 @@ frappe.ui.form.on('Payment Schedule', {
 		}
 	}
 })
-
-
-// class MyPurchaseOrderController extends erpnext.buying.PurchaseOrderController {
-// 	constructor(frm) {
-// 	  super(frm);
-// 	  this.frm = frm;
-// 	}
-  
-// 	refresh() {
-// 	  super.refresh(this.frm.doc);
-  
-// 	  console.log(333333333)
-// 	  this.frm.page.set_inner_btn_group_as_primary(__('Create'));
-// 	  this.frm.remove_custom_button('Purchase Receipt');
-// 	//   this.frm.page.clear_inner_toolbar();
-	  
-// 	}
-//   }
-
-//   frappe.ui.form.on('Purchase Order', {
-// 	refresh: function(frm) {
-// 		frm.controller = new MyPurchaseOrderController(frm);
-// 		frm.controller.refresh();
-// 	}
-// });
-
-
-
-
-
-
-// frappe.provide("erpnext.buying");
-
-// erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends erpnext.buying.BuyingController {
-// 	setup() {
-// 		this.frm.custom_make_buttons = {
-// 			'Purchase Receipt': 'Purchase Receipt',
-// 			'Purchase Invoice': 'Purchase Invoice',
-// 			'Payment Entry': 'Payment',
-// 			'Subcontracting Order': 'Subcontracting Order',
-// 			'Stock Entry': 'Material to Supplier'
-// 		}
-
-// 		super.setup();
-// 	}
-
-// 	refresh(doc, cdt, cdn) {
-// 		var me = this;
-// 		super.refresh();
-// 		var allow_receipt = false;
-// 		var is_drop_ship = false;
-
-// 		for (var i in cur_frm.doc.items) {
-// 			var item = cur_frm.doc.items[i];
-// 			if(item.delivered_by_supplier !== 1) {
-// 				allow_receipt = true;
-// 			} else {
-// 				is_drop_ship = true;
-// 			}
-
-// 			if(is_drop_ship && allow_receipt) {
-// 				break;
-// 			}
-// 		}
-
-// 		this.frm.set_df_property("drop_ship", "hidden", !is_drop_ship);
-
-// 		if(doc.docstatus == 1) {
-// 			this.frm.fields_dict.items_section.wrapper.addClass("hide-border");
-// 			if(!this.frm.doc.set_warehouse) {
-// 				this.frm.fields_dict.items_section.wrapper.removeClass("hide-border");
-// 			}
-
-// 			if(!in_list(["Closed", "Delivered"], doc.status)) {
-// 				if(this.frm.doc.status !== 'Closed' && flt(this.frm.doc.per_received) < 100 && flt(this.frm.doc.per_billed) < 100) {
-// 					// Don't add Update Items button if the PO is following the new subcontracting flow.
-// 					if (!(this.frm.doc.is_subcontracted && !this.frm.doc.is_old_subcontracting_flow)) {
-// 						this.frm.add_custom_button(__('Update Items'), () => {
-// 							erpnext.utils.update_child_items({
-// 								frm: this.frm,
-// 								child_docname: "items",
-// 								child_doctype: "Purchase Order Detail",
-// 								cannot_add_row: false,
-// 							})
-// 						});
-// 					}
-// 				}
-// 				if (this.frm.has_perm("submit")) {
-// 					if(flt(doc.per_billed, 6) < 100 || flt(doc.per_received, 6) < 100) {
-// 						if (doc.status != "On Hold") {
-// 							this.frm.add_custom_button(__('Hold'), () => this.hold_purchase_order(), __("Status"));
-// 						} else{
-// 							this.frm.add_custom_button(__('Resume'), () => this.unhold_purchase_order(), __("Status"));
-// 						}
-// 						this.frm.add_custom_button(__('Close'), () => this.close_purchase_order(), __("Status"));
-// 					}
-// 				}
-
-// 				if(is_drop_ship && doc.status!="Delivered") {
-// 					this.frm.add_custom_button(__('Delivered'),
-// 						this.delivered_by_supplier, __("Status"));
-
-// 					this.frm.page.set_inner_btn_group_as_primary(__("Status"));
-// 				}
-// 			} else if(in_list(["Closed", "Delivered"], doc.status)) {
-// 				if (this.frm.has_perm("submit")) {
-// 					this.frm.add_custom_button(__('Re-open'), () => this.unclose_purchase_order(), __("Status"));
-// 				}
-// 			}
-// 			if(doc.status != "Closed") {
-// 				if (doc.status != "On Hold") {
-// 					if(flt(doc.per_received) < 100 && allow_receipt) {
-// 						// cur_frm.add_custom_button(__('Purchase Receipt'), this.make_purchase_receipt, __('Create'));
-// 						if (doc.is_subcontracted) {
-// 							if (doc.is_old_subcontracting_flow) {
-// 								if (me.has_unsupplied_items()) {
-// 									cur_frm.add_custom_button(__('Material to Supplier'), function() { me.make_stock_entry(); }, __("Transfer"));
-// 								}
-// 							}
-// 							else {
-// 								cur_frm.add_custom_button(__('Subcontracting Order'), this.make_subcontracting_order, __('Create'));
-// 							}
-// 						}
-// 					}
-// 					if(flt(doc.per_billed) < 100)
-// 						cur_frm.add_custom_button(__('Purchase Invoice'),
-// 							this.make_purchase_invoice, __('Create'));
-
-// 					if(flt(doc.per_billed) < 100 && doc.status != "Delivered") {
-// 						cur_frm.add_custom_button(__('Payment'), cur_frm.cscript.make_payment_entry, __('Create'));
-// 					}
-
-// 					if(flt(doc.per_billed) < 100) {
-// 						this.frm.add_custom_button(__('Payment Request'),
-// 							function() { me.make_payment_request() }, __('Create'));
-// 					}
-
-// 					if(!doc.auto_repeat) {
-// 						cur_frm.add_custom_button(__('Subscription'), function() {
-// 							erpnext.utils.make_subscription(doc.doctype, doc.name)
-// 						}, __('Create'))
-// 					}
-
-// 					if (doc.docstatus === 1 && !doc.inter_company_order_reference) {
-// 						let me = this;
-// 						let internal = me.frm.doc.is_internal_supplier;
-// 						if (internal) {
-// 							let button_label = (me.frm.doc.company === me.frm.doc.represents_company) ? "Internal Sales Order" :
-// 								"Inter Company Sales Order";
-
-// 							me.frm.add_custom_button(button_label, function() {
-// 								me.make_inter_company_order(me.frm);
-// 							}, __('Create'));
-// 						}
-
-// 					}
-// 				}
-
-// 				cur_frm.page.set_inner_btn_group_as_primary(__('Create'));
-// 			}
-// 		} else if(doc.docstatus===0) {
-// 			cur_frm.cscript.add_from_mappers();
-// 		}
-// 	}
-	
-//     // ...
-
-//     make_packing_slip() {
-//         // ...
-//     }
-
-// 	make_purchase_receipt() {
-// 		console.log("44444444444444444444444444");
-// 		frappe.model.open_mapped_doc({
-// 			method: "erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_receipt",
-// 			frm: cur_frm,
-// 			freeze_message: __("Creating Purchase Receipt ...")
-// 		})
-// 	}
-
-//     // ...
-
-//     make_payment_request() {
-//         // ...
-//     }
-// }
-
-$.extend(cur_frm.cscript, new erpnext.buying.PurchaseOrderController({frm: cur_frm}));
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [X] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To make the purchase receipt button visible to store keeper, project manager, and those with the role of warehouse supervisor, in the absence of the previous 2



## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Wrote a validator that validates for the necessary conditions and sends a response, this response would be used to show the button or hide it

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2023-05-29 14-12-08](https://github.com/ONE-F-M/One-FM/assets/99317649/014c2616-a3bf-4293-8957-3b68cda2dec8)
![Screenshot from 2023-05-29 14-12-18](https://github.com/ONE-F-M/One-FM/assets/99317649/43ad89f1-1818-4204-940b-b195f1018162)


## Areas affected and ensured
List out the areas affected by your code changes.
Purchase order


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
