### PR TITLE
chore: set required for fields in Incident Form

### DIFF
--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -6829,7 +6829,7 @@
   "doctype": "Workflow",
   "document_type": "Contracts",
   "is_active": 1,
-  "modified": "2023-09-18 08:12:03.204892",
+  "modified": "2023-09-19 14:22:36.625321",
   "name": "Contracts",
   "override_status": 0,
   "send_email_alert": 0,
@@ -7737,7 +7737,7 @@
   "doctype": "Workflow",
   "document_type": "Incident Form",
   "is_active": 1,
-  "modified": "2023-09-18 14:08:44.447803",
+  "modified": "2023-09-19 14:25:28.317095",
   "name": "Incident Form",
   "override_status": 0,
   "send_email_alert": 1,
@@ -7865,7 +7865,7 @@
     "parent": "Incident Form",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "skip_creation_of_workflow_action": 0,
+    "skip_creation_of_workflow_action": 1,
     "skip_multiple_action": 0,
     "state": "Approved"
    },
@@ -7880,7 +7880,7 @@
     "parent": "Incident Form",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "skip_creation_of_workflow_action": 0,
+    "skip_creation_of_workflow_action": 1,
     "skip_multiple_action": 0,
     "state": "Rejected"
    }

--- a/one_fm/operations/doctype/incident_form/incident_form.json
+++ b/one_fm/operations/doctype/incident_form/incident_form.json
@@ -202,7 +202,8 @@
    "fieldname": "employees",
    "fieldtype": "Table",
    "label": "Employees",
-   "options": "Incident Form Employee"
+   "options": "Incident Form Employee",
+   "reqd": 1
   },
   {
    "fieldname": "incident_details_section",
@@ -213,7 +214,8 @@
   {
    "fieldname": "incident_description",
    "fieldtype": "Small Text",
-   "label": "Incident Description"
+   "label": "Incident Description",
+   "reqd": 1
   },
   {
    "fieldname": "actions_taken",
@@ -224,7 +226,8 @@
   {
    "fieldname": "recommendation",
    "fieldtype": "Small Text",
-   "label": "Recommendation"
+   "label": "Recommendation",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_bgvyf",
@@ -246,7 +249,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-09-18 14:01:26.331303",
+ "modified": "2023-09-19 14:21:00.629246",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Incident Form",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Set required for fields in Incident Form
- Workflow - Cancel notification is skipped

## Areas affected and ensured
- `one_fm/fixtures/workflow.json`
- `one_fm/operations/doctype/incident_form/incident_form.json`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome