### PR TITLE
Feat: change Employee ID when changed Under Company Residency.

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -54,6 +54,8 @@ class EmployeeOverride(EmployeeMaster):
 
     def before_save(self):
         self.assign_role_profile_based_on_designation()
+        if self.under_company_residency=='1':
+            self.employee_id = get_new_employee_id(self.employee_id)
 
     def after_insert(self):
         employee_after_insert(self, method=None)
@@ -120,3 +122,11 @@ class EmployeeOverride(EmployeeMaster):
                     '{getdate()}' BETWEEN from_date AND to_date
                 """, as_dict=1):
                 frappe.throw(f"Status cannot be 'Vacation' when no Leave Application exists for {self.employee_name} today {getdate()}.")
+
+@frappe.whitelist()
+def get_new_employee_id(employee_id):
+    length = len(employee_id)
+    num = employee_id[length-3] #get the third-last character.
+    if num == '0':
+        new_emp_id = employee_id[:length-3] + '1' + employee_id[length-2:]
+        return new_emp_id

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -43,6 +43,9 @@ frappe.ui.form.on('Employee', {
         } else {
             frm.set_df_property("reports_to", "reqd", 1);
         }
+	},
+	under_company_residency: function(frm){
+		change_employee_id(frm);
 	}
 
 });
@@ -81,7 +84,22 @@ let toggle_required = (frm, state) => {
 	});
 }
 
-
+var change_employee_id = function(frm) {
+	if(frm.doc.under_company_residency == 1){
+		frappe.call({
+			method: 'one_fm.overrides.employee.get_new_employee_id',
+			args: {
+			employee_id:frm.doc.employee_id,
+			},
+			callback: function (r) {
+				if (r && r.message) {
+					frm.set_value('employee_id',  r.message)
+				}
+				
+			}
+		});
+	}
+}
 // Hide un-needed fields
 const hideFields = frm => {
     $("[data-doctype='Employee Checkin']").hide();
@@ -143,4 +161,9 @@ const TransferToNonShift = frm => {
             'site': '',
             'holiday_list': '',
         })
+}
+
+function setCharAt(str,index,chr) {
+    if(index > str.length-1) return str;
+    return str.substring(0,index) + chr + str.substring(index+1);
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- when an employee is changed to under_company_residency, the Employee ID needs to be changed.

## Solution description
- change employee ID, when under_company_residency = 1

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/5bddb0c2-c2b1-4ee8-91c6-10caeb6f87a9

## Areas affected and ensured
- Employee ID value set

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
