### PR TITLE
feat: project warehouse in RFM

### DIFF
--- a/one_fm/purchase/doctype/request_for_material/request_for_material.js
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.js
@@ -44,7 +44,7 @@ frappe.ui.form.on('Request for Material', {
 		if(!frm.doc.requested_by){
 			frm.set_value('requested_by', frappe.session.user);
 		}
-
+		set_t_warehouse_hidden(frm);
 		// set schedule_date
 		set_schedule_date(frm);
 		frm.fields_dict["items"].grid.get_field("t_warehouse").get_query = function(doc) {
@@ -318,6 +318,7 @@ frappe.ui.form.on('Request for Material', {
 		set_filters(frm);
 	},
 	project: function(frm) {
+		set_t_warehouse_hidden(frm);
 		set_warehouse_filters(frm);
 	},
 	department: function(frm) {
@@ -327,6 +328,15 @@ frappe.ui.form.on('Request for Material', {
 		set_warehouse_filters(frm);
 	}
 });
+
+var set_t_warehouse_hidden = function(frm) {
+	if(frm.doc.project){
+		frm.set_df_property('t_warehouse', 'hidden', false);
+	}
+	else {
+		frm.set_df_property('t_warehouse', 'hidden', true);
+	}
+}
 
 frappe.ui.form.on('Request for Material Item', { // The child table is defined in a DoctType called "Dynamic Link"
 	items_on_form_rendered: (frm) => {
@@ -475,7 +485,10 @@ var set_warehouse_filters = function(frm) {
 		wh_filters = {'is_group': 0, 'department': frm.doc.department};
 	}
 	if(frm.doc.type == 'Project'){
-		wh_filters = {'is_group': 0, 'one_fm_project': frm.doc.project, 'one_fm_site': frm.doc.site};
+		wh_filters = {'is_group': 0, 'one_fm_project': frm.doc.project};
+		if(frm.doc.site){
+			wh_filters['one_fm_site'] = frm.doc.site;
+		}
 	}
 	frm.set_query("t_warehouse", function() {
 		return {

--- a/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
+++ b/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
@@ -333,7 +333,7 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval:doc.docstatus==1",
+   "depends_on": "eval:doc.docstatus==1||doc.t_warehouse",
    "fieldname": "t_warehouse",
    "fieldtype": "Link",
    "label": "Target Warehouse",
@@ -425,7 +425,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-11-27 15:01:56.293959",
+ "modified": "2023-08-20 18:28:26.601642",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Request for Material Item",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Option to select project warehouse in RFM with project and site filter

## Solution description
- Filters and project field property are adjusted

## Areas affected and ensured
- `one_fm/purchase/doctype/request_for_material/request_for_material.js`
- `one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json`

## Is there any existing behavior change of other features due to this code change?
Yes, now the target warehouse can be selected in the RFM for Project

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome