### PR TITLE
Fix: Fetching of Current Shift

### DIFF
--- a/one_fm/api/v1/roster.py
+++ b/one_fm/api/v1/roster.py
@@ -584,7 +584,7 @@ def get_current_shift(employee):
         if len(shift) == 1:
             cur_shift = shift[0]
         elif len(shift) == 2: #2 shift colliding
-            if has_checkout(shift[0], employee, date): #
+            if has_checkout(shift[0], employee): #
                 cur_shift = shift[1]
             else:
                 cur_shift = shift[0]
@@ -593,15 +593,13 @@ def get_current_shift(employee):
         return cur_shift
             
     except Exception as e:
-        print(frappe.get_traceback())
         return frappe.utils.response.report_error(e.http_status_code)
 
 def has_checkout(shift, employee, date):
     checkin = frappe.db.sql("""SELECT * FROM `tabEmployee Checkin` empChkin
-							WHERE date(empChkin.time)='{date}'
-                            AND shift_assignment = '{shift}'
+							WHERE shift_assignment = '{shift}'
                             AND employee ='{employee}'
-                            AND log_type = 'OUT'""".format(date=cstr(date), shift=shift.name, employee=employee), as_dict=1)
+                            AND log_type = 'OUT'""".format(shift=shift.name, employee=employee), as_dict=1)
     if checkin:
         return True
     else:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Fetching double shift based on CHeckout dependent on date.

## Solution description
- Should be based on just the shift assignment.

Output:
<img width="1072" alt="Screen Shot 2023-09-19 at 9 53 35 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/4de0c550-3601-438e-8bc8-d0452b306b8a">

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Areas affected and ensured
- Fetching of Shift Assignment.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
