### PR TITLE
feat: Justification dependent fields

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.json
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.json
@@ -24,8 +24,11 @@
   "shift_supervisor_user",
   "justification_section",
   "attendance_status",
-  "column_break_wtkg0",
   "justification",
+  "column_break_wtkg0",
+  "mobile_brand",
+  "mobile_model",
+  "screenshot",
   "employee_checkin_details_section",
   "has_checkin_record",
   "has_checkout_record",
@@ -401,6 +404,28 @@
    "fieldname": "comment",
    "fieldtype": "Small Text",
    "label": "Comment"
+  },
+  {
+   "depends_on": "eval:doc.justification == \"Mobile isn't supporting the app\"",
+   "fieldname": "mobile_brand",
+   "fieldtype": "Data",
+   "label": "Mobile Brand",
+   "mandatory_depends_on": "eval:doc.justification == \"Mobile isn't supporting the app\""
+  },
+  {
+   "depends_on": "eval:doc.justification == \"Mobile isn't supporting the app\"",
+   "fieldname": "mobile_model",
+   "fieldtype": "Data",
+   "label": "Mobile Model",
+   "mandatory_depends_on": "eval:doc.justification == \"Mobile isn't supporting the app\""
+  },
+  {
+   "depends_on": "eval:[\"Invalid media content\",\"Out-of-site location\", \"User not assigned to shift\", \"Suddenly, the App stop working!\"].includes(doc.justification)",
+   "description": "Upload screenshot with the same issue!",
+   "fieldname": "screenshot",
+   "fieldtype": "Attach",
+   "label": "Screenshot",
+   "mandatory_depends_on": "eval:[\"Invalid media content\",\"Out-of-site location\", \"User not assigned to shift\", \"Suddenly, the App stop working!\"].includes(doc.justification)"
   }
  ],
  "in_create": 1,
@@ -411,7 +436,7 @@
    "link_fieldname": "reference_docname"
   }
  ],
- "modified": "2023-09-11 00:55:47.189349",
+ "modified": "2023-09-12 10:22:14.491633",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Attendance Check",

--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -534,14 +534,3 @@ def mark_missing_attendance(attendance_checkin_found):
 				frappe.db.set_value("Employee Checkin", i.checkout_record, "attendance", attendance.name)
 		except Exception as e:
 			frappe.log_error(frappe.get_traceback(), 'Attendance Remark')
-
-def create_att_check():
-	employee = frappe.get_doc("Employee", "HR-EMP-00001")
-	at_check = frappe._dict({
-		"doctype":"Attendance Check",
-		"employee": employee.name,
-		"employee_name":employee.employee_name,
-		"department":employee.department,
-		"date":str(today()),
-	})
-	frappe.get_doc(at_check).insert(ignore_permissions=1)

--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -8,6 +8,21 @@ from frappe.utils import nowdate, add_to_date, cstr, add_days, today
 from one_fm.utils import production_domain
 
 class AttendanceCheck(Document):
+	def validate(self):
+		self.validate_justification()
+
+	def validate_justification(self):
+		'''
+			The method is used to validate the justification and its dependend fields
+		'''
+		if self.justification != "Mobile isn't supporting the app":
+			self.mobile_brand = ""
+			self.mobile_model = ""
+
+		if self.justification not in ["Invalid media content","Out-of-site location", "User not assigned to shift", "Suddenly, the App stop working!"]:
+			self.screenshot = ""
+
+
 	def on_submit(self):
 		self.validate_justification_and_attendance_status()
 		self.mark_attendance()
@@ -21,7 +36,7 @@ class AttendanceCheck(Document):
 				'roster_type':self.roster_type
 				}):
 				att = frappe.get_doc("Attendance", {
-					'attendance_date': self.date, 'employee': self.employee, 
+					'attendance_date': self.date, 'employee': self.employee,
 					'docstatus': ['<', 2],
 					'roster_type':self.roster_type
 				})
@@ -65,7 +80,7 @@ class AttendanceCheck(Document):
 						shift_assignment.submit()
 						att.shift_Assignment = shift_assignment.name
 			if att.shift_assignment and att.status=='Present':
-				att.working_hours = frappe.db.get_value("Operations Shift", 
+				att.working_hours = frappe.db.get_value("Operations Shift",
 					frappe.db.get_value("Shift Assignment", att.shift_assignment, 'shift'), 'duration')
 			if att.status != 'Day Off':
 				if not att.working_hours:
@@ -88,9 +103,9 @@ def create_attendance_check(attendance_date=None):
 		all_attendance = frappe.get_all("Attendance", filters={
 			'attendance_date':attendance_date}, fields="*")
 		all_attendance_employee = [i.employee for i in all_attendance]
-		
+
 		# employee_schedules = frappe.db.get_list("Employee Schedule", filters={'date':attendance_date, 'employee_availability':'Working'}, fields="*")
-		employee_schedules = frappe.db.sql(f"""SELECT * from `tabEmployee Schedule` 
+		employee_schedules = frappe.db.sql(f"""SELECT * from `tabEmployee Schedule`
 								WHERE date = '{attendance_date}'
 								AND employee_availability = 'Working'
 								AND employee in (SELECT name from `tabEmployee` WHERE status = 'Active')""", as_dict=1)
@@ -151,52 +166,52 @@ def create_attendance_check(attendance_date=None):
 		else:
 			checkin_ot_filter_tuple = ()
 
-		in_checkins_basic = frappe.db.sql(f""" 
-			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee, 
-			employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance, 
-			shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type, 
-			shift_permission, actual_time, MIN(time) as time FROM `tabEmployee Checkin` 
-			WHERE 
+		in_checkins_basic = frappe.db.sql(f"""
+			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee,
+			employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance,
+			shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type,
+			shift_permission, actual_time, MIN(time) as time FROM `tabEmployee Checkin`
+			WHERE
 			roster_type='Basic' AND log_type='IN' AND employee IN {checkin_basic_filter_tuple} AND
-			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59' 
+			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59'
 			GROUP BY employee
 			ORDER BY employee
 		""", as_dict=1)
-		
-		out_checkins_basic = frappe.db.sql(f""" 
-			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee, 
-			employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance, 
-			shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type, 
-			shift_permission, actual_time, MAX(time) as time FROM `tabEmployee Checkin` 
-			WHERE 
+
+		out_checkins_basic = frappe.db.sql(f"""
+			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee,
+			employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance,
+			shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type,
+			shift_permission, actual_time, MAX(time) as time FROM `tabEmployee Checkin`
+			WHERE
 			roster_type='Basic' AND log_type='OUT' AND employee IN {checkin_basic_filter_tuple} AND
-			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59' 
+			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59'
 			GROUP BY employee
 			ORDER BY employee
 		""", as_dict=1)
-		
-		in_checkins_ot = frappe.db.sql(f""" 
-			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee, 
-            employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance, 
+
+		in_checkins_ot = frappe.db.sql(f"""
+			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee,
+            employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance,
             shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type,
             roster_type, operations_site, project, company, operations_role, post_abbrv,
-            shift_permission, actual_time, MIN(time) as time  FROM `tabEmployee Checkin` 
-			WHERE 
+            shift_permission, actual_time, MIN(time) as time  FROM `tabEmployee Checkin`
+			WHERE
 			roster_type='Over-Time' AND log_type='IN' AND employee IN {checkin_ot_filter_tuple} AND
-			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59' 
+			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59'
 			GROUP BY employee
 			ORDER BY employee
 		""", as_dict=1)
-		
-		out_checkins_ot = frappe.db.sql(f""" 
-			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee, 
-            employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance, 
+
+		out_checkins_ot = frappe.db.sql(f"""
+			SELECT name, owner, creation, modified, modified_by, docstatus, idx, employee,
+            employee_name, log_type, late_entry, early_exit, time, date, skip_auto_attendance,
             shift_actual_start, shift_actual_end, shift_assignment, operations_shift, shift_type,
             roster_type, operations_site, project, company, operations_role, post_abbrv,
-            shift_permission, actual_time, MIN(time) as time  FROM `tabEmployee Checkin` 
-			WHERE 
+            shift_permission, actual_time, MIN(time) as time  FROM `tabEmployee Checkin`
+			WHERE
 			roster_type='Over-Time' AND log_type='OUT' AND employee IN {checkin_ot_filter_tuple} AND
-			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59' 
+			shift_actual_start BETWEEN '{attendance_date} 00:00:00' AND '{attendance_date} 23:59:59'
 			GROUP BY employee
 			ORDER BY employee
 		""", as_dict=1)
@@ -228,12 +243,12 @@ def create_attendance_check(attendance_date=None):
 		timesheets_dict = {}
 		for i in timesheets:
 			timesheets_dict[i.employee] = i
-		
+
 		# Attendance Request
 		attendance_requests_dict = {}
 		for i in attendance_requests:
 			attendance_requests_dict[i.employee] = i
-		
+
 		# Attendance
 		absent_attendance_basic_dict = {}
 		for i in absent_attendance_basic:absent_attendance_basic_dict[i.employee] = i
@@ -257,13 +272,13 @@ def create_attendance_check(attendance_date=None):
 		for i in operations_shifts: operations_shifts_dict[i.name] = i
 		operations_sites_dict = {}
 		for i in operations_sites: operations_sites_dict[i.name] = i
-		
+
 		# Employees
 		employees_dict = {}
 		for i in frappe.get_all("Employee", filters={"name":["IN", missing_ot+missing_basic+absent_attendance_basic_list+absent_attendance_ot_list]}, fields="*"):
 			employees_dict[i.name] = i
-		
-		
+
+
 		### Create records
 		# disable workflow
 		workflow = frappe.get_doc("Workflow", "Attendance Check")
@@ -333,7 +348,7 @@ def create_attendance_check(attendance_date=None):
 					site_supervisor = operations_sites_dict.get(employee.site)
 					at_check.site_supervisor = site_supervisor.account_supervisor
 					at_check.site_supervisor_name = site_supervisor.account_supervisor_name
-			
+
 			if not frappe.db.exists("Attendance Check", {"employee":i, 'date':attendance_date, 'roster_type':at_check.roster_type}):
 				try:
 					# if at_check.has_checkin_record and not str(at_check.comment).startswith('4'):
@@ -390,7 +405,7 @@ def create_attendance_check(attendance_date=None):
 				at_check.has_shift_permission
 				at_check.shift_permission = shift_permission.name
 				at_check.roster_type = shift_permission.roster_type
-			
+
 					# add supervisor
 			if not at_check.shift_supervisor:
 				if employee.shift:
@@ -424,7 +439,7 @@ def create_attendance_check(attendance_date=None):
 		if attendance_check_list:
 			frappe.db.sql(f"""
 				UPDATE `tabAttendance Check` SET workflow_state="Pending Approval"
-				WHERE name in {attendance_check_tuple}     
+				WHERE name in {attendance_check_tuple}
 			""")
 		# Enable workflow
 		workflow = frappe.get_doc("Workflow", "Attendance Check")
@@ -463,7 +478,7 @@ def mark_missing_attendance(attendance_checkin_found):
 			out_time = ''
 			comment = ''
 			day_off_ot = 0
-			
+
 			if i.attendance:
 				att = frappe.get_doc("Attendance", i.attendance)
 			if i.shift_assignment:
@@ -477,7 +492,7 @@ def mark_missing_attendance(attendance_checkin_found):
 				checkin_record = frappe.get_doc("Employee Checkin", i.checkin_record)
 			if i.checkout_record:
 				checkout_record = frappe.get_doc("Employee Checkin", i.checkout_record)
-			
+
 			# calculate working hours
 			if checkin_record and not checkout_record and shift_assignment:
 				working_hours = (shift_assignment.end_datetime - checkin_record.time).total_seconds() / (60 * 60)
@@ -519,3 +534,14 @@ def mark_missing_attendance(attendance_checkin_found):
 				frappe.db.set_value("Employee Checkin", i.checkout_record, "attendance", attendance.name)
 		except Exception as e:
 			frappe.log_error(frappe.get_traceback(), 'Attendance Remark')
+
+def create_att_check():
+	employee = frappe.get_doc("Employee", "HR-EMP-00001")
+	at_check = frappe._dict({
+		"doctype":"Attendance Check",
+		"employee": employee.name,
+		"employee_name":employee.employee_name,
+		"department":employee.department,
+		"date":str(today()),
+	})
+	frappe.get_doc(at_check).insert(ignore_permissions=1)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
in case of present and the justification is
- Mobile isn't supporting the app then two more mandatory fields should appear "Mobile brand " and "Mobile model"
- Invalid media content / Out of site location / User not assigned to shift / Suddenly,App stop working! then one me mandatory field should appear " upload screenshot with the same issue"

## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/20554466/5c6e5728-1ff7-40db-8cac-50041c830d2e


## Areas affected and ensured
- `one_fm/one_fm/doctype/attendance_check/attendance_check.json`
- `one_fm/one_fm/doctype/attendance_check/attendance_check.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome