### PR TITLE
Fix: prefered_contact_email in employee Doc.

### DIFF
--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.py
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.py
@@ -168,6 +168,8 @@ class OnboardEmployee(Document):
 						employee.date_of_joining = getdate(date_of_joining)
 						self.date_of_joining = getdate(date_of_joining)
 					employee.company_email = self.company_email
+					if self.company_email:
+						employee.prefered_contact_email = 'Company Email'
 					employee.employment_type = self.employment_type
 					employee.attendance_by_timesheet = self.attendance_by_timesheet
 					employee.auto_attendance = self.auto_attendance


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- prefered_contact_email is not set to "Company Email", when company email exists.

## Solution description
- Set value "Company Email" as prefered_contact_email for employees who have company email.
 
## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/29017559/d583db17-bd03-4350-9e96-a2544669295d



## Areas affected and ensured
- value added during creation of employee, from onboard.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
