### PR TITLE
fix: employee status on leave approval

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -378,9 +378,8 @@ class LeaveApplicationOverride(LeaveApplication):
                     frappe.db.commit()
         if self.status == "Approved":
             if getdate(self.from_date) <= getdate() <= getdate(self.to_date):
-                emp = frappe.get_doc("Employee", self.employee)
-                emp.status = "Vacation"
-                emp.save()
+                # frappe.db.set_value(), will not call the validate.
+                frappe.db.set_value("Employee", self.employee, "status", "Vacation")
                 frappe.db.commit()
             if frappe.db.exists("Attendance Check",{'employee':self.employee, 'date': ['between', (getdate(self.from_date), getdate(self.to_date))]}):
                 att_check = frappe.get_doc("Attendance Check",{'employee':self.employee, 'date': ['between', (getdate(self.from_date), getdate(self.to_date))]})
@@ -467,7 +466,5 @@ def process_change(start_leave, end_leave):
 
 def change_employee_status(employee_list, status):
     for e in employee_list:
-        emp = frappe.get_doc("Employee", e.employee)
-        emp.status = status
-        emp.save()
+        frappe.db.set_value("Employee", e.employee, "status", status)
     frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
![Pasted Image at 2023_10_30_11_38 am](https://github.com/ONE-F-M/One-FM/assets/20554466/ad2a7c81-a4a3-4d82-a9c0-e129f074fce3)

## Solution description
- On validation it calls the `validate_employee_status_access` so while approving the leave application update the status not the employee record.

## Areas affected and ensured
- `one_fm/overrides/leave_application.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome