### PR TITLE
Feat: Update Holiday Attendance on update in holiday date

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -471,6 +471,7 @@ override_doctype_class = {
 	"Attendance": "one_fm.overrides.attendance.AttendanceOverride",
 	"Shift Type": "one_fm.overrides.shift_type.ShiftTypeOverride",
 	"Employee Transfer": "one_fm.overrides.employee_transfer.EmployeeTransferOverride",
+	"Holiday List": "one_fm.overrides.holiday_list.HolidayListOverride",
 	"Leave Application": "one_fm.overrides.leave_application.LeaveApplicationOverride",
 	"Employee": "one_fm.overrides.employee.EmployeeOverride",
 	"Employee Checkin": "one_fm.overrides.employee_checkin.EmployeeCheckinOverride",

--- a/one_fm/overrides/holiday_list.py
+++ b/one_fm/overrides/holiday_list.py
@@ -79,6 +79,7 @@ class HolidayListOverride(HolidayList):
 					att_doc.submit()
 				else:
 					frappe.delete_doc("Attendance", att.name)
+		
 		#Attendance For New Date
 		new_date_attendance = frappe.get_list("Attendance",{'attendance_date':new_date},['*'])
 		if new_date_attendance:
@@ -88,10 +89,7 @@ class HolidayListOverride(HolidayList):
 					doc.db_set("status",'Holiday')
 					doc.db_set('leave_type','')
 					doc.db_set('leave_application','')
-		frappe.db.commit()
-
-
-		
+		frappe.db.commit()	
 
 	def get_weekly_off_date_list(self, start_date, end_date):
 		start_date, end_date = getdate(start_date), getdate(end_date)

--- a/one_fm/overrides/holiday_list.py
+++ b/one_fm/overrides/holiday_list.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+
+import json
+
+import frappe
+from frappe import _, throw
+from frappe.model.document import Document
+from frappe.utils import cint, formatdate, getdate, today
+
+
+class OverlapError(frappe.ValidationError):
+	pass
+
+
+class HolidayListOverride(HolidayList):
+	def validate(self):
+		self.validate_days()
+		self.total_holidays = len(self.holidays)
+    
+
+	@frappe.whitelist()
+	def get_weekly_off_dates(self):
+		self.validate_values()
+		date_list = self.get_weekly_off_date_list(self.from_date, self.to_date)
+		last_idx = max(
+			[cint(d.idx) for d in self.get("holidays")]
+			or [
+				0,
+			]
+		)
+		for i, d in enumerate(date_list):
+			ch = self.append("holidays", {})
+			ch.description = _(self.weekly_off)
+			ch.holiday_date = d
+			ch.weekly_off = 1
+			ch.idx = last_idx + i + 1
+
+	def validate_values(self):
+		if not self.weekly_off:
+			throw(_("Please select weekly off day"))
+
+	def validate_days(self):
+		if getdate(self.from_date) > getdate(self.to_date):
+			throw(_("To Date cannot be before From Date"))
+
+		for day in self.get("holidays"):
+			if not (getdate(self.from_date) <= getdate(day.holiday_date) <= getdate(self.to_date)):
+				frappe.throw(
+					_("The holiday on {0} is not between From Date and To Date").format(
+						formatdate(day.holiday_date)
+					)
+				)
+
+	def get_weekly_off_date_list(self, start_date, end_date):
+		start_date, end_date = getdate(start_date), getdate(end_date)
+
+		import calendar
+		from datetime import timedelta
+
+		from dateutil import relativedelta
+
+		date_list = []
+		existing_date_list = []
+		weekday = getattr(calendar, (self.weekly_off).upper())
+		reference_date = start_date + relativedelta.relativedelta(weekday=weekday)
+
+		existing_date_list = [getdate(holiday.holiday_date) for holiday in self.get("holidays")]
+
+		while reference_date <= end_date:
+			if reference_date not in existing_date_list:
+				date_list.append(reference_date)
+			reference_date += timedelta(days=7)
+
+		return date_list
+
+
+	@frappe.whitelist()
+	def clear_table(self):
+		self.set("holidays", [])
+
+
+@frappe.whitelist()
+def get_events(start, end, filters=None):
+	"""Returns events for Gantt / Calendar view rendering.
+
+	:param start: Start date-time.
+	:param end: End date-time.
+	:param filters: Filters (JSON).
+	"""
+	if filters:
+		filters = json.loads(filters)
+	else:
+		filters = []
+
+	if start:
+		filters.append(["Holiday", "holiday_date", ">", getdate(start)])
+	if end:
+		filters.append(["Holiday", "holiday_date", "<", getdate(end)])
+
+	return frappe.get_list(
+		"Holiday List",
+		fields=[
+			"name",
+			"`tabHoliday`.holiday_date",
+			"`tabHoliday`.description",
+			"`tabHoliday List`.color",
+		],
+		filters=filters,
+		update={"allDay": 1},
+	)
+
+
+def is_holiday(holiday_list, date=None):
+	"""Returns true if the given date is a holiday in the given holiday list"""
+	if date is None:
+		date = today()
+	if holiday_list:
+		return bool(
+			frappe.db.exists("Holiday", {"parent": holiday_list, "holiday_date": date}, cache=True)
+		)
+	else:
+		return False

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -167,7 +167,6 @@ class LeaveApplicationOverride(LeaveApplication):
             
 
     def create_or_update_attendance(self, attendance_name, date, status):
-        print(attendance_name)
         if attendance_name:
             # update existing attendance, change absent to on leave
             doc = frappe.get_doc("Attendance", attendance_name)

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -140,9 +140,8 @@ class LeaveApplicationOverride(LeaveApplication):
 
         holiday_dates = []
         if self.leave_type == 'Annual Leave' :
-            holidays = get_holidays_for_employee(employee=self.employee, start_date=self.from_date, end_date=self.to_date, only_non_weekly=False)
+            holidays = get_holidays_for_employee(employee=self.employee, start_date=self.from_date, end_date=self.to_date, only_non_weekly=True)
             holiday_dates = [cstr(h.holiday_date) for h in holidays]
-            print(holiday_dates)
             
         for dt in daterange(getdate(self.from_date), getdate(self.to_date)):
             date = dt.strftime("%Y-%m-%d")
@@ -153,7 +152,6 @@ class LeaveApplicationOverride(LeaveApplication):
             # don't mark attendance for holidays
             # if leave type does not include holidays within leaves as leaves
             if date in holiday_dates:
-                print("holiday")
                 if attendance_name:
                     # cancel and delete existing attendance for holidays
                     attendance = frappe.get_doc("Attendance", attendance_name)
@@ -169,7 +167,7 @@ class LeaveApplicationOverride(LeaveApplication):
             
 
     def create_or_update_attendance(self, attendance_name, date, status):
-
+        print(attendance_name)
         if attendance_name:
             # update existing attendance, change absent to on leave
             doc = frappe.get_doc("Attendance", attendance_name)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- When the Holiday Date is Updated, Attendance needs to be updated too.

## Solution description
- on the update of the holiday date, Find the old and new dates.
- Fix and update attendance for old date.
- and then fix and update the attendance for the new date.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/29017559/89ed843b-877f-4685-831e-e5573abaa4bf



## Areas affected and ensured
Holiday Attendance Marked.
Only employees which holiday attendance are considered.


## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
