### PR TITLE
Fix: Datetime Format issue in Leave Approval.

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -271,7 +271,7 @@ class LeaveApplicationOverride(LeaveApplication):
                 frappe.log_error(frappe.get_traceback(),"Error Sending Notification")
 
     def on_cancel(self):
-        if self.status == "Cancelled"  and self.leave_type == 'Annual Leave' and self.from_date <= nowdate() <= self.to_date:
+        if self.status == "Cancelled"  and self.leave_type == 'Annual Leave' and getdate(self.from_date) <= getdate() <= getdate(self.to_date):
             emp = frappe.get_doc("Employee", self.employee)
             emp.status = "Active"
             emp.save()
@@ -309,7 +309,7 @@ class LeaveApplicationOverride(LeaveApplication):
 
                     frappe.db.commit()
         if self.status == "Approved":
-            if self.from_date <= nowdate() <= self.to_date and self.leave_type == 'Annual Leave':
+            if getdate(self.from_date) <= getdate() <= getdate(self.to_date) and self.leave_type == 'Annual Leave':
                 emp = frappe.get_doc("Employee", self.employee)
                 emp.status = "Vacation"
                 emp.save()
@@ -337,8 +337,9 @@ def employee_leave_status():
     It also changes it back to Active when the leave ends. 
     The method is called as a cron job before  assigning shift.
     """
-    today = nowdate()
-    tomorrow = add_to_date(today, days=1).split(" ")[0]
+    today = getdate()
+    # print(type(getdate()))
+    tomorrow = add_to_date(today, days=1)
 
     start_leave = frappe.get_list("Leave Application", {'from_date': tomorrow,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])
     end_leave = frappe.get_list("Leave Application", {'to_date': today,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -338,7 +338,6 @@ def employee_leave_status():
     The method is called as a cron job before  assigning shift.
     """
     today = getdate()
-    # print(type(getdate()))
     tomorrow = add_to_date(today, days=1)
 
     start_leave = frappe.get_list("Leave Application", {'from_date': tomorrow,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- The nowdate() was datetime and was compared with str in staging.

## Solution description
- use getdate

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/b08a1e33-2194-49f5-a58a-2f6fd6ee371e

## Areas affected and ensured
- Leave application approval and cancellation works.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
