### PR TITLE
feat: capture company contact details in career history

### DIFF
--- a/one_fm/one_fm/doctype/career_history_company/career_history_company.json
+++ b/one_fm/one_fm/doctype/career_history_company/career_history_company.json
@@ -9,10 +9,20 @@
   "company_name",
   "job_title",
   "monthly_salary_in_kwd",
-  "country_of_employment",
   "column_break_4",
+  "country_of_employment",
   "start_date",
   "end_date",
+  "company_contact_details_section",
+  "first_contact_name",
+  "first_contact_email",
+  "first_contact_phone",
+  "first_contact_designation",
+  "column_break_jc0pn",
+  "second_contact_name",
+  "second_contact_email",
+  "second_contact_phone",
+  "second_contact_designation",
   "responsibilities_and_accomplishment_section",
   "responsibility_one",
   "responsibility_two",
@@ -44,6 +54,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "collapsible": 1,
    "fieldname": "responsibilities_and_accomplishment_section",
    "fieldtype": "Section Break",
    "label": "Responsibilities and Accomplishment"
@@ -133,16 +144,67 @@
   {
    "fieldname": "column_break_20",
    "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "company_contact_details_section",
+   "fieldtype": "Section Break",
+   "label": "Company Contact Details"
+  },
+  {
+   "fieldname": "first_contact_name",
+   "fieldtype": "Data",
+   "label": "First Contact Person Name"
+  },
+  {
+   "fieldname": "first_contact_email",
+   "fieldtype": "Data",
+   "label": "First Contact Email"
+  },
+  {
+   "fieldname": "first_contact_phone",
+   "fieldtype": "Data",
+   "label": "First Contact Phone"
+  },
+  {
+   "fieldname": "first_contact_designation",
+   "fieldtype": "Data",
+   "label": "First Contact Designation"
+  },
+  {
+   "fieldname": "column_break_jc0pn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "second_contact_name",
+   "fieldtype": "Data",
+   "label": "Second Contact Person Name"
+  },
+  {
+   "fieldname": "second_contact_email",
+   "fieldtype": "Data",
+   "label": "Second Contact Email"
+  },
+  {
+   "fieldname": "second_contact_phone",
+   "fieldtype": "Data",
+   "label": "Second Contact Phone"
+  },
+  {
+   "fieldname": "second_contact_designation",
+   "fieldtype": "Data",
+   "label": "Second Contact Designation"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-12-12 22:25:31.752203",
+ "modified": "2023-09-25 19:39:45.019662",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Career History Company",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/one_fm/templates/pages/career_history.js
+++ b/one_fm/templates/pages/career_history.js
@@ -210,9 +210,32 @@ career_history = Class.extend({
 				<input type="text" class="form-control starting_job_title_company_${company_no}" placeholder="Enter the Job Title"/>
 			</div>
 
-		  	<div class="mt-5 promotion_section_${company_no}" style="width: 100%">
+			<div class="mt-5 promotion_section_${company_no}" style="width: 100%">
 
-		  	</div>
+			</div>
+
+			<div class="col-lg-12 col-md-12 mb-3">
+				<label>Tell us about contact person details from ${stringifyNumber(company_no)} company you worked!</label>
+			</div>
+			<div class="col-lg-6 col-md-6 mb-3">
+				<label>Full name</label>
+				<input type="text" class="form-control first_contact_name_${company_no}" placeholder="Full Name"/>
+			</div>
+			<div class="col-lg-6 col-md-6 mb-3">
+				<label>Email</label>
+				<input type="text" class="form-control first_contact_email_${company_no}" placeholder="Email"/>
+			</div>
+			<div class="col-lg-6 col-md-6 mb-3">
+				<label>Designation</label>
+				<input type="text" class="form-control first_contact_designation_${company_no}" placeholder="Designation"/>
+			</div>
+			<div class="col-lg-6 col-md-6 mb-3">
+				<label>Phone number with country code</label>
+				<input type="text" class="form-control first_contact_phone_${company_no}" placeholder="Phone number with country code"/>
+			</div>
+			<div class="col-lg-12 col-md-12 mb-3 add_more_contact_${company_no}">
+				<button class="btn btn-dark float-left btn_add_more_contact_${company_no}" type="button">{{ _(" + Add more contact person") }}</button>
+			</div>
 
 			<div class="col-lg-12 col-md-12 mb-3">
 				<label>Are you still working for the same company?</label>
@@ -223,11 +246,37 @@ career_history = Class.extend({
 				</select>
 			</div>
 	</div>
+
   </div>`;
     $(".main_section").append(company_section_html);
     TOTAL_COMPANY_NO += 1;
     this.set_promotion_section_html(company_no, 1);
     this.on_change_still_working_on_same_company(company_no);
+    this.on_click_add_more_contact_person(company_no);
+  },
+  on_click_add_more_contact_person: function(company_no) {
+    var company_contact_html = `
+      <div class="col-lg-6 col-md-6 mb-3">
+        <label>What is name of the second contact person?</label>
+        <input type="text" class="form-control second_contact_name_${company_no}" placeholder="Full Name"/>
+      </div>
+      <div class="col-lg-6 col-md-6 mb-3">
+        <label>What is the Email of the second contact person?</label>
+        <input type="text" class="form-control second_contact_email_${company_no}" placeholder="Email"/>
+      </div>
+      <div class="col-lg-6 col-md-6 mb-3">
+        <label>What is designation of the second contact person?</label>
+        <input type="text" class="form-control second_contact_designation_${company_no}" placeholder="Designation"/>
+      </div>
+      <div class="col-lg-6 col-md-6 mb-3">
+        <label>What is the phone number of the second contact person?</label>
+        <input type="text" class="form-control second_contact_phone_${company_no}" placeholder="Phone number with country code"/>
+      </div>
+    `
+    $(`.btn_add_more_contact_${company_no}`).click(function(){
+      $(`.btn_add_more_contact_${company_no}`).fadeOut();
+      $(company_contact_html).insertAfter(`.add_more_contact_${company_no}`);
+    });
   },
   next_career_history: function(company_no) {
     // Move to Next Career History
@@ -303,6 +352,16 @@ career_history = Class.extend({
       career_history['responsibility_two'] = $(`.responisbility_2_company${company_no}`).val();
       career_history['responsibility_three'] = $(`.responisbility_3_company${company_no}`).val();
       career_history['job_title'] = $(`.starting_job_title_company_${company_no}`).val();
+
+      career_history['first_contact_name'] = $(`.first_contact_name_${company_no}`).val();
+      career_history['first_contact_email'] = $(`.first_contact_email_${company_no}`).val();
+      career_history['first_contact_phone'] = $(`.first_contact_phone_${company_no}`).val();
+      career_history['first_contact_designation'] = $(`.first_contact_designation_${company_no}`).val();
+
+      career_history['second_contact_name'] = $(`.second_contact_name_${company_no}`).val();
+      career_history['second_contact_email'] = $(`.second_contact_email_${company_no}`).val();
+      career_history['second_contact_phone'] = $(`.second_contact_phone_${company_no}`).val();
+      career_history['second_contact_designation'] = $(`.second_contact_designation_${company_no}`).val();
 
       /*
         Still working in same company

--- a/one_fm/templates/pages/career_history.py
+++ b/one_fm/templates/pages/career_history.py
@@ -34,7 +34,9 @@ def create_career_history_from_portal(job_applicant, career_history_details):
     career_histories = json.loads(career_history_details)
     for history in career_histories:
         career_history_fields = ['company_name', 'country_of_employment', 'start_date', 'responsibility_one',
-            'responsibility_two', 'responsibility_three', 'job_title', 'monthly_salary_in_kwd']
+            'responsibility_two', 'responsibility_three', 'job_title', 'monthly_salary_in_kwd', 'first_contact_name',
+            'first_contact_email', 'first_contact_phone', 'first_contact_designation', 'second_contact_name',
+            'second_contact_email', 'second_contact_phone', 'second_contact_designation']
 
         company = career_history.append('career_history_company')
         for field in career_history_fields:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Capture two company contact details in career history

## Solution description
- Added contact person name, email, phone and designation field in career history company table
- Capture the values from career history page for each company

## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/20554466/5c0f7b8d-ab6c-4022-9ba2-3a7fd7ff596d

## Areas affected and ensured
- `one_fm/one_fm/doctype/career_history_company/career_history_company.json`
- `one_fm/templates/pages/career_history.js`
- `one_fm/templates/pages/career_history.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome