### PR TITLE
hotfix: create attendance on leave approval

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -65,7 +65,14 @@ def is_app_user(emp):
         pass
 
 
-class LeaveApplicationOverride(LeaveApplication): 
+class LeaveApplicationOverride(LeaveApplication):
+    def onload(self):
+        leave_attendances = frappe.db.get_all("Attendance", {"leave_application": self.name}, "name")
+        attendance_not_created = False
+        if self.total_leave_days > len(leave_attendances):
+            attendance_not_created = True
+        self.set_onload("attendance_not_created", attendance_not_created)
+
     def validate(self):
         self.validate_applicable_after()
 
@@ -84,7 +91,6 @@ class LeaveApplicationOverride(LeaveApplication):
     def on_submit(self):
         self.close_todo()
         self.close_shifts()
-        self.update_attendance()
         return super().on_submit()
         self.db_set('status', 'Approved')
 
@@ -165,37 +171,14 @@ class LeaveApplicationOverride(LeaveApplication):
             self.validate_optional_leave()
         self.validate_applicable_after()
 
+    @frappe.whitelist()
     def update_attendance(self):
         if self.status != "Approved":
             return
-
-        holiday_dates = []
-        if self.leave_type == 'Annual Leave' :
-            holidays = get_holidays_for_employee(employee=self.employee, start_date=self.from_date, end_date=self.to_date, only_non_weekly=True)
-            holiday_dates = [cstr(h.holiday_date) for h in holidays]
-
-        for dt in daterange(getdate(self.from_date), getdate(self.to_date)):
-            date = dt.strftime("%Y-%m-%d")
-            attendance_name = frappe.db.exists(
-                "Attendance", dict(employee=self.employee, attendance_date=date, docstatus=("!=", 2))
-            )
-
-            # don't mark attendance for holidays
-            # if leave type does not include holidays within leaves as leaves
-            if date in holiday_dates:
-                if attendance_name:
-                    # cancel and delete existing attendance for holidays
-                    attendance = frappe.get_doc("Attendance", attendance_name)
-                    attendance.flags.ignore_permissions = True
-                    if attendance.docstatus == 1:
-                        print('True')
-                        attendance.db_set('status','Holiday')
-                        frappe.db.commit()
-                else:
-                    self.create_or_update_attendance(attendance_name, date, 'Holiday')
-            else:
-                self.create_or_update_attendance(attendance_name, date, 'On Leave')
-
+        if self.total_leave_days > 20:
+            frappe.enqueue(update_attendance_recods, self=self, is_async=True)
+        else:
+            update_attendance_recods(self)
 
     def create_or_update_attendance(self, attendance_name, date, status):
         if attendance_name:
@@ -396,7 +379,7 @@ class LeaveApplicationOverride(LeaveApplication):
         except:
             frappe.log_error(title = "Error Updating Attendance Check",message=frappe.get_traceback())
             frappe.throw("An Error Occured while updating Attendance Checks. Please review the error logs")
-    
+
     def on_update(self):
         if self.status=='Rejected':
             self.notify_employee()
@@ -430,19 +413,52 @@ class LeaveApplicationOverride(LeaveApplication):
                 frappe.db.set_value("Employee", self.employee, "status", "Vacation")
             self.validate_attendance_check()
         self.clear_employee_schedules()
-            
-    
+
+
     def clear_employee_schedules(self):
         last_doc = self.get_doc_before_save()
         if last_doc and last_doc.get('workflow_state') != self.workflow_state:
             if self.workflow_state == "Approved":
                 frappe.db.sql(
                     '''
-                    DELETE FROM `tabEmployee Schedule` WHERE 
+                    DELETE FROM `tabEmployee Schedule` WHERE
                     employee = %s AND
                     date BETWEEN %s AND %s;
                     ''', (self.employee, self.from_date, self.to_date)
                 )
+
+
+def update_attendance_recods(self):
+    if self.status != "Approved":
+        return
+
+    holiday_dates = []
+    if self.leave_type == 'Annual Leave' :
+        holidays = get_holidays_for_employee(employee=self.employee, start_date=self.from_date, end_date=self.to_date, only_non_weekly=True)
+        holiday_dates = [cstr(h.holiday_date) for h in holidays]
+
+    for dt in daterange(getdate(self.from_date), getdate(self.to_date)):
+        date = dt.strftime("%Y-%m-%d")
+        attendance_name = frappe.db.exists(
+            "Attendance", dict(employee=self.employee, attendance_date=date, docstatus=("!=", 2))
+        )
+
+        # don't mark attendance for holidays
+        # if leave type does not include holidays within leaves as leaves
+        if date in holiday_dates:
+            if attendance_name:
+                # cancel and delete existing attendance for holidays
+                attendance = frappe.get_doc("Attendance", attendance_name)
+                attendance.flags.ignore_permissions = True
+                if attendance.docstatus == 1:
+                    attendance.db_set('status','Holiday')
+                    frappe.db.commit()
+            else:
+                self.create_or_update_attendance(attendance_name, date, 'Holiday')
+        else:
+            self.create_or_update_attendance(attendance_name, date, 'On Leave')
+
+    frappe.msgprint(_("Attendance are created for the leave Appication {0}!".format(self.name)), alert=True)
 
 @frappe.whitelist()
 def get_leave_details(employee, date):

--- a/one_fm/public/js/doctype_js/leave_application.js
+++ b/one_fm/public/js/doctype_js/leave_application.js
@@ -30,15 +30,28 @@ frappe.ui.form.on("Leave Application", {
                 // $('.btn .btn-primary .btn-sm').show();
             }
         }
+        if (frm.doc.status == 'Approved' && frm.doc.__onload && frm.doc.__onload.attendance_not_created){
+          frm.add_custom_button(__('Update Attendance'),
+            function () {
+              frappe.call({
+                doc: frm.doc,
+                method: 'update_attendance',
+                callback: function(r) {
+                  frm.reload_doc();
+                }
+              });
+            }
+          );
+        }
     },
     onload: function(frm) {
         $.each(frm.fields_dict, function(fieldname, field) {
           field.df.onchange = frm =>{
             if (cur_frm.doc.employee && cur_frm.doc.leave_type == "Sick Leave"){
-                frappe.db.get_value("Employee", cur_frm.doc.employee, "is_in_kuwait").then(res=>{ 
+                frappe.db.get_value("Employee", cur_frm.doc.employee, "is_in_kuwait").then(res=>{
                     res.message.is_in_kuwait ? cur_frm.set_value("is_proof_document_required", 1) : cur_frm.set_value("is_proof_document_required", 0)
                     cur_frm.refresh_field("is_proof_document_required")
-                    
+
                 })
             }
           };
@@ -48,13 +61,13 @@ frappe.ui.form.on("Leave Application", {
 })
 
 
-var prefillForm = frm => { 
+var prefillForm = frm => {
     const url = new URL(window.location.href);
 
     const params = new URLSearchParams(url.search);
 
     const doc_id = params.get('doc_id');
-    const doctype = params.get('doctype'); 
+    const doctype = params.get('doctype');
 
     if (doctype == "Attendance Check"){
         frappe.call({
@@ -69,7 +82,7 @@ var prefillForm = frm => {
             callback: function(r) {
                 if (r.message) {
                     cur_frm.set_value("employee", r.message.employee)
-                    
+
                 }
             }
         });


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Attendance not created for approved Leave Application

## Analysis and design (optional)
- Attendance creation method gets timed out when the no of leave taken increases

## Solution description
- Added a button to run the attendance creation method
- Queued the method is leave taken is more than 20 days

## Output screenshots (optional)

https://github.com/ONE-F-M/One-FM/assets/20554466/fe79905f-9037-4cc1-8593-f777c38399bb

## Areas affected and ensured
- `one_fm/overrides/leave_application.py`
- `one_fm/public/js/doctype_js/leave_application.js`

## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome