### PR TITLE
[BUG] Make reports to not mandatory for shift workers

### DIFF
--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -93,7 +93,9 @@ class JobOfferOverride(JobOffer):
     def validate_job_offer_mandatory_fields(self):
         if self.workflow_state == 'Submit for Candidate Response':
             mandatory_field_required = False
-            fields = ['Reports To', 'Project', 'Base', 'Salary Structure', 'Project']
+            fields = ['Project', 'Base', 'Salary Structure', 'Project']
+            if not self.shift_working:
+                fields.append("reports_to")
             if not self.attendance_by_timesheet:
                 fields.append('Operations Shift')
                 if self.shift_working:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
To make the reports to not mandatory for shift workers


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
added a condition that only makes the report to mandatory when, the prospective employee is not a shift worker

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Job Offer

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
