### PR TITLE
Feat: Add employees by timesheet to attendance check

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.json
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.json
@@ -11,6 +11,7 @@
   "employee_name",
   "department",
   "roster_type",
+  "attendance_by_timesheet",
   "column_break_1",
   "date",
   "reports_to",
@@ -366,6 +367,13 @@
   {
    "fieldname": "column_break_eekf",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "attendance_by_timesheet",
+   "fieldtype": "Check",
+   "label": "Attendance By Timesheet",
+   "read_only": 1
   }
  ],
  "in_create": 1,
@@ -376,7 +384,7 @@
    "link_fieldname": "reference_docname"
   }
  ],
- "modified": "2024-01-22 21:34:29.849434",
+ "modified": "2024-01-24 13:03:12.127598",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Attendance Check",

--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -307,15 +307,21 @@ def create_attendance_check(attendance_date=None):
             'status':'Absent',
             'attendance_date':attendance_date}, 
             fields="*"
-        )
+        ) 
         
+        attendance_by_timesheet = 0
+
         for count, i in enumerate(absentees):
             try:
+                if frappe.get_value("Employee", "HR-EMP-01986" , ['attendance_by_timesheet']) == 1:
+                   attendance_by_timesheet = 1 
+
                 doc = frappe.get_doc({
                     "doctype":"Attendance Check",
                     "employee":i.employee,
                     "roster_type":i.roster_type,
                     "date":i.attendance_date,
+                    "attendance_by_timesheet": attendance_by_timesheet,
                     "attendance":i.name,
                     "attendance_comment":i.comment,
                     "shift_assignment":i.shift_assignment,

--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -313,7 +313,7 @@ def create_attendance_check(attendance_date=None):
 
         for count, i in enumerate(absentees):
             try:
-                if frappe.get_value("Employee", "HR-EMP-01986" , ['attendance_by_timesheet']) == 1:
+                if frappe.get_value("Employee", i.employee , ['attendance_by_timesheet']) == 1:
                    attendance_by_timesheet = 1 
 
                 doc = frappe.get_doc({

--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -307,7 +307,7 @@ def create_attendance_check(attendance_date=None):
             'status':'Absent',
             'attendance_date':attendance_date}, 
             fields="*"
-        ) 
+        )
         
         attendance_by_timesheet = 0
 

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -69,3 +69,4 @@ one_fm.patches.v14_0.set_erf_workflow_state_with_status
 one_fm.patches.v14_0.update_rejected_attendance_check
 one_fm.patches.v14_0.update_timesheet_status
 one_fm.patches.v14_0.add_super_user_role
+one_fm.patches.v15_0.update_attendance_check #2024-01-24

--- a/one_fm/patches/v15_0/update_attendance_check.py
+++ b/one_fm/patches/v15_0/update_attendance_check.py
@@ -1,0 +1,14 @@
+import frappe
+
+def execute():
+    # update the attendance_by_timesheet value in Attendance Check
+    frappe.db.sql(f"""  UPDATE
+                    `tabAttendance Check` ac,
+                    `tabEmployee` e
+                SET
+                    ac.attendance_by_timesheet = 1 
+                WHERE
+                    ac.employee = e.name AND e.attendance_by_timesheet = 1;""") 
+
+
+   

--- a/one_fm/patches/v15_0/update_attendance_check.py
+++ b/one_fm/patches/v15_0/update_attendance_check.py
@@ -8,7 +8,4 @@ def execute():
                 SET
                     ac.attendance_by_timesheet = 1 
                 WHERE
-                    ac.employee = e.name AND e.attendance_by_timesheet = 1;""") 
-
-
-   
+                    ac.employee = e.name AND e.attendance_by_timesheet = 1;""")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Add the `employees by timesheet` field to the attendance check.

## Solution description
- Add field
- While attendance check creation if employee's attendance is by timesheet, set employees_by_timesheet = 1
- create patch to update old record.

## Is there a business logic within a doctype?
    - [x] Yes
    - [ ] No


## Output screenshots (optional)
<img width="400" alt="Screen Shot 2024-01-30 at 2 45 57 PM" src="https://github.com/ONE-F-M/one_fm/assets/29017559/ace86d3b-5834-4e81-b423-af871eee60fe">
<img width="400" alt="Screen Shot 2024-01-30 at 2 46 05 PM" src="https://github.com/ONE-F-M/one_fm/assets/29017559/46ac561f-1d48-4e3d-98c1-e91e47c3c20b">



## Areas affected and ensured
- employees_by_timesheet field in Attendance Check doctype.

## Is there any existing behaviour change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [ ] No
    ## Was the patch test?
- yes.

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
