### PR TITLE
chore: Attendance Check - Assignment Rule

### DIFF
--- a/one_fm/fixtures/assignment_rule.json
+++ b/one_fm/fixtures/assignment_rule.json
@@ -1,5 +1,191 @@
 [
  {
+  "assign_condition": "docstatus == 0",
+  "assignment_days": [
+   {
+    "day": "Monday",
+    "parent": "Attendance Check Reports To",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Tuesday",
+    "parent": "Attendance Check Reports To",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Wednesday",
+    "parent": "Attendance Check Reports To",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Thursday",
+    "parent": "Attendance Check Reports To",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Friday",
+    "parent": "Attendance Check Reports To",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Saturday",
+    "parent": "Attendance Check Reports To",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Sunday",
+    "parent": "Attendance Check Reports To",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   }
+  ],
+  "close_condition": "workflow_state in ('Approved', 'Rejected')",
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n\t\t\t<br>\n\t\t\tThe details of the request are as follows:<br>\n\t\t\t</p><table border=\"1\" cellpadding=\"0\" cellspacing=\"0\" style=\"border-collapse: collapse;\">\n\t\t\t\t<thead>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n\t\t\t\t\t</tr>\n\t\t\t\t</thead>\n\t\t\t\t<tbody>\n\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee Name</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee_name}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Date</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{date}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Department</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{department}}</td>\n\t\t\t\t</tr>\n\t\t\t</tbody></table><p></p>",
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Assignment Rule",
+  "document_type": "Attendance Check",
+  "due_date_based_on": null,
+  "field": "reports_to_user",
+  "last_user": "",
+  "modified": "2023-06-08 08:21:52.623492",
+  "name": "Attendance Check Reports To",
+  "priority": 2,
+  "rule": "Based on Field",
+  "unassign_condition": null,
+  "users": []
+ },
+ {
+  "assign_condition": "docstatus == 0",
+  "assignment_days": [
+   {
+    "day": "Monday",
+    "parent": "Attendance Check Site Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Tuesday",
+    "parent": "Attendance Check Site Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Wednesday",
+    "parent": "Attendance Check Site Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Thursday",
+    "parent": "Attendance Check Site Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Friday",
+    "parent": "Attendance Check Site Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Saturday",
+    "parent": "Attendance Check Site Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Sunday",
+    "parent": "Attendance Check Site Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   }
+  ],
+  "close_condition": "workflow_state in ('Approved', 'Rejected')",
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n\t\t\t<br>\n\t\t\tThe details of the request are as follows:<br>\n\t\t\t</p><table border=\"1\" cellpadding=\"0\" cellspacing=\"0\" style=\"border-collapse: collapse;\">\n\t\t\t\t<thead>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n\t\t\t\t\t</tr>\n\t\t\t\t</thead>\n\t\t\t\t<tbody>\n\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee Name</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee_name}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Date</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{date}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Department</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{department}}</td>\n\t\t\t\t</tr>\n\t\t\t</tbody></table><p></p>",
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Assignment Rule",
+  "document_type": "Attendance Check",
+  "due_date_based_on": null,
+  "field": "site_supervisor_user",
+  "last_user": "",
+  "modified": "2023-06-08 08:22:10.786821",
+  "name": "Attendance Check Site Supervisor",
+  "priority": 1,
+  "rule": "Based on Field",
+  "unassign_condition": null,
+  "users": []
+ },
+ {
+  "assign_condition": "docstatus == 0",
+  "assignment_days": [
+   {
+    "day": "Monday",
+    "parent": "Attendance Check Shift Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Tuesday",
+    "parent": "Attendance Check Shift Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Wednesday",
+    "parent": "Attendance Check Shift Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Thursday",
+    "parent": "Attendance Check Shift Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Friday",
+    "parent": "Attendance Check Shift Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Saturday",
+    "parent": "Attendance Check Shift Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   },
+   {
+    "day": "Sunday",
+    "parent": "Attendance Check Shift Supervisor",
+    "parentfield": "assignment_days",
+    "parenttype": "Assignment Rule"
+   }
+  ],
+  "close_condition": "workflow_state in ('Approved', 'Rejected')",
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n\t\t\t<br>\n\t\t\tThe details of the request are as follows:<br>\n\t\t\t</p><table border=\"1\" cellpadding=\"0\" cellspacing=\"0\" style=\"border-collapse: collapse;\">\n\t\t\t\t<thead>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n\t\t\t\t\t\t<th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n\t\t\t\t\t</tr>\n\t\t\t\t</thead>\n\t\t\t\t<tbody>\n\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Employee Name</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{employee_name}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Date</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{date}}</td>\n\t\t\t\t</tr>\n\t\t\t\n\t\t\t\t<tr>\n\t\t\t\t\t<td style=\"padding: 10px;\">Department</td>\n\t\t\t\t\t<td style=\"padding: 10px;\">{{department}}</td>\n\t\t\t\t</tr>\n\t\t\t</tbody></table><p></p>",
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Assignment Rule",
+  "document_type": "Attendance Check",
+  "due_date_based_on": null,
+  "field": "shift_supervisor_user",
+  "last_user": "",
+  "modified": "2023-06-08 08:22:03.174673",
+  "name": "Attendance Check Shift Supervisor",
+  "priority": 0,
+  "rule": "Based on Field",
+  "unassign_condition": null,
+  "users": []
+ },
+ {
   "assign_condition": "workflow_state == 'Pending Approval'",
   "assignment_days": [
    {

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -726,7 +726,12 @@ fixtures = [
 	},
 	{
 		"dt": "Assignment Rule",
-		"filters": [["name", "in",["RFM Approver", "Shift Permission Approver"]]]
+		"filters": [["name", "in",
+			[
+				"RFM Approver", "Shift Permission Approver", "Attendance Check Reports To",
+				"Attendance Check Site Supervisor", "Attendance Check Shift Supervisor"
+			]
+		]]
 	},
 	{
 		"dt": "Email Template"

--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -5,17 +5,11 @@ from frappe.model.document import Document
 import frappe
 from frappe import _
 from frappe.utils import nowdate, add_to_date, cstr, add_days, today
-from frappe.desk.form.assign_to import add as add_assignment, DuplicateToDoError, close_all_assignments
 
 class AttendanceCheck(Document):
-	def after_insert(self):
-		self.assign_to_supervisor()
-
 	def on_submit(self):
 		self.validate_justification_and_attendance_status()
-		close_all_assignments(self.doctype, self.name)
 		self.mark_attendance()
-		# frappe.throw('')
 
 	def mark_attendance(self):
 		if self.workflow_state == 'Approved':
@@ -115,54 +109,6 @@ class AttendanceCheck(Document):
 				message = message + ' and Attendance Status' if message else 'Attendance Status'
 			if message:
 				frappe.throw(_('To Approve or Reject the Record set {0}'.format(message)))
-
-	def assign_to_supervisor(self):
-		try:
-			users = []
-			if self.reports_to:
-				users.append(self.reports_to_user)
-			if self.shift_supervisor_user:
-				users.append(self.shift_supervisor_user)
-			if self.site_supervisor_user:
-				users.append(self.site_supervisor_user)
-			description = f"""
-				<p>Here is to inform you that the following {self.doctype}({self.name}) requires your attention/action.
-				<br>
-				The details of the request are as follows:<br>
-				</p>
-				<table border="1" cellpadding="0" cellspacing="0" style="border-collapse: collapse;">
-					<thead>
-						<tr>
-							<th style="padding: 10px; text-align: left; background-color: #f2f2f2;">Label</th>
-							<th style="padding: 10px; text-align: left; background-color: #f2f2f2;">Value</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td style="padding: 10px;">Employee</td>
-							<td style="padding: 10px;">{self.employee} - {self.employee_name}</td>
-						</tr>
-						<tr>
-							<td style="padding: 10px;">Date</td>
-							<td style="padding: 10px;">{self.date}</td>
-						</tr>
-						<tr>
-							<td style="padding: 10px;">Department</td>
-							<td style="padding: 10px;">{self.department}</td>
-						</tr>
-					</tbody>
-				</table>
-			"""
-			add_assignment({
-				'doctype': self.doctype,
-				'name': self.name,
-				'assign_to': users,
-				'description': description,
-			})
-		except DuplicateToDoError:
-			frappe.message_log.pop()
-			pass
-
 
 def create_attendance_check(attendance_date=None):
 	if not attendance_date:

--- a/one_fm/patches/v14_0/set_shift_permission_roster_type.py
+++ b/one_fm/patches/v14_0/set_shift_permission_roster_type.py
@@ -4,5 +4,6 @@ import frappe
 def execute():
     print("Setting roster_type in Shift Permission")
     shift_permissions = frappe.get_all("Shift Permission", filters={'date':[">=", "2023-06-01"]}, fields="*")
+    frappe.reload_doctype('Shift Permission')
     for i in shift_permissions:
         frappe.db.set_value("Shift Permission", i.name, 'roster_type', frappe.db.get_value("Shift Assignment", i.shift_assignment, 'roster_type'))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Attendance Check - Assignment Rule
- Update attendance comment from attendance check
- Reload shift permission doctype in path
![Screenshot 2023-06-08 at 10 08 55 AM](https://github.com/ONE-F-M/One-FM/assets/20554466/a7cd5d9c-d30a-4e14-ba0b-5f84a56fee05)

## Areas affected and ensured
- `one_fm/fixtures/assignment_rule.json`
- `one_fm/hooks.py`
- `one_fm/one_fm/doctype/attendance_check/attendance_check.py`
- `one_fm/patches/v14_0/set_shift_permission_roster_type.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome