### PR TITLE
Fix: Day Off Attendance

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -518,7 +518,7 @@ def mark_daily_attendance(start_date, end_date):
             
         # create BASIC DAY OFF
         for i in basic_employee_schedules:
-            if i.employee_availability == "Day Off" and getdate(i.start_date) == getdate(i.date):
+            if i.employee_availability == "Day Off" and getdate(start_date) == getdate(i.date):
                 emp = employees_dict.get(i.employee)
                 query_body+= f"""
                 (


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Day off Attendance Not getting Marked.

## Solution description
- `for i in basic_employee_schedules` doesn't have start_date.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Output screenshots (optional)
<img width="1017" alt="Screen Shot 2023-09-05 at 11 00 39 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/f54646f4-e535-4b33-b1ec-7dd29aa3cbc8">


## Areas affected and ensured
- Day off Attendance 

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
