### PR TITLE
Shift Permission create Checkin Log

### DIFF
--- a/one_fm/operations/doctype/shift_permission/shift_permission.js
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.js
@@ -53,8 +53,8 @@ function set_options_for_permission_type(frm) {
 };
 
 function get_shift_assignment(frm){
-	let {employee, emp_name, start_date} = frm.doc;
-	if(employee != undefined && !frm.doc.assigned_shift){
+	let {employee, emp_name} = frm.doc;
+	if(employee != undefined){
 		frappe.call({
             method: 'one_fm.operations.doctype.shift_permission.shift_permission.fetch_approver',
             args:{

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -189,12 +189,15 @@ def create_checkin(shift_permission):
 	shift_assignment = frappe.get_doc("Shift Assignment", shift_permission.assigned_shift)
 	start_time = shift_assignment.start_datetime
 	end_time = shift_assignment.end_datetime
+
+	#get the last checkin log ordered by time.
 	log = frappe.db.sql(f""" SELECT * FROM `tabEmployee Checkin`
 						WHERE employee='{shift_permission.employee}'
 						AND time between '{start_time}' AND '{end_time}'
 						ORDER BY time DESC LIMIT 1;	
 	""",as_dict=1)
-
+	#If log exists and the last checkin log type is same as the shift permission logtype, 
+	# create checkin log opposite to it.
 	if log and log[0].log_type == shift_permission.log_type:
 		ec = frappe.new_doc('Employee Checkin')
 		ec.employee = shift_permission.employee


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- If the approver takes action after the employee has checked in, it gives an error.

## Solution description
- get the last check-in record for the day. If check-in exists, create a checkout before check-in.
- If check-out exists, create a check-in before check-out.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Output screenshots (optional)
<img width="400" alt="Screen Shot 2023-07-04 at 10 13 57 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/c4509ead-fb06-4251-80cd-b8389288e3d1">
<img width="400" alt="Screen Shot 2023-07-04 at 10 14 23 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/307ecde8-2b68-4781-a301-5987f98503c9">

## Areas affected and ensured
- Shift Permission Approval Process.
- fetching of the shift details when employee is inserted.

## Is there any existing behavior change of other features due to this code change?
- The workflow is tested and works fine is all the scenarios.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
