### PR TITLE
fix: get_mandatory_fields - workflow notification

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -436,7 +436,7 @@ def get_job_openig_description_template():
 def send_email(doc, recipients):
 	page_link = get_url(doc.get_url())
 	message = "<p>Here is the ERF <a href='{0}'>{1}</a> requested by {2}. Please Review it and take action.</p>".format(page_link, doc.name,doc.erf_requested_by_name)
-	mandatory_field, labels = get_mandatory_fields(doc.doctype, doc.name)
+	mandatory_field, labels = get_mandatory_fields(doc)
 
 	if mandatory_field and labels:
 		message = create_message_with_details(message, mandatory_field, labels)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- get_mandatory_fields - workflow notification - TypeError: cannot unpack non-iterable NoneType object

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.py`
- `one_fm/utils.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome