### PR TITLE
[CHORE] Change Employee Master Role From Link to Table

### DIFF
--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
@@ -9,7 +9,6 @@
  "field_order": [
   "mobile_app_version",
   "column_break_xyl05",
-  "super_user_role",
   "section_break_2",
   "zenquote_keyword_category",
   "zenquotes_api_key",
@@ -95,9 +94,9 @@
   {
    "description": "All users with this role have edit access on the Employee Form",
    "fieldname": "employee_master_role",
-   "fieldtype": "Link",
+   "fieldtype": "Table",
    "label": "Employee Master Role",
-   "options": "Role"
+   "options": "ONEFM Document Access Roles Detail"
   },
   {
    "fieldname": "column_break_xyl05",
@@ -122,7 +121,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-01-04 04:44:59.408601",
+ "modified": "2024-01-07 13:30:09.074476",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ONEFM General Setting",

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -136,10 +136,12 @@ def validate_employee_status_access(self):
 def is_employee_master(user:str) -> int:
     #Return 1 if the employee has the required roles to modify the employee form.
     can_edit = 0
-    employee_master_role = frappe.get_doc("ONEFM General Setting").get("employee_master_role")
+    employee_master_role = frappe.get_all("ONEFM Document Access Roles Detail",{'parent':"ONEFM General Setting",'parentfield':"employee_master_role"},['role'])
     if employee_master_role:
+        master_roles = [i.role for i in employee_master_role]
         user_roles = frappe.get_roles(user)
-        if employee_master_role in user_roles:
+        role_intersect = [i for i in master_roles if i in user_roles]
+        if role_intersect:
             return 1
     return can_edit
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [*] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Change Employee Master Role From Link to Table and update the logic for access to the employee form

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Changed Employee Master Role From Link to Table and updated the logic for access to the employee form
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="934" alt="image" src="https://github.com/ONE-F-M/One-FM/assets/38866184/88357056-8112-4750-9958-f3f7f81ab57b">


## Areas affected and ensured
List out the areas affected by your code changes.
Employee Form

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Employee form becomes readonly if current user does not have the required role

## Did you test with the following dataset?
- [*] Existing Data
- [] New Data

## Was child table created? No
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
