### PR TITLE
added: Change log v14_4_4

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -40,7 +40,7 @@ from  one_fm.overrides.stock_ledger import get_valuation_rate_
 from erpnext.stock import stock_ledger
 from hrms.hr.doctype.leave_allocation.leave_allocation import LeaveAllocation
 
-__version__ = '14.4.3'
+__version__ = '14.4.4'
 
 PaymentEntry.add_party_gl_entries = add_party_gl_entries_
 workflow_action.send_workflow_action_email = override_frappe_send_workflow_action_email

--- a/one_fm/change_log/v14/v14_4_4.md
+++ b/one_fm/change_log/v14/v14_4_4.md
@@ -1,0 +1,24 @@
+
+# Version 14.4.4 Release Notes 
+
+### ONE FM NEW FEATURES
+
+- [As a roster employee action user I would like that any employee set as vacation in employee status does not show up as employee not rostered.]
+- [Lock the option of creating new job applicants manually]
+
+### Bug Fixes
+
+- [Unable to create New Item Code]
+- [Fix: Shift Permission]
+- [OKR PErformance Profile fixes](https://github.com/ONE-F-M/One-FM/pull/2521)
+- [Fix:queue_send_workflow_action_email](https://github.com/ONE-F-M/One-FM/pull/2509)
+- [Job Offer Change of Salary Strcuture Issues]
+- [Todo does not close for Shift Permission](https://github.com/ONE-F-M/One-FM/pull/2512)
+- [Error upon closing issues](https://github.com/ONE-F-M/One-FM/pull/2511)
+- [Shift Issue](https://github.com/ONE-F-M/One-FM/pull/2513)
+- [Job Offer List View]
+- [Post not rostering day off - Warehouse-MOH Central Medical Store-Morning-1](https://github.com/ONE-F-M/One-FM/pull/2500)
+
+### Chores
+- [Actions in Job Applicant - in mobile view - Organize Action button for better mobile user experience](https://github.com/ONE-F-M/One-FM/pull/2518)
+- 


### PR DESCRIPTION

# Version 14.4.4 Release Notes 

### ONE FM NEW FEATURES

- [As a roster employee action user I would like that any employee set as vacation in employee status does not show up as employee not rostered.]
- [Lock the option of creating new job applicants manually]

### Bug Fixes

- [Unable to create New Item Code]
- [Fix: Shift Permission]
- [OKR PErformance Profile fixes](https://github.com/ONE-F-M/One-FM/pull/2521)
- [Fix:queue_send_workflow_action_email](https://github.com/ONE-F-M/One-FM/pull/2509)
- [Job Offer Change of Salary Strcuture Issues]
- [Todo does not close for Shift Permission](https://github.com/ONE-F-M/One-FM/pull/2512)
- [Error upon closing issues](https://github.com/ONE-F-M/One-FM/pull/2511)
- [Shift Issue](https://github.com/ONE-F-M/One-FM/pull/2513)
- [Job Offer List View]
- [Post not rostering day off - Warehouse-MOH Central Medical Store-Morning-1](https://github.com/ONE-F-M/One-FM/pull/2500)

### Chores
- [Actions in Job Applicant - in mobile view - Organize Action button for better mobile user experience](https://github.com/ONE-F-M/One-FM/pull/2518)
- 