### PR TITLE
Fix: fetching Shift Assignment in Checking log.

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -88,7 +88,7 @@ def after_insert_background(self):
 	self = frappe.get_doc("Employee Checkin", self)
 	try:
 		# update shift if not exists
-		curr_shift = get_shift_from_checkin(self)
+		curr_shift = get_current_shift(self.employee)
 		if curr_shift:
 			shift_type = frappe.db.sql(f"""SELECT * FROM `tabShift Type` WHERE name='{curr_shift.shift_type}' """, as_dict=1)[0]
 			# calculate entry


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Fetching of Shift Assignments doesn't consider overtime.

## Solution description
- Fetching shift assignment from get_current_shift API.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
<img width="400" alt="Screen Shot 2023-08-06 at 9 27 15 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/3dd5ab32-6c8b-45ec-a356-c7afe0f47204">


## Areas affected and ensured
- Checkin after insert modified.

## Is there any existing behaviour change of other features due to this code change?
Check-in works fine.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
