### PR TITLE
feat: Change ERF - Selected Job Applicant

### DIFF
--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -65,17 +65,17 @@ def notify_recruiter_and_requester_from_job_applicant(doc, method):
             "cv": frappe.utils.get_url(doc.resume_attachment) if doc.resume_attachment else None,
             "passport_type": doc.one_fm_passport_type,
             "job_applicant": get_url(doc.get_url()),
-            "contact_email": doc.one_fm_email_id 
+            "contact_email": doc.one_fm_email_id
         }
-        
+
         message = frappe.render_template('one_fm/templates/emails/job_application_notification.html', context=context)
         # page_link = get_url(doc.get_url())
         # mandatory_field, labels = get_mandatory_fields(doc.doctype, doc.name)
         # message = "<p>There is a Job Application created for the position {2} <a href='{0}'>{1}</a></p>".format(page_link, doc.name, designation)
-        
+
         # if mandatory_field and labels:
             # message = create_message_with_details(message, mandatory_field, labels, cv=cv_link)
-            
+
         if recipients:
             sendemail(
                 recipients= recipients,
@@ -841,6 +841,10 @@ def change_applicant_erf(job_applicant, old_erf, new_erf):
 		job_applicant_obj.one_fm_hiring_method = new_erf_obj.hiring_method
 		job_applicant_obj.interview_round = new_erf_obj.interview_round
 		job_applicant_obj.save(ignore_permissions=True)
+		job_offer = frappe.db.exists('Job Offer', {'job_applicant': job_applicant, 'docstatus': ['<', 2]})
+		if job_offer:
+			job_offer_obj = frappe.get_doc('Job Offer', job_offer)
+			job_offer_obj.save(ignore_permissions=True)
 
 @frappe.whitelist()
 def send_magic_link_to_applicant_based_on_link_for(name, link_for):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- ERF in Job Applicant should be able to change by HR Manager after applicant is Selected.

## Solution description
- Allow change ERF in selected Job Applicant

## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/20554466/58a66db6-6928-4571-b930-90b390659caf

## Areas affected and ensured
- `one_fm/hiring/utils.py`
- `one_fm/public/js/doctype_js/job_applicant.js`

## Is there any existing behavior change of other features due to this code change?
Yes, ERF in Job Applicant can change by HR Manager after applicant is Selected.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome