### PR TITLE
Fix: Attendance Check for Left Employee

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -89,7 +89,11 @@ def create_attendance_check(attendance_date=None):
 			'attendance_date':attendance_date}, fields="*")
 		all_attendance_employee = [i.employee for i in all_attendance]
 		
-		employee_schedules = frappe.db.get_list("Employee Schedule", filters={'date':attendance_date, 'employee_availability':'Working'}, fields="*")
+		# employee_schedules = frappe.db.get_list("Employee Schedule", filters={'date':attendance_date, 'employee_availability':'Working'}, fields="*")
+		employee_schedules = frappe.db.sql(f"""SELECT * from `tabEmployee Schedule` 
+								WHERE date = '{attendance_date}'
+								AND employee_availability = 'Working'
+								AND employee in (SELECT name from `tabEmployee` WHERE status = 'Active')""", as_dict=1)
 		employee_schedules_basic = [i for i in employee_schedules if i.roster_type=='Basic']
 		employee_schedules_ot = [i for i in employee_schedules if i.roster_type=='Over-Time']
 		shift_assignments = frappe.db.get_list("Shift Assignment", filters={'start_date':attendance_date}, fields="*")

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -85,8 +85,7 @@ class EmployeeOverride(EmployeeMaster):
 
     def clear_schedules(doc):
         # clear future employee schedules
-        todays_date = getdate()
-        if doc.status == 'Left' and doc.relieving_date <= todays_date:
+        if doc.status == 'Left':
             frappe.db.sql(f"""
                 DELETE FROM `tabEmployee Schedule` WHERE employee='{doc.name}'
                 AND date>'{doc.relieving_date}'


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Attendance Check should be created for Active Employees Only.
- Remove Employee Schedule for employees that have left.

## Solution description
- Employee schedule fetching for active employees.
- Remove date condition when deleting the employee schedule of employees who have left.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/fc1c3a18-f070-4794-b5eb-522b9bd7fe4d



## Areas affected and ensured
- For employees who exit, their employee schedule from the relieving date is deleted.
- Attendance checks will only include employees who are active.

## Is there any existing behaviour change of other features due to this code change?
no.

## Could you let me know if you tested with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Could you let me know if you deleted custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
