### PR TITLE
Chore: Match ERF Report Status Filter with ERF 

### DIFF
--- a/one_fm/hiring/report/erf_report/erf_report.js
+++ b/one_fm/hiring/report/erf_report/erf_report.js
@@ -26,7 +26,7 @@ frappe.query_reports["ERF Report"] = {
 			"fieldname":"status",
 			"label": __("Status"),
 			"fieldtype": "Select",
-			"options": "\nDraft\nAccepted\nDeclined\nClosed",
+			"options": "\nOpen\nAccepted\nRejected\nHold\nCancelled\nClosed",
 			"default": 'Accepted'
 		}
 	]


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- ERF Report has status: Draft / Accepted / Declined / Closed
and ERF List: Open / Accepted / Rejected / Hold / Cancelled / Closed
Both need to be matched.

## Solution description
- Fix Status filter options.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/5090f85a-6fe1-4072-835e-fb93bfe74f90


## Areas affected and ensured
- ERF Report Status Filter fixed.
- Report fetches proper data.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
