### PR TITLE
Fix: Payroll Report is Blank.

### DIFF
--- a/one_fm/public/js/doctype_js/payroll_entry.js
+++ b/one_fm/public/js/doctype_js/payroll_entry.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Payroll Entry', {
     refresh: function(frm) {
-		if(!frm.is_new() && frm.doc.salary_slips_created == 1){
+		if(!frm.is_new()){
 			check_salary_slip_counts(frm)
 		}
 		if (frm.doc.status == "Pending Salary Slip"){


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- The Payroll Report is blank, due to salary_slips_created value being set as 0.

## Solution description
- salary_slips_created should be set every time, the payroll entry doc is reloaded. 

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="1390" alt="Screen Shot 2023-08-28 at 10 49 20 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/6229c38b-b18d-4c10-911e-ee7f5c2711fa">


## Areas affected and ensured
- Payroll Entry, salary_slips_created field.


## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
