### PR TITLE
feat: remove frappe desk module and doctype

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -69,3 +69,4 @@ one_fm.patches.v14_0.set_erf_workflow_state_with_status
 one_fm.patches.v14_0.update_rejected_attendance_check
 one_fm.patches.v14_0.update_timesheet_status
 one_fm.patches.v14_0.add_super_user_role
+one_fm.patches.v14_0.remove_frappe_desk_module_doctype

--- a/one_fm/patches/v14_0/remove_frappe_desk_module_doctype.py
+++ b/one_fm/patches/v14_0/remove_frappe_desk_module_doctype.py
@@ -1,0 +1,15 @@
+from __future__ import unicode_literals
+
+import frappe
+
+def execute():
+    module = frappe.db.exists("Module Def", {"module_name": "FrappeDesk"})
+    if module:
+        print("Deleting the doctypes from module {0} \n DocTypes:".format(module))
+        doctypes = frappe.db.get_all("DocType", {"module": module})
+        for doc in doctypes:
+            print(doc.name)
+            frappe.delete_doc("DocType", doc.name)
+            frappe.db.commit()
+        frappe.delete_doc("Module Def", module)
+        frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- HD tickets under Helpdesk, so that all relevant data can be in one place

## Output screenshots (optional)
![Screenshot 2024-01-07 at 4 19 34 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/499ccdda-3efb-48d5-9bb1-0d9b3c602f78)
![Screenshot 2024-01-07 at 12 46 49 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/64dd0876-a058-401b-a110-8f8c6a66a0db)
![Screenshot 2024-01-07 at 12 47 08 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/705890e5-edf8-4f9c-9226-206073870209)
![Screenshot 2024-01-07 at 12 47 25 PM](https://github.com/ONE-F-M/One-FM/assets/20554466/d31e1158-293b-43dd-9f8b-e583ac337380)

## Areas affected and ensured
- `one_fm/patches.txt`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes
   Was the patch test? Yes


## Which browser(s) did you use for testing?
- [x] Chrome