### PR TITLE
hot fix: Not able to update submitted erf

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -155,7 +155,7 @@ class ERF(Document):
 		self.notify_recruitment_manager()
 		# self.notify_approver()
 		self.reload()
-  
+
 	def notify_recruitment_manager(self):
 		try:
 			role_profile = frappe.db.get_list("Role Profile", {"role_profile": ["IN", ["Recruitment Manager", "Director"]]}, pluck="name")
@@ -178,8 +178,8 @@ class ERF(Document):
 					frappe.msgprint(_('Recruitment manager will be notified by email.'))
 		except:
 			frappe.log_error(frappe.get_traceback(), "Error while sending mail to recruitment manager(ERF) ")
-      		
-		
+
+
 
 
 
@@ -346,8 +346,8 @@ class ERF(Document):
 			if not frappe.db.exists("Job Opening", {'one_fm_erf':self.name}):
 				create_job_opening_from_erf(self)
 		self.reload()
-        
-        
+
+
 
 def get_erf_approver(reason_for_request):
 	erf_approver_role = 'Unplanned ERF Approver' if reason_for_request == 'UnPlanned' else 'ERF Approver'
@@ -355,6 +355,8 @@ def get_erf_approver(reason_for_request):
 
 def create_job_opening_from_erf(erf):
 	job_opening = frappe.new_doc("Job Opening")
+	# TODO: job_title needs to be unique,
+	# since job_title will be set a route in Job Opening and the route is set as name in Job Opening
 	job_opening.job_title = erf.job_title
 	job_opening.designation = erf.designation
 	job_opening.employment_type = erf.employment_type

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -47,3 +47,4 @@ one_fm.patches.v14_0.close_shift_perm_todo #2023-07-06
 one_fm.patches.v14_0.update_job_offer_status
 one_fm.patches.v14_0.update_erf_with_hiring_method
 one_fm.patches.v14_0.update_job_application_with_hiring_method
+one_fm.patches.v14_0.update_erf_with_job_title

--- a/one_fm/patches/v14_0/update_erf_with_job_title.py
+++ b/one_fm/patches/v14_0/update_erf_with_job_title.py
@@ -1,0 +1,13 @@
+import frappe
+
+
+def execute():
+    query = """
+        UPDATE
+            tabERF
+        SET
+            job_title = CONCAT(erf_code, '-', designation, '-', department)
+        WHERE
+            job_title IS NULL
+    """
+    frappe.db.sql(query)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Submitted ERF is not allowing to update by showing the error, Job Title is mandatory.
- ![Screenshot 2023-08-10 at 12 21 53 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/a73c6f62-fbab-473b-8e5b-87d2240e2009)


## Solution description
- Job Title is a newly introduced field in ERF and it is mandatory. In this PR we write a patch to set the job title in old ERF

## Output screenshots (optional)
![Screenshot 2023-08-10 at 1 16 00 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/4532dfa6-d42a-42b1-9456-6df657ac3671)

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.py`
- `one_fm/patches.txt`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes
    ## Was the patch test? Yes

## Which browser(s) did you use for testing?
- [x] Chrome