### PR TITLE
feat: get language proficiency from applicant portal

### DIFF
--- a/one_fm/templates/pages/job_application.html
+++ b/one_fm/templates/pages/job_application.html
@@ -58,7 +58,7 @@
         <input type="radio" id="work_shift_no" name="work_shift" value="no">
         <label for="work_shift_no">No</label>
     </div>
-    
+
     <div class="col-sm-12 night_shift hide" id="night_shift">
       <h5>Are you willing to work in night shifts?</h5>
         <input type="radio" id="night_shift_yes" name="night_shift" value="yes">
@@ -116,10 +116,68 @@
         <label for="in_kuwait_no">No</label>
     </div>
   </div>
-  
-  
-  
+
+
+
   <br/>
+  <!-- Language Section -->
+  {% if language_exists %}
+  <h5 class="languages_heading hide">Tell me about your language proficiency, so we can arrange the interview smoothly.</h5>
+  <div class="row languages_table_div hide" data="{{languages_list}}" id="languages_table_div">
+    <div class="col-sm-6">
+      <table class="table">
+        <thead>
+          <tr>
+            <th style="width:31%">Language</th>
+            <th style="width:23%">Read</th>
+            <th style="width:23%">Write</th>
+            <th style="width:23%">Speak</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for language in languages %}
+            <tr>
+              <td>{{ language.language_name }}</td>
+              <td>
+                <select class="form-control {{language.language}}_read">
+                  <option value="0.1">Select</option>
+                  <option value="0.2">1</option>
+                  <option value="0.4">2</option>
+                  <option value="0.6">3</option>
+                  <option value="0.8">4</option>
+                  <option value="1.0">5</option>
+                </select>
+              </td>
+              <td>
+                <select class="form-control {{language.language}}_write">
+                  <option value="0.1">Select</option>
+                  <option value="0.2">1</option>
+                  <option value="0.4">2</option>
+                  <option value="0.6">3</option>
+                  <option value="0.8">4</option>
+                  <option value="1.0">5</option>
+                </select>
+              </td>
+              <td>
+                <select class="form-control {{language.language}}_speak">
+                  <option value="0.1">Select</option>
+                  <option value="0.2">1</option>
+                  <option value="0.4">2</option>
+                  <option value="0.6">3</option>
+                  <option value="0.8">4</option>
+                  <option value="1.0">5</option>
+                </select>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
+
+  <br/>
+
   <!-- CV Section -->
   <p style='margin-top: 30px' class="applicant_cv"></p>
 
@@ -129,7 +187,7 @@
     </div>
   </div>
   <br/>
-  
+
   <div class="col-sm-12">
     <button class="btn btn-dark btn-submit-application" type="button">{{ _("Submit") }}</button>
   </div>

--- a/one_fm/templates/pages/job_application.js
+++ b/one_fm/templates/pages/job_application.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
       setupReader(value, file_input);
     });
     window.file_reading = false;
-     
+
   });
 });
 var rotation_shift = $("#work_details").attr("rotation_shift")
@@ -77,7 +77,7 @@ job_application = Class.extend({
   },
   show_applicant_contact_details: function() {
     $(".applicant_contact").empty();
-    $(".applicant_contact").append(`<h5>Please provide your email address and mobile number so we could contact you.</h5>`)
+    $(".applicant_contact").append(`<h5>Please provide your mobile number and email address so we could contact you.</h5>`)
     $(".contact_number").removeClass('hide');
     $(".contact_email").removeClass('hide');
   },
@@ -101,7 +101,7 @@ job_application = Class.extend({
           // Show CV section
           me.show_cv_section();
       }
-      
+
     }
   },
   on_change_email: function() {
@@ -208,9 +208,15 @@ job_application = Class.extend({
     }
   },
   show_cv_section: function() {
+    var me  = this;
+    me.show_language_section();
     $(".applicant_cv").empty();
     $(".applicant_cv").append(`<h5>Please attach your CV here so we can get to know you better.</h5>`)
     $(".cv-file").removeClass('hide');
+  },
+  show_language_section: function() {
+    $(".languages_heading").removeClass('hide');
+    $(".languages_table_div").removeClass('hide');
   },
   submit_job_application: function() {
     // Submit Job Application
@@ -223,17 +229,26 @@ job_application = Class.extend({
 
       var cv = document.getElementById("cv").files[0]
       if (cv && !cv.type.includes(["application/pdf"])){
-        return frappe.msgprint(frappe._("CV must be in PDF format !"));      
+        return frappe.msgprint(frappe._("CV must be in PDF format !"));
       }
 
       // POST Job Application if all the conditions are satisfied
-      
+
       if ($(".applicant_name").val() && $(".country_list").val() && $(".contact_email").val() && $(".contact_number").val() && cv){
         frappe.freeze();
         var response = await upload_image_to_server(cv)
         var url = (response && response.message) ? response.message.file_url : "";
-        var name_of_file = (response && response.message) ? response.message.name : ""; 
-
+        var name_of_file = (response && response.message) ? response.message.name : "";
+        var erf_languages = document.getElementById('languages_table_div').getAttribute('data').split(",");
+        var languages = [];
+        for (const language of erf_languages) {
+          languages.push({
+            language: language,
+            speak: $(`.${language}_speak`).val(),
+            read: $(`.${language}_read`).val(),
+            write: $(`.${language}_write`).val()
+          });
+        }
         frappe.call({
           type: "POST",
           method: "one_fm.templates.pages.job_application.create_job_applicant_from_job_portal",
@@ -253,6 +268,7 @@ job_application = Class.extend({
             visa: $("#visa input[type='radio']:checked").val(),
             visa_type: $(".visa_type").val(),
             in_kuwait: $("#in_kuwait input[type='radio']:checked").val(),
+            languages: languages,
             name_of_file: name_of_file
           },
           btn: this,
@@ -308,4 +324,3 @@ async function upload_image_to_server(file) {
     xhr.send(form_data);
   });
 }
-


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Capture job applicant language proficiency from the job application portal
- Correct the order of label and field in job application portal for mobile number and email id

## Solution description
- Show the languages in job application portal, those are selected in the ERF
- Capture the proficiency

## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/20554466/8462cfbf-5ab8-47e6-921a-1d72a9caf55d

## Areas affected and ensured
- `one_fm/templates/pages/job_application.html`
- `one_fm/templates/pages/job_application.js`
- `one_fm/templates/pages/job_application.py`

## Is there any existing behavior change of other features due to this code change?
Yes, now job application portal can capture the language proficiency

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome