### PR TITLE
Feat: Change Status to Vacation regardless of the Leave Type.

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -319,7 +319,7 @@ class LeaveApplicationOverride(LeaveApplication):
 
                     frappe.db.commit()
         if self.status == "Approved":
-            if getdate(self.from_date) <= getdate() <= getdate(self.to_date) and self.leave_type == 'Annual Leave':
+            if getdate(self.from_date) <= getdate() <= getdate(self.to_date):
                 emp = frappe.get_doc("Employee", self.employee)
                 emp.status = "Vacation"
                 emp.save()
@@ -350,8 +350,8 @@ def employee_leave_status():
     today = getdate()
     yesterday = add_to_date(today, days=-1)
 
-    start_leave = frappe.get_list("Leave Application", {'from_date': today,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])
-    end_leave = frappe.get_list("Leave Application", {'to_date': yesterday,'leave_type':'Annual Leave', 'status':'Approved'}, ['employee'])
+    start_leave = frappe.get_list("Leave Application", {'from_date': today, 'status':'Approved'}, ['employee'])
+    end_leave = frappe.get_list("Leave Application", {'to_date': yesterday, 'status':'Approved'}, ['employee'])
 
     frappe.enqueue(process_change,start_leave=start_leave,end_leave=end_leave, is_async=True, queue="long")
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Employee status needs to change the Vacation, no matter what the leave type is.

## Solution description
- Remove leave type = Annual Leave from filter.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/889c09e5-0b01-495f-a6f9-d9866d2327eb



## Areas affected and ensured
- Change in Employee Status on approval.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
