### PR TITLE
fix: ERF and Job Title

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.js
+++ b/one_fm/one_fm/doctype/erf/erf.js
@@ -172,6 +172,11 @@ frappe.ui.form.on('ERF', {
 			});
 		}
 	},
+	before_workflow_action: function(frm) {
+		if(frm.doc.workflow_state == 'Open' && frm.doc.hiring_method == 'Bulk Recruitment' && (!frm.doc.number_of_interview_rounds || frm.doc.number_of_interview_rounds < 1)){
+			frm.scroll_to_field('number_of_interview_rounds');
+		}
+	},
 	validate: function(frm) {
 		if(frm.doc.gender_height_requirement){
 			frm.doc.gender_height_requirement.forEach((item, i) => {

--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -365,9 +365,9 @@ def get_erf_approver(reason_for_request):
 
 def create_job_opening_from_erf(erf):
 	job_opening = frappe.new_doc("Job Opening")
-	# TODO: job_title needs to be unique,
+	# Set unique job_title
 	# since job_title will be set a route in Job Opening and the route is set as name in Job Opening
-	job_opening.job_title = erf.job_title
+	job_opening.job_title = erf.job_title+'('+erf.name+')'
 	job_opening.designation = erf.designation
 	job_opening.employment_type = erf.employment_type
 	job_opening.department = erf.department


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Job title in the ERF is properly set for the title in the Job Opening
- Show proper validation with scroll to the field for fill it

## Output screenshots (optional)
Before the PR

https://github.com/ONE-F-M/One-FM/assets/20554466/d6f8cf76-2fe6-4c0d-bb2e-b483948c62cc

After the PR


https://github.com/ONE-F-M/One-FM/assets/20554466/3efbeb89-c570-456a-8efc-66f90b0d7fdb

![Screenshot 2023-10-16 at 1 08 49 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/161f25d7-3613-4594-8311-4a67d571b323)

![Screenshot 2023-10-16 at 1 08 29 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/fae51d63-95b3-48dc-a383-c3dec77bf9ce)


## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.js`
- `one_fm/one_fm/doctype/erf/erf.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome