### PR TITLE
FEAT:Permissions for employee status update

### DIFF
--- a/one_fm/one_fm/doctype/onefm_employee_access/onefm_employee_access.json
+++ b/one_fm/one_fm/doctype/onefm_employee_access/onefm_employee_access.json
@@ -1,0 +1,39 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-10-19 17:05:02.152714",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "employee",
+  "employee_name"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "label": "Employee",
+   "options": "Employee",
+   "unique": 1
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-10-19 17:07:31.095719",
+ "modified_by": "Administrator",
+ "module": "one_fm",
+ "name": "ONEFM Employee Access",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/one_fm/doctype/onefm_employee_access/onefm_employee_access.py
+++ b/one_fm/one_fm/doctype/onefm_employee_access/onefm_employee_access.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, omar jaber and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ONEFMEmployeeAccess(Document):
+	pass

--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
@@ -16,7 +16,10 @@
   "wiki_page_access",
   "section_break_7yvzt",
   "mark_atttendance_per_employee",
-  "attendance_manager"
+  "attendance_manager",
+  "attendance_manager_name",
+  "employee_section",
+  "employee_access"
  ],
  "fields": [
   {
@@ -80,11 +83,29 @@
    "fieldtype": "Link",
    "label": "Attendance Manager",
    "options": "Employee"
+  },
+  {
+   "fetch_from": "attendance_manager.employee_name",
+   "fieldname": "attendance_manager_name",
+   "fieldtype": "Data",
+   "label": "Attendance Manager Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "employee_section",
+   "fieldtype": "Section Break",
+   "label": "Employee"
+  },
+  {
+   "fieldname": "employee_access",
+   "fieldtype": "Table",
+   "label": "Employee Access",
+   "options": "ONEFM Employee Access"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-10-11 17:48:58.871087",
+ "modified": "2023-10-19 17:06:21.594157",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ONEFM General Setting",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To add a medium to prevent just anyone from updating a employee permissions

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a table in permitted employees name could be added

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![image](https://github.com/ONE-F-M/One-FM/assets/99317649/be2da8a0-39a7-467e-8789-3569bf5f9608)
![image](https://github.com/ONE-F-M/One-FM/assets/99317649/473cd562-25a4-409f-b86d-3a97d6b428f5)


## Areas affected and ensured
List out the areas affected by your code changes.
Employee

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
