### PR TITLE
Fix: Set ERF from Job Applicant

### DIFF
--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -19,10 +19,10 @@ class JobOfferOverride(JobOffer):
         o_employee = frappe.db.get_value("Onboard Employee", {"job_offer": self.name}, "name") or ""
         self.set_onload("onboard_employee", o_employee)
 
-
     def validate(self):
         super(JobOfferOverride, self).validate()
         job_applicant = frappe.get_doc("Job Applicant", self.job_applicant)
+        self.one_fm_erf = job_applicant.one_fm_erf
         validate_mandatory_fields(job_applicant)
         self.job_offer_validate_attendance_by_timesheet()
         self.validate_job_offer_mandatory_fields()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- no erf set when created though select Applicant

## Solution description
- set ERF on creation of Job Offer, fetched from job applicant

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Areas affected and ensured
- Value set properly.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
