### PR TITLE
feat: cancel assignments on attendance check approval

### DIFF
--- a/one_fm/fixtures/assignment_rule.json
+++ b/one_fm/fixtures/assignment_rule.json
@@ -118,11 +118,11 @@
   "field": "reports_to_user",
   "is_assignment_rule_with_workflow": 0,
   "last_user": "",
-  "modified": "2023-06-08 08:21:52.623492",
+  "modified": "2024-01-24 18:00:54.349067",
   "name": "Attendance Check Reports To",
   "priority": 2,
   "rule": "Based on Field",
-  "unassign_condition": null,
+  "unassign_condition": "workflow_state in ('Approved', 'Rejected')",
   "users": []
  },
  {
@@ -181,11 +181,11 @@
   "field": "site_supervisor_user",
   "is_assignment_rule_with_workflow": 0,
   "last_user": "",
-  "modified": "2023-06-08 08:22:10.786821",
+  "modified": "2024-01-24 18:00:38.952572",
   "name": "Attendance Check Site Supervisor",
   "priority": 1,
   "rule": "Based on Field",
-  "unassign_condition": null,
+  "unassign_condition": "workflow_state in ('Approved', 'Rejected')",
   "users": []
  },
  {
@@ -244,11 +244,11 @@
   "field": "shift_supervisor_user",
   "is_assignment_rule_with_workflow": 0,
   "last_user": "",
-  "modified": "2023-06-08 08:22:03.174673",
+  "modified": "2024-01-24 18:00:07.832120",
   "name": "Attendance Check Shift Supervisor",
   "priority": 0,
   "rule": "Based on Field",
-  "unassign_condition": null,
+  "unassign_condition": "workflow_state in ('Approved', 'Rejected')",
   "users": []
  },
  {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Assignment on Attendance Check to be removed upon approval, so that it no longer shows among assigned records.

## Solution description
- Unassign condition updated in the Assignment Rules 

## Output screenshots (optional)

https://github.com/ONE-F-M/one_fm/assets/20554466/8a0aabea-e7c1-4753-8213-f60162ab63d3

## Areas affected and ensured
- `one_fm/fixtures/assignment_rule.json`

## Is there any existing behavior change of other features due to this code change?
Yes, ToDo will cancel on Approval of Attendance Check

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
