### PR TITLE
feat: auto payroll entry for different payroll cycle

### DIFF
--- a/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.py
+++ b/one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.py
@@ -31,3 +31,15 @@ def get_projects_not_configured_in_payroll_cycle_but_linked_in_employee(project_
 			project NOT IN ({0})
 	'''
 	return frappe.db.sql(query.format(project_list), as_dict=True)
+
+def get_projects_configured_in_payroll_cycle(payroll_start_day):
+	query = '''
+		select
+			project
+		from
+			`tabProject Payroll Cycle`
+		where
+			payroll_start_day = '{0}'
+	'''
+	projects = frappe.db.sql(query.format(payroll_start_day), as_dict=True)
+	return ', '.join(['"{}"'.format(project.project) for project in projects])


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Create different payroll entry for different payroll  cycle configured in the HR and Payroll Attendance Settings

## Analysis and design (optional)
E1, E2, E3 and E4 are employee record

E1 linked to Pro1, E2 linked to Pro2 and E3 linked to Pro3
E4 not linked to any project(Attendance by timesheet)

Default Payroll Start Day = Month Start
Pro2 - Payroll Start Day = 24th of Month
Pro3 - Payroll Start Day = Month Start

There should be 2 Basic PE
PE1(Month Start - Default) will have E1, E3 and E4
PE2(24th) will have E2

## Areas affected and ensured
- `one_fm/api/doc_methods/payroll_entry.py`
- `one_fm/one_fm/doctype/hr_and_payroll_additional_settings/hr_and_payroll_additional_settings.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome