### PR TITLE
HotFix: Attendance Marking For Non-Shift and Duplicates

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -1058,7 +1058,6 @@ class AttendanceMarking():
                     DELETE FROM `tabAttendance` WHERE employee="{record.employee}" AND
                     attendance_date="{_date}" 
                     AND roster_type="{record.roster_type}"
-                    AND status="Absent"
                 """)
             except:
                 pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
- No Attendance Created for non-shift employee
- Duplicate attendance for On Hold.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
- Non-shift workers have no Operation Role. 
- fetch shift assignments for non-shift employees.
- Delete duplicate regardless of the status.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="1203" alt="Screen Shot 2024-02-06 at 1 02 49 PM" src="https://github.com/ONE-F-M/one_fm/assets/29017559/be558758-75bf-4cf4-9ebb-d2a587bf7202">


## Areas affected and ensured
- Attendance For non-shift worker 
- no duplicates created.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [x] Yes
    - [ ] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
