### PR TITLE
feat: Run employee after insert by button

### DIFF
--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -173,7 +173,6 @@ def set_map_job_applicant_details(target, job_applicant_id, job_applicant=False)
 
 def employee_after_insert(doc, method):
     create_salary_structure_assignment(doc, method)
-    update_erf_close_with(doc)
     create_wp_for_transferable_employee(doc)
     create_leave_policy_assignment(doc)
     if frappe.db.get_single_value("HR and Payroll Additional Settings", "auto_generate_employee_id_on_employee_creation") and not doc.employee_id:
@@ -184,6 +183,7 @@ def employee_after_insert(doc, method):
             create_employee_user_from_employee_id(doc)
         else:
             create_employee_user_from_company_email(doc)
+    update_erf_close_with(doc)
 
 def employee_before_insert(doc, method):
     # check for nationality, then set residency
@@ -278,7 +278,7 @@ def create_leave_policy_assignment(doc):
 		args:
 			doc: Employee Object
     """
-    if doc.leave_policy:
+    if doc.leave_policy and not frappe.db.exists("Leave Policy Assignment", {"employee": doc.name}):
         assignment = frappe.new_doc("Leave Policy Assignment")
         assignment.employee = doc.name
         assignment.assignment_based_on = 'Joining Date'
@@ -317,7 +317,10 @@ def notify_grd_operator_for_transfer_wp_record(tp):
         create_notification_log(subject, message, [operator], wp_record)
 
 def update_erf_close_with(doc):
-    if doc.one_fm_erf:
+    closed_with_exists = frappe.db.exists("ERF Employee",
+        {"employee": doc.name, "parenttype": "ERF", "parentfield": "erf_employee", "parent": doc.one_fm_erf}
+    )
+    if doc.one_fm_erf and not closed_with_exists:
         erf_employee = frappe.new_doc("ERF Employee")
         erf_employee.parent = doc.one_fm_erf
         erf_employee.parentfield = "erf_employee"
@@ -328,7 +331,7 @@ def update_erf_close_with(doc):
 
 @frappe.whitelist()
 def create_salary_structure_assignment(doc, method):
-    if doc.job_offer_salary_structure:
+    if doc.job_offer_salary_structure and not frappe.db.exists("Salary Structure Assignment", {"employee": doc.name}):
         assignment = frappe.new_doc("Salary Structure Assignment")
         assignment.employee = doc.name
         assignment.salary_structure = doc.job_offer_salary_structure

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -34,25 +34,6 @@ class EmployeeOverride(EmployeeMaster):
                     "Employee", self.name, existing_user_id)
         employee_validate_attendance_by_timesheet(self, method=None)
         validate_leaves(self)
-        
-    
-def update_user_doc(doc):
-    if not doc.is_new():
-        old_self = doc.get_doc_before_save().status
-        if doc.status in ['Left','Absconding','Court Case'] and doc.status not in [old_self] and doc.user_id:
-            user_doc = frappe.get_doc('User',doc.user_id)
-            if user_doc.enabled == 1:
-                user_doc.enabled = 0
-                user_doc.save(ignore_permissions=1)
-                frappe.msgprint(f"User {doc.user_id} disabled",alert=1)
-                frappe.db.commit()
-        elif doc.status == "Active" and doc.status not in [old_self] and doc.user_id:
-            user_doc = frappe.get_doc('User',doc.user_id)
-            if user_doc.enabled == 0:
-                user_doc.enabled = 1
-                user_doc.save(ignore_permissions=1)
-                frappe.msgprint(f"User {doc.user_id} enabled",alert=1)
-                frappe.db.commit()
 
     def before_save(self):
         self.assign_role_profile_based_on_designation()
@@ -62,7 +43,11 @@ def update_user_doc(doc):
     def after_insert(self):
         employee_after_insert(self, method=None)
         self.assign_role_profile_based_on_designation()
-    
+
+    @frappe.whitelist()
+    def run_employee_id_generation(self):
+        employee_after_insert(self, method=None)
+
     def before_insert(self):
         employee_before_insert(self, method=None)
 
@@ -70,18 +55,9 @@ def update_user_doc(doc):
         validate_onboarding_process(self)
 
     def assign_role_profile_based_on_designation(self):
-        if self.designation:
-            if self.is_new():
-                if self.user_id:
-                    designation = self.designation
-                else:
-                    return
-            else:
-                if self.designation != self.get_doc_before_save().designation:
-                    designation = self.designation
-                else:
-                    return
-            role_profile = frappe.db.get_value("Designation", designation, "role_profile")
+        previous_designation = frappe.db.get_value("Employee", self.name, "designation")
+        if self.designation and self.user_id and self.designation != previous_designation:
+            role_profile = frappe.db.get_value("Designation", self.designation, "role_profile")
             if role_profile:
                 user = frappe.get_doc("User", self.user_id)
                 user.role_profile_name = role_profile
@@ -113,7 +89,7 @@ def update_user_doc(doc):
                 AND date>'{doc.relieving_date}'
             """)
             frappe.msgprint(f"""
-                Employee Schedule cleared for {doc.employee_name} starting from {add_days(doc.relieving_date, 1)} 
+                Employee Schedule cleared for {doc.employee_name} starting from {add_days(doc.relieving_date, 1)}
             """)
 
 def validate_leaves(self):
@@ -124,8 +100,8 @@ def validate_leaves(self):
                 '{getdate()}' BETWEEN from_date AND to_date
             """, as_dict=1):
             frappe.throw(f"Status cannot be 'Vacation' when no Leave Application exists for {self.employee_name} today {getdate()}.")
-            
-            
+
+
 def validate_employee_status_access(self):
     if self.status:
         if self.is_new():
@@ -136,7 +112,7 @@ def validate_employee_status_access(self):
                     frappe.throw("You are not allowed to make changes to an employee's status.")
 
 
-@frappe.whitelist()      
+@frappe.whitelist()
 def check_employee_access(email: str) -> bool:
     employee_setting = frappe.get_doc("ONEFM General Setting").get("employee_access")
     return frappe.db.get_value("Employee", {"user_id": email}) in [obj.employee for obj in employee_setting]
@@ -148,3 +124,21 @@ def get_new_employee_id(employee_id):
     if num == '0':
         new_emp_id = employee_id[:length-3] + '1' + employee_id[length-2:]
         return new_emp_id
+
+def update_user_doc(doc):
+    if not doc.is_new():
+        old_self = doc.get_doc_before_save().status
+        if doc.status in ['Left','Absconding','Court Case'] and doc.status not in [old_self] and doc.user_id:
+            user_doc = frappe.get_doc('User',doc.user_id)
+            if user_doc.enabled == 1:
+                user_doc.enabled = 0
+                user_doc.save(ignore_permissions=1)
+                frappe.msgprint(f"User {doc.user_id} disabled",alert=1)
+                frappe.db.commit()
+        elif doc.status == "Active" and doc.status not in [old_self] and doc.user_id:
+            user_doc = frappe.get_doc('User',doc.user_id)
+            if user_doc.enabled == 0:
+                user_doc.enabled = 1
+                user_doc.save(ignore_permissions=1)
+                frappe.msgprint(f"User {doc.user_id} enabled",alert=1)
+                frappe.db.commit()

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -7,6 +7,21 @@ frappe.ui.form.on('Employee', {
         filterDefaultShift(frm);
         setProjects(frm);
 		setReadOnly(frm);
+		if(frappe.user.has_role('HR Manager') && !frm.doc.employee_id){
+			frm.add_custom_button(__('Run Employee ID Generation Method'), function() {
+				frappe.call({
+					doc: frm.doc,
+					method: 'run_employee_id_generation',
+					callback: function(r) {
+						if(!r.exc) {
+							frm.reload_doc();
+						}
+					},
+					freaze: true,
+					freaze_message: __("Running Employee ID Generation Method..")
+				});
+			});
+		}
 	},
 	status: function(frm){
 		set_mandatory(frm);
@@ -96,7 +111,7 @@ var change_employee_id = function(frm) {
 				if (r && r.message) {
 					frm.set_value('employee_id',  r.message)
 				}
-				
+
 			}
 		});
 	}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- If employee Id, leave policy and salary structure assignments are not created for an employee on insert, then provide a button to run employee id generation


## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/20554466/1dbd4100-5686-4c36-a13b-c6a24d79e62b


## Areas affected and ensured
- `one_fm/hiring/utils.py`
- `one_fm/overrides/employee.py`
- `one_fm/public/js/doctype_js/employee.js`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome