### PR TITLE
fix: erf - notification - permission issue

### DIFF
--- a/one_fm/one_fm/doctype/erf/erf.py
+++ b/one_fm/one_fm/doctype/erf/erf.py
@@ -168,7 +168,7 @@ class ERF(Document):
 
 	def notify_recruitment_manager(self):
 		try:
-			role_profile = frappe.db.get_list("Role Profile", {"role_profile": ["IN", ["Recruitment Manager", "Director"]]}, pluck="name")
+			role_profile = frappe.db.get_list("Role Profile", {"role_profile": ["IN", ["Recruitment Manager", "Director"]]}, pluck="name", ignore_permissions=True)
 			if role_profile:
 				manager_emails = frappe.db.get_list("User", {"role_profile_name": ["IN", role_profile]}, pluck="name")
 				if manager_emails:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Traceback (most recent call last): File "apps/onefm/onefm/onefm/doctype/erf/erf.py", line 171, in notifyrecruitmentmanager roleprofile = frappe.db.getlist("Role Profile", {"roleprofile": ["IN", ["Recruitment Manager", "Director"]]}, pluck="name") File "apps/frappe/frappe/database/database.py", line 741, in getlist return frappe.getlist(args, *kwargs) File "apps/frappe/frappe/init.py", line 1912, in getlist return frappe.model.dbquery.DatabaseQuery(doctype).execute(args, *kwargs) File "apps/frappe/frappe/model/dbquery.py", line 120, in execute self.checkreadpermission(self.doctype, parentdoctype=parentdoctype) File "apps/frappe/frappe/model/dbquery.py", line 497, in checkreadpermission self.setpermissionmap(doctype, parentdoctype) File "apps/frappe/frappe/model/dbquery.py", line 510, in _setpermission_map raise frappe.PermissionError(doctype) frappe.exceptions.PermissionError: Role Profile

## Areas affected and ensured
- `one_fm/one_fm/doctype/erf/erf.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome