### PR TITLE
FEAT:Set default Employment Type and Residency Status for Subcontracted Employees

### DIFF
--- a/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
+++ b/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
@@ -20,7 +20,8 @@
   "job_applicaion_section",
   "easy_apply_to",
   "subcontract_hiring_settings_section",
-  "subcontract_employment_type"
+  "subcontract_employment_type",
+  "subcontract_residency_status"
  ],
  "fields": [
   {
@@ -110,15 +111,22 @@
    "label": "Subcontract Hiring Settings"
   },
   {
+   "default": "Subcontractor",
    "fieldname": "subcontract_employment_type",
    "fieldtype": "Link",
    "label": "Subcontract Employment Type",
    "options": "Employment Type"
+  },
+  {
+   "default": "0",
+   "fieldname": "subcontract_residency_status",
+   "fieldtype": "Check",
+   "label": "Subcontract Residency Status"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-12-05 09:34:45.053425",
+ "modified": "2023-12-19 10:52:20.936673",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Hiring Settings",

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -186,8 +186,9 @@ def employee_after_insert(doc, method):
     update_erf_close_with(doc)
 
 def employee_before_insert(doc, method):
+    ...
     # check for nationality, then set residency
-    if doc.one_fm_nationality != "Kuwaiti":
+    if doc.one_fm_nationality != "Kuwaiti" and doc.employment_type != "Subcontractor":
         doc.under_company_residency = 1
 
 def create_employee_user_from_company_email(doc):

--- a/one_fm/subcontract/doctype/onboard_subcontract_employee/onboard_subcontract_employee.py
+++ b/one_fm/subcontract/doctype/onboard_subcontract_employee/onboard_subcontract_employee.py
@@ -58,7 +58,6 @@ class OnboardSubcontractEmployee(Document):
 	            }
 	        }
 	    }, None, set_missing_values)
-		print(vars(employee))
 		employee.save(ignore_permissions=True)
 
 		self.db_set("employee", employee.name)

--- a/one_fm/subcontract/doctype/onboard_subcontract_employee/onboard_subcontract_employee.py
+++ b/one_fm/subcontract/doctype/onboard_subcontract_employee/onboard_subcontract_employee.py
@@ -31,7 +31,8 @@ class OnboardSubcontractEmployee(Document):
 			else:
 				target.shift_working = False
 			target.permanent_address = "Address"
-			target.employment_type = self.employment_type
+			target.employment_type = frappe.db.get_single_value("Hiring Settings", "subcontract_employment_type")
+			target.under_company_residency = frappe.db.get_single_value("Hiring Settings", "subcontract_residency_status")
 
 		employee = get_mapped_doc(self.doctype, self.name, {
 	        self.doctype: {
@@ -57,6 +58,7 @@ class OnboardSubcontractEmployee(Document):
 	            }
 	        }
 	    }, None, set_missing_values)
+		print(vars(employee))
 		employee.save(ignore_permissions=True)
 
 		self.db_set("employee", employee.name)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [X] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To set a default employment type and company residency status for subcontracted employee

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a field to the settings where the values would be fetched from

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
