### PR TITLE
chore: remove error log on Shift Assignment auto creation

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1064,10 +1064,11 @@ def create_overtime_shift_assignment(schedule, date):
 					shift_assignment.check_in_site = shift_assignment.check_in_site
 					shift_assignment.check_out_site = shift_assignment.check_out_site
 			shift_assignment.submit()
-		except Exception:
-			# TODO: Need to log all the errors except the OverlappingShiftError
+		except frappe.ValidationError:
 			pass
-
+		except Exception:
+			# Log all the errors except the OverlappingShiftError(ValidationError)
+			frappe.log_error(frappe.get_traceback(), "Create Overtime Shift Assignment")
 
 def update_shift_type():
 	today_datetime = now_datetime()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- Do not log duplicate shift assignment to error log

## Solution description
- Removed error log while creating the Shift Assignment

## Areas affected and ensured
- `one_fm/api/tasks.py L #1041, 1068`

## Is there any existing behavior change of other features due to this code change?
No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
