### PR TITLE
fix: employee query

### DIFF
--- a/one_fm/overrides/queries.py
+++ b/one_fm/overrides/queries.py
@@ -69,12 +69,12 @@ def employee_query(doctype, txt, searchfield, start, page_len, filters):
 
     return frappe.db.sql(
         """select {fields} from `tabEmployee`
-        where status = 'Active'
+        where (status = 'Active' or status = 'Vacation')
             and docstatus < 2
             and ({key} like %(txt)s
                 or employee_name like %(txt)s
                 or employee_id like %(txt)s)
-            {fcond} {mcond}
+            {fcond}
         order by
             (case when locate(%(_txt)s, name) > 0 then locate(%(_txt)s, name) else 99999 end),
             (case when locate(%(_txt)s, employee_name) > 0 then locate(%(_txt)s, employee_name) else 99999 end),
@@ -86,8 +86,9 @@ def employee_query(doctype, txt, searchfield, start, page_len, filters):
                 "fields": ", ".join(fields),
                 "key": searchfield,
                 "fcond": get_filters_cond(doctype, filters, conditions),
-                "mcond": get_match_cond(doctype),
+
             }
         ),
         {"txt": "%%%s%%" % txt, "_txt": txt.replace("%", ""), "start": start, "page_len": page_len},
+
     )


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- All employees having Vacation or Active status not listed in the links which set to ignore_user_permissions

## Output screenshots (optional)
Before the PR
![Screenshot 2024-01-16 at 4 10 56 PM](https://github.com/ONE-F-M/one_fm/assets/20554466/06c4bb4c-4f14-461a-b30c-b20f8bcf66b4)


After the PR

https://github.com/ONE-F-M/one_fm/assets/20554466/060c9f05-c658-455c-8136-8ddbda3bd198



## Areas affected and ensured
- `one_fm/overrides/queries.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome