### PR TITLE
[BUG 185553455] Fix Incorrect Shift assignment time

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -701,6 +701,7 @@ def fetch_non_shift(date, s_type):
 
 	return roster
 
+
 def assign_am_shift():
 	date = cstr(getdate())
 	end_previous_shifts("AM")
@@ -724,6 +725,7 @@ def assign_am_shift():
 		roster.extend(non_shift)
 
 	create_shift_assignment(roster, date, 'AM')
+
 
 def assign_pm_shift():
 	date = cstr(getdate())
@@ -763,9 +765,9 @@ def end_previous_shifts(time):
 
 def get_shift_type(time):
 	if time == "AM":
-		shift_type = frappe.get_list("Shift Type", {"start_time": [">=", "00:00"], "start_time": ["<", "12:00"]},['name'], pluck='name')
+		shift_type = frappe.get_list("Shift Type", {"start_time": [">=", "01:00"], "start_time": ["<", "13:00"]},['name'], pluck='name')
 	else:
-		shift_type = frappe.get_list("Shift Type", {"start_time": [">=", "12:00"]},['name'], pluck='name')
+		shift_type = frappe.get_list("Shift Type", {"start_time": [">=", "13:00"]},['name'], pluck='name')
 	return shift_type
 
 def create_shift_assignment(roster, date, time):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
The start and end times of all shift assignments for a shift type is wrong, it prevents the employees from checkin out

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
I updated the query to fetch the correct list of schedules
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
NO

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
