### PR TITLE
fix: interview round - allow on submit

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.json
+++ b/one_fm/one_fm/doctype/erf/erf.json
@@ -979,6 +979,7 @@
    "reqd": 1
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "number_of_interview_rounds",
    "fieldname": "interview_rounds",
    "fieldtype": "Table",
@@ -987,6 +988,7 @@
    "options": "ERF Interview Round"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "number_of_interview_rounds",
    "fieldtype": "Int",
    "label": "Number of Interview Rounds"
@@ -994,7 +996,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-02 20:57:46.237232",
+ "modified": "2023-11-21 10:31:21.063977",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ERF",

--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -49,7 +49,7 @@ class ERF(Document):
 		if self.number_of_interview_rounds and self.number_of_interview_rounds != len(self.interview_rounds):
 			frappe.throw(_("Number of rows of the 'Intreview Rounds' must be equal to 'Number of Interview Rounds'!"))
 
-		if self.hiring_method == 'Bulk Recruitment' and self.number_of_interview_rounds < 1:
+		if self.hiring_method == 'Bulk Recruitment' and not self.number_of_interview_rounds:
 			frappe.throw(_("Minimum one intreview rounds must be added for bulk recruitment!"))
 
 	def validate_attendance_by_timesheet(self):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Set interview round - allow on submit

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.json`
- `one_fm/one_fm/doctype/erf/erf.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome