### PR TITLE
Feat: Shift Assignment to active employee's only. 

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -714,6 +714,9 @@ def assign_am_shift():
 				SELECT name from `tabShift Type` st
 				WHERE st.start_time >= '01:00:00'
 				AND  st.start_time < '13:00:00')
+			AND ES.employee IN(
+				SELECT name from `tabEmployee` e
+				WHERE e.status = "Active")
 	""".format(date=cstr(date)), as_dict=1)
 
 	non_shift = fetch_non_shift(date, "AM")
@@ -735,6 +738,9 @@ def assign_pm_shift():
 				SELECT name from `tabShift Type` st
 				WHERE st.start_time < '01:00:00' OR st.start_time >= '13:00:00'
 				)
+			AND ES.employee IN(
+				SELECT name from `tabEmployee` e
+				WHERE e.status = "Active")
 	""".format(date=cstr(date)), as_dict=1)
 
 	non_shift = fetch_non_shift(date, "PM")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
- Only active employees should have shifts assigned.

## Solution description
- Query to include only active employee.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="678" alt="Screen Shot 2023-06-21 at 1 05 14 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/3031d107-9d53-4969-906e-f4e973bfb35b">


## Areas affected and ensured
- Query to fetch rostered employee

## Is there any existing behavior change of other features due to this code change?
Only active employee assigned with shift.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
