### PR TITLE
chore: ignore user permission on store keeper field in warehouse

### DIFF
--- a/one_fm/one_fm/custom/warehouse.json
+++ b/one_fm/one_fm/custom/warehouse.json
@@ -146,7 +146,7 @@
    "hide_days": 0,
    "hide_seconds": 0,
    "idx": 5,
-   "ignore_user_permissions": 0,
+   "ignore_user_permissions": 1,
    "ignore_xss_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Ignore user permission on store keeper field in warehouse


## Areas affected and ensured
- `one_fm/one_fm/custom/warehouse.json`


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome