### PR TITLE
fix: Job Opening title from ERF

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -367,7 +367,7 @@ def create_job_opening_from_erf(erf):
 	job_opening = frappe.new_doc("Job Opening")
 	# Set unique job_title
 	# since job_title will be set a route in Job Opening and the route is set as name in Job Opening
-	job_opening.job_title = erf.job_title+'('+erf.name+')'
+	job_opening.job_title = erf.job_title+' '+erf.name
 	job_opening.job_title_in_arabic = job_opening.job_title
 	job_opening.designation = erf.designation
 	job_opening.employment_type = erf.employment_type


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Job opening title was set like <Job Opening Title>(<ERF>)

## Solution description
- Job opening title is set as <Job Opening Title> <ERF>

## Output screenshots (optional)
Before PR
![Screenshot 2023-10-31 at 12 20 08 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/adacd3c1-6d04-4957-9c33-25d89b5de796)

After PR
![Screenshot 2023-10-31 at 12 22 02 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/51742002-6a67-4dd1-a710-5285b69ad901)

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome