### PR TITLE
FEAT: Notify supervisor on pending Shift permission, an hour to shift start

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -686,7 +686,8 @@ scheduler_events = {
 			'one_fm.overrides.leave_application.employee_leave_status'
 		],
 		"0 * * * *":[ # Creates the missing checkin record per shift, runs every hour
-			"one_fm.one_fm.doctype.missing_checkin.missing_checkin.create_missing_checkin_record"
+			"one_fm.one_fm.doctype.missing_checkin.missing_checkin.create_missing_checkin_record",
+			"one_fm.operations.doctype.shift_permission.shift_permission.notify_approver_about_pending_shift_permission"
 		]
 	}
 }

--- a/one_fm/templates/emails/notify_shift_permission_approver.html
+++ b/one_fm/templates/emails/notify_shift_permission_approver.html
@@ -1,0 +1,55 @@
+<style>
+    table {
+      font-family: Arial, sans-serif;
+      border-collapse: collapse;
+      width: 100%;
+    }
+    
+    th, .shift_permission td {
+      border: 1px solid #ddd;
+      padding: 8px;
+    }
+    
+    th {
+      background-color: #f2f2f2;
+      color: #333;
+      width: 30%;
+      text-align: left;
+    }
+    
+    tr:nth-child(even) {
+      background-color: #f9f9f9;
+    }
+    
+    tr:hover {
+      background-color: #ddd;
+    }
+    
+    </style>
+    
+    
+<table>
+    <tr>
+        <td style="font-family: 'Cairo', sans-serif;color:#4b4b4c;" mc:edit="tm2-04" valign="top" >
+            <p>Hello {{ approver_name}},</p><br>
+            <p>The following Shift permissions needs your immediate action</p>
+            <br>
+        </td>
+    </tr>
+    <br><br>
+
+
+    <tbody class="shift_permission">
+
+    {% for obj in data %}
+        {% for key, value in obj.items() %}
+            <tr>
+                <th>{{ key}}</th>
+                <td><a href={{ value }}>Link to form</a></td>
+            </tr>
+        {% endfor %}
+    {% endfor %}
+    
+    </tbody>
+</table>
+    

--- a/one_fm/templates/emails/notify_shift_permission_approver.html
+++ b/one_fm/templates/emails/notify_shift_permission_approver.html
@@ -27,25 +27,22 @@
     
     </style>
     
-    
+
+    <p>Hello {{ approver_name}}, The following Shift permissions needs your immediate action</p><br>
+
 <table>
-    <tr>
-        <td style="font-family: 'Cairo', sans-serif;color:#4b4b4c;" mc:edit="tm2-04" valign="top" >
-            <p>Hello {{ approver_name}},</p><br>
-            <p>The following Shift permissions needs your immediate action</p>
-            <br>
-        </td>
-    </tr>
-    <br><br>
-
-
     <tbody class="shift_permission">
+      <tr>
+        <th>Employee Name</th>
+        <td>Link to Shift Perimission</a></td>
+      </tr>
 
     {% for obj in data %}
+
         {% for key, value in obj.items() %}
             <tr>
                 <th>{{ key}}</th>
-                <td><a href={{ value }}>Link to form</a></td>
+                <td><a href={{ value }}>Link</a></td>
             </tr>
         {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To notify supervisors about pending shift permissions, before shift starts

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a method that notifies the supervisors, and a cronjob that runs every hour

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2023-11-25 16-30-11](https://github.com/ONE-F-M/One-FM/assets/99317649/114d580f-14f0-4aed-87a1-a53bca984865)


## Areas affected and ensured
List out the areas affected by your code changes.
Shift Permission

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
