### PR TITLE
feat: streamline shift permission notifications 

### DIFF
--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -11,7 +11,6 @@ from one_fm.api.notification import create_notification_log, get_employee_user_i
 from hrms.hr.doctype.shift_assignment.shift_assignment import get_shift_details
 from one_fm.api.tasks import get_action_user
 from one_fm.api.utils import get_reports_to_employee_name
-from one_fm.utils import (workflow_approve_reject, send_workflow_action_email)
 
 class PermissionTypeandLogTypeError(frappe.ValidationError):
 	pass
@@ -95,7 +94,10 @@ class ShiftPermission(Document):
 			frappe.throw(message, exc=frappe.MandatoryError)
 
 	def after_insert(self):
-		pass
+		if self.log_type == 'IN':
+			frappe.msgprint(_("Please ensure checkin once arriving the site!"), alert=True, indicator='orange')
+		if self.log_type == 'OUT':
+			frappe.msgprint(_("Please ensure checkout before leaving the site!"), alert=True, indicator='orange')
 
 	def send_notification(self):
 		date = getdate(self.date).strftime('%d-%m-%Y')
@@ -104,21 +106,30 @@ class ShiftPermission(Document):
 		message = _("{employee} has applied for permission to {type} on {date}.".format(employee=self.emp_name, type=self.permission_type.lower(), date=date))
 		create_notification_log(subject, message, [user], self)
 
-	def on_update(self):
-		if self.workflow_state == 'Approved':
-			create_employee_checkin_for_shift_permission(self)
-			workflow_approve_reject(self, [get_employee_user_id(self.employee)])
-
-		if self.workflow_state == 'Pending':
-			send_workflow_action_email(self, recipients=[get_employee_user_id(self.shift_supervisor)])
-
-		if self.workflow_state in ['Rejected']:
-			workflow_approve_reject(self, [get_employee_user_id(self.employee)])
-
 	def validate_approver(self):
 		if self.workflow_state in ["Approved", "Rejected"]:
 			if frappe.session.user not in [self.approver_user_id, 'abdullah@one-fm.com']:
 				frappe.throw(_("This document can only be approved/rejected by the approver."))
+
+	def on_submit(self):
+		employee_user = frappe.get_value('Employee', self.employee, 'user_id')
+		subject = _('Your shift request {0} has been {1} by {2}'.format(self.name, self.workflow_state, self.approver_name))
+		if self.workflow_state == 'Approved':
+			create_employee_checkin_for_shift_permission(self)
+			if employee_user:
+				create_notification_log(subject, subject, [employee_user], self)
+
+		if self.workflow_state == 'Rejected':
+			message = False
+			if self.log_type == 'IN':
+				message = _('Your shift request has been rejected, Please checkin once you arrive to the site before [half way mark] or your attendance will be marked absent!')
+			if self.log_type == 'OUT':
+				message = _('Your shift request has been rejected, Please make sure to checkout!')
+			if message and employee_user:
+				create_notification_log(subject, message, [employee_user], self)
+
+	def on_cancel(self):
+		pass
 
 def create_employee_checkin_for_shift_permission(shift_permission):
 	"""
@@ -178,9 +189,10 @@ def create_checkin(name):
 		'shift_permission':name
 		}):
 		sp = frappe.get_doc("Shift Permission", name)
-		sp.db_set('Workflow_state', 'Approved')
-		sp.db_set('docstatus', 1)
-		sp.reload()
+		if not sp.workflow_state == 'Approved':
+			sp.db_set('Workflow_state', 'Approved')
+			sp.db_set('docstatus', 1)
+			sp.reload()
 		# Get shift details for the employee shift_assignment = frappe.get_doc("Shift Assignment", sp.assigned_shift)
 		employee_checkin = frappe.new_doc('Employee Checkin')
 		shift_assignment = frappe.get_doc("Shift Assignment", sp.assigned_shift)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Streamlined process to apply for permission and set the notification
- Remove employee checkin record validation

## Solution description
- Once Employee submits shift permission there should be notification that tells employee please checkin when at site and checkout before you leave the site.
- Remove shift permission validation, allow shift permission to created record even if checkin and out record exists

## Output screenshots (optional)
![Screenshot 2023-06-04 at 1 24 54 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/c1922725-d06b-49fb-8b85-43aac8597147)
![Screenshot 2023-06-04 at 2 01 34 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/943a91b7-ffad-4b6f-a0a8-a6c2d919db36)

## Areas affected and ensured
- `one_fm/api/notification.py`
- `one_fm/operations/doctype/shift_permission/shift_permission.py`

## Is there any existing behavior change of other features due to this code change?
Yes.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome