### PR TITLE
feat: capture designation of subcontract employee

### DIFF
--- a/one_fm/subcontract/doctype/onboard_subcontract_employee/onboard_subcontract_employee.json
+++ b/one_fm/subcontract/doctype/onboard_subcontract_employee/onboard_subcontract_employee.json
@@ -38,9 +38,10 @@
   "day_off_category",
   "number_of_days_off",
   "date_of_joining",
-  "column_break_ci4ac",
   "employment_type",
+  "column_break_ci4ac",
   "department",
+  "designation",
   "basic_salary",
   "section_break_9kwnq",
   "provide_accommodation_by_company",
@@ -379,6 +380,7 @@
    "fetch_if_empty": 1,
    "fieldname": "department",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Department",
    "options": "Department",
    "reqd": 1
@@ -388,16 +390,22 @@
    "fieldtype": "Currency",
    "hidden": 1,
    "label": "Basic Salary"
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Designation",
+   "options": "Designation"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-12-05 09:43:37.699957",
+ "modified": "2024-01-26 19:58:54.149573",
  "modified_by": "Administrator",
  "module": "Subcontract",
  "name": "Onboard Subcontract Employee",
- "name_case": "UPPER CASE",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [

--- a/one_fm/subcontract/doctype/subcontract_staff_shortlist/subcontract_staff_shortlist.js
+++ b/one_fm/subcontract/doctype/subcontract_staff_shortlist/subcontract_staff_shortlist.js
@@ -3,7 +3,6 @@
 
 frappe.ui.form.on('Subcontract Staff Shortlist', {
 	refresh: function(frm) {
-		;
 	},
 	set_full_name:function(frm,cdt,cdn,lang){
 		let row = locals[cdt][cdn]
@@ -17,6 +16,11 @@ frappe.ui.form.on('Subcontract Staff Shortlist', {
 		}
 		frm.refresh_fields()
 	},
+	default_designation: function(frm) {
+		$.each(frm.doc.subcontract_staff_shortlist_detail || [], function(i, item) {
+			frappe.model.set_value('Subcontract Staff Shortlist Detail', item.name, 'designation', frm.doc.default_designation);
+		});
+	}
 });
 
 
@@ -50,6 +54,12 @@ frappe.ui.form.on('Subcontract Staff Shortlist Detail', {
 	},
 	last_name_in_arabic:function(frm,cdt,cdn){
 		frm.events.set_full_name(frm,cdt,cdn,'ar')
+	},
+	subcontract_staff_shortlist_detail_add: function (frm, cdt, cdn) {
+		var row = frappe.get_doc(cdt, cdn);
+		if (!row.designation) {
+			frm.script_manager.copy_from_first_row("subcontract_staff_shortlist_detail", row, "designation");
+		}
+		if(!row.designation) row.designation = frm.doc.default_designation;
 	}
-
 });

--- a/one_fm/subcontract/doctype/subcontract_staff_shortlist/subcontract_staff_shortlist.json
+++ b/one_fm/subcontract/doctype/subcontract_staff_shortlist/subcontract_staff_shortlist.json
@@ -16,6 +16,7 @@
   "company",
   "date",
   "expected_date_of_joining",
+  "default_designation",
   "subcontract_staff_shortlist_detail_section",
   "subcontract_staff_shortlist_detail",
   "amended_from"
@@ -103,6 +104,13 @@
    "fieldname": "expected_date_of_joining",
    "fieldtype": "Date",
    "label": "Expected Date of Joining"
+  },
+  {
+   "description": "Selected Designation will copied to Designation field in Subcontract Staff Shortlist Detail, there you can change the designation if you wish.",
+   "fieldname": "default_designation",
+   "fieldtype": "Link",
+   "label": "Default Designation",
+   "options": "Designation"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -114,11 +122,10 @@
   }
  ],
  "max_attachments": 5,
- "modified": "2023-12-05 09:18:26.391675",
+ "modified": "2024-01-26 15:25:04.672394",
  "modified_by": "Administrator",
  "module": "Subcontract",
  "name": "Subcontract Staff Shortlist",
- "name_case": "UPPER CASE",
  "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
@@ -133,7 +140,6 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
-   "set_user_permissions": 1,
    "share": 1,
    "submit": 1,
    "write": 1

--- a/one_fm/subcontract/doctype/subcontract_staff_shortlist_detail/subcontract_staff_shortlist_detail.json
+++ b/one_fm/subcontract/doctype/subcontract_staff_shortlist_detail/subcontract_staff_shortlist_detail.json
@@ -33,6 +33,7 @@
   "day_off_category",
   "column_break_tqyqa",
   "number_of_days_off",
+  "designation",
   "is_uniform_needed_for_this_job",
   "provide_accommodation_by_company",
   "provide_transport_by_company"
@@ -217,16 +218,21 @@
   {
    "fieldname": "column_break_tqyqa",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Link",
+   "label": "Designation",
+   "options": "Designation"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-28 20:23:28.228612",
+ "modified": "2024-01-26 16:01:21.816652",
  "modified_by": "Administrator",
  "module": "Subcontract",
  "name": "Subcontract Staff Shortlist Detail",
- "name_case": "UPPER CASE",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- The designation of subcontracted employees to be captured, so that their relevant details are shown on the Employee record


## Areas affected and ensured
- `one_fm/subcontract/doctype/onboard_subcontract_employee/onboard_subcontract_employee.json`
- `one_fm/subcontract/doctype/subcontract_staff_shortlist/subcontract_staff_shortlist.js`
- `one_fm/subcontract/doctype/subcontract_staff_shortlist/subcontract_staff_shortlist.json`
- `one_fm/subcontract/doctype/subcontract_staff_shortlist_detail/subcontract_staff_shortlist_detail.json`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
