### PR TITLE
feat: Item group abbreviation - validation

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -245,7 +245,8 @@ doc_events = {
 	"Item Group": {
 		"autoname": "one_fm.utils.item_group_naming_series",
 		"before_insert": "one_fm.utils.validate_get_item_group_parent",
-		"after_insert": "one_fm.utils.after_insert_item_group"
+		"after_insert": "one_fm.utils.after_insert_item_group",
+		"validate": "one_fm.overrides.item_group.validate_item_group"
 	},
 	"Item": {
 		"autoname": "one_fm.utils.item_naming_series",

--- a/one_fm/overrides/item_group.py
+++ b/one_fm/overrides/item_group.py
@@ -1,0 +1,9 @@
+import frappe
+from frappe import _
+
+@frappe.whitelist()
+def validate_item_group(doc, method):
+    if doc.one_fm_item_group_abbr:
+        abbr = frappe.db.get_value("Item Group", {"one_fm_item_group_abbr": doc.one_fm_item_group_abbr}, "one_fm_item_group_abbr")
+        if abbr:
+            frappe.throw(_("Item Group Abbreviation {0} already exists. Select another abbreviation".format(abbr)))

--- a/one_fm/public/js/doctype_js/item_group.js
+++ b/one_fm/public/js/doctype_js/item_group.js
@@ -26,6 +26,24 @@ frappe.ui.form.on('Item Group', {
 				}
 			});
 		}
+	},
+	one_fm_item_group_abbr: function(frm) {
+		var description = "";
+		if(frm.doc.one_fm_item_group_abbr){
+			// check if abbreviation exists
+			frappe.db.get_value(
+				"Item Group", {"one_fm_item_group_abbr": frm.doc.one_fm_item_group_abbr}, "one_fm_item_group_abbr",
+				(val) => {
+					if (val && val.one_fm_item_group_abbr) {
+						description = __("{0} already exists. Select another abbreviation", [val.one_fm_item_group_abbr])
+					}
+					frm.set_df_property("one_fm_item_group_abbr", "description", description);
+				}
+			);
+		}
+		else{
+			frm.set_df_property("one_fm_item_group_abbr", "description", description);
+		}
 	}
 });
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Abbreviation in item group is need to be validated as unique.

## Solution description
- Check for the existence of same abbreviation on  field change and notify the user by the field description and show validation from the server side

## Output screenshots (optional)
- ![Screenshot 2023-08-14 at 1 25 49 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/2b23120d-29dd-4e17-889c-5942939824c8)
- ![Screenshot 2023-08-14 at 1 26 07 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/6dc9f1a2-4b9c-4f83-9786-13ac3b5354f6)

## Areas affected and ensured
- `one_fm/hooks.py`
- `one_fm/public/js/doctype_js/item_group.js`

## Is there any existing behavior change of other features due to this code change?
Yes, validates the abbreviation in the item group 

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome