### PR TITLE
Fix: Auto Checkin has no Shift Assignment 

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -313,14 +313,15 @@ def process_list(employee_list):
 	for e in employee_list:
 		checkin_time = e.start_datetime + (e.start_datetime + timedelta(minutes=60) - e.start_datetime) * random.random()
 		checkout_time = e.end_datetime + (e.end_datetime + timedelta(minutes=30) - e.end_datetime) * random.random()
-		create_checkin_record(e.ename, "IN", checkin_time)
-		create_checkin_record(e.ename, "OUT", checkout_time)
+		create_checkin_record(e.ename, "IN", checkin_time, e.sname)
+		create_checkin_record(e.ename, "OUT", checkout_time, e.sname)
 
-def create_checkin_record(employee, log_type, time):
+def create_checkin_record(employee, log_type, time, shift_assignment):
 	employee_checkin = frappe.new_doc('Employee Checkin')
 	employee_checkin.employee = employee
 	employee_checkin.log_type = log_type
 	employee_checkin.time = time
+	employee_checkin.shift_assignment = shift_assignment
 	employee_checkin.flags.ignore_validate = True
 	employee_checkin.save(ignore_permissions=True)
 	employee_checkin.db_set('creation', str(time))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Auto Checkin Record has no Shift Assignment, because of which they appear in the Attendance Check.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
- Insert Shift Assignment in check-in doc.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="884" alt="Screen Shot 2023-08-16 at 3 41 09 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/84611af3-9fac-4783-a554-6f765636f62b">


## Areas affected and ensured
- Shift assignment field in employee check-in log.

## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
