### PR TITLE
CHORE: MADE MISSING DATES READ ONLY(Roster employee actions)

### DIFF
--- a/one_fm/one_fm/doctype/employees_not_rostered/employees_not_rostered.json
+++ b/one_fm/one_fm/doctype/employees_not_rostered/employees_not_rostered.json
@@ -33,13 +33,14 @@
    "fieldtype": "Long Text",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Missing Dates"
+   "label": "Missing Dates",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-12-09 21:47:30.901309",
+ "modified": "2023-12-13 12:40:03.948912",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Employees Not Rostered",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To make the missing dates field on the roster employee actions doctype, to be read only

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Employee Actions

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
