### PR TITLE
feat: validate qty against requested qty - purchase

### DIFF
--- a/one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py
+++ b/one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py
@@ -51,6 +51,7 @@ class RequestforSupplierQuotation(Document):
                 item = quotation.append('items')
                 item.item_name = rfq_item.item_name
                 item.description = rfq_item.description
+                item.qty_requested = rfq_item.qty
                 item.qty = rfq_item.qty
                 item.uom = rfq_item.uom
                 item.stock_uom = rfq_item.uom

--- a/one_fm/purchase/doctype/comparison_sheet_quotation_item/comparison_sheet_quotation_item.json
+++ b/one_fm/purchase/doctype/comparison_sheet_quotation_item/comparison_sheet_quotation_item.json
@@ -58,7 +58,8 @@
    "fieldname": "quantity",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Quantity"
+   "label": "Quantity",
+   "read_only": 1
   },
   {
    "columns": 2,
@@ -106,7 +107,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-10-25 08:57:51.669421",
+ "modified": "2023-05-30 08:16:44.763169",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Comparison Sheet Quotation Item",

--- a/one_fm/purchase/doctype/quotation_comparison_sheet/quotation_comparison_sheet.py
+++ b/one_fm/purchase/doctype/quotation_comparison_sheet/quotation_comparison_sheet.py
@@ -67,6 +67,7 @@ def update_request_for_purchase(doc):
 			items_to_order.item_name = item.item_name
 			items_to_order.description = item.description
 			items_to_order.uom = item.uom
+			items_to_order.qty_requested = item.qty
 			items_to_order.qty = item.qty
 			items_to_order.item_code = item.item_code
 			items_to_order.t_warehouse = item.t_warehouse

--- a/one_fm/purchase/doctype/quotation_comparison_sheet_item/quotation_comparison_sheet_item.json
+++ b/one_fm/purchase/doctype/quotation_comparison_sheet_item/quotation_comparison_sheet_item.json
@@ -64,6 +64,7 @@
    "oldfieldname": "qty",
    "oldfieldtype": "Currency",
    "print_width": "60px",
+   "read_only": 1,
    "reqd": 1,
    "width": "60px"
   },
@@ -190,7 +191,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-10-25 09:13:32.489976",
+ "modified": "2023-05-30 08:18:38.289600",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Quotation Comparison Sheet Item",

--- a/one_fm/purchase/doctype/quotation_from_supplier/quotation_from_supplier.py
+++ b/one_fm/purchase/doctype/quotation_from_supplier/quotation_from_supplier.py
@@ -5,12 +5,20 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
+from frappe import _
 
 class QuotationFromSupplier(Document):
 	def validate(self):
 		if not self.items:
 			self.set_items()
+		self.validate_item_qty()
 		self.set_totals()
+
+	def validate_item_qty(self):
+		# Get items qty is greater than the requested qty
+		items = [item.idx for item in self.items if (item.qty_requested and item.qty_requested < item.qty)]
+		if items and len(items) > 0:
+			frappe.throw(_("Items are greater in quantity than requested in rows {0}".format(items)))
 
 	def set_totals(self):
 		if self.items:
@@ -31,6 +39,7 @@ class QuotationFromSupplier(Document):
 					item = self.append('items')
 					item.item_name = rfq_item.item_name
 					item.description = rfq_item.description
+					item.qty_requested = rfq_item.qty
 					item.qty = rfq_item.qty
 					item.uom = rfq_item.uom
 					item.item_code = rfq_item.item_code

--- a/one_fm/purchase/doctype/quotation_from_supplier_item/quotation_from_supplier_item.json
+++ b/one_fm/purchase/doctype/quotation_from_supplier_item/quotation_from_supplier_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "QFSI.#######",
  "creation": "2020-06-07 18:02:36.976771",
  "doctype": "DocType",
@@ -23,6 +24,7 @@
   "column_break_15",
   "manufacturer_part_no",
   "quantity_and_rate",
+  "qty_requested",
   "qty",
   "stock_uom",
   "price_list_rate",
@@ -544,17 +546,26 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "qty_requested",
+   "fieldtype": "Float",
+   "label": "Quantity Requested",
+   "read_only": 1
   }
  ],
  "istable": 1,
- "modified": "2021-04-30 05:02:25.253796",
- "modified_by": "o.asim@armor-services.com",
+ "links": [],
+ "modified": "2023-05-30 08:03:11.767422",
+ "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Quotation From Supplier Item",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [],
  "search_fields": "item_name",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js
@@ -88,6 +88,13 @@ frappe.ui.form.on('Request for Purchase', {
 			frappe.throw(__("Not able to create PO, Set Item Code/Supplier/Rate in <b>Items to Order</b> rows {0}", [idx_mandatory_fields_not_set_for_po]))
 		}
 
+		var items = frm.doc.items_to_order.filter(item => (item.qty_requested && item.qty_requested < item.qty));
+		var idx_items = items.map(pt => {return pt.idx}).join(', ');
+		if(idx_items && idx_items.length > 0) {
+			frm.scroll_to_field('items_to_order');
+			frappe.throw(__("Items <b>Items Order</b> are greater in quantity than requested in rows {0}", [idx_items]))
+		}
+
 		var stock_item_in_items_to_order = frm.doc.items_to_order.filter(items_to_order => items_to_order.is_stock_item === 1 && !items_to_order.t_warehouse);
 		var stock_item_code_in_items_to_order = stock_item_in_items_to_order.map(pt => {return pt.item_code}).join(', ');
 		if(stock_item_in_items_to_order && stock_item_in_items_to_order.length > 0 && !frm.doc.warehouse) {
@@ -115,6 +122,7 @@ frappe.ui.form.on('Request for Purchase', {
 			items_to_order.description = item.description
 			items_to_order.uom = item.uom
 			items_to_order.t_warehouse = item.t_warehouse
+			items_to_order.qty_requested = item.qty
 			items_to_order.qty = item.qty
 			items_to_order.delivery_date = item.schedule_date
 			items_to_order.request_for_material = item.request_for_material

--- a/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
+++ b/one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py
@@ -49,6 +49,11 @@ class RequestforPurchase(Document):
 		if no_item_code_in_items_to_order and len(no_item_code_in_items_to_order) > 0:
 			frappe.throw(_("Set Item Code/Supplier in <b>Items to Order</b> rows {0}".format(no_item_code_in_items_to_order)))
 
+		# Get items qty is greater than the requested qty
+		items = [item.idx for item in self.items_to_order if (item.qty_requested and item.qty_requested < item.qty)]
+		if items and len(items) > 0:
+			frappe.throw(_("Items <b>Items Order</b> are greater in quantity than requested in rows {0}".format(items)))
+
 	@frappe.whitelist()
 	def make_purchase_order_for_quotation(self, warehouse=None):
 		self.validate_items_to_order()

--- a/one_fm/purchase/doctype/request_for_purchase_quotation_item/request_for_purchase_quotation_item.json
+++ b/one_fm/purchase/doctype/request_for_purchase_quotation_item/request_for_purchase_quotation_item.json
@@ -14,6 +14,7 @@
   "section_break_5",
   "description",
   "quantity",
+  "qty_requested",
   "qty",
   "uom",
   "rate",
@@ -168,11 +169,18 @@
    "fieldtype": "Link",
    "label": "Warehouse",
    "options": "Warehouse"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "qty_requested",
+   "fieldtype": "Float",
+   "label": "Quantity Requested",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-05-15 19:32:38.049118",
+ "modified": "2023-05-30 08:27:51.080212",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Request for Purchase Quotation Item",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- RFP needs to push the item codes etc, detailed list to supplier RFQ, comparison. Items list and quantity must be picked from the RFP to ensure validation

## Solution description
- Update quantity field property and set requested quantity field and value to validate

## Output screenshots (optional)
![Screenshot 2023-05-30 at 10 35 31 AM](https://github.com/ONE-F-M/One-FM/assets/20554466/b9adfb73-fc74-407a-b308-a738ff320b87)
![Screenshot 2023-05-30 at 11 05 53 AM](https://github.com/ONE-F-M/One-FM/assets/20554466/cfa88240-b044-40ef-92b9-35ee5fe6e3a3)

## Areas affected and ensured
- `one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py`
- `one_fm/purchase/doctype/request_for_purchase_quotation_item/request_for_purchase_quotation_item.json`
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.py`
- `one_fm/purchase/doctype/request_for_purchase/request_for_purchase.js`
- `one_fm/purchase/doctype/quotation_from_supplier_item/quotation_from_supplier_item.json`
- `one_fm/purchase/doctype/quotation_from_supplier/quotation_from_supplier.py`
- `one_fm/purchase/doctype/quotation_comparison_sheet_item/quotation_comparison_sheet_item.json`
- `one_fm/purchase/doctype/quotation_comparison_sheet/quotation_comparison_sheet.py`
- `one_fm/purchase/doctype/comparison_sheet_quotation_item/comparison_sheet_quotation_item.json`


## Is there any existing behavior change of other features due to this code change?
Yes, validates quantity of item against requested quantity

## Did you test with the following dataset?
- [x] New Data

## Did you delete custom field?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome