### PR TITLE
feat: rfm - approval assignment rule

### DIFF
--- a/one_fm/fixtures/assignment_rule.json
+++ b/one_fm/fixtures/assignment_rule.json
@@ -1,0 +1,64 @@
+[
+ {
+  "assign_condition": "workflow_state == 'Pending Approval'",
+  "assignment_days": [
+   {
+    "day": "Monday",
+    "parent": "RFM Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Tuesday",
+    "parent": "RFM Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Wednesday",
+    "parent": "RFM Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Thursday",
+    "parent": "RFM Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Friday",
+    "parent": "RFM Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Saturday",
+    "parent": "RFM Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Sunday",
+    "parent": "RFM Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   }
+  ],
+  "close_condition": "workflow_state in ('Approved', 'Rejected')",
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n\t\t\t<br>\n\t\t\tThe details of the request are as follows:<br>\n\t\t\t</p><table border=\"1\" cellpadding=\"0\" cellspacing=\"0\" style=\"border-collapse: collapse;\">\n\t\t\t\t<thead>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n\t\t\t\t\t</tr>\n\t\t\t\t</thead>\n\t\t\t\t<tbody>\n\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Type</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{type}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Required Date</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{schedule_date}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Transaction Date</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{transaction_date}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Company</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{company}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee}}</td>\n\t\t\t\t</tr>\n\t\t\t</tbody></table><p></p>",
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Assignment Rule",
+  "document_type": "Request for Material",
+  "due_date_based_on": null,
+  "field": "request_for_material_approver",
+  "last_user": "",
+  "modified": "2023-05-28 23:23:27.725768",
+  "name": "RFM Approver",
+  "priority": 0,
+  "rule": "Based on Field",
+  "unassign_condition": "",
+  "users": []
+ }
+]

--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -4,7 +4,7 @@
   "doctype": "Workflow",
   "document_type": "Request for Material",
   "is_active": 1,
-  "modified": "2023-05-15 07:55:50.830891",
+  "modified": "2023-05-26 10:10:37.942113",
   "name": "RFM",
   "override_status": 0,
   "send_email_alert": 0,
@@ -24,7 +24,7 @@
    },
    {
     "allow_edit": "Employee",
-    "doc_status": "1",
+    "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,
@@ -50,7 +50,7 @@
    },
    {
     "allow_edit": "Employee",
-    "doc_status": "2",
+    "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,
@@ -59,7 +59,7 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "status",
-    "update_value": "Rjected"
+    "update_value": "Rejected"
    }
   ],
   "transitions": [

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -99,8 +99,9 @@ doctype_js = {
 	"Leave Application" : "public/js/doctype_js/leave_application.js",
 	"Salary Structure Assignment" :  "public/js/doctype_js/salary_structure_assignment.js",
 	"Attendance" :  "public/js/doctype_js/attendance.js",
-    "Wiki Page": "public/js/doctype_js/wiki_page.js",
-    "Error Log": "public/js/doctype_js/error_log.js",
+	"Wiki Page": "public/js/doctype_js/wiki_page.js",
+	"Error Log": "public/js/doctype_js/error_log.js",
+	"Assignment Rule": "public/js/doctype_js/assignment_rule.js"
 }
 doctype_list_js = {
 	"Job Applicant" : "public/js/doctype_js/job_applicant_list.js",
@@ -706,6 +707,10 @@ fixtures = [
 	{
 		"dt": "Role",
 		"filters": [["name", "in",["Operations Manager", "Shift Supervisor", "Site Supervisor", "Projects Manager"]]]
+	},
+	{
+		"dt": "Assignment Rule",
+		"filters": [["name", "in",["RFM Approver"]]]
 	},
 	{
 		"dt": "Email Template"

--- a/one_fm/public/js/doctype_js/assignment_rule.js
+++ b/one_fm/public/js/doctype_js/assignment_rule.js
@@ -1,0 +1,16 @@
+frappe.ui.form.on('Assignment Rule', {
+	refresh: function(frm){
+		frm.add_custom_button("Set the Description", function() {
+			frappe.call({
+				method: 'one_fm.utils.get_assignment_rule_description',
+				args: {doctype: frm.doc.document_type},
+				callback: function(r) {
+					console.log(r);
+					if(r && r.message){
+						frm.set_value('description', r.message)
+					}
+				}
+			});
+		})
+	}
+});

--- a/one_fm/purchase/doctype/request_for_material/request_for_material.py
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.py
@@ -19,12 +19,6 @@ from one_fm.utils import send_workflow_action_email
 from frappe.desk.form.assign_to import add as add_assignment, DuplicateToDoError, remove as remove_assignment
 
 class RequestforMaterial(BuyingController):
-	def on_submit(self):
-		if self.workflow_state == 'Pending Approval':
-			send_workflow_action_email(self, [self.request_for_material_approver])
-			subject = '{0}: Request for Material by {1}'.format(self.workflow_state, get_fullname(self.requested_by))
-			create_notification_log(subject, subject, [self.request_for_material_approver], self)
-
 	@frappe.whitelist()
 	def get_default_warehouse(self):
 		return frappe.db.get_single_value('Stock Settings', 'default_warehouse')

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2577,6 +2577,17 @@ def workflow_approve_reject(doc, recipients=None):
     frappe.enqueue(method=sendemail, queue="short", **email_args)
 
 def get_mandatory_fields(doctype, doc_name):
+	mandatory_fields, employee_fields, labels = get_doctype_mandatory_fields(doctype)
+
+	doc = frappe.get_value(doctype, {'name':doc_name}, mandatory_fields, as_dict=True)
+
+	for employee_field in employee_fields:
+		employee_details = frappe.get_value('Employee', doc[employee_field], ['employee_name', 'employee_id'], as_dict=True)
+		doc[employee_field] += ' : ' + ' - '.join([employee_details.employee_name, employee_details.employee_id])
+
+	return doc, labels
+
+def get_doctype_mandatory_fields(doctype):
 	meta = frappe.get_meta(doctype)
 	mandatory_fields = []
 	labels = {}
@@ -2598,13 +2609,7 @@ def get_mandatory_fields(doctype, doc_name):
 		mandatory_fields = ['name']
 		labels['name'] = 'Document Name'
 
-	doc = frappe.get_value(doctype, {'name':doc_name}, mandatory_fields, as_dict=True)
-
-	for employee_field in employee_fields:
-		employee_details = frappe.get_value('Employee', doc[employee_field], ['employee_name', 'employee_id'], as_dict=True)
-		doc[employee_field] += ' : ' + ' - '.join([employee_details.employee_name, employee_details.employee_id])
-
-	return doc, labels
+	return mandatory_fields, employee_fields, labels
 
 @frappe.whitelist()
 def notify_live_user(company, message, users=False):
@@ -2973,3 +2978,31 @@ def get_users_with_role_permitted_to_doctype(role, doctype=False):
 	if filtered_users and len(filtered_users) > 0:
 		return filtered_users
 	return False
+
+@frappe.whitelist()
+def get_assignment_rule_description(doctype):
+	mandatory_fields, employee_fields, labels = get_doctype_mandatory_fields(doctype)
+	message_html = '<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.'
+	if mandatory_fields:
+		message_html += '''
+			<br/>
+			The details of the request are as follows:<br/>
+			<table cellpadding="0" cellspacing="0" border="1" style="border-collapse: collapse;">
+				<thead>
+					<tr>
+						<th style="padding: 10px; text-align: left; background-color: #f2f2f2;">Label</th>
+						<th style="padding: 10px; text-align: left; background-color: #f2f2f2;">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+		'''
+		for mandatory_field in mandatory_fields:
+			message_html += '''
+				<tr>
+					<td style="padding: 10px;">'''+labels[mandatory_field]+'''</td>
+					<td style="padding: 10px;">{{'''+mandatory_field+'''}}</td>
+				</tr>
+			'''
+		message_html += '</tbody></table>'
+	message_html += '</p>'
+	return message_html


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Make a New Assignment Rule for the RFM upon Submitting by the User  with Assign to the Material Approver which is Reports to. Assignment of the Reports to would close once the Record is approved.

## Solution description
- Added the assignment rule for rfm approver
- Set description in assignment rule like workflow notification
- ![Screenshot 2023-05-30 at 11 29 22 AM](https://github.com/ONE-F-M/One-FM/assets/20554466/39caf11f-60fd-4163-9e83-1b3f29cf1361)

- Allow user to update rfm before approval

## Areas affected and ensured
- `one_fm/fixtures/workflow.json`
- `one_fm/hooks.py`
- `one_fm/purchase/doctype/request_for_material/request_for_material.py`
- `one_fm/utils.py`

## Is there any existing behavior change of other features due to this code change?
Yes, rfm approval notification is set from assignment rule


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome