### PR TITLE
Fix: Leave Approver Fetching

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -389,17 +389,17 @@ def get_action_user(employee, shift):
 		action_user = get_employee_user_id(report_to)
 		Role = "Report To"
 	else:
-		if operations_shift.supervisor:
-			shift_supervisor = get_employee_user_id(operations_shift.supervisor)
-			if shift_supervisor != operations_shift.owner and shift_supervisor != current_user:
-				action_user = shift_supervisor
-				Role = "Shift Supervisor"
-
-		elif operations_site.account_supervisor:
+		if operations_site.account_supervisor:
 			site_supervisor = get_employee_user_id(operations_site.account_supervisor)
 			if site_supervisor != operations_shift.owner and site_supervisor != current_user:
 				action_user = site_supervisor
 				Role = "Site Supervisor"
+
+		elif operations_shift.supervisor:
+			shift_supervisor = get_employee_user_id(operations_shift.supervisor)
+			if shift_supervisor != operations_shift.owner and shift_supervisor != current_user:
+				action_user = shift_supervisor
+				Role = "Shift Supervisor"
 
 		elif operations_site.project:
 			if project.account_manager:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- If an employee doesn't have shift or reports to, the approver needs to be department approver.

## Solution description
- fetch department leave approver.
- change the fetching priority to site supervisor, if reports don't exist.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No
 
## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/b19217a5-cc78-4238-b7a0-3191a7f15fa5

## Areas affected and ensured
- fetch_leave_approver

## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
