### PR TITLE
feat: erf - interview round filter update

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.js
+++ b/one_fm/one_fm/doctype/erf/erf.js
@@ -21,9 +21,8 @@ frappe.ui.form.on('ERF', {
 		});
 		frm.set_query('interview_round', 'interview_rounds', function () {
 			return {
-				filters: {
-					'designation': frm.doc.designation
-				}
+				query: "one_fm.one_fm.doctype.erf.erf.interview_round_filter",
+				filters: {'designation': frm.doc.designation}
 			};
 		});
 

--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -540,3 +540,22 @@ def recruitment_manager_check(user: str):
 	if role_profile:
 		return frappe.db.exists('User', {"role_profile_name": role_profile, "name": user})
 	return False
+
+@frappe.whitelist()
+def interview_round_filter(doctype, txt, searchfield, start, page_len, filters):
+	query = """
+		select
+			name
+		from
+			`tabInterview Round`
+		where
+			(designation = %(designation)s or designation = '' or designation is NULL) and name like %(txt)s
+			limit %(start)s, %(page_len)s"""
+	return frappe.db.sql(query,
+		{
+			'designation': filters.get("designation"),
+			'start': start,
+			'page_len': page_len,
+			'txt': "%%%s%%" % txt
+		}
+	)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Update interview round filter in ERF

## Output screenshots (optional)
The Interview rounds with and without designation
![Screenshot 2023-11-19 at 5 46 23 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/425002c1-9933-496a-b996-cfaaaacab63d)

Before PR
![Screenshot 2023-11-19 at 5 47 12 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/3f9b0e6c-19df-4b2b-9b27-25d5ceb3b261)

After the PR
![Screenshot 2023-11-19 at 5 48 07 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/90bcc3d5-00b2-4ff8-85eb-0cc8b3ada195)

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.js`
- `one_fm/one_fm/doctype/erf/erf.py`


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
