### PR TITLE
Fix: set Approver

### DIFF
--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -172,8 +172,11 @@ def validate_approver(self):
 @frappe.whitelist()
 def fetch_approver(employee):
 	if employee:
+		reports_to = frappe.get_value("Employee", employee,["reports_to"])
 		department = frappe.get_value("Employee", employee,["department"])
-		if department == "Operations - ONEFM":
+		if reports_to:
+			return frappe.get_value("Employee", reports_to, "user_id")
+		elif department == "Operations - ONEFM":
 			approvers = frappe.db.sql(
 				"""select approver from `tabDepartment Approver` where parent= %s and parentfield = 'shift_request_approver'""",
 				(department),
@@ -181,10 +184,6 @@ def fetch_approver(employee):
 			approvers = [approver[0] for approver in approvers]
 			return approvers[0]
 		else:
-			reports_to = frappe.get_value("Employee", employee,["reports_to"])
-			if reports_to:
-				return frappe.get_value("Employee", reports_to, "user_id")
-
 			shift = frappe.get_value("Employee", employee, ["shift"])
 			if shift:
 				shift_supervisor = frappe.get_value("Operations Shift", shift, "supervisor")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- If employee is in Operation Team, and has Reports_to, Fetch approver as Reports to. 

## Solution description
Change If Conditioning.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/93efb49a-a781-4e2f-8ce1-8134eee552fe



## Areas affected and ensured
- Arrover Fetched should be a reports_to if exists.

## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
