### PR TITLE
[BUG} FIx DocType ONEFM General Settings not found

### DIFF
--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
@@ -7,20 +7,20 @@
  "engine": "InnoDB",
  "field_order": [
   "mobile_app_version",
+  "column_break_xyl05",
   "section_break_2",
   "zenquote_keyword_category",
-  "column_break_v0wzm",
   "zenquotes_api_key",
+  "section_break_nsc7h",
+  "document_access_roles",
   "section_break_7yvzt",
+  "super_user_role",
   "mark_atttendance_per_employee",
   "attendance_manager",
   "attendance_manager_name",
-  "permissions_section",
+  "employee_section",
   "employee_master_role",
   "employee_access",
-  "super_user_role",
-  "column_break_gng83",
-  "document_access_roles",
   "wiki_page_access"
  ],
  "fields": [
@@ -32,8 +32,7 @@
   {
    "collapsible": 1,
    "fieldname": "section_break_2",
-   "fieldtype": "Section Break",
-   "label": "Zenquote"
+   "fieldtype": "Section Break"
   },
   {
    "description": "A table of approved keywords from Zenquotes.io.\nRequests are going to be restricted to keywords in this table.",
@@ -68,7 +67,6 @@
    "options": "ONEFM Document Access Roles Detail"
   },
   {
-   "collapsible": 1,
    "fieldname": "section_break_7yvzt",
    "fieldtype": "Section Break",
    "label": "Attendance"
@@ -96,33 +94,33 @@
    "description": "All users with this role have edit access on the Employee Form",
    "fieldname": "employee_master_role",
    "fieldtype": "Table",
-   "label": "Employee Master Roles",
+   "label": "Employee Master Role",
    "options": "ONEFM Document Access Roles Detail"
   },
   {
-   "description": "Default it will be the role 'Director'\nYou can select any role here, then it will be the Super User Role\n\nUser having this role can be self approve configured documents like Shift Permission.\nThe user having this role no need reports to, since it will be the same employee linked to the user.",
+   "fieldname": "column_break_xyl05",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_nsc7h",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "employee_section",
+   "fieldtype": "Section Break",
+   "label": "Employee"
+  },
+  {
    "fieldname": "super_user_role",
    "fieldtype": "Link",
    "label": "Super User Role",
    "options": "Role"
-  },
-  {
-   "fieldname": "column_break_gng83",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "permissions_section",
-   "fieldtype": "Section Break",
-   "label": "Permissions"
-  },
-  {
-   "fieldname": "column_break_v0wzm",
-   "fieldtype": "Column Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-01-02 14:41:19.773895",
+ "modified": "2024-01-03 16:49:59.299150",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ONEFM General Setting",

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3015,7 +3015,7 @@ def has_super_user_role(user=None):
             return True
         else:
             # Get configured super user in ONEFM General Settings
-            super_user_role = frappe.db.get_single_value("ONEFM General Settings", "super_user_role")
+            super_user_role = frappe.db.get_single_value("ONEFM General Setting", "super_user_role")
             # Check if the super user role exists in the user role list
             if super_user_role and super_user_role in user_roles:
                 return True


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
DocType ONEFM General Settings not found error message showing when loading ONEFM General Setting
<img width="688" alt="image" src="https://github.com/ONE-F-M/One-FM/assets/38866184/2f1b6939-2444-475b-aa19-df683a6fdbf8">

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated the links to the doctype
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
ONE FM General Settings

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [*] Existing Data
- [] New Data

## Was child table created? no
    - [] is attachment required? No
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
