### PR TITLE
fix: wrong leave approver in leave application

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -775,7 +775,7 @@ override_whitelisted_methods = {
     "frappe.model.workflow.get_transitions":"one_fm.overrides.workflow.get_transitions",
 	"frappe.model.workflow.apply_workflow":"one_fm.overrides.workflow.apply_workflow",
 	"hrms.hr.doctype.leave_application.leave_application.get_leave_approver" : "one_fm.api.v1.leave_application.fetch_leave_approver",
-
+	"hrms.hr.doctype.leave_application.leave_application.get_leave_details" : "one_fm.overrides.leave_application.get_leave_approver",
     "frappe.desk.form.load.getdoc": "one_fm.permissions.getdoc",
     "frappe.desk.form.load.get_docinfo": "one_fm.permissions.get_docinfo",
 	"erpnext.controllers.accounts_controller.update_child_qty_rate":"one_fm.overrides.accounts_controller.update_child_qty_rate"

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -95,7 +95,7 @@ class LeaveApplicationOverride(LeaveApplication):
                 frappe.msgprint(msg = f"Shift Assignments for {self.employee_name} between {self.from_date} and {self.to_date} have been deleted",alert=1)
         except:
             frappe.log_error(frappe.get_traceback(),"Error Closing Shifts")
-        
+
 
     def notify_employee(self):
         template = frappe.db.get_single_value("HR Settings", "leave_status_notification_template")
@@ -143,7 +143,7 @@ class LeaveApplicationOverride(LeaveApplication):
         if self.leave_type == 'Annual Leave' :
             holidays = get_holidays_for_employee(employee=self.employee, start_date=self.from_date, end_date=self.to_date, only_non_weekly=True)
             holiday_dates = [cstr(h.holiday_date) for h in holidays]
-            
+
         for dt in daterange(getdate(self.from_date), getdate(self.to_date)):
             date = dt.strftime("%Y-%m-%d")
             attendance_name = frappe.db.exists(
@@ -165,7 +165,7 @@ class LeaveApplicationOverride(LeaveApplication):
                     self.create_or_update_attendance(attendance_name, date, 'Holiday')
             else:
                 self.create_or_update_attendance(attendance_name, date, 'On Leave')
-            
+
 
     def create_or_update_attendance(self, attendance_name, date, status):
         if attendance_name:
@@ -389,19 +389,59 @@ class LeaveApplicationOverride(LeaveApplication):
                 frappe.db.commit()
 
 @frappe.whitelist()
+def get_leave_details(employee, date):
+	allocation_records = get_leave_allocation_records(employee, date)
+	leave_allocation = {}
+	precision = cint(frappe.db.get_single_value("System Settings", "float_precision", cache=True))
+
+	for d in allocation_records:
+		allocation = allocation_records.get(d, frappe._dict())
+		remaining_leaves = get_leave_balance_on(
+			employee, d, date, to_date=allocation.to_date, consider_all_leaves_in_the_allocation_period=True
+		)
+
+		end_date = allocation.to_date
+		leaves_taken = get_leaves_for_period(employee, d, allocation.from_date, end_date) * -1
+		leaves_pending = get_leaves_pending_approval_for_period(
+			employee, d, allocation.from_date, end_date
+		)
+		expired_leaves = allocation.total_leaves_allocated - (remaining_leaves + leaves_taken)
+
+		leave_allocation[d] = {
+			"total_leaves": flt(allocation.total_leaves_allocated, precision),
+			"expired_leaves": flt(expired_leaves, precision) if expired_leaves > 0 else 0,
+			"leaves_taken": flt(leaves_taken, precision),
+			"leaves_pending_approval": flt(leaves_pending, precision),
+			"remaining_leaves": flt(remaining_leaves, precision),
+		}
+
+	# is used in set query
+	lwp = frappe.get_list("Leave Type", filters={"is_lwp": 1}, pluck="name")
+
+	return {
+		"leave_allocation": leave_allocation,
+		"leave_approver": get_leave_approver(employee),
+		"lwps": lwp,
+	}
+
+@frappe.whitelist()
 def get_leave_approver(employee):
-    leave_approver, department = frappe.db.get_value(
-        "Employee", employee, ["leave_approver", "department"]
-    )
-
-    if not leave_approver and department:
-        leave_approver = frappe.db.get_value(
-            "Department Approver",
-            {"parent": department, "parentfield": "leave_approvers", "idx": 1},
-            "approver",
-        )
-
-    return leave_approver
+    employee_details = frappe.db.get_list("Employee", {"name":employee}, ["reports_to", "department"])
+    reports_to = employee_details[0].reports_to
+    department = employee_details[0].department
+    employee_shift = frappe.get_list("Shift Assignment",fields=["*"],filters={"employee":employee}, order_by='creation desc',limit_page_length=1)
+    if reports_to:
+        approver = frappe.get_value("Employee", reports_to, ["user_id"])
+    elif len(employee_shift) > 0 and employee_shift[0].shift:
+        approver, Role = get_action_user(employee,employee_shift[0].shift)
+    else:
+        approvers = frappe.db.sql(
+				"""select approver from `tabDepartment Approver` where parent= %s and parentfield = 'leave_approvers'""",
+				(department),
+			)
+        approvers = [approver[0] for approver in approvers]
+        approver = approvers[0]
+    return approver
 
 @frappe.whitelist()
 def employee_leave_status():


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Set wrong leave approver in leave application

## Areas affected and ensured
- `one_fm/hooks.py`
- `one_fm/overrides/leave_application.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome