### PR TITLE
fix: visibility of include_actual_hour 

### DIFF
--- a/one_fm/operations/doctype/contract_item/contract_item.json
+++ b/one_fm/operations/doctype/contract_item/contract_item.json
@@ -223,6 +223,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.rate_type=='Hourly'",
    "fieldname": "include_actual_hour",
    "fieldtype": "Check",
    "label": "Include Actual Hour"
@@ -230,7 +231,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-06-11 13:12:36.724869",
+ "modified": "2023-06-13 11:04:43.785579",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contract Item",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- include_actual_hour to be visible only if rate_type = Hourly.

## Is there a business logic within a doctype?
    - [x] Yes
    - [ ] No

## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/29017559/bba3db1c-a9cb-497d-a8a0-4cc4a9db3278


## Areas affected and ensured
the view

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
