### PR TITLE
Chore: Prioritize Site Supervisor Before Shift Supervisor.

### DIFF
--- a/one_fm/public/js/doctype_js/job_applicant_list.js
+++ b/one_fm/public/js/doctype_js/job_applicant_list.js
@@ -7,6 +7,7 @@ frappe.listview_settings['Job Applicant'] = {
 		reject_applicat_directly(listview);
 		send_magic_link_to_selected_applicants(listview, 'Career History')
 		send_magic_link_to_selected_applicants(listview, 'Applicant Doc')
+		$('.btn.btn-primary.btn-sm.primary-action').hide();
 	}
 };
 

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2869,12 +2869,12 @@ def get_approver(employee):
     emp_data = frappe.db.get_value('Employee', employee, ['reports_to', 'shift', 'site', 'department'], as_dict=1)
     # Get for IT - ONEFM
     if emp_data.department=='IT - ONEFM':
-         return emp_data.reports_to
+        return emp_data.reports_to
     
-    if emp_data.shift:
-        operations_shift = frappe.db.get_value('Operations Shift', emp_data.shift, 'supervisor')
-    elif emp_data.site:
+    if emp_data.site:
         operations_site = frappe.db.get_value('Operations Site', emp_data.site, 'account_supervisor')
+    elif emp_data.shift:
+        operations_shift = frappe.db.get_value('Operations Shift', emp_data.shift, 'supervisor')
     elif emp_data.reports_to:
         return emp_data.reports_to
     if operations_site:return operations_site


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Shift Supervisor is returned before site supervisor.

## Solution description
- Return shift supervisor before site supervisor.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
Site Supervisor:
<img width="300" alt="Screen Shot 2023-06-26 at 3 33 37 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/3367bceb-b769-42cf-9b5a-3f68d18f4546">
Shift Supervisor:
<img width="300" alt="Screen Shot 2023-06-26 at 3 33 50 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/b894ea91-2ca0-4b13-b40b-ca967aa68993">
Output:
<img width="300" alt="Screen Shot 2023-06-26 at 3 35 10 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/eeb37bdd-1d58-43e1-8b95-ac0f8e2d9274">


## Areas affected and ensured
- get_approver() method modified.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
