### PR TITLE
feat: Employee Uniform - link to Stock Entry

### DIFF
--- a/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.js
+++ b/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.js
@@ -12,6 +12,9 @@ frappe.ui.form.on('Employee Uniform', {
 				filters: {'is_uniform_warehouse': true}
 			}
 		});
+		if(frm.is_new() && frm.doc.stock_entry){
+			frm.set_value("stock_entry", "");
+		}
 	},
 	employee: function(frm) {
 		set_uniform_details(frm);

--- a/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.json
+++ b/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.json
@@ -26,7 +26,8 @@
   "uniforms",
   "total_quantity",
   "pay_back_to_company",
-  "handover_form"
+  "handover_form",
+  "stock_entry"
  ],
  "fields": [
   {
@@ -165,14 +166,23 @@
    "fieldtype": "Int",
    "label": "Total Quantity",
    "read_only": 1
+  },
+  {
+   "fieldname": "stock_entry",
+   "fieldtype": "Link",
+   "label": "Stock Entry Reference",
+   "no_copy": 1,
+   "options": "Stock Entry",
+   "read_only": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-09-03 19:31:37.906993",
+ "modified": "2023-10-09 16:27:50.236905",
  "modified_by": "Administrator",
  "module": "Uniform Management",
  "name": "Employee Uniform",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -193,5 +203,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py
+++ b/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py
@@ -37,8 +37,25 @@ class EmployeeUniform(Document):
 		self.onboard_employee_update()
 		make_stock_entry(self)
 
-	# def on_cancel(self):
-	# 	self.onboard_employee_update(True)
+	def on_cancel(self):
+		# self.onboard_employee_update(True)
+		self.cancel_stock_entry()
+
+	def cancel_stock_entry(self):
+		'''
+			Method to cancel the stock entry linked to the Employee Uniform
+			args:
+				self: the object of Employee Uniform
+		'''
+		# Check if there is a Stock Entry reference in the Employee Uniform
+		if self.stock_entry:
+			# Get the Draft/Submitted Stock Entry linked to the Employee Uniform
+			se_exists = frappe.db.exists("Stock Entry", {"name": self.stock_entry, "docstatus": ["<", 2]})
+			# Cancel the linked stock entry
+			frappe.get_doc("Stock Entry", se_exists).cancel()
+			# Unlink the Stock Entry reference from the Employee Uniform
+			frappe.db.set_value("Employee Uniform", self.name, "stock_entry", "")
+			frappe.msgprint(_("Cancelled the Stock Entry {0} linked with this Employee Uniform".format(self.stock_entry)))
 
 	def onboard_employee_update(self, on_cancel=False):
 		if self.type == 'Issue':
@@ -204,6 +221,7 @@ def make_stock_entry(employee_uniform):
 
 	doclist.save(ignore_permissions=True)
 	doclist.submit()
+	frappe.db.set_value("Employee Uniform", employee_uniform.name, "stock_entry", doclist.name)
 
 def get_issued_item_quantity(item, employee):
 	issued_qty = 0


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Employee Uniform link to the Stock Entry and handle Employee Uniform cancellation

## Solution description
- Added a link to Stock Entry in Employee Uniform

## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/20554466/764ed33f-8c46-4cad-bd3e-5fd14c2f913e


## Areas affected and ensured
- `one_fm/uniform_management/doctype/employee_uniform/employee_uniform.js`
- `one_fm/uniform_management/doctype/employee_uniform/employee_uniform.json`
- `one_fm/uniform_management/doctype/employee_uniform/employee_uniform.py`

## Is there any existing behavior change of other features due to this code change?
Yes, Now the Employee uniform have the stock entry reference

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome