### PR TITLE
Fix: Post Schedule Checker

### DIFF
--- a/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
+++ b/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
@@ -136,7 +136,7 @@ def get_post_schedules(project, post, first_day, last_day):
 			"date": ['BETWEEN', [first_day, last_day]],
 			"project": project,
 			"post": post.name,
-			# 'post_status': 'Planned'
+			'post_status': 'Planned'
 		}
 	)
 

--- a/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
+++ b/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
@@ -136,7 +136,7 @@ def get_post_schedules(project, post, first_day, last_day):
 			"date": ['BETWEEN', [first_day, last_day]],
 			"project": project,
 			"post": post.name,
-			'post_status': 'Planned'
+			"post_status": 'Planned'
 		}
 	)
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- The checker fetches Post off Schedule which gives the wrong calculation.

## Solution description
- Include Planned only post schedules.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
When only Planned Post scheduled is considered, the expected and posted schedule as same:
<img width="300" alt="Screen Shot 2023-07-11 at 12 44 39 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/b080fddd-8152-4996-9505-f21b123a83b6">


## Areas affected and ensured
- Get Post Schedule method fetching only planned schedules for given period.

## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
