### PR TITLE
patch: set erf workflow state with status

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -58,10 +58,11 @@ one_fm.patches.v14_0.update_post_abbr #2023-09-24
 one_fm.patches.v14_0.change_educational_qualification_options_in_job_applicant
 one_fm.patches.v14_0.remove_unused_pri_custom_field
 one_fm.patches.v14_0.remove_magic_link_field_from_job_applicant
-one_fm.patches.v14_0.update_operation_shift 
+one_fm.patches.v14_0.update_operation_shift
 one_fm.patches.v14_0.copy_ml_to_ch_applicant_doc_url
 one_fm.patches.v14_0.update_attendance_check
 one_fm.patches.v14_0.payroll_salary_slip_created
 one_fm.patches.v14_0.missing_shift_assignment
 one_fm.patches.v14_0.update_docstatus
 one_fm.patches.v14_0.rejected_attendance_check
+one_fm.patches.v14_0.set_erf_workflow_state_with_status

--- a/one_fm/patches/v14_0/set_erf_workflow_state_with_status.py
+++ b/one_fm/patches/v14_0/set_erf_workflow_state_with_status.py
@@ -1,0 +1,12 @@
+import frappe
+
+def execute():
+	query = '''
+		update
+			`tabERF`
+		set
+			workflow_state = 'Closed'
+		where
+			status = 'Closed'
+	'''
+	frappe.db.sql(query)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Chore

## Clearly and concisely describe the feature, chore or bug.
- set erf workflow state with status

## Output screenshots (optional)
Before the PR
![Screenshot 2023-11-18 at 4 25 32 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/127164bc-d0a8-4028-b7dc-51f81b56df2b)

After the PR
![Screenshot 2023-11-18 at 4 26 36 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/da90d08c-1d9e-4fa7-88cb-0e40f9a269dc)
![Screenshot 2023-11-18 at 4 34 11 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/a4c67c9e-1421-4fbb-a6dc-b64488967bf3)

## Areas affected and ensured
-`one_fm/patches.txt`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Which browser(s) did you use for testing?
- [x] Chrome