### PR TITLE
feat: employee id based on residency and employment type

### DIFF
--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -268,9 +268,20 @@ def generate_employee_id(doc):
 		count = count + 1
 		serial_number = str(count).zfill(3)
 
-	doc.db_set("employee_id", f"{joining_year}{joining_month}{serial_number}{country}{1 if doc.under_company_residency else 0}{doc.date_of_birth.strftime('%y')}".upper())
+	residency_digit = 1 if doc.under_company_residency else 0
+
+	if is_subcontract_employee(doc.name, doc.employment_type):
+		residency_digit = 'S'
+
+	doc.db_set("employee_id", f"{joining_year}{joining_month}{serial_number}{country}{residency_digit}{doc.date_of_birth.strftime('%y')}".upper())
 	doc.reload()
 
+def is_subcontract_employee(employee, employment_type=False):
+    if frappe.db.exists("Onboard Subcontract Employee", {"employee": employee}):
+        return True
+    elif employment_type == frappe.db.get_single_value('Hiring Settings', 'subcontract_employment_type'):
+        return True
+    return False
 
 def create_leave_policy_assignment(doc):
     """

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -8,6 +8,7 @@ from hrms.overrides.employee_master import *
 from one_fm.hiring.utils import (
     employee_after_insert, employee_before_insert, set_employee_name,
     employee_validate_attendance_by_timesheet, set_mandatory_feilds_in_employee_for_Kuwaiti,
+    is_subcontract_employee
 )
 from one_fm.processor import sendemail
 from one_fm.utils import get_domain
@@ -43,7 +44,7 @@ class EmployeeOverride(EmployeeMaster):
 
     def set_employee_id_based_on_residency(self):
         if self.employee_id:
-            residency_employee_id = get_employee_id_based_on_residency(self.employee_id, self.under_company_residency)
+            residency_employee_id = get_employee_id_based_on_residency(self.employee_id, self.under_company_residency, self.name, self.employment_type)
             if self.employee_id != residency_employee_id:
                 self.employee_id = residency_employee_id
 
@@ -144,11 +145,13 @@ def is_employee_master(user:str) -> int:
 
 
 @frappe.whitelist()
-def get_employee_id_based_on_residency(employee_id, residency):
+def get_employee_id_based_on_residency(employee_id, residency, employee=False, employment_type=False):
     length = len(employee_id)
     if isinstance(residency, string_types):
         residency = int(residency)
     employee_id_residency_digit = '1' if residency==1 else '0'
+    if is_subcontract_employee(employee, employment_type):
+        employee_id_residency_digit = 'S'
     # Change third last character in employee id
     return employee_id[:length-3] + employee_id_residency_digit + employee_id[length-2:]
 

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -11,6 +11,7 @@ from one_fm.hiring.utils import (
 )
 from one_fm.processor import sendemail
 from one_fm.utils import get_domain
+from six import string_types
 
 class EmployeeOverride(EmployeeMaster):
     def validate(self):
@@ -20,6 +21,7 @@ class EmployeeOverride(EmployeeMaster):
         self.employee = self.name
         self.set_employee_name()
         set_employee_name(self, method=None)
+        self.set_employee_id_based_on_residency()
         self.validate_date()
         self.validate_email()
         self.validate_status()
@@ -39,10 +41,14 @@ class EmployeeOverride(EmployeeMaster):
         employee_validate_attendance_by_timesheet(self, method=None)
         validate_leaves(self)
 
+    def set_employee_id_based_on_residency(self):
+        if self.employee_id:
+            residency_employee_id = get_employee_id_based_on_residency(self.employee_id, self.under_company_residency)
+            if self.employee_id != residency_employee_id:
+                self.employee_id = residency_employee_id
+
     def before_save(self):
         self.assign_role_profile_based_on_designation()
-        if self.under_company_residency=='1':
-            self.employee_id = get_new_employee_id(self.employee_id)
 
     def after_insert(self):
         employee_after_insert(self, method=None)
@@ -86,13 +92,13 @@ class EmployeeOverride(EmployeeMaster):
         self.clear_schedules()
         self.update_subcontract_onboard()
         self.notify_attendance_manager_on_status_change()
-        
+
 
     def update_subcontract_onboard(self):
         subcontract_onboard = frappe.db.exists("Onboard Subcontract Employee", {"employee": self.name, "enrolled": ['!=', '1']})
         if subcontract_onboard and self.enrolled:
             frappe.db.set_value("Onboard Subcontract Employee", subcontract_onboard, "enrolled", self.enrolled)
-            
+
     def notify_attendance_manager_on_status_change(self):
         last_doc = self.get_doc_before_save()
         if last_doc and last_doc.get('status') == "Active":
@@ -138,12 +144,13 @@ def is_employee_master(user:str) -> int:
 
 
 @frappe.whitelist()
-def get_new_employee_id(employee_id):
+def get_employee_id_based_on_residency(employee_id, residency):
     length = len(employee_id)
-    num = employee_id[length-3] #get the third-last character.
-    if num == '0':
-        new_emp_id = employee_id[:length-3] + '1' + employee_id[length-2:]
-        return new_emp_id
+    if isinstance(residency, string_types):
+        residency = int(residency)
+    employee_id_residency_digit = '1' if residency==1 else '0'
+    # Change third last character in employee id
+    return employee_id[:length-3] + employee_id_residency_digit + employee_id[length-2:]
 
 def update_user_doc(doc):
     if not doc.is_new():
@@ -166,30 +173,30 @@ def update_user_doc(doc):
 
 
 class NotifyAttendanceManagerOnStatusChange:
-    
+
     def __init__(self, employee_object: EmployeeOverride) -> None:
         self.employee_object = employee_object
-        
+
     @property
     def _operations_shift_supervisor(self) -> list():
         operation_shifts = frappe.db.sql(""" SELECT name from `tabOperations Shift` WHERE supervisor = %s AND status = 'Active' """, (self.employee_object.name), as_list=1)
         return list(chain.from_iterable(operation_shifts)) if operation_shifts else list()
-    
+
     @property
     def _operations_site_supervisor(self) -> list:
         operation_sites = frappe.db.sql(""" SELECT name from `tabOperations Site` WHERE account_supervisor = %s AND status = 'Active' """, (self.employee_object.name), as_list=1)
         return list(chain.from_iterable(operation_sites)) if operation_sites else list()
-    
+
     @property
     def _projects_manager(self) -> list:
         projects = frappe.db.sql(""" SELECT name from `tabProject` WHERE account_manager = %s AND is_active = 'Yes' """, (self.employee_object.name), as_list=1)
         return list(chain.from_iterable(projects)) if projects else list()
-    
+
     @property
     def _employee_reports_to(self) -> list:
         reports_to = frappe.db.sql(""" SELECT name, employee_name from `tabEmployee` where reports_to = %s AND status= 'Active' """, (self.employee_object.name), as_dict=1)
-        return reports_to 
-    
+        return reports_to
+
     @property
     def _to_do(self) -> str:
         try:
@@ -204,20 +211,20 @@ class NotifyAttendanceManagerOnStatusChange:
             return f"{get_domain()}/app/todo?status=Open&allocated_to={self.employee_object.user_id}" if is_to_do else ""
         except Exception as e:
             return ""
-    
+
     @property
     def _operation_manager(self) -> str | None:
         return frappe.db.get_single_value("Operation Settings", "default_operation_manager") == self.employee_object.user_id
-    
+
     @property
     def _attendance_manager(self) -> str:
         return frappe.db.get_single_value('ONEFM General Setting', 'attendance_manager') ==  self.employee_object.name
-    
+
     @property
     def _directors(self) -> list:
         return frappe.db.get_list("User", filters={"role_profile_name": "Director"}, pluck="name")
-    
-    
+
+
     def generate_data(self) -> dict:
         try:
             data_dict = dict()
@@ -226,42 +233,42 @@ class NotifyAttendanceManagerOnStatusChange:
                 data_dict.update({"operations_shift": dict()})
                 for obj in operations_shift:
                     data_dict.get("operations_shift").update({obj: get_url_to_form("Operations Shift", obj)})
-                
-            
+
+
             operations_site = self._operations_site_supervisor
             if operations_site:
                 data_dict.update({"operations_site": dict()})
                 for obj in operations_site:
                     data_dict.get("operations_site").update({obj: get_url_to_form("Operations Site", obj)})
-                    
-            
+
+
             projects = self._projects_manager
             if projects:
                 data_dict.update({"projects": dict()})
                 for obj in projects:
                     data_dict.get("projects").update({obj: get_url_to_form("Projects", obj)})
-            
+
             reports_to = self._employee_reports_to
             if reports_to:
                 data_dict.update({"reports_to": list()})
                 for obj in reports_to:
                     data_dict.get("reports_to").append(dict(name=obj.get("name"), employee_name=obj.get("employee_name"), url=get_url_to_form("Employee", obj.get("name"))))
-                    
+
             if self._operation_manager:
                 data_dict.update({"operations_manager": f"{get_domain()}/app/operation-settings"})
-                
+
             if self._attendance_manager:
                 data_dict.update({"attendance_manager": f"{get_domain()}/app/onefm-general-setting"})
-                
+
             if self._to_do:
                 data_dict.update({"to_do": self._to_do})
-            
+
             return data_dict
         except Exception as e:
             frappe.log_error(frappe.get_traceback(), "Employee Status Change Notification")
             return dict()
-            
-            
+
+
     def notify_authorities(self):
         try:
             data = self.generate_data()
@@ -278,11 +285,3 @@ class NotifyAttendanceManagerOnStatusChange:
                 sendemail(recipients=the_recipient, subject=title, content=msg)
         except Exception as e:
             frappe.log_error(frappe.get_traceback(), "Error while sending mail on status change(Employee)")
-        
-        
-        
-        
-        
-        
-        
-    

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -110,11 +110,17 @@ var update_employee_id_based_on_residency = function(frm) {
 				method: 'one_fm.overrides.employee.get_employee_id_based_on_residency',
 				args: {
 					employee_id: frm.doc.employee_id,
-					residency: frm.doc.under_company_residency
+					residency: frm.doc.under_company_residency,
+					employee: frm.doc.name,
+					employment_type: frm.doc.employment_type
 				},
 				callback: function (r) {
 					if (r && r.message) {
-						let employee_id
+
+						if(frm.doc.employee_id == r.message){
+							return
+						}
+
 						let empid_msg = __(
 							'<b>{0}<u style="color: red;">{1}</u>{2}</b>',
 							[frm.doc.employee_id.substring(0, 9), frm.doc.employee_id.substring(9, 10), frm.doc.employee_id.substring(10, 12)]
@@ -124,6 +130,7 @@ var update_employee_id_based_on_residency = function(frm) {
 							[r.message.substring(0, 9), r.message.substring(9, 10), r.message.substring(10, 12)]
 						)
 						let msg = __('This action will change the employee id from {0} to {1}.<br/>Are you sure you want to proceed?', [empid_msg, new_empid_msg])
+
 						frappe.confirm(msg,
 							() => {
 								// action to perform if Yes is selected

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -1,7 +1,7 @@
 frappe.ui.form.on('Employee', {
 	refresh: function(frm) {
 		hideFields(frm);
-		
+
 		set_grd_fields(frm)
 		frm.trigger('set_queries');
 		set_mandatory(frm);
@@ -63,9 +63,10 @@ frappe.ui.form.on('Employee', {
         }
 	},
 	under_company_residency: function(frm){
-		change_employee_id(frm);
+		if(frm.doc.employee_id){
+			update_employee_id_based_on_residency(frm);
+		}
 	}
-
 });
 
 
@@ -102,22 +103,48 @@ let toggle_required = (frm, state) => {
 	});
 }
 
-var change_employee_id = function(frm) {
-	if(frm.doc.under_company_residency == 1){
-		frappe.call({
-			method: 'one_fm.overrides.employee.get_new_employee_id',
-			args: {
-			employee_id:frm.doc.employee_id,
-			},
-			callback: function (r) {
-				if (r && r.message) {
-					frm.set_value('employee_id',  r.message)
+var update_employee_id_based_on_residency = function(frm) {
+	frappe.db.get_value('Employee', frm.doc.name, 'under_company_residency', function(r) {
+		if(r.under_company_residency != frm.doc.under_company_residency){
+			frappe.call({
+				method: 'one_fm.overrides.employee.get_employee_id_based_on_residency',
+				args: {
+					employee_id: frm.doc.employee_id,
+					residency: frm.doc.under_company_residency
+				},
+				callback: function (r) {
+					if (r && r.message) {
+						let employee_id
+						let empid_msg = __(
+							'<b>{0}<u style="color: red;">{1}</u>{2}</b>',
+							[frm.doc.employee_id.substring(0, 9), frm.doc.employee_id.substring(9, 10), frm.doc.employee_id.substring(10, 12)]
+						)
+						let new_empid_msg = __(
+							'<b>{0}<u style="color: green;">{1}</u>{2}</b>',
+							[r.message.substring(0, 9), r.message.substring(9, 10), r.message.substring(10, 12)]
+						)
+						let msg = __('This action will change the employee id from {0} to {1}.<br/>Are you sure you want to proceed?', [empid_msg, new_empid_msg])
+						frappe.confirm(msg,
+							() => {
+								// action to perform if Yes is selected
+								frm.set_value('employee_id',  r.message);
+								frappe.show_alert({
+									message: __("Employee ID is set to {0}, on saving the doc it will reflect on the employee record", [frm.doc.employee_id]),
+									indicator:'green'
+								});
+							}, () => {
+								// action to perform if No is selected
+								frm.set_value('under_company_residency', !frm.doc.under_company_residency);
+							}
+						);
+					}
 				}
+			});
+		}
+	})
 
-			}
-		});
-	}
 }
+
 // Hide un-needed fields
 const hideFields = frm => {
     $("[data-doctype='Employee Checkin']").hide();
@@ -128,15 +155,12 @@ let is_employee_master = frm =>{
 		method: "one_fm.overrides.employee.is_employee_master",
 		args: {"user": frappe.session.user},
 		callback: function (r) {
-			console.log(r.message)
 			if (!parseInt(r.message)){
 				frm.disable_form()
 			}
 		}
-
-	})
-	
-}
+	});
+};
 
 let set_grd_fields= frm=>{
 	frm.set_df_property('custom_employee_photo',"hidden",1)
@@ -207,4 +231,3 @@ function setCharAt(str,index,chr) {
     if(index > str.length-1) return str;
     return str.substring(0,index) + chr + str.substring(index+1);
 }
-


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- When under company residency (in Employee) is checked/unchecked, then the digit indicating residency status on the employee ID changes to 1/0
- When the Employee record is being created, then the digit indicating residency status on the employee is "S"

## Output screenshots (optional)

https://github.com/ONE-F-M/one_fm/assets/20554466/9e22f583-50ad-4aa1-a12c-b11f3672ef52

## Areas affected and ensured
- `one_fm/hiring/utils.py`
- `one_fm/overrides/employee.py`
- `one_fm/public/js/doctype_js/employee.js`

## Is there any existing behavior change of other features due to this code change?
Yes, On update of residency status or employment type the system will update the employee id and notify the supervisor

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
