### PR TITLE
feat: set frequency days and date in r task

### DIFF
--- a/one_fm/operations/doctype/routine_task/routine_task.js
+++ b/one_fm/operations/doctype/routine_task/routine_task.js
@@ -16,17 +16,22 @@ var set_custom_buttons = function(frm) {
 var remove_task_and_auto_repeat = function(frm) {
 	if (frm.doc.task_reference || frm.doc.auto_repeat_reference){
 		frm.add_custom_button(__("Remove Task and Auto Repeat"), function() {
-			frappe.call({
-				method: "remove_task_and_auto_repeat",
-				doc: frm.doc,
-				callback: function(r){
-					if(!r.exc){
-						frm.reload_doc()
-					}
-				},
-				freeze: true,
-				freeze_message: __('Remove Task and Auto Repeat')
-			});
+			if(frm.is_dirty()){
+				frappe.throw(__('Please Save the Document and Continue .!'))
+			}
+			else{
+				frappe.call({
+					method: "remove_task_and_auto_repeat",
+					doc: frm.doc,
+					callback: function(r){
+						if(!r.exc){
+							frm.reload_doc()
+						}
+					},
+					freeze: true,
+					freeze_message: __('Remove Task and Auto Repeat')
+				});
+			}
 		});
 	}
 };
@@ -34,17 +39,22 @@ var remove_task_and_auto_repeat = function(frm) {
 var set_task_and_auto_repeat = function(frm) {
 	if (!frm.doc.task_reference && !frm.doc.auto_repeat_reference){
 		frm.add_custom_button(__("Set Task and Auto Repeat"), function() {
-			frappe.call({
-				method: "set_task_and_auto_repeat",
-				doc: frm.doc,
-				callback: function(r){
-					if(!r.exc){
-						frm.reload_doc()
-					}
-				},
-				freeze: true,
-				freeze_message: __('Setting up Task and Auto Repeat')
-			});
+			if(frm.is_dirty()){
+				frappe.throw(__('Please Save the Document and Continue .!'))
+			}
+			else{
+				frappe.call({
+					method: "set_task_and_auto_repeat",
+					doc: frm.doc,
+					callback: function(r){
+						if(!r.exc){
+							frm.reload_doc()
+						}
+					},
+					freeze: true,
+					freeze_message: __('Setting up Task and Auto Repeat')
+				});
+			}
 		});
 	}
 };

--- a/one_fm/operations/doctype/routine_task/routine_task.json
+++ b/one_fm/operations/doctype/routine_task/routine_task.json
@@ -22,10 +22,15 @@
   "task_type",
   "column_break_im0w3",
   "frequency",
+  "repeat_on_day",
+  "repeat_on_last_day",
+  "repeat_on_days",
   "hours_per_frequency",
   "coordination_needed",
   "coordination_method",
   "column_break_vzutu",
+  "start_date",
+  "end_date",
   "remark",
   "reporting_section",
   "report_frequency",
@@ -218,11 +223,42 @@
    "label": "Task Type",
    "options": "Task Type",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval: in_list([\"Monthly\", \"Quarterly\", \"Half-yearly\", \"Yearly\"], doc.frequency) && !doc.repeat_on_last_day",
+   "fieldname": "repeat_on_day",
+   "fieldtype": "Int",
+   "label": "Repeat on Day"
+  },
+  {
+   "depends_on": "eval:doc.frequency==='Weekly';",
+   "fieldname": "repeat_on_days",
+   "fieldtype": "Table",
+   "label": "Repeat on Days",
+   "options": "Auto Repeat Day"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.frequency === 'Monthly'",
+   "fieldname": "repeat_on_last_day",
+   "fieldtype": "Check",
+   "label": "Repeat on Last Day of the Month"
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date"
+  },
+  {
+   "default": "Today",
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": "Start Date"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-04-30 14:15:01.618605",
+ "modified": "2023-05-30 10:34:43.472561",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Routine Task",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
For Daily it will set the task Daily. 
For Weekly we need  a specific Day of the Week
For Monthly we need a Specific Day of the Month.

## Solution description
Set frequency and day details with respect to the frequency

## Areas affected and ensured
- `one_fm/operations/doctype/routine_task/routine_task.js`
- `one_fm/operations/doctype/routine_task/routine_task.json`
- `one_fm/operations/doctype/routine_task/routine_task.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome