### PR TITLE
Fix: Notification to Supervisor And Shift Assignment for Active Employee's only

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -82,7 +82,8 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 		if not (self.shift_assignment and self.shift_type and self.operations_shift and self.shift_actual_start and self.shift_actual_end):
 			frappe.enqueue(after_insert_background, self=self.name)
 		if self.log_type == "IN":
-			frappe.enqueue(notify_supervisor_about_late_entry, checkin=self)
+			notify_supervisor_about_late_entry(self)
+			# frappe.enqueue(notify_supervisor_about_late_entry, checkin=self)
 
 def after_insert_background(self):
 	self = frappe.get_doc("Employee Checkin", self)
@@ -237,32 +238,34 @@ def notify_supervisor_about_late_entry(checkin):
 	This method notify the supervisor about the late entry of an employee
 	"""
 	try:
-		shift_permission = frappe.db.sql(f""" select name from `tabShift Permission` where employee = '{checkin.employee}' and date = '{now_datetime().date()}' and log_type = 'IN' and permission_type = 'Arrive Late' and workflow_state = 'Approved' ;  """)
-		if checkin.shift_assignment:
-			last_shift_assignment = checkin.shift_assignment
-			shift_late_minutes = frappe.db.get_value("Shift Type", {"name": checkin.shift_type}, ['supervisor_reminder_shift_start', 'start_time'], as_dict=1)
-			the_roster_type = checkin.roster_type
-			op_shift = frappe.get_doc("Operations Shift", checkin.operations_shift)
+		auto_attendance_employee = frappe.get_value("Employee", {'name':checkin.employee}, ['auto_attendance'])
+		if auto_attendance_employee == 0:
+			shift_permission = frappe.db.sql(f""" select name from `tabShift Permission` where employee = '{checkin.employee}' and date = '{now_datetime().date()}' and log_type = 'IN' and permission_type = 'Arrive Late' and workflow_state = 'Approved' ;  """)
+			if checkin.shift_assignment:
+				last_shift_assignment = checkin.shift_assignment
+				shift_late_minutes = frappe.db.get_value("Shift Type", {"name": checkin.shift_type}, ['supervisor_reminder_shift_start', 'start_time'], as_dict=1)
+				the_roster_type = checkin.roster_type
+				op_shift = frappe.get_doc("Operations Shift", checkin.operations_shift)
 
-		else:
-			last_shift_assignment = get_shift_from_checkin(checkin)
-			if last_shift_assignment:
-				shift_late_minutes = frappe.db.get_value("Shift Type", {"name": last_shift_assignment["shift_type"]}, ['supervisor_reminder_shift_start', 'start_time'], as_dict=1)
-				the_roster_type = last_shift_assignment.roster_type
-				op_shift = frappe.get_doc("Operations Shift", last_shift_assignment.shift)
+			else:
+				last_shift_assignment = get_shift_from_checkin(checkin)
+				if last_shift_assignment:
+					shift_late_minutes = frappe.db.get_value("Shift Type", {"name": last_shift_assignment["shift_type"]}, ['supervisor_reminder_shift_start', 'start_time'], as_dict=1)
+					the_roster_type = last_shift_assignment.roster_type
+					op_shift = frappe.get_doc("Operations Shift", last_shift_assignment.shift)
 
-		if last_shift_assignment and not shift_permission:
-			if checkin.time.time() > datetime.strptime(str(shift_late_minutes["start_time"] + timedelta(minutes=shift_late_minutes['supervisor_reminder_shift_start'])), "%H:%M:%S").time():
-				time_diff = calculate_time_diffrence_for_checkin(shift_late_minutes["start_time"], checkin.time)
-				time_of_arrival = parse(str(checkin.time)).time()
-				get_reports_to = frappe.db.get_value("Employee", {"name": checkin.employee}, ['reports_to'])
-				if get_reports_to:
-					return send_push_notification_for_late_entry(get_reports_to, checkin.employee_name, roster_type=the_roster_type if the_roster_type else "Basic", time_difference=time_diff, shift=op_shift, time_of_arrival=time_of_arrival)
-				get_site = frappe.db.get_value("Employee", {"name": checkin.employee}, ['site'])
-				if get_site:
-					get_site_supervisor = frappe.db.get_value("Operations Site", {"name": get_site}, ['account_supervisor'])
-					if get_site_supervisor:
-						return send_push_notification_for_late_entry(get_site_supervisor, checkin.employee, roster_type=the_roster_type if the_roster_type else "Basic", time_difference=time_diff, shift=op_shift, time_of_arrival=time_of_arrival)
+			if last_shift_assignment and not shift_permission:
+				if checkin.time.time() > datetime.strptime(str(shift_late_minutes["start_time"] + timedelta(minutes=shift_late_minutes['supervisor_reminder_shift_start'])), "%H:%M:%S").time():
+					time_diff = calculate_time_diffrence_for_checkin(shift_late_minutes["start_time"], checkin.time)
+					time_of_arrival = parse(str(checkin.time)).time()
+					get_reports_to = frappe.db.get_value("Employee", {"name": checkin.employee}, ['reports_to'])
+					if get_reports_to:
+						return send_push_notification_for_late_entry(get_reports_to, checkin.employee_name, roster_type=the_roster_type if the_roster_type else "Basic", time_difference=time_diff, shift=op_shift, time_of_arrival=time_of_arrival)
+					get_site = frappe.db.get_value("Employee", {"name": checkin.employee}, ['site'])
+					if get_site:
+						get_site_supervisor = frappe.db.get_value("Operations Site", {"name": get_site}, ['account_supervisor'])
+						if get_site_supervisor:
+							return send_push_notification_for_late_entry(get_site_supervisor, checkin.employee, roster_type=the_roster_type if the_roster_type else "Basic", time_difference=time_diff, shift=op_shift, time_of_arrival=time_of_arrival)
 	except Exception as e:
 		frappe.log_error(e)
 		pass

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -82,8 +82,7 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 		if not (self.shift_assignment and self.shift_type and self.operations_shift and self.shift_actual_start and self.shift_actual_end):
 			frappe.enqueue(after_insert_background, self=self.name)
 		if self.log_type == "IN":
-			notify_supervisor_about_late_entry(self)
-			# frappe.enqueue(notify_supervisor_about_late_entry, checkin=self)
+			frappe.enqueue(notify_supervisor_about_late_entry, checkin=self)
 
 def after_insert_background(self):
 	self = frappe.get_doc("Employee Checkin", self)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Notification To the supervisor if the employee is a dummy needs to be disabled.
- Shift assignment creation of employee on Vacation.

## Solution description
- For Late arrival notifications, check if the employee has Auto_attendance == 0.
- Create shift assignment if the employee is Active.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Areas affected and ensured
- Checkin Notification ensured.
- shift assignment creation ensured.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
