### PR TITLE
Fix: Fetching of employee that where not rostered.

### DIFF
--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
@@ -80,7 +80,7 @@ def create_roster_employee_actions():
     # fetch employees that are active and don't have a schedule in the specified date range
     active_employees = frappe.db.sql("""select employee from `tabEmployee` where status = 'Active' AND shift_working = 1""", as_dict=1)
 
-    all_combinations = [(employee.employee, date) for employee in active_employees for date in [(start_date + timedelta(days=x)).strftime('%Y-%m-%d') for x in range((end_date - start_date).days + 1)]]
+    active_employees_combinations = [(employee.employee, date) for employee in active_employees for date in [(start_date + timedelta(days=x)).strftime('%Y-%m-%d') for x in range((end_date - start_date).days + 1)]]
     
     employees_rostered = frappe.db.sql(f"""SELECT s.employee, s.date
                                     FROM `tabEmployee Schedule` s 
@@ -88,7 +88,7 @@ def create_roster_employee_actions():
                                     """, as_dict= True)
     employees_rostered_combination = [(roster.employee, (roster.date).strftime('%Y-%m-%d')) for roster in employees_rostered]
     
-    employees_not_rostered = set(all_combinations) - set(employees_rostered_combination)
+    employees_not_rostered = set(active_employees_combinations) - set(employees_rostered_combination)
 
     list_of_leaves_within_employee_action_period = frappe.db.get_list("Leave Application", {"status": "Approved", "from_date":["<", start_date ], "to_date": [">", end_date]}, pluck="employee")
 

--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
@@ -73,9 +73,9 @@ def create_roster_employee_actions():
     """
 
     # start date to be from tomorrow
-    start_date = getdate('2023-10-04') #getdate(add_to_date(cstr(getdate()), days=1))
+    start_date = getdate(add_to_date(cstr(getdate()), days=1))
     # end date to be 14 days after start date
-    end_date = getdate('2023-10-04') #getdate(add_to_date(start_date, days=14))
+    end_date = getdate(add_to_date(start_date, days=14))
     #-------------------- Roster Employee actions ------------------#
     # fetch employees that are active and don't have a schedule in the specified date range
     active_employees = frappe.db.sql("""select employee from `tabEmployee` where status = 'Active' AND shift_working = 1""", as_dict=1)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- Employee not rostered for a day where not fetched.

## Solution description
- Fetch Active employee and Schedule of employee in a separate query. 
- create combination of employee and date(Date range between start and end date)
- subtract the sets. 

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="1368" alt="Screen Shot 2023-11-16 at 10 53 22 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/f87cf0a5-b848-468d-8cbc-75ca16686cee">


## Areas affected and ensured
- Employee fetched even if One day is missed.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
