### PR TITLE
fix: send supplier email from rfq

### DIFF
--- a/one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py
+++ b/one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py
@@ -87,7 +87,7 @@ class RequestforSupplierQuotation(Document):
             if rec != None and supplier.send_email:
                 try:
                     sendemail(sender=sender, recipients= rec, cc= rec_cc,
-                        content=msg, subject="Request for Quotation - {0}".format(self.name))
+                        content=msg, subject="Request for Quotation - {0}".format(self.name), is_external_mail=True)
                     supplier.email_sent = 1
                     self.save()
                     frappe.msgprint(_("Email sent to supplier {0}").format(supplier.supplier))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- `Send Supplier Email` button in RFQ is not sending email

## Solution description
- external email filter is applied

## Areas affected and ensured
- `one_fm/one_fm/doctype/request_for_supplier_quotation/request_for_supplier_quotation.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome