### PR TITLE
chore: ERF - set status open on Amend

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.js
+++ b/one_fm/one_fm/doctype/erf/erf.js
@@ -62,7 +62,7 @@ frappe.ui.form.on('ERF', {
 				frm.add_custom_button(__('Close ERF'), () => frm.events.close_erf(frm)).addClass('btn-primary');
 			}
 		}
-		if (!frm.is_new()){
+		if (!frm.is_new() && frm.doc.status){
 			frm.set_intro(__("STATUS: "+frm.doc.status), 'green');
 		}
 		frm.set_query('recruiter_assigned', function() {

--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -24,6 +24,8 @@ class ERF(Document):
 		self.set_onload('erf_approver', get_erf_approver(self.reason_for_request))
 
 	def validate(self):
+		if self.is_new():
+			self.status = "Open"
 		if not self.erf_requested_by:
 			self.erf_requested_by = frappe.session.user
 		if not self.erf_requested_by_name and self.erf_requested_by:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Status of ERF is set as Cancelled when we amend an ERF

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.js`
- `one_fm/one_fm/doctype/erf/erf.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No
 
## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome