### PR TITLE
feat: remove custom button on interview in mobile view

### DIFF
--- a/one_fm/public/js/doctype_js/interview.js
+++ b/one_fm/public/js/doctype_js/interview.js
@@ -1,6 +1,7 @@
 frappe.ui.form.on('Interview', {
 	refresh: function (frm) {
-		frm.remove_custom_button('Submit Feedback')
+		frm.remove_custom_button('Submit Feedback');
+		remove_custom_button_from_mobile_view(frm, "Submit Feedback");
 		let allowed_interviewers = [];
 		frm.doc.interview_details.forEach(values => {
 			allowed_interviewers.push(values.interviewer);
@@ -144,6 +145,15 @@ frappe.ui.form.on('Interview', {
 
 	},
 });
+
+var remove_custom_button_from_mobile_view = function(frm, label) {
+	// Find the span element with the specified data-label attribute
+	var span_element = $(`.menu-item-label[data-label='${encodeURIComponent(label)}']`);
+	// Get the parent li element
+	var parent_li_element = span_element.closest("li");
+	// Hide the parent li element
+	parent_li_element.hide();
+}
 
 var create_interview_feedback = function(frm, values, feedback_exists, save_submit) {
 	var args = {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Remove the custom submit feedback button in mobile view

## Solution description
- Identify the element and hide it

## Output screenshots (optional)
Before the PR

https://github.com/ONE-F-M/One-FM/assets/20554466/8e669069-ab90-43aa-b920-1d5efbd3a8fc

After the PR

https://github.com/ONE-F-M/One-FM/assets/20554466/dd2222a1-5e72-4202-aa10-3fbff9a680fb

## Areas affected and ensured
- `one_fm/public/js/doctype_js/interview.js`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome