### PR TITLE
Fix: Data Loading Issue due to caching

### DIFF
--- a/one_fm/www/careers/index.py
+++ b/one_fm/www/careers/index.py
@@ -3,7 +3,7 @@ from frappe.utils import getdate
 from .utils import remove_html_tags, get_department_list
 
 def get_context(context):
-    no_cache = 1
+    context.no_cache = 1
     # Get recent openings
     context.recent_openings = get_recent_openings()
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- the Job Opening data doesn't collect the new data due to caching.
- the list gets renewed only when the browser's cache is cleared.

## Solution description
- no_cache not defined correctly. Define it with the context.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/ae1bc3e5-984d-4842-a7c8-f44ccf998ba4


## Areas affected and ensured
Get Context method with no_cache enabled.

## Is there any existing behavior change of other features due to this code change?
no cache enabled.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
