### PR TITLE
Feat: Getting Current shift for employee with multiple shift a day 

### DIFF
--- a/one_fm/api/v1/roster.py
+++ b/one_fm/api/v1/roster.py
@@ -605,27 +605,56 @@ def get_current_shift(employee):
     try:
         # fetch datetime
         current_datetime = now_datetime()
-
-        # fetch the last shift assignment
-        shift = frappe.get_last_doc("Shift Assignment", filters={"employee": employee}, order_by="creation desc")
-
-        if shift:
-            before_time, after_time = frappe.get_value("Shift Type", shift.shift_type,
-                                                       ["begin_check_in_before_shift_start_time",
-                                                        "allow_check_out_after_shift_end_time"])
-
-            if shift.start_datetime and shift.end_datetime:
-                # include early entry and late exit time
-                start_time = shift.start_datetime - datetime.timedelta(minutes=before_time)
-                end_time = shift.end_datetime + datetime.timedelta(minutes=after_time)
-
-                # Check if current time is within the shift start and end time.
-                if start_time <= current_datetime <= end_time:
-                    return shift
+        date, time = current_datetime.strftime("%Y-%m-%d %H:%M:%S").split(" ")
+        
+        shift = frappe.get_list("Shift Assignment", {"employee":employee, 'start_date': ['>=', date]}, ['*'], order_by="creation asc")
+        # print(shift)
+        if len(shift) == 1:
+            if shift_is_within_timeframe(shift[0], current_datetime):
+                cur_shift = shift[0]
+        elif len(shift) == 2:
+            if shift_is_within_timeframe(shift[0], current_datetime):
+                cur_shift = shift[0]
+            if shift_is_within_timeframe(shift[1], current_datetime):
+                cur_shift = shift[1]
+            if shift_is_within_timeframe(shift[0], current_datetime) and  shift_is_within_timeframe(shift[1], current_datetime):
+                if has_checkout(shift[0], employee, date):
+                    cur_shift = shift[1]
+                else:
+                    cur_shift = shift[0]
+        else:
+            cur_shift =  shift
+        return cur_shift
+            
     except Exception as e:
         print(frappe.get_traceback())
         return frappe.utils.response.report_error(e.http_status_code)
 
+def has_checkout(shift, employee, date):
+    checkin = frappe.db.sql("""SELECT * FROM `tabEmployee Checkin` empChkin
+							WHERE date(empChkin.time)='{date}'
+                            AND shift_assignment = '{shift}'
+                            AND employee ='{employee}'
+                            AND log_type = 'OUT'""".format(date=cstr(date), shift=shift.name, employee=employee), as_dict=1)
+    if checkin:
+        return True
+    else:
+        return False
+
+def shift_is_within_timeframe(shift, current_datetime):
+    if shift:
+        before_time, after_time = frappe.get_value("Shift Type", shift.shift_type,
+                                                       ["begin_check_in_before_shift_start_time",
+                                                        "allow_check_out_after_shift_end_time"])
+        if shift.start_datetime and shift.end_datetime:
+            # include early entry and late exit time
+            start_time = shift.start_datetime - datetime.timedelta(minutes=before_time)
+            end_time = shift.end_datetime + datetime.timedelta(minutes=after_time)
+            # Check if current time is within the shift start and end time.
+            if start_time <= current_datetime <= end_time:
+                return True
+    else:
+        return False
 
 @frappe.whitelist()
 def get_report_comments(report_name):

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -33,9 +33,9 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 			try:			
 				existing_perm = None
 				checkin_time = get_datetime(self.time)
-				curr_shift = get_current_shift_checkin(self.employee)
+				curr_shift = get_current_shift(self.employee)
 				if curr_shift:
-					curr_shift = curr_shift[0]
+					curr_shift = curr_shift
 					start_date = curr_shift["start_date"].strftime("%Y-%m-%d")
 					existing_perm = frappe.db.sql(f""" select name from `tabShift Permission` where date = '{start_date}' and employee = '{self.employee}' and permission_type = '{perm_map[self.log_type]}' and workflow_state = 'Approved' """, as_dict=1)
 					self.shift_assignment = curr_shift["name"]

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -35,7 +35,7 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 				checkin_time = get_datetime(self.time)
 				curr_shift = get_current_shift(self.employee)
 				if curr_shift:
-					curr_shift = curr_shift
+					curr_shift = curr_shift[0]
 					start_date = curr_shift["start_date"].strftime("%Y-%m-%d")
 					existing_perm = frappe.db.sql(f""" select name from `tabShift Permission` where date = '{start_date}' and employee = '{self.employee}' and permission_type = '{perm_map[self.log_type]}' and workflow_state = 'Approved' """, as_dict=1)
 					self.shift_assignment = curr_shift["name"]


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
- Employees with 2 shifts a day cannot checkout if both shifts collide.

## Solution description
a. If only one shift, check if within the time period. return the given shift
b. If an employee has 2 shifts, check if the shift is within the time period. return shift which is within the current time period.
b. if both shifts assigned collide in time, check if the first shift has checkout. If checkout exists, return 2nd shift. else, return 1st shift.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Areas affected and ensured
- Method tested with multiple scenarios
- Related methods are ensured if they work.

## Is there any existing behaviour change of other features due to this code change?
- No effect unless the employee has multiple shifts.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
