### PR TITLE
Chore: Make Item Table Read Only if the status is Approved.

### DIFF
--- a/one_fm/purchase/doctype/request_for_material/request_for_material.js
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.js
@@ -76,6 +76,10 @@ frappe.ui.form.on('Request for Material', {
 				frm.set_df_property('type', 'options', "\nIndividual\nDepartment\nProject\nOnboarding");
 			}
 		}
+		if(frm.doc.workflow_state == "Approved" || frm.doc.workflow_state == "Rejected"){
+			frm.set_df_property('items', 'allow_on_submit', 0);
+			frm.set_df_property('items', 'read_only', 1);
+		}
 		if(frm.is_new()){
 			frappe.call({
 				doc: frm.doc,


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
Make Item Table Read Only if the status is Approved.

## Solution description
Set Property based on workflow_state.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="1215" alt="Screen Shot 2024-02-07 at 4 09 56 PM" src="https://github.com/ONE-F-M/one_fm/assets/29017559/9e1b3109-da71-476b-97e6-c7c8d13b6939">

## Areas affected and ensured
Editing of Item Tables.

## Is there any existing behavior change of other features due to this code change?
no

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
