### PR TITLE
Feat: No supervisor Notification if employee is Dummy.

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -333,6 +333,7 @@ def checkin_checkout_query(date, shift_type, log_type):
 					FROM `tabShift Assignment` tSA, `tabEmployee` emp
 					WHERE
 						tSA.employee=emp.name
+					AND emp.auto_attendance = 0
 					AND tSA.start_date='{date}'
 					AND tSA.shift_type='{shift_type}'
 					AND tSA.docstatus=1

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -79,9 +79,10 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 	def after_insert(self):
 		frappe.db.commit()
 		self.reload()
+		auto_attendance = frappe.get_value("Employee", {'name':self.employee}, ['auto_attendance'])
 		if not (self.shift_assignment and self.shift_type and self.operations_shift and self.shift_actual_start and self.shift_actual_end):
 			frappe.enqueue(after_insert_background, self=self.name)
-		if self.log_type == "IN":
+		if self.log_type == "IN" and auto_attendance == 0:
 			frappe.enqueue(notify_supervisor_about_late_entry, checkin=self)
 
 def after_insert_background(self):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- If employee is a dummy, disable the supervisor notification for the employee check-in.

## Solution description
- Skip if auto_attendance = 1.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
- supervisor check-in notification

## Is there any existing behaviour change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
