### PR TITLE
Fix: Fetching of Operation roles

### DIFF
--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -177,8 +177,7 @@ def get_operations_posts(doctype, txt, searchfield, start, page_len, filters):
 	shift = filters.get('operations_shift')
 	operations_roles = frappe.db.sql("""
 		SELECT DISTINCT name
-		FROM `tabOperations Post`
-		WHERE site_shift="{shift}"
+		FROM `tabOperations Role`
+		WHERE shift="{shift}"
 	""".format(shift=shift))
-	print(operations_roles)
 	return operations_roles

--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -173,7 +173,7 @@ def update_request(shift_request, from_date, to_date):
 	apply_workflow(shift_request_obj, "Update Request")
 
 @frappe.whitelist()
-def get_operations_posts(doctype, txt, searchfield, start, page_len, filters):
+def get_operations_role(doctype, txt, searchfield, start, page_len, filters):
 	shift = filters.get('operations_shift')
 	operations_roles = frappe.db.sql("""
 		SELECT DISTINCT name

--- a/one_fm/public/js/doctype_js/shift_request.js
+++ b/one_fm/public/js/doctype_js/shift_request.js
@@ -34,7 +34,7 @@ frappe.ui.form.on('Shift Request', {
 			console.log(operations_shift)
 			frm.set_query("operations_role", function() {
 				return {
-					query: "one_fm.api.doc_methods.shift_request.get_operations_posts",
+					query: "one_fm.api.doc_methods.shift_request.get_operations_role",
 					filters: {operations_shift}
 				};
 			});


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Operation Post was being fetched instead of Operation Role.

## Solution description
- Fetch Operation Role, in the get_operations_role query.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/0a7e4379-895b-4065-b174-a8ae615119c4


## Areas affected and ensured
- Operation Role Fetched.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
