### PR TITLE
[BUG] Stop Copying Item Code into Item Name

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -334,11 +334,11 @@ def create_attendance_check(attendance_date=None):
 			
 			if not frappe.db.exists("Attendance Check", {"employee":i, 'date':attendance_date, 'roster_type':at_check.roster_type}):
 				try:
-					if at_check.has_checkin_record and not str(at_check.comment).startswith('4'):
-						attendance_checkin_found.append(at_check)
-					else:
-						at_check_doc = frappe.get_doc(at_check).insert(ignore_permissions=1)
-						attendance_check_list.append(at_check_doc.name)
+					# if at_check.has_checkin_record and not str(at_check.comment).startswith('4'):
+					# 	attendance_checkin_found.append(at_check)
+					# else:
+					at_check_doc = frappe.get_doc(at_check).insert(ignore_permissions=1)
+					attendance_check_list.append(at_check_doc.name)
 				except Exception as e:
 					print(e)
 
@@ -403,11 +403,11 @@ def create_attendance_check(attendance_date=None):
 
 			if not frappe.db.exists("Attendance Check", {"employee":i, 'date':attendance_date, 'roster_type':at_check.roster_type}):
 				try:
-					if at_check.has_checkin_record and not str(at_check.comment).startswith('4'):
-						attendance_checkin_found.append(at_check)
-					else:
-						at_check_doc = frappe.get_doc(at_check).insert(ignore_permissions=1)
-						attendance_check_list.append(at_check_doc.name)
+					# if at_check.has_checkin_record and not str(at_check.comment).startswith('4'):
+					# 	attendance_checkin_found.append(at_check)
+					# else:
+					at_check_doc = frappe.get_doc(at_check).insert(ignore_permissions=1)
+					attendance_check_list.append(at_check_doc.name)
 				except Exception as e:
 					print(e)
 

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1247,7 +1247,7 @@ def scrub_options_list(ol):
 @frappe.whitelist(allow_guest=True)
 def item_naming_series(doc, method):
     doc.name = doc.item_code
-    doc.item_name = doc.item_code
+    
 
 @frappe.whitelist()
 def before_insert_warehouse(doc, method):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
Stop Copying Item Code into Item Name while creating an Item for the first time

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Stop Copying Item Code into Item Name while creating an Item for the first time
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Item Page

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? No
    - [] is attachment required? No
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
