### PR TITLE
CHORE: Employee status field, made read only dor those without access

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -134,7 +134,9 @@ def validate_employee_status_access(self):
             if self.status != self.get_doc_before_save().status:
                 if not check_employee_access(email=frappe.session.user):
                     frappe.throw("You are not allowed to make changes to an employee's status.")
-        
+
+
+@frappe.whitelist()      
 def check_employee_access(email: str) -> bool:
     employee_setting = frappe.get_doc("ONEFM General Setting").get("employee_access")
     return frappe.db.get_value("Employee", {"user_id": email}) in [obj.employee for obj in employee_setting]

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -6,6 +6,7 @@ frappe.ui.form.on('Employee', {
         set_shift_working_btn(frm);
         filterDefaultShift(frm);
         setProjects(frm);
+		setReadOnly(frm);
 	},
 	status: function(frm){
 		set_mandatory(frm);
@@ -166,4 +167,18 @@ const TransferToNonShift = frm => {
 function setCharAt(str,index,chr) {
     if(index > str.length-1) return str;
     return str.substring(0,index) + chr + str.substring(index+1);
+}
+
+
+let setReadOnly = (frm) => {
+	frappe.call({
+		method: "one_fm.overrides.employee.check_employee_access",
+		args: {"email": frappe.session.user},
+		callback: function (r) {
+			if (!r.message){
+				frm.set_df_property("status", "read_only", 1)
+			}
+		}
+
+	})
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To make the status field read only for those without access

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a js function that makes the field read only, if the person is not part of those who have been given access

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
