### PR TITLE
chore: preparation - optimise renewal costing calculation

### DIFF
--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -124,6 +124,20 @@ class Preparation(Document):
         frappe.db.set_value("GRD Settings", None, "last_preparation_record_created_on", self.creation)
         frappe.db.set_value("GRD Settings", None, "last_preparation_record_created_by", self.owner)
 
+    @frappe.whitelist()
+    def set_renewal_for_all_preparation_record(self, renew_all):
+        # Get costing of renewal for an year
+        costing  = get_grd_renewal_extension_cost("Renewal", "1 Year")
+        # Set the costing of renewal for an year in preparation record
+        for preparation in self.preparation_record:
+            preparation.renewal_or_extend = "Renewal" if renew_all else ""
+            preparation.no_of_years = "1 Year" if renew_all else ""
+            preparation.work_permit_amount = costing.work_permit_amount if renew_all else ""
+            preparation.medical_insurance_amount = costing.medical_insurance_amount if renew_all else ""
+            preparation.residency_stamp_amount = costing.residency_stamp_amount if renew_all else ""
+            preparation.civil_id_amount = costing.civil_id_amount if renew_all else ""
+            preparation.total_amount = costing.total_amount if renew_all else ""
+
 # Calculate the date of the next month (First & Last) (monthly cron in hooks)
 def auto_create_preparation_record():
     """


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Preparation is slow while check renew all
 https://github.com/ONE-F-M/One-FM/assets/20554466/778b3b82-4b2b-4968-b8ae-0c78fe5d7af1
 https://github.com/ONE-F-M/One-FM/assets/20554466/d224e07d-27cb-46c8-92ca-291717251fce

## Solution description
- Optimised the code

## Areas affected and ensured
- `one_fm/grd/doctype/preparation/preparation.js`
- `one_fm/grd/doctype/preparation/preparation.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome