### PR TITLE
Feat: Lock the option of creating new job applicants manually

### DIFF
--- a/one_fm/public/js/doctype_js/job_applicant_list.js
+++ b/one_fm/public/js/doctype_js/job_applicant_list.js
@@ -7,6 +7,7 @@ frappe.listview_settings['Job Applicant'] = {
 		reject_applicat_directly(listview);
 		send_magic_link_to_selected_applicants(listview, 'Career History')
 		send_magic_link_to_selected_applicants(listview, 'Applicant Doc')
+		$('.btn.btn-primary.btn-sm.primary-action').hide();
 	}
 };
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Do not allow user to create Job Applicant through Add button

## Solution description
Remove add button through js listview.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="1353" alt="Screen Shot 2023-06-26 at 4 26 22 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/1ce9caa4-1950-4c62-a68f-9f85c05be563">


## Areas affected and ensured
- Job application list view js.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
