### PR TITLE
HotFix: Overlapping Shifts

### DIFF
--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -74,7 +74,7 @@ def process_shift_assignemnt(doc):
 	if doc.assign_day_off == 1:
 		assign_day_off(doc)
 	else:
-		if doc.roster_type == "Basic":
+		if doc.roster_type == "Basic" and doc.from_date == getdate():
 			shift_assignemnt = frappe.get_value("Shift Assignment", {'employee':doc.employee, 'start_date': doc.from_date, 'roster_type':"Basic"}, ['name'])
 			if shift_assignemnt:
 				update_shift_assignment(shift_assignemnt, doc )

--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -74,7 +74,7 @@ def process_shift_assignemnt(doc):
 	if doc.assign_day_off == 1:
 		assign_day_off(doc)
 	else:
-		if doc.roster_type == "Basic" and doc.from_date == getdate():
+		if doc.roster_type == "Basic" and cstr(doc.from_date) == cstr(getdate()):
 			shift_assignemnt = frappe.get_value("Shift Assignment", {'employee':doc.employee, 'start_date': doc.from_date, 'roster_type':"Basic"}, ['name'])
 			if shift_assignemnt:
 				update_shift_assignment(shift_assignemnt, doc )


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Since Shift Assignment doesn't have an end_date, creating a new shift assignment creates an Overlapping issue.
- If the requested date is not equal to the current date, a Shift assignment doesn't need to be created.  

## Solution description
- Check if the Current Date is equal to From Date, before creating or updating the shift assignment.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/8d3626d4-20bc-4acc-909c-cdeb4d190408

## Areas affected and ensured
- process_shift_assignment

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
