### PR TITLE
hot fix: arabic job title from erf to job opening

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -368,6 +368,7 @@ def create_job_opening_from_erf(erf):
 	# Set unique job_title
 	# since job_title will be set a route in Job Opening and the route is set as name in Job Opening
 	job_opening.job_title = erf.job_title+'('+erf.name+')'
+	job_opening.job_title_in_arabic = job_opening.job_title
 	job_opening.designation = erf.designation
 	job_opening.employment_type = erf.employment_type
 	job_opening.department = erf.department


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Not creating job opening on accept the ERF
![Screenshot 2023-10-23 at 5 43 19 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/ed4db222-a64b-4fd9-a022-e5368c8580d1)

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome