### PR TITLE
chore: leave approval email

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -79,9 +79,6 @@ class LeaveApplicationOverride(LeaveApplication):
 
     def on_submit(self):
         self.close_todo()
-        if self.docstatus == 1:
-            self.notify_employee()
-
         return super().on_submit()
 
     def notify_employee(self):
@@ -146,7 +143,7 @@ class LeaveApplicationOverride(LeaveApplication):
                 return
             email_template = frappe.get_doc("Email Template", template)
             message = frappe.render_template(email_template.response_html, args)
-        
+
             if self.proof_documents:
                 proof_doc = self.proof_documents
                 for p in proof_doc:
@@ -334,7 +331,7 @@ def get_leave_approver(employee):
 def employee_leave_status():
     """
     This method is to change the status of employee Doc from Active to Vacation, when Leave starts.
-    It also changes it back to Active when the leave ends. 
+    It also changes it back to Active when the leave ends.
     The method is called as a cron job before  assigning shift.
     """
     today = getdate()
@@ -344,7 +341,7 @@ def employee_leave_status():
     end_leave = frappe.get_list("Leave Application", {'to_date': today,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])
 
     frappe.enqueue(process_change,start_leave=start_leave,end_leave=end_leave, is_async=True, queue="long")
-    
+
 def process_change(start_leave, end_leave):
     change_employee_status(start_leave, "Vacation")
     change_employee_status(end_leave, "Active")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Double Leave application email sent, while approving the leave
- ![Screenshot 2023-08-14 at 7 34 14 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/6ccf5c88-7a2d-4844-a805-c539df45dd5d)

## Solution description
- one fm overrides leave application class, and the one fm app notify the employee on submit of override class and call on_submit of supper class too. The core leave application on_submit method again notify the employee. 

## Output screenshots (optional)
- ![Screenshot 2023-08-14 at 7 28 22 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/5cd42c6c-0d32-49e0-b912-2e9e68c2ee15)

## Areas affected and ensured
- `one_fm/overrides/leave_application.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome