### PR TITLE
feat: approve attendance check for shift and non-shift

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -69,11 +69,11 @@ class AttendanceCheck(Document):
 
     def on_submit(self):
         shift_working = frappe.db.get_value("Employee", self.employee, "shift_working")
-        if self.attendance_status == "Present" and not shift_working:
+        if self.attendance_status == "Present" and shift_working:
             self.validate_unscheduled_check()
         if self.attendance_status == "On Leave":
             self.check_on_leave_record()
-        if self.attendance_status == "Day Off" and not shift_working:
+        if self.attendance_status == "Day Off" and shift_working:
             validate_day_off(self,convert=0)
         self.validate_justification_and_attendance_status()
         self.mark_attendance()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Approve attendance check for shift and non-shift - Given that a record is created for non shift employee, when approval is made the shift request/shift related steps should be skipped.

## Areas affected and ensured
- `one_fm/one_fm/doctype/attendance_check/attendance_check.py`


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome