### PR TITLE
Feat: Update employee status when leave begins.

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -673,6 +673,9 @@ scheduler_events = {
 		],
 		"45 23 23 * *": [ #approve all the open leave application
 		'one_fm.api.doc_methods.payroll_entry.close_all_leave_application'
+		],
+		"30 23 * * *":[
+			'one_fm.overrides.leave_application.employee_leave_status'
 		]
 	}
 }

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -1,6 +1,6 @@
 import frappe,json
 from frappe import _
-from frappe.utils import get_fullname,nowdate
+from frappe.utils import get_fullname, nowdate, add_to_date
 from hrms.hr.doctype.leave_application.leave_application import *
 from one_fm.processor import sendemail
 from frappe.desk.form.assign_to import add
@@ -271,6 +271,11 @@ class LeaveApplicationOverride(LeaveApplication):
                 frappe.log_error(frappe.get_traceback(),"Error Sending Notification")
 
     def on_cancel(self):
+        if self.status == "Cancelled"  and self.leave_type == 'Annual Leave' and self.from_date <= nowdate() <= self.to_date:
+            emp = frappe.get_doc("Employee", self.employee)
+            emp.status = "Active"
+            emp.save()
+            frappe.db.commit()
         self.create_leave_ledger_entry(submit=False)
 		# notify leave applier about cancellation
         self.cancel_attendance()
@@ -303,6 +308,12 @@ class LeaveApplicationOverride(LeaveApplication):
                         }).submit()
 
                     frappe.db.commit()
+        if self.status == "Approved":
+            if self.from_date <= nowdate() <= self.to_date and self.leave_type == 'Annual Leave':
+                emp = frappe.get_doc("Employee", self.employee)
+                emp.status = "Vacation"
+                emp.save()
+                frappe.db.commit()
 
 @frappe.whitelist()
 def get_leave_approver(employee):
@@ -318,3 +329,29 @@ def get_leave_approver(employee):
         )
 
     return leave_approver
+
+@frappe.whitelist()
+def employee_leave_status():
+    """
+    This method is to change the status of employee Doc from Active to Vacation, when Leave starts.
+    It also changes it back to Active when the leave ends. 
+    The method is called as a cron job before  assigning shift.
+    """
+    today = nowdate()
+    tomorrow = add_to_date(today, days=1).split(" ")[0]
+
+    start_leave = frappe.get_list("Leave Application", {'from_date': tomorrow,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])
+    end_leave = frappe.get_list("Leave Application", {'to_date': today,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])
+
+    frappe.enqueue(process_change,start_leave=start_leave,end_leave=end_leave, is_async=True, queue="long")
+    
+def process_change(start_leave, end_leave):
+    change_employee_status(start_leave, "Vacation")
+    change_employee_status(end_leave, "Active")
+
+def change_employee_status(employee_list, status):
+    for e in employee_list:
+        emp = frappe.get_doc("Employee", e.employee)
+        emp.status = status
+        emp.save()
+    frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- When an employee applies for annual leave, and it gets approved, It should change his employee doc status from Active to Vacation. 
- The status should change only when the leave date starts.
- When leave ends, it should be changed back to "Active"

## Solution description
- Create cron to check for leave date, and change status accordingly.
- if the employee applies today, then on approval the status should turn automatically.
- On cancellation of leave on today's date, it should change the status to Active.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/29017559/1d10ced3-43da-4852-a06f-a241995a8604



## Areas affected and ensured
- Leave on approval and on cancellation updates the employee doc status.
- corn job created to change status when leave employee starts.

## Is there any existing behaviour change of other features due to this code change?
no.

## Did you test with the following dataset?
- []  Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
