### PR TITLE
CHORE: Clean up styling overlap on career history homepage

### DIFF
--- a/one_fm/templates/pages/career_history.html
+++ b/one_fm/templates/pages/career_history.html
@@ -23,7 +23,7 @@
 <html lang="en">
 <body>
 <div class="intro_section">
-		<img class="back_illustration" src="assets/one_fm/assets/img/career-history/clip-career-boost.png"/>
+	<img class="back_illustration" src="assets/one_fm/assets/img/career-history/clip-career-boost.png"  style="position: absolute; right: 10%; bottom: 1%; width: 30%;"/>
 <div class="intro">
 
 </div>

--- a/one_fm/templates/pages/career_history.js
+++ b/one_fm/templates/pages/career_history.js
@@ -30,6 +30,8 @@ career_history = Class.extend({
     <h5>Give us some details about your career, and tell us how great you are!</h5>
   `
     $(".intro").append(intro_section_html);
+    const pageContentWrapper = document.querySelector('.page-content-wrapper');
+    pageContentWrapper.style.position = 'relative';
   },
   on_change_promotion: function(company_no, promotion_no) {
     var me = this;


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
The image on the career history homepage, was overlapping the introductory message.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Changed the styling to stop the overlap


## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Career history

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
