### PR TITLE
fix: comment - scheduler for process_expired_allocation

### DIFF
--- a/one_fm/after_migrate/execute.py
+++ b/one_fm/after_migrate/execute.py
@@ -27,7 +27,7 @@ def comment_timesheet_in_hrms():
             '#"Employee": "hrms.overrides.employee_master.EmployeeMaster",',
         )
         found = True
-    
+
     if found:
         f = open(app_path+"hooks.py",'w')
         f.write(newdata)
@@ -53,7 +53,7 @@ def comment_payment_entry_in_hrms():
     """
         HRMS overrides Payment Entry, this restricts the overide in ONE_FM
     """
- 
+
     app_path = frappe.utils.get_bench_path()+"/apps/hrms/hrms/"
     f = open(app_path+"hooks.py",'r')
     filedata = f.read()
@@ -69,7 +69,28 @@ def comment_payment_entry_in_hrms():
         f.write(newdata)
         f.close()
 
-   
+
+def comment_process_expired_allocation_in_hrms():
+    """
+        Comment hrms scheduler to process_expired_allocation
+    """
+
+    app_path = frappe.utils.get_bench_path()+"/apps/hrms/hrms/"
+    f = open(app_path+"hooks.py",'r')
+    filedata = f.read()
+    f.close()
+
+    if not filedata.find('#"hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry.process_expired_allocation",') > 0:
+        newdata = filedata.replace(
+                '"hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry.process_expired_allocation",',
+                '#"hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry.process_expired_allocation",'
+        )
+
+        f = open(app_path+"hooks.py",'w')
+        f.write(newdata)
+        f.close()
+
+
 
 def disable_workflow_emails():
     """

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -789,6 +789,7 @@ after_migrate = [
     "one_fm.after_migrate.execute.comment_timesheet_in_hrms",
     "one_fm.after_migrate.execute.disable_workflow_emails",
     "one_fm.after_migrate.execute.comment_payment_entry_in_hrms",
+    "one_fm.after_migrate.execute.comment_process_expired_allocation_in_hrms",
 ]
 
 before_migrate = [


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
In ONEFM App
Scheduler - daily: trigger `one_fm/../update_leave_policy_assignments_expires_today` -> `one_fm/..../create_leave_policy`  (submit leave policy assignment) -> `one_fm/..../grant_leave_alloc_for_employee` -> `one_fm/.../create_leave_allocation` (Submit the leave allocation) -> `hrms/../create_leave_ledger_entry`


In HRMS App
Scheduler - daily_long: trigger `hrms/../process_expired_allocation` -> `hrms/../create_expiry_ledger_entry` 


In ONEFM App
Scheduler - daily:  trigger `one_fm/../increase_daily_leave_balance` -> `one_fm/../update_leave_ledger_for_paid_annual_leave` -> `hrms/../create_leave_ledger_entry`

## Areas affected and ensured
- `one_fm/after_migrate/execute.py`
- `one_fm/hooks.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome