### PR TITLE
Fix: Add end_date to Shift assignment.

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1031,6 +1031,7 @@ def process_overtime_shift(roster, date, time):
 				#check if the given shift has ended
 				# Set status inactive before creating new shift
 				if str(shift_end_time) == str(time):
+					frappe.set_value("Shift Assignment", shift_assignment.name,'end_date', date)
 					frappe.set_value("Shift Assignment", shift_assignment.name,'status', "Inactive")
 					create_overtime_shift_assignment(schedule, date)
 			else:


### PR DESCRIPTION
master to staging

## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- When creating an OT shift assignment, the existing shift should have an end_date to it.

## Solution description
If a shift assignment exists, add an end date, when setting status to inactive.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Areas affected and ensured
- End_date Set in the shift assignment

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [ ] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
