### PR TITLE
Fix: Leave Policy Assignment

### DIFF
--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -644,20 +644,25 @@ def create_new_work_permit(work_permit):
     wp.save(ignore_permissions=True)
     return wp
 
-def update_leave_policy_assignments_expires_today():
+ddef update_leave_policy_assignments_expires_today():
     '''
         Method to create Leave Policy Assignment when existing one expires today
     '''
     # Get Active Leave Policy Assignment List thats ends today
     leave_policy_assignments = frappe.db.get_list('Leave Policy Assignment', {'effective_to': getdate(today())})
+    frappe.enqueue(create_leave_policy,leave_policy_assignments=leave_policy_assignments, is_async=True, queue='long')
+
+def create_leave_policy(leave_policy_assignments):
     for policy_assignment in leave_policy_assignments:
         doc = frappe.get_doc('Leave Policy Assignment', policy_assignment.name)
+        effective_from = add_days(getdate(doc.effective_to), 1)
+        effective_to = add_days(add_years(effective_from, 1), -1)
         # Check if the employee status not Left
-        if frappe.db.get_value('Employee', doc.employee, 'status') not in ['Left']:
+        if frappe.db.get_value('Employee', doc.employee, 'status') not in ['Left'] and not frappe.db.exists("Leave Policy Assignment", {'employee':doc.employee, 'effective_from':effective_from, 'effective_to':effective_to}):
             leave_policy_assignment = frappe.new_doc('Leave Policy Assignment')
             leave_policy_assignment.employee = doc.employee
-            leave_policy_assignment.effective_from = add_days(getdate(doc.effective_to), 1)
-            leave_policy_assignment.effective_to = add_days(add_years(leave_policy_assignment.effective_from, 1), -1)
+            leave_policy_assignment.effective_from = effective_from
+            leave_policy_assignment.effective_to = effective_to
             leave_policy_assignment.leave_policy = doc.leave_policy
             leave_policy_assignment.carry_forward = doc.carry_forward
             leave_policy_assignment.leaves_allocated = False

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -644,7 +644,7 @@ def create_new_work_permit(work_permit):
     wp.save(ignore_permissions=True)
     return wp
 
-ddef update_leave_policy_assignments_expires_today():
+def update_leave_policy_assignments_expires_today():
     '''
         Method to create Leave Policy Assignment when existing one expires today
     '''


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Deadlock when running update_leave_policy_assignments_expires_today() because there was another schedule that makes changes in leave allocation


## Solution description
- Frappe Enqueue the job.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
