### PR TITLE
fix: get_leave_apporver

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -800,7 +800,7 @@ fixtures = [
 override_whitelisted_methods = {
     "frappe.model.workflow.get_transitions":"one_fm.overrides.workflow.get_transitions",
 	"frappe.model.workflow.apply_workflow":"one_fm.overrides.workflow.apply_workflow",
-	"hrms.hr.doctype.leave_application.leave_application.get_leave_approver" : "one_fm.api.v1.leave_application.fetch_leave_approver",
+	"hrms.hr.doctype.leave_application.leave_application.get_leave_approver" : "one_fm.overrides.leave_application.get_leave_approver",
 	"hrms.hr.doctype.leave_application.leave_application.get_leave_details" : "one_fm.overrides.leave_application.get_leave_details",
     "frappe.desk.form.load.getdoc": "one_fm.permissions.getdoc",
     "frappe.desk.form.load.get_docinfo": "one_fm.permissions.get_docinfo",

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -502,6 +502,7 @@ def get_leave_approver(employee):
     reports_to = employee_details[0].reports_to
     department = employee_details[0].department
     employee_shift = frappe.get_list("Shift Assignment",fields=["*"],filters={"employee":employee}, order_by='creation desc',limit_page_length=1)
+    approver = False
     if reports_to:
         approver = frappe.get_value("Employee", reports_to, ["user_id"])
     elif len(employee_shift) > 0 and employee_shift[0].shift:
@@ -511,8 +512,9 @@ def get_leave_approver(employee):
                 """select approver from `tabDepartment Approver` where parent= %s and parentfield = 'leave_approvers'""",
                 (department),
             )
-        approvers = [approver[0] for approver in approvers]
-        approver = approvers[0]
+        if approvers and len(approvers) > 0:
+            approvers = [approver[0] for approver in approvers]
+            approver = approvers[0]
     return approver
 
 @frappe.whitelist()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Get leave approver error
```
File "apps/one_fm/one_fm/overrides/leave_application.py", line 515, in get_leave_approver
    approver = approvers[0]
IndexError: list index out of range
```

## Areas affected and ensured
- `one_fm/hooks.py`
- `one_fm/overrides/leave_application.py`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes

## Which browser(s) did you use for testing?
- [x] Chrome