### PR TITLE
Fix: Unlink Shift assignment in Attendance Check

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -101,10 +101,9 @@ class LeaveApplicationOverride(LeaveApplication):
             frappe.log_error(frappe.get_traceback(),"Error Closing Shifts")
 
     def unlink_attendance_check(self, shift):
-        if frappe.db.exists("Attendance Check", {'shift_assignment':shift}):
-            att_check_doc = frappe.get_doc("Attendance Check", {'shift_assignment':shift})
-            att_check_doc.db_set('shift_assignment', "")
-            att_check_doc.db_set('has_shift_assignment',0)
+        attcheck_exists = frappe.db.exists("Attendance Check",  {"shift_assignment": shift})
+        if attcheck_exists:
+            frappe.db.set_value("Attendance Check", attcheck_exists, {'shift_assignment': "",'has_shift_assignment': 0})
         frappe.db.commit()
 
 

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -90,11 +90,22 @@ class LeaveApplicationOverride(LeaveApplication):
         #delete the shifts if a leave application is approved
         try:
             if self.status == "Approved":
-                query =f"""DELETE from `tabShift Assignment` where employee = '{self.employee}' and start_date BETWEEN '{self.from_date}' and '{self.to_date}' and docstatus = 1 """
-                frappe.db.sql(query)
+                shift_assignment = frappe.db.sql(f"""SELECT name from `tabShift Assignment` where employee = '{self.employee}' and start_date BETWEEN '{self.from_date}' and '{self.to_date}' and docstatus = 1 """, as_dict=True)
+                for shift in shift_assignment:
+                    #unlink from attendance check
+                    self.unlink_attendance_check(shift.name)
+                    query =f"""DELETE from `tabShift Assignment` where name = '{shift.name}' and docstatus = 1 """
+                    frappe.db.sql(query)
                 frappe.msgprint(msg = f"Shift Assignments for {self.employee_name} between {self.from_date} and {self.to_date} have been deleted",alert=1)
         except:
             frappe.log_error(frappe.get_traceback(),"Error Closing Shifts")
+
+    def unlink_attendance_check(self, shift):
+        if frappe.db.exists("Attendance Check", {'shift_assignment':shift}):
+            att_check_doc = frappe.get_doc("Attendance Check", {'shift_assignment':shift})
+            att_check_doc.db_set('shift_assignment', "")
+            att_check_doc.db_set('has_shift_assignment',0)
+        frappe.db.commit()
 
 
     def notify_employee(self):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- issue in approving Attendance Check, since the shift is deleted.

## Solution description
Unlink Shift assignment in Attendance Check

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/One-FM/assets/29017559/7364ca8a-2e4b-446d-a893-e9d52cda40f1

## Areas affected and ensured
Approval of Leave Application

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
  ## Was the patch test?


## Which browser(s) did you use for testing?
- [x] Chrome
- [x] Safari
- [x] Firefox
