### PR TITLE
hot fix: interview overlap

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -37,11 +37,14 @@ from one_fm.utils import override_frappe_send_workflow_action_email
 from erpnext.accounts.doctype.payment_entry.payment_entry import PaymentEntry
 from one_fm.overrides.payment_entry import add_party_gl_entries_
 from one_fm.overrides.stock_ledger import get_valuation_rate_
+from one_fm.overrides.interview import validate_interview_overlap
 from erpnext.stock import stock_ledger
 from hrms.hr.doctype.leave_allocation.leave_allocation import LeaveAllocation
+from hrms.hr.doctype.interview.interview import Interview
 
 __version__ = '14.5.0'
 
+Interview.validate_overlap = validate_interview_overlap
 PaymentEntry.add_party_gl_entries = add_party_gl_entries_
 workflow_action.send_workflow_action_email = override_frappe_send_workflow_action_email
 stock_ledger.get_valuation_rate = get_valuation_rate_

--- a/one_fm/overrides/interview.py
+++ b/one_fm/overrides/interview.py
@@ -1,0 +1,39 @@
+import frappe
+from frappe import _
+from frappe.utils import get_link_to_form
+
+def validate_interview_overlap(self):
+    interviewers = [entry.interviewer for entry in self.interview_details] or [""]
+
+    query = """
+        SELECT interview.name
+        FROM `tabInterview` as interview
+        INNER JOIN `tabInterview Detail` as detail
+        WHERE
+        interview.scheduled_on = %s and interview.name != %s and interview.docstatus != 2
+        and (interview.job_applicant = %s and detail.interviewer IN %s) and
+        ((from_time < %s and to_time > %s) or
+        (from_time > %s and to_time < %s) or
+        (from_time = %s))
+    """
+
+    overlaps = frappe.db.sql(
+        query,
+        (
+        self.scheduled_on,
+        self.name,
+        self.job_applicant,
+        interviewers,
+        self.from_time,
+        self.to_time,
+        self.from_time,
+        self.to_time,
+        self.from_time,
+        ),
+    )
+
+    if overlaps:
+        overlapping_details = _("Interview overlaps with {0}").format(
+            get_link_to_form("Interview", overlaps[0][0])
+        )
+        frappe.throw(overlapping_details, title=_("Overlap"))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Need to remove the restriction on creating two different interviews at the same time on the same day? As two meetings could be happening to two different candidates at the same time for different reasons.

## Solution description
- Override interview overlap method and implemented the business logic

## Areas affected and ensured
- `one_fm/__init__.py`

## Is there any existing behavior change of other features due to this code change?
Yes, Interview overlap validation streamlined

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome