### PR TITLE
hot fix: Employee Uniform - Not allowing to submit

### DIFF
--- a/one_fm/public/js/doctype_js/stock_entry.js
+++ b/one_fm/public/js/doctype_js/stock_entry.js
@@ -1,7 +1,9 @@
 frappe.ui.form.on('Stock Entry', {
   refresh(frm) {
-    set_stock_entry_type_for_issuer(frm);
-    set_store_keeper_warehouses(frm);
+    if(frm.doc.docstatus < 1){
+      set_stock_entry_type_for_issuer(frm);
+      set_store_keeper_warehouses(frm);
+    }
   },
   onload(frm) {
     if(frappe.user.has_role('Stock Issuer')){
@@ -21,9 +23,11 @@ frappe.ui.form.on('Stock Entry', {
 		});
 	},
   stock_entry_type(frm){
-    frm.set_value('from_warehouse', '');
-    frm.set_value('to_warehouse', '');
-    set_store_keeper_warehouses(frm);
+    if(frm.doc.docstatus < 1){
+      frm.set_value('from_warehouse', '');
+      frm.set_value('to_warehouse', '');
+      set_store_keeper_warehouses(frm);
+    }
   },
   project(frm) {
     auto_fill_project(frm);

--- a/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py
+++ b/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py
@@ -195,7 +195,8 @@ def make_stock_entry(employee_uniform):
 			"doctype": "Stock Entry Detail",
 			"field_map": {
 				"item": "item_code",
-				"quantity": "qty"
+				"quantity": "qty",
+				"allow_zero_valuation_rate": "allow_zero_valuation_rate"
 			},
 			"postprocess": update_item,
 			"condition": lambda doc: doc.item

--- a/one_fm/uniform_management/doctype/employee_uniform_item/employee_uniform_item.json
+++ b/one_fm/uniform_management/doctype/employee_uniform_item/employee_uniform_item.json
@@ -10,6 +10,7 @@
   "actual_quantity",
   "quantity",
   "uom",
+  "allow_zero_valuation_rate",
   "column_break_4",
   "issued_on",
   "expire_on",
@@ -90,16 +91,23 @@
    "fieldtype": "Float",
    "label": "Actual Quantity",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_zero_valuation_rate",
+   "fieldtype": "Check",
+   "label": "Allow Zero Valuation Rate"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-12-16 06:58:21.458870",
+ "modified": "2023-10-09 09:45:37.155248",
  "modified_by": "Administrator",
  "module": "Uniform Management",
  "name": "Employee Uniform Item",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Employee Uniform is not allowing to submit
![imageeef596](https://github.com/ONE-F-M/One-FM/assets/20554466/52018e0a-e040-459f-bc3b-c8a9a4704aed)

## Solution description
- Introduced Allow Zero Valuation Rate check in the Employee Uniform Item line and it copy to Stock Entry Item lines

## Output screenshots (optional)
![Screenshot 2023-10-09 at 1 03 15 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/085d0482-341f-4379-ad08-9bbd1e1d34c3)

## Areas affected and ensured
- `one_fm/public/js/doctype_js/stock_entry.js`
- `one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py`
- `one_fm/uniform_management/doctype/employee_uniform_item/employee_uniform_item.json`

## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome