### PR TITLE
fix: unable to choose option in ERF

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.js
+++ b/one_fm/one_fm/doctype/erf/erf.js
@@ -712,16 +712,14 @@ var yes_no_html_buttons = function(frm, val, html_field, field_name, label) {
 	$wrapper
 		.html(field_html);
 	$wrapper.on('click', '.'+field_btn_html, function() {
-		if(frm.doc.docstatus == 1 || field_name == 'shift_working'){
-			var $btn = $(this);
-			$wrapper.find('.'+field_btn_html).removeClass('btn-primary');
-			$btn.addClass('btn-primary');
-			if(field_name == 'open_to_different'){
-				frm.set_value(field_name, $btn.attr('data'));
-			}
-			else{
-				frm.set_value(field_name, $btn.attr('data')=='Yes'? true:false);
-			}
+		var $btn = $(this);
+		$wrapper.find('.'+field_btn_html).removeClass('btn-primary');
+		$btn.addClass('btn-primary');
+		if(field_name == 'open_to_different'){
+			frm.set_value(field_name, $btn.attr('data'));
+		}
+		else{
+			frm.set_value(field_name, $btn.attr('data')=='Yes'? true:false);
 		}
 	});
 };


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Not able to select the options Yes/No for the values Travel Required, Night Shift and etc.

https://github.com/ONE-F-M/One-FM/assets/20554466/67e06c51-1093-4e53-b25f-77fac59dca85

## Solution description
- Updated the condition in the html field setup

## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/20554466/785a0406-5c57-49e8-903c-2a8c1e57930b


## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.js`


## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome