### PR TITLE
Feat: add Rows in Payroll Entry.

### DIFF
--- a/one_fm/one_fm/report/payroll_report/payroll_report.py
+++ b/one_fm/one_fm/report/payroll_report/payroll_report.py
@@ -217,6 +217,20 @@ def get_columns(filters):
 			"width": 180,
 		},
 		{
+			"label": ("Payment Days(Basic)"),
+			"fieldname": "pd",
+			"fieldtype": "Int",
+			"default": 0,
+			"width": 180,
+		},
+		{
+			"label": ("Payment Days(OT)"),
+			"fieldname": "pdot",
+			"fieldtype": "Int",
+			"default": 0,
+			"width": 180,
+		},
+		{
 			"label": ("Total"),
 			"fieldname": "total",
 			"fieldtype": "Int",
@@ -280,6 +294,8 @@ def get_data(filters):
 			
 		i.theoretical_days_off = theoretical_days_off(i.day_off_category, i.number_of_days_off, i.start_date, i.end_date)
 		i.theoretical_working_days = i.days_in_period - i.theoretical_days_off
+		i.pd = i.present_days + i.do_att + i.sl + i.al + i.ol + i.att_public_holidays
+		i.pdot = i.present_days_ot + i.do_ot
 		i.total = i.present_days + i.do_att + i.sl + i.al + i.ol + i.ab + i.att_public_holidays
 
 	if not query:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Add rows in the Payroll report to show Payment days(Basic and OT), which is the total day - Absent days.

## Solution description
- Add 2 rows, Basic and OT Payment days.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="410" alt="Screen Shot 2023-11-20 at 10 23 25 AM" src="https://github.com/ONE-F-M/One-FM/assets/29017559/b7aa2879-1569-4659-a212-31d828271d8d">


## Areas affected and ensured
Payroll Report Rows

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
