### PR TITLE
Fix: Day Off Not getting assigned due to Date Constrain

### DIFF
--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -18,9 +18,8 @@ def shift_request_submit(self):
 	if self.workflow_state != 'Update Request':
 		self.db_set("status", self.workflow_state)
 	
-	if self.from_date == cstr(getdate()):
-		if self.workflow_state == 'Approved':
-			process_shift_assignemnt(self)
+	if self.workflow_state == 'Approved':
+		process_shift_assignemnt(self)
 
 def validate_default_shift(self):
 	default_shift = frappe.get_value("Employee", self.employee, "default_shift")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Day off not updated in Employee Schedule if applied for future.

## Solution description
- Remove Date constrain since it's not required.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/7242f539-2684-41f8-a29e-720957af7e6a


## Areas affected and ensured
All shift request approval features checked.

## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
