### PR TITLE
feat: shift permission - approver assignment rule

### DIFF
--- a/one_fm/fixtures/assignment_rule.json
+++ b/one_fm/fixtures/assignment_rule.json
@@ -60,5 +60,67 @@
   "rule": "Based on Field",
   "unassign_condition": "",
   "users": []
+ },
+ {
+  "assign_condition": "workflow_state == 'Pending'",
+  "assignment_days": [
+   {
+    "day": "Monday",
+    "parent": "Shift Permission Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Tuesday",
+    "parent": "Shift Permission Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Wednesday",
+    "parent": "Shift Permission Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Thursday",
+    "parent": "Shift Permission Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Friday",
+    "parent": "Shift Permission Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Saturday",
+    "parent": "Shift Permission Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Sunday",
+    "parent": "Shift Permission Approver",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   }
+  ],
+  "close_condition": "workflow_state == 'Approved'",
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n\t\t\t<br>\n\t\t\tThe details of the request are as follows:<br>\n\t\t\t</p><table border=\"1\" cellpadding=\"0\" cellspacing=\"0\" style=\"border-collapse: collapse;\">\n\t\t\t\t<thead>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n\t\t\t\t\t</tr>\n\t\t\t\t</thead>\n\t\t\t\t<tbody>\n\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee Id</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Date</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{date}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Log Type</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{log_type}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Permission Type</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{permission_type}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Reason</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{reason}}</td>\n\t\t\t\t</tr>\n\t\t\t</tbody></table><p></p>",
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Assignment Rule",
+  "document_type": "Shift Permission",
+  "due_date_based_on": null,
+  "field": "approver_user_id",
+  "last_user": "j.poil@one-fm.com",
+  "modified": "2023-06-03 14:18:47.029237",
+  "name": "Shift Permission Approver",
+  "priority": 0,
+  "rule": "Based on Field",
+  "unassign_condition": null,
+  "users": []
  }
 ]

--- a/one_fm/fixtures/assignment_rule.json
+++ b/one_fm/fixtures/assignment_rule.json
@@ -107,7 +107,7 @@
     "parenttype": "Assignment Rule"
    }
   ],
-  "close_condition": "workflow_state == 'Approved'",
+  "close_condition": "workflow_state in ('Approved', 'Rejected')",
   "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n\t\t\t<br>\n\t\t\tThe details of the request are as follows:<br>\n\t\t\t</p><table border=\"1\" cellpadding=\"0\" cellspacing=\"0\" style=\"border-collapse: collapse;\">\n\t\t\t\t<thead>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n\t\t\t\t\t</tr>\n\t\t\t\t</thead>\n\t\t\t\t<tbody>\n\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee Id</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Date</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{date}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Log Type</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{log_type}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Permission Type</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{permission_type}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Reason</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{reason}}</td>\n\t\t\t\t</tr>\n\t\t\t</tbody></table><p></p>",
   "disabled": 0,
   "docstatus": 0,
@@ -116,7 +116,7 @@
   "due_date_based_on": null,
   "field": "approver_user_id",
   "last_user": "j.poil@one-fm.com",
-  "modified": "2023-06-03 14:18:47.029237",
+  "modified": "2023-06-04 11:45:04.269847",
   "name": "Shift Permission Approver",
   "priority": 0,
   "rule": "Based on Field",

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -723,7 +723,7 @@ fixtures = [
 	},
 	{
 		"dt": "Assignment Rule",
-		"filters": [["name", "in",["RFM Approver"]]]
+		"filters": [["name", "in",["RFM Approver", "Shift Permission Approver"]]]
 	},
 	{
 		"dt": "Email Template"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Assigning record to supervisor should be automated in Shift Permission using Assignment Rule

## Output screenshots (optional)
![Screenshot 2023-06-03 at 4 57 17 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/37599dc8-d7bf-4d75-bb13-6cfcedc85aa6)

## Areas affected and ensured
- `one_fm/fixtures/assignment_rule.json`
- `one_fm/hooks.py`
- `one_fm/operations/doctype/shift_permission/shift_permission.py`

## Is there any existing behavior change of other features due to this code change?
Yes

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome