### PR TITLE
Feat: Set actual hours and shift hours when hourly is selected in contracts items

### DIFF
--- a/one_fm/operations/doctype/contract_item/contract_item.json
+++ b/one_fm/operations/doctype/contract_item/contract_item.json
@@ -27,6 +27,7 @@
   "rate_type_off",
   "days_off_category",
   "no_of_days_off",
+  "include_actual_hour",
   "overtime_rate",
   "site"
  ],
@@ -219,11 +220,17 @@
    "fieldname": "no_of_days_off",
    "fieldtype": "Int",
    "label": "No of Days Off"
+  },
+  {
+   "default": "0",
+   "fieldname": "include_actual_hour",
+   "fieldtype": "Check",
+   "label": "Include Actual Hour"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-01-27 19:44:00.255255",
+ "modified": "2023-06-11 13:12:36.724869",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contract Item",

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -519,9 +519,9 @@ def get_item_hourly_amount(item, project, first_day_of_month, last_day_of_month,
 
     item_price = item.item_price
     item_rate = item.rate
-
+    days_off = frappe.get_value("Item Price", item_price, ["days_off"])
     shift_hours = item.shift_hours
-    working_days_in_month = days_in_month - (int(item.days_off) * 4)
+    working_days_in_month = days_in_month - (int(days_off) * 4)
 
     item_hours = 0
     expected_item_hours = working_days_in_month * shift_hours * cint(item.count)
@@ -549,15 +549,17 @@ def get_item_hourly_amount(item, project, first_day_of_month, last_day_of_month,
     # Compute working hours
     for attendance in attendances:
         hours = 0
-        if attendance.working_hours:
-            hours += attendance.working_hours
+        if item.include_actual_hour == 1:
+            if attendance.working_hours:
+                hours += attendance.working_hours
 
-        elif attendance.in_time and attendance.out_time:
-            hours += round((get_datetime(attendance.in_time) - get_datetime(attendance.out_time)).total_seconds() / 3600, 1)
+            elif attendance.in_time and attendance.out_time:
+                hours += round((get_datetime(attendance.in_time) - get_datetime(attendance.out_time)).total_seconds() / 3600, 1)
 
         # Use working hours as duration of shift if no in-out time available in attendance
-        elif attendance.operations_shift:
-            hours += float(frappe.db.get_value("Operations Shift", {'name': attendance.operations_shift}, ["duration"]))
+        else:
+            if attendance.operations_shift:
+                hours += float(frappe.db.get_value("Operations Shift", {'name': attendance.operations_shift}, ["duration"]))
 
         item_hours += hours
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
- when include_actual_shift is enabled in the item, calculate the hours by operation shift's actual hour. 
- else, use the employee's working hour/ difference of in and out. 

## Solution description
- add check box field: include_actual_shift
- if include_actual_shift is 0, take working hours.
- else, use the operation shift's duration.

## Is there a business logic within a doctype?
    - [x] Yes
    - [ ] No

## Areas affected and ensured
- Hourly Rate calculation during invoice generation.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
