### PR TITLE
Fix: salary_slips_created value

### DIFF
--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -754,8 +754,6 @@ def check_salary_slip_count(doc):
 		""", as_dict=1)
 	if salary_count[0] != payroll_entry.number_of_employees:
 		payroll_entry.db_set({"status": "Pending Salary Slip", "error_message": "", "salary_slips_created": 0})
-	else:
-		payroll_entry.db_set({"salary_slips_created": 1})
 	frappe.db.commit()
 	return True
 

--- a/one_fm/api/doc_methods/payroll_entry.py
+++ b/one_fm/api/doc_methods/payroll_entry.py
@@ -642,6 +642,7 @@ def create_salary_slips(doc):
 			create_salary_slips_for_employees(employees, payroll_entry = doc, publish_progress=False)
 			# since this method is called via frm.call this doc needs to be updated manually
 			doc.reload()
+		
 
 def log_payroll_failure(process, payroll_entry, error):
 	error_log = frappe.log_error(
@@ -715,7 +716,8 @@ def create_salary_slips_for_employees(employees, payroll_entry, publish_progress
 
 			if salary_slip_chunk:
 				frappe.enqueue(create_salary_slip_chunk,slips=salary_slip_chunk, queue="long")
-		payroll_entry.db_set("status", "Submitted")
+		
+		payroll_entry.db_set({"status": "Submitted", "salary_slips_created": 1, "error_message": ""})
 		
 		if salary_slips_exist_for:
 			frappe.msgprint(
@@ -742,24 +744,19 @@ def create_salary_slip_chunk(slips):
 @frappe.whitelist()
 def check_salary_slip_count(doc):
 	payroll_entry = frappe.get_doc("Payroll Entry", doc)
-	if payroll_entry.salary_slips_created == 1:
-		salary_count = frappe.db.sql_list(
-			f"""
-			select Count(distinct employee) as salary_count from `tabSalary Slip`
-			where docstatus!= 2 
-				and company = '{payroll_entry.company}'
-				and start_date = '{payroll_entry.start_date}'
-				and end_date = '{payroll_entry.end_date}'
-			""", as_dict=1)
-		print(salary_count[0])
-		if salary_count[0] != payroll_entry.number_of_employees:
-			
-			payroll_entry.db_set({"status": "Pending Salary Slip", "error_message": ""})
-		else:
-			payroll_entry.db_set({"status": "Submitted", "error_message": ""})
-		frappe.db.commit()
+	salary_count = frappe.db.sql_list(
+		f"""
+		select Count(distinct employee) as salary_count from `tabSalary Slip`
+		where docstatus!= 2
+			and company = '{payroll_entry.company}'
+			and start_date = '{payroll_entry.start_date}'
+			and end_date = '{payroll_entry.end_date}'
+		""", as_dict=1)
+	if salary_count[0] != payroll_entry.number_of_employees:
+		payroll_entry.db_set({"status": "Pending Salary Slip", "error_message": "", "salary_slips_created": 0})
 	else:
-		payroll_entry.db_set({"status": "Draft", "error_message": ""})
+		payroll_entry.db_set({"salary_slips_created": 1})
+	frappe.db.commit()
 	return True
 
 @frappe.whitelist()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -61,3 +61,4 @@ one_fm.patches.v14_0.remove_magic_link_field_from_job_applicant
 one_fm.patches.v14_0.update_operation_shift 
 one_fm.patches.v14_0.copy_ml_to_ch_applicant_doc_url
 one_fm.patches.v14_0.update_attendance_check
+one_fm.patches.v14_0.payroll_salary_slip_created

--- a/one_fm/patches/v14_0/payroll_salary_slip_created.py
+++ b/one_fm/patches/v14_0/payroll_salary_slip_created.py
@@ -1,0 +1,21 @@
+import frappe
+
+def execute():
+    payroll_list = frappe.get_list("Payroll Entry",{'status':"Submitted"})
+    
+    for doc in payroll_list:
+        payroll_entry = frappe.get_doc("Payroll Entry", doc)
+        salary_count = frappe.db.sql_list(
+            f"""
+            select Count(distinct employee) as salary_count from `tabSalary Slip`
+            where docstatus!= 2 
+                and company = '{payroll_entry.company}'
+                and start_date = '{payroll_entry.start_date}'
+                and end_date = '{payroll_entry.end_date}'
+            """, as_dict=1)
+        if salary_count[0] != payroll_entry.number_of_employees:
+            payroll_entry.db_set({"status": "Pending Salary Slip", "error_message": "", "salary_slips_created": 0})
+        else:
+            if payroll_entry.salary_slips_created == 0:
+                payroll_entry.db_set({"salary_slips_created": 1})
+    frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- salary_slips_created value not set correctly.

## Solution description
- Fix setting of value.
- Fix query.
- add a patch.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/29017559/cd77902d-47e0-4492-a09e-d6d4c4d589d3

<img width="1034" alt="Screen Shot 2023-11-06 at 2 56 43 PM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/651cefd3-2243-413b-a44d-7cc4d66eb810">


## Areas affected and ensured
- salary_slips_created value

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [ ] No
    ## Was the patch test?
yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
