### PR TITLE
feat: override goal filter and validation

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -486,8 +486,8 @@ override_doctype_class = {
     "Notification Log": "one_fm.overrides.notification_log.NotificationLogOverride",
     "Job Applicant": "one_fm.overrides.job_applicant.JobApplicantOverride",
     "Job Opening": "one_fm.overrides.job_opening.JobOpeningOverride",
-    "Shift Assignment": "one_fm.overrides.shift_assignment.ShiftAssignmentOverride"
-	# "User": "one_fm.overrides.user.UserOverrideLMS",
+    "Shift Assignment": "one_fm.overrides.shift_assignment.ShiftAssignmentOverride",
+    "Goal": "one_fm.overrides.goal.GoalOverride"
 }
 
 

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -111,6 +111,7 @@ doctype_js = {
     "Workflow": "public/js/doctype_js/workflow.js",
     "Stock Entry": "public/js/doctype_js/stock_entry.js",
     "Gratuity": "public/js/doctype_js/gratuity.js",
+    "Goal": "public/js/doctype_js/goal.js"
 }
 doctype_list_js = {
 	"Job Applicant" : "public/js/doctype_js/job_applicant_list.js",

--- a/one_fm/overrides/goal.py
+++ b/one_fm/overrides/goal.py
@@ -1,0 +1,25 @@
+import frappe
+from hrms.hr.doctype.goal.goal import Goal
+
+class GoalOverride(Goal):
+    def validate_parent_fields(self):
+        '''
+            Overriding the super class method here to remove the validation of employee link in the parent
+        '''
+        if not self.parent_goal:
+            return
+
+        parent_details = frappe.db.get_value(
+            "Goal", self.parent_goal, ["kra", "appraisal_cycle"], as_dict=True
+        )
+        if not parent_details:
+            return
+
+        if self.kra != parent_details.kra:
+            frappe.throw(
+                _("Goal should be aligned with the same KRA as its parent goal."), title=_("Not Allowed")
+            )
+        if self.appraisal_cycle != parent_details.appraisal_cycle:
+            frappe.throw(
+                _("Goal should belong to the same Appraisal Cycle as its parent goal."), title=_("Not Allowed"),
+            )

--- a/one_fm/public/js/doctype_js/goal.js
+++ b/one_fm/public/js/doctype_js/goal.js
@@ -1,0 +1,12 @@
+frappe.ui.form.on("Goal", {
+	refresh(frm) {
+		frm.set_query("parent_goal", () => {
+			return {
+				filters: {
+					is_group: 1,
+					name: ["!=", frm.doc.name]
+				}
+			}
+		});
+	}
+})


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Override goal - parent goal field filter and validation

## Output screenshots (optional)
Before PR
![Screenshot 2023-12-19 at 3 47 42 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/4fad4ae2-7af6-48be-ba03-a886f5f85029)

## Areas affected and ensured
- `one_fm/hooks.py`

## Is there any existing behavior change of other features due to this code change?
Yes, able to add parent goal not linked to the same employee

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome