### PR TITLE
fix: not create shift assignment - att check approval

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -107,29 +107,12 @@ class AttendanceCheck(Document):
             if not frappe.db.get_value("Employee", self.employee, "attendance_by_timesheet"):
                 if self.shift_assignment:
                     att.shift_assignment = self.shift_assignment
-                if not att.shift_assignment:
-                    if frappe.db.exists("Shift Assignment", {
-                            'employee':self.employee, 'start_date':self.date, 'roster_type':self.roster_type
-                        }):
-                        shift_assignment = frappe.get_doc("Shift Assignment", {
+                else:
+                    shift_assignment = frappe.db.exists("Shift Assignment", {
                             'employee':self.employee, 'start_date':self.date, 'roster_type':self.roster_type
                         })
-                        att.shift_Assignment = shift_assignment.name
-                    elif frappe.db.exists("Employee Schedule", {
-                            'employee':self.employee, 'date':self.date, 'roster_type':self.roster_type
-                        }):
-                        employee_schedule = frappe.get_doc("Employee Schedule", {
-                            'employee':self.employee, 'date':self.date, 'roster_type':self.roster_type
-                        })
-                        shift_assignment = frappe.get_doc({
-                            'doctype':"Shift Assignment",
-                            'employee':employee_schedule.employee,
-                            'shift_type':employee_schedule.shift_type,
-                            'start_date':employee_schedule.date,
-                            'status':'Active'
-                        }).insert(ignore_permissions=1)
-                        shift_assignment.submit()
-                        att.shift_Assignment = shift_assignment.name
+                    if shift_assignment:
+                        att.shift_assignment = shift_assignment
                 if att.shift_assignment and att.status=='Present':
                     att.working_hours = frappe.db.get_value("Operations Shift",
                         frappe.db.get_value("Shift Assignment", att.shift_assignment, 'shift'), 'duration')


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Do not create shift assignment on attendance check approval

## Areas affected and ensured
- `one_fm/one_fm/doctype/attendance_check/attendance_check.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome