### PR TITLE
fix: GRD section access in ERF for GRD Supervisor

### DIFF
--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -4,13 +4,14 @@
   "doctype": "Workflow",
   "document_type": "ERF",
   "is_active": 1,
-  "modified": "2023-09-07 10:27:02.179526",
+  "modified": "2024-02-12 15:16:50.626957",
   "name": "ERF",
   "override_status": 0,
   "send_email_alert": 1,
   "states": [
    {
     "allow_edit": "System Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -20,10 +21,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Hiring Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -33,10 +36,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -46,10 +51,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -59,10 +66,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -72,10 +81,12 @@
     "parenttype": "Workflow",
     "state": "Submit to Recruitment Manager",
     "update_field": "status",
-    "update_value": "Open"
+    "update_value": "Open",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -85,10 +96,12 @@
     "parenttype": "Workflow",
     "state": "Accepted",
     "update_field": "status",
-    "update_value": "Accepted"
+    "update_value": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -98,10 +111,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -111,10 +126,12 @@
     "parenttype": "Workflow",
     "state": "Hold",
     "update_field": "status",
-    "update_value": "Hold"
+    "update_value": "Hold",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -124,10 +141,12 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": "status",
-    "update_value": "Cancelled"
+    "update_value": "Cancelled",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -137,7 +156,23 @@
     "parenttype": "Workflow",
     "state": "Closed",
     "update_field": "status",
-    "update_value": "Closed"
+    "update_value": "Closed",
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "ERF",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Accepted",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -154,7 +189,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -169,7 +205,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit to Recruitment Manager"
+    "state": "Submit to Recruitment Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -184,7 +221,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit to Recruitment Manager"
+    "state": "Submit to Recruitment Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -199,7 +237,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Accepted"
+    "state": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "action": "Hold",
@@ -214,7 +253,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Accepted"
+    "state": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -229,7 +269,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Hold"
+    "state": "Hold",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -244,7 +285,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Hold"
+    "state": "Hold",
+    "workflow_builder_id": null
    },
    {
     "action": "Close",
@@ -259,7 +301,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Accepted"
+    "state": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "action": "Close",
@@ -274,9 +317,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit to Recruitment Manager"
+    "state": "Submit to Recruitment Manager",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "ERF",
   "workflow_state_field": "workflow_state"
  },
@@ -292,6 +337,7 @@
   "states": [
    {
     "allow_edit": "Junior Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -301,10 +347,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -314,10 +362,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -327,10 +377,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -340,10 +392,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -353,10 +407,12 @@
     "parenttype": "Workflow",
     "state": "Cancellation Requested",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -366,10 +422,12 @@
     "parenttype": "Workflow",
     "state": "Published",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts Manager",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -379,7 +437,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -396,7 +455,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Post as Draft",
@@ -411,7 +471,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Post as Draft",
@@ -426,7 +487,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Post as Draft",
@@ -441,7 +503,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Publish",
@@ -456,7 +519,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Return",
@@ -471,7 +535,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -486,7 +551,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Publish",
@@ -501,7 +567,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Return",
@@ -516,7 +583,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -531,7 +599,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Publish",
@@ -546,7 +615,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Return",
@@ -561,7 +631,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -576,7 +647,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Request Cancel",
@@ -591,7 +663,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Published"
+    "state": "Published",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -606,7 +679,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Cancellation Requested"
+    "state": "Cancellation Requested",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -621,9 +695,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Published"
+    "state": "Published",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Journal Entry",
   "workflow_state_field": "workflow_state"
  },
@@ -639,6 +715,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -648,10 +725,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -661,7 +740,8 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -678,7 +758,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -693,7 +774,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -708,7 +790,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -723,9 +806,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Attendance Check",
   "workflow_state_field": "workflow_state"
  },
@@ -741,6 +826,7 @@
   "states": [
    {
     "allow_edit": "Warehouse Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -750,10 +836,12 @@
     "parenttype": "Workflow",
     "state": "Submit to Purchase Officer",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -763,10 +851,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -776,10 +866,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": "status",
-    "update_value": "Approved"
+    "update_value": "Approved",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase Manager",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -789,7 +881,8 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "status",
-    "update_value": "Rjected"
+    "update_value": "Rjected",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -806,7 +899,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit to Purchase Officer"
+    "state": "Submit to Purchase Officer",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -821,7 +915,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -836,9 +931,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "RFP",
   "workflow_state_field": "workflow_state"
  },
@@ -854,6 +951,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -863,10 +961,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -876,10 +976,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": "status",
-    "update_value": "Draft"
+    "update_value": "Draft",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -889,10 +991,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": "status",
-    "update_value": "Approved"
+    "update_value": "Approved",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -902,7 +1006,8 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -919,7 +1024,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -934,7 +1040,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -949,9 +1056,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "RFM",
   "workflow_state_field": "workflow_state"
  },
@@ -967,6 +1076,7 @@
   "states": [
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -976,10 +1086,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "disabled",
-    "update_value": "1"
+    "update_value": "1",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -989,10 +1101,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "disabled",
-    "update_value": "1"
+    "update_value": "1",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1002,10 +1116,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "disabled",
-    "update_value": "1"
+    "update_value": "1",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1015,10 +1131,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": "disabled",
-    "update_value": "1"
+    "update_value": "1",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1028,10 +1146,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": "disabled",
-    "update_value": "1"
+    "update_value": "1",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1041,10 +1161,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": "disabled",
-    "update_value": "1"
+    "update_value": "1",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1054,10 +1176,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": "disabled",
-    "update_value": "0"
+    "update_value": "0",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1067,7 +1191,8 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "disabled",
-    "update_value": "1"
+    "update_value": "1",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -1084,7 +1209,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit for Approval",
@@ -1099,7 +1225,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit for Approval",
@@ -1114,7 +1241,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -1129,7 +1257,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -1144,7 +1273,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Change Request",
@@ -1159,7 +1289,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Change Request",
@@ -1174,9 +1305,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Item",
   "workflow_state_field": "workflow_state"
  },
@@ -1192,6 +1325,7 @@
   "states": [
    {
     "allow_edit": "Purchase User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 1,
     "message": null,
@@ -1201,10 +1335,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1214,10 +1350,12 @@
     "parenttype": "Workflow",
     "state": "Pending HOD Approval",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1227,10 +1365,12 @@
     "parenttype": "Workflow",
     "state": "Pending Procurement Manager Approval",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Finance Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1240,10 +1380,12 @@
     "parenttype": "Workflow",
     "state": "Pending Finance Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1253,10 +1395,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Purchase User",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -1266,7 +1410,8 @@
     "parenttype": "Workflow",
     "state": "Submitted",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -1283,7 +1428,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -1298,7 +1444,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending HOD Approval"
+    "state": "Pending HOD Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -1313,7 +1460,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending HOD Approval"
+    "state": "Pending HOD Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -1328,7 +1476,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Procurement Manager Approval"
+    "state": "Pending Procurement Manager Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -1343,7 +1492,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Procurement Manager Approval"
+    "state": "Pending Procurement Manager Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -1358,7 +1508,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Finance Manager"
+    "state": "Pending Finance Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -1373,9 +1524,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Finance Manager"
+    "state": "Pending Finance Manager",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Purchase Order",
   "workflow_state_field": "workflow_state"
  },
@@ -1391,6 +1544,7 @@
   "states": [
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1400,10 +1554,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1413,10 +1569,12 @@
     "parenttype": "Workflow",
     "state": "Submitted for Applicant Review",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1426,10 +1584,12 @@
     "parenttype": "Workflow",
     "state": "Applicant Signed and Uploaded",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1439,10 +1599,12 @@
     "parenttype": "Workflow",
     "state": "Applicant not Signed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1452,7 +1614,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -1469,7 +1632,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Applicant Signed and Upload",
@@ -1484,7 +1648,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted for Applicant Review"
+    "state": "Submitted for Applicant Review",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -1499,7 +1664,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Signed and Uploaded"
+    "state": "Applicant Signed and Uploaded",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -1514,9 +1680,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted for Applicant Review"
+    "state": "Submitted for Applicant Review",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Duty Commencement 1",
   "workflow_state_field": "workflow_state"
  },
@@ -1532,6 +1700,7 @@
   "states": [
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1541,10 +1710,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -1554,10 +1725,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1567,7 +1740,8 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -1584,7 +1758,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -1599,9 +1774,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Request Employee Assignment",
   "workflow_state_field": "workflow_state"
  },
@@ -1617,6 +1794,7 @@
   "states": [
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1626,10 +1804,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -1639,10 +1819,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1652,7 +1834,8 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -1669,7 +1852,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -1684,9 +1868,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Request Employee Schedule",
   "workflow_state_field": "workflow_state"
  },
@@ -1702,6 +1888,7 @@
   "states": [
    {
     "allow_edit": "HR User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1711,10 +1898,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "form_status",
-    "update_value": "Open"
+    "update_value": "Open",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1724,10 +1913,12 @@
     "parenttype": "Workflow",
     "state": "Form Printed",
     "update_field": "form_status",
-    "update_value": "Printed"
+    "update_value": "Printed",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1737,10 +1928,12 @@
     "parenttype": "Workflow",
     "state": "Apply Online by PRO",
     "update_field": "form_status",
-    "update_value": "Pending by GRD"
+    "update_value": "Pending by GRD",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1750,10 +1943,12 @@
     "parenttype": "Workflow",
     "state": "Awaiting Response",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1763,7 +1958,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -1780,7 +1976,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to GRD",
@@ -1795,7 +1992,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Form Printed"
+    "state": "Form Printed",
+    "workflow_builder_id": null
    },
    {
     "action": "Apply",
@@ -1810,7 +2008,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Apply Online by PRO"
+    "state": "Apply Online by PRO",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -1825,7 +2024,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Awaiting Response"
+    "state": "Awaiting Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -1840,9 +2040,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Awaiting Response"
+    "state": "Awaiting Response",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "MGRP",
   "workflow_state_field": "workflow_state"
  },
@@ -1858,6 +2060,7 @@
   "states": [
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1867,10 +2070,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "work_permit_status",
-    "update_value": "Draft"
+    "update_value": "Draft",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1880,10 +2085,12 @@
     "parenttype": "Workflow",
     "state": "Apply Online by PRO",
     "update_field": "work_permit_status",
-    "update_value": "Draft"
+    "update_value": "Draft",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1893,10 +2100,12 @@
     "parenttype": "Workflow",
     "state": "Pending By Supervisor",
     "update_field": "work_permit_status",
-    "update_value": "Pending by Supervisor"
+    "update_value": "Pending by Supervisor",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1906,10 +2115,12 @@
     "parenttype": "Workflow",
     "state": "Pending By Previous Company",
     "update_field": "work_permit_status",
-    "update_value": "Pending by Previous Company"
+    "update_value": "Pending by Previous Company",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1919,10 +2130,12 @@
     "parenttype": "Workflow",
     "state": "Pending  For Payment",
     "update_field": "work_permit_status",
-    "update_value": "Pending by Supervisor for Payment"
+    "update_value": "Pending by Supervisor for Payment",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1932,10 +2145,12 @@
     "parenttype": "Workflow",
     "state": "Pending By Operator",
     "update_field": "work_permit_status",
-    "update_value": "Pending by Operator"
+    "update_value": "Pending by Operator",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1945,10 +2160,12 @@
     "parenttype": "Workflow",
     "state": "Pending By PAM",
     "update_field": "work_permit_status",
-    "update_value": "Pending by Operator"
+    "update_value": "Pending by Operator",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -1958,10 +2175,12 @@
     "parenttype": "Workflow",
     "state": "Reason of Rejection",
     "update_field": "work_permit_status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -1971,10 +2190,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "work_permit_status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -1984,7 +2205,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2001,7 +2223,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Apply",
@@ -2016,7 +2239,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Apply Online by PRO"
+    "state": "Apply Online by PRO",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -2031,7 +2255,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Supervisor"
+    "state": "Pending By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -2046,7 +2271,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Supervisor"
+    "state": "Pending By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -2061,7 +2287,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Supervisor"
+    "state": "Pending By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -2076,7 +2303,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By PAM"
+    "state": "Pending By PAM",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -2091,7 +2319,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By PAM"
+    "state": "Pending By PAM",
+    "workflow_builder_id": null
    },
    {
     "action": "Informed Previous Company",
@@ -2106,7 +2335,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Previous Company"
+    "state": "Pending By Previous Company",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -2121,7 +2351,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By PAM"
+    "state": "Pending By PAM",
+    "workflow_builder_id": null
    },
    {
     "action": "Paid",
@@ -2136,7 +2367,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending  For Payment"
+    "state": "Pending  For Payment",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -2151,7 +2383,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Operator"
+    "state": "Pending By Operator",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -2166,7 +2399,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By PAM"
+    "state": "Pending By PAM",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -2181,9 +2415,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Reason of Rejection"
+    "state": "Reason of Rejection",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Work Permit",
   "workflow_state_field": "workflow_state"
  },
@@ -2199,6 +2435,7 @@
   "states": [
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2208,10 +2445,12 @@
     "parenttype": "Workflow",
     "state": "Apply Online by PRO",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2221,7 +2460,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2238,9 +2478,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Apply Online by PRO"
+    "state": "Apply Online by PRO",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Medical Insurance",
   "workflow_state_field": "workflow_state"
  },
@@ -2256,6 +2498,7 @@
   "states": [
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2265,10 +2508,12 @@
     "parenttype": "Workflow",
     "state": "Apply Online by PRO",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2278,7 +2523,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2295,9 +2541,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Apply Online by PRO"
+    "state": "Apply Online by PRO",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "MOI",
   "workflow_state_field": "workflow_state"
  },
@@ -2313,6 +2561,7 @@
   "states": [
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2322,10 +2571,12 @@
     "parenttype": "Workflow",
     "state": "Apply Online by PRO",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2335,10 +2586,12 @@
     "parenttype": "Workflow",
     "state": "Under Process",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2348,7 +2601,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2365,7 +2619,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Apply Online by PRO"
+    "state": "Apply Online by PRO",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -2380,9 +2635,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Under Process"
+    "state": "Under Process",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "PACI",
   "workflow_state_field": "workflow_state"
  },
@@ -2398,6 +2655,7 @@
   "states": [
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2407,10 +2665,12 @@
     "parenttype": "Workflow",
     "state": "Awaiting for Appointment",
     "update_field": "status",
-    "update_value": "Awaiting for Appointment"
+    "update_value": "Awaiting for Appointment",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2420,10 +2680,12 @@
     "parenttype": "Workflow",
     "state": "Booked",
     "update_field": "status",
-    "update_value": "Booked"
+    "update_value": "Booked",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2433,7 +2695,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": "status",
-    "update_value": "Completed"
+    "update_value": "Completed",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2450,7 +2713,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Awaiting for Appointment"
+    "state": "Awaiting for Appointment",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -2465,9 +2729,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Booked"
+    "state": "Booked",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Fingerprint Appointment",
   "workflow_state_field": "workflow_state"
  },
@@ -2483,6 +2749,7 @@
   "states": [
    {
     "allow_edit": "Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2492,10 +2759,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "tp_status",
-    "update_value": "Opened"
+    "update_value": "Opened",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2505,10 +2774,12 @@
     "parenttype": "Workflow",
     "state": "Form Printed",
     "update_field": "tp_status",
-    "update_value": "Printed"
+    "update_value": "Printed",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2518,10 +2789,12 @@
     "parenttype": "Workflow",
     "state": "Pending by Onboarding",
     "update_field": "tp_status",
-    "update_value": "Pending by Onboarding"
+    "update_value": "Pending by Onboarding",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2531,10 +2804,12 @@
     "parenttype": "Workflow",
     "state": "Under Process",
     "update_field": "tp_status",
-    "update_value": "Pending By GRD"
+    "update_value": "Pending By GRD",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2544,7 +2819,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": "tp_status",
-    "update_value": "Completed"
+    "update_value": "Completed",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2561,7 +2837,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to Onboarding Officer",
@@ -2576,7 +2853,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Form Printed"
+    "state": "Form Printed",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to GRD",
@@ -2591,7 +2869,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending by Onboarding"
+    "state": "Pending by Onboarding",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -2606,9 +2885,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Under Process"
+    "state": "Under Process",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Transfer Paper",
   "workflow_state_field": "workflow_state"
  },
@@ -2624,6 +2905,7 @@
   "states": [
    {
     "allow_edit": "HR User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2633,10 +2915,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "status",
-    "update_value": "Draft"
+    "update_value": "Draft",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2646,10 +2930,12 @@
     "parenttype": "Workflow",
     "state": "Form Printed",
     "update_field": "status",
-    "update_value": "Printed"
+    "update_value": "Printed",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": "You Need To Set The Reference Number Taken from PIFSS website",
@@ -2659,10 +2945,12 @@
     "parenttype": "Workflow",
     "state": "Pending by GRD",
     "update_field": "status",
-    "update_value": "Pending by GRD"
+    "update_value": "Pending by GRD",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2672,10 +2960,12 @@
     "parenttype": "Workflow",
     "state": "Awaiting Response",
     "update_field": "status",
-    "update_value": "Awaiting Response by PIFSS"
+    "update_value": "Awaiting Response by PIFSS",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2685,10 +2975,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2698,10 +2990,12 @@
     "parenttype": "Workflow",
     "state": "Under Process",
     "update_field": "status",
-    "update_value": "Under Process"
+    "update_value": "Under Process",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2711,10 +3005,12 @@
     "parenttype": "Workflow",
     "state": "Accepted",
     "update_field": "status",
-    "update_value": "Accepted"
+    "update_value": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2724,7 +3020,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": "status",
-    "update_value": "Completed"
+    "update_value": "Completed",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -2741,7 +3038,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to GRD",
@@ -2756,7 +3054,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Form Printed"
+    "state": "Form Printed",
+    "workflow_builder_id": null
    },
    {
     "action": "Apply",
@@ -2771,7 +3070,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending by GRD"
+    "state": "Pending by GRD",
+    "workflow_builder_id": null
    },
    {
     "action": "Under Process",
@@ -2786,7 +3086,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Awaiting Response"
+    "state": "Awaiting Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -2801,7 +3102,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Awaiting Response"
+    "state": "Awaiting Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -2816,7 +3118,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Awaiting Response"
+    "state": "Awaiting Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Under Process",
@@ -2831,7 +3134,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Under Process"
+    "state": "Under Process",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -2846,7 +3150,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Under Process"
+    "state": "Under Process",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -2861,7 +3166,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Under Process"
+    "state": "Under Process",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -2876,7 +3182,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Accepted"
+    "state": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "action": "Restart Application",
@@ -2891,9 +3198,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Rejected"
+    "state": "Rejected",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "PIFSS Form 103",
   "workflow_state_field": "workflow_state"
  },
@@ -2909,6 +3218,7 @@
   "states": [
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2918,10 +3228,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -2931,10 +3243,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2944,10 +3258,12 @@
     "parenttype": "Workflow",
     "state": "Open Request",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR User",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2957,10 +3273,12 @@
     "parenttype": "Workflow",
     "state": "Open Request",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Legal User",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2970,10 +3288,12 @@
     "parenttype": "Workflow",
     "state": "Request Accepted",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Legal User",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -2983,10 +3303,12 @@
     "parenttype": "Workflow",
     "state": "Request Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Legal User",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -2996,7 +3318,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -3013,7 +3336,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Open Request",
@@ -3028,7 +3352,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -3043,7 +3368,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open Request"
+    "state": "Open Request",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -3058,7 +3384,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open Request"
+    "state": "Open Request",
+    "workflow_builder_id": null
    },
    {
     "action": "Mark Completed",
@@ -3073,9 +3400,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Request Accepted"
+    "state": "Request Accepted",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Employee ID",
   "workflow_state_field": "workflow_state"
  },
@@ -3091,6 +3420,7 @@
   "states": [
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3100,10 +3430,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": "status",
-    "update_value": "Open"
+    "update_value": "Open",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3113,10 +3445,12 @@
     "parenttype": "Workflow",
     "state": "Submitted for Applicant Review",
     "update_field": "status",
-    "update_value": "Processing"
+    "update_value": "Processing",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3126,10 +3460,12 @@
     "parenttype": "Workflow",
     "state": "Applicant Signed",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3139,10 +3475,12 @@
     "parenttype": "Workflow",
     "state": "Applicant not Signed",
     "update_field": "status",
-    "update_value": "Process Finished"
+    "update_value": "Process Finished",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3152,10 +3490,12 @@
     "parenttype": "Workflow",
     "state": "Submitted to Legal",
     "update_field": "",
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Legal User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3165,10 +3505,12 @@
     "parenttype": "Workflow",
     "state": "Send to Authorised Signatory",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Legal User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3178,10 +3520,12 @@
     "parenttype": "Workflow",
     "state": "Awaiting Employee Received Copy",
     "update_field": "",
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3191,10 +3535,12 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": "status",
-    "update_value": "Process Finished"
+    "update_value": "Process Finished",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3204,7 +3550,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": "status",
-    "update_value": "Process Finished"
+    "update_value": "Process Finished",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -3221,7 +3568,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Applicant Signed",
@@ -3236,7 +3584,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted for Applicant Review"
+    "state": "Submitted for Applicant Review",
+    "workflow_builder_id": null
    },
    {
     "action": "Applicant not Signed",
@@ -3251,7 +3600,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted for Applicant Review"
+    "state": "Submitted for Applicant Review",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to Legal",
@@ -3266,7 +3616,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Signed"
+    "state": "Applicant Signed",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit for Review",
@@ -3281,7 +3632,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted to Legal"
+    "state": "Submitted to Legal",
+    "workflow_builder_id": null
    },
    {
     "action": "Send to Authorised Signatory",
@@ -3296,7 +3648,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted to Legal"
+    "state": "Submitted to Legal",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -3311,7 +3664,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted to Legal"
+    "state": "Submitted to Legal",
+    "workflow_builder_id": null
    },
    {
     "action": "Authority Signed",
@@ -3326,7 +3680,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Send to Authorised Signatory"
+    "state": "Send to Authorised Signatory",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -3341,7 +3696,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Send to Authorised Signatory"
+    "state": "Send to Authorised Signatory",
+    "workflow_builder_id": null
    },
    {
     "action": "Mark Completed",
@@ -3356,7 +3712,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Awaiting Employee Received Copy"
+    "state": "Awaiting Employee Received Copy",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -3371,9 +3728,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Completed"
+    "state": "Completed",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Work Contract",
   "workflow_state_field": "workflow_state"
  },
@@ -3389,6 +3748,7 @@
   "states": [
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3398,10 +3758,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3411,10 +3773,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3424,10 +3788,12 @@
     "parenttype": "Workflow",
     "state": "Submit for Candidate Response",
     "update_field": "status",
-    "update_value": "Awaiting Response"
+    "update_value": "Awaiting Response",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3437,10 +3803,12 @@
     "parenttype": "Workflow",
     "state": "Submit for Candidate Response",
     "update_field": "status",
-    "update_value": "Awaiting Response"
+    "update_value": "Awaiting Response",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3450,10 +3818,12 @@
     "parenttype": "Workflow",
     "state": "Submit to Onboarding Officer",
     "update_field": "status",
-    "update_value": "Accepted"
+    "update_value": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3463,10 +3833,12 @@
     "parenttype": "Workflow",
     "state": "Submit to Onboarding Officer",
     "update_field": "status",
-    "update_value": "Accepted"
+    "update_value": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -3476,10 +3848,12 @@
     "parenttype": "Workflow",
     "state": "Offer Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -3489,10 +3863,12 @@
     "parenttype": "Workflow",
     "state": "Offer Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Senior Recruiter",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -3502,10 +3878,12 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3515,10 +3893,12 @@
     "parenttype": "Workflow",
     "state": "Process Onboarding",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3528,10 +3908,12 @@
     "parenttype": "Workflow",
     "state": "Accepted",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3541,7 +3923,8 @@
     "parenttype": "Workflow",
     "state": "Onboarding Officer Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -3558,7 +3941,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit for Candidate Response",
@@ -3573,7 +3957,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Offer Accepted",
@@ -3588,7 +3973,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit for Candidate Response"
+    "state": "Submit for Candidate Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Offer Accepted",
@@ -3603,7 +3989,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit for Candidate Response"
+    "state": "Submit for Candidate Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Offer Rejected",
@@ -3618,7 +4005,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit for Candidate Response"
+    "state": "Submit for Candidate Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Offer Rejected",
@@ -3633,7 +4021,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit for Candidate Response"
+    "state": "Submit for Candidate Response",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -3648,7 +4037,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit to Onboarding Officer"
+    "state": "Submit to Onboarding Officer",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -3663,7 +4053,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submit to Onboarding Officer"
+    "state": "Submit to Onboarding Officer",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to Onboarding Officer",
@@ -3678,7 +4069,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Onboarding Officer Rejected"
+    "state": "Onboarding Officer Rejected",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to Onboarding Officer",
@@ -3693,7 +4085,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Onboarding Officer Rejected"
+    "state": "Onboarding Officer Rejected",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -3708,7 +4101,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Accepted"
+    "state": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -3723,9 +4117,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Onboarding Officer Rejected"
+    "state": "Onboarding Officer Rejected",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Job Offer",
   "workflow_state_field": "workflow_state"
  },
@@ -3741,6 +4137,7 @@
   "states": [
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3750,10 +4147,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3763,10 +4162,12 @@
     "parenttype": "Workflow",
     "state": "Informed Applicant",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3776,10 +4177,12 @@
     "parenttype": "Workflow",
     "state": "Applicant Attended",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3789,10 +4192,12 @@
     "parenttype": "Workflow",
     "state": "Applicant Not Attended",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -3802,10 +4207,12 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -3815,7 +4222,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -3832,7 +4240,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Applicant Attended",
@@ -3847,7 +4256,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Informed Applicant"
+    "state": "Informed Applicant",
+    "workflow_builder_id": null
    },
    {
     "action": "Applicant Not Attended",
@@ -3862,7 +4272,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Informed Applicant"
+    "state": "Informed Applicant",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -3877,7 +4288,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Not Attended"
+    "state": "Applicant Not Attended",
+    "workflow_builder_id": null
    },
    {
     "action": "Mark Completed",
@@ -3892,7 +4304,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Attended"
+    "state": "Applicant Attended",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -3907,9 +4320,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Completed"
+    "state": "Completed",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Candidate Orientation",
   "workflow_state_field": "workflow_state"
  },
@@ -3925,6 +4340,7 @@
   "states": [
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3934,10 +4350,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3947,10 +4365,12 @@
     "parenttype": "Workflow",
     "state": "Submitted for Applicant Review",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3960,10 +4380,12 @@
     "parenttype": "Workflow",
     "state": "Applicant Signed and Uploaded",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3973,10 +4395,12 @@
     "parenttype": "Workflow",
     "state": "Applicant not Signed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -3986,7 +4410,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4003,7 +4428,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Applicant Signed and Upload",
@@ -4018,7 +4444,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted for Applicant Review"
+    "state": "Submitted for Applicant Review",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -4033,7 +4460,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Signed and Uploaded"
+    "state": "Applicant Signed and Uploaded",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -4048,9 +4476,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted for Applicant Review"
+    "state": "Submitted for Applicant Review",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Duty Commencement",
   "workflow_state_field": "workflow_state"
  },
@@ -4066,6 +4496,7 @@
   "states": [
    {
     "allow_edit": "Accommodation User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4075,10 +4506,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4088,10 +4521,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4101,10 +4536,12 @@
     "parenttype": "Workflow",
     "state": "Open Request",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4114,10 +4551,12 @@
     "parenttype": "Workflow",
     "state": "Open Request",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4127,10 +4566,12 @@
     "parenttype": "Workflow",
     "state": "Processing Bank Account Opening",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4140,10 +4581,12 @@
     "parenttype": "Workflow",
     "state": "Rejected by Accounts",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4153,7 +4596,8 @@
     "parenttype": "Workflow",
     "state": "Active Account",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4170,7 +4614,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Open Request",
@@ -4185,7 +4630,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Process Bank Account Opening",
@@ -4200,7 +4646,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open Request"
+    "state": "Open Request",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -4215,7 +4662,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open Request"
+    "state": "Open Request",
+    "workflow_builder_id": null
    },
    {
     "action": "Open Bank Account",
@@ -4230,7 +4678,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Processing Bank Account Opening"
+    "state": "Processing Bank Account Opening",
+    "workflow_builder_id": null
    },
    {
     "action": "Open Bank Account",
@@ -4245,9 +4694,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Bank Account",
   "workflow_state_field": "workflow_state"
  },
@@ -4263,6 +4714,7 @@
   "states": [
    {
     "allow_edit": "Site Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4272,10 +4724,12 @@
     "parenttype": "Workflow",
     "state": "Assign to Site Supervisor",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4285,10 +4739,12 @@
     "parenttype": "Workflow",
     "state": "Review by Projects Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4298,10 +4754,12 @@
     "parenttype": "Workflow",
     "state": "Approved By Projects Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4311,7 +4769,8 @@
     "parenttype": "Workflow",
     "state": "Issue Penalty",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4328,7 +4787,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Assign to Site Supervisor"
+    "state": "Assign to Site Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -4343,7 +4803,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Projects Manager"
+    "state": "Review by Projects Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject & Issue Penalty",
@@ -4358,9 +4819,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Projects Manager"
+    "state": "Review by Projects Manager",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Missed MOM Follow-up Action Workflow",
   "workflow_state_field": "workflow_state"
  },
@@ -4376,6 +4839,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4385,10 +4849,12 @@
     "parenttype": "Workflow",
     "state": "Penalty Issued",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4398,10 +4864,12 @@
     "parenttype": "Workflow",
     "state": "Penalty Accepted",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4411,7 +4879,8 @@
     "parenttype": "Workflow",
     "state": "Penalty Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4428,7 +4897,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Penalty Issued"
+    "state": "Penalty Issued",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -4443,9 +4913,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Penalty Issued"
+    "state": "Penalty Issued",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Penalty",
   "workflow_state_field": "workflow_state"
  },
@@ -4461,6 +4933,7 @@
   "states": [
    {
     "allow_edit": "Site Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4470,10 +4943,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4483,10 +4958,12 @@
     "parenttype": "Workflow",
     "state": "Review by Projects Manager",
     "update_field": "",
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4496,10 +4973,12 @@
     "parenttype": "Workflow",
     "state": "Approved By Projects Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4509,10 +4988,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Operations Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4522,10 +5003,12 @@
     "parenttype": "Workflow",
     "state": "Review by Projects Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Site Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4535,10 +5018,12 @@
     "parenttype": "Workflow",
     "state": "Review by Site Supervisor",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4548,7 +5033,8 @@
     "parenttype": "Workflow",
     "state": "Review by Operations Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4565,7 +5051,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Approval Request",
@@ -4580,7 +5067,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Projects Manager"
+    "state": "Review by Projects Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -4595,7 +5083,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Operations Manager"
+    "state": "Review by Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Review",
@@ -4610,7 +5099,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Projects Manager"
+    "state": "Review by Projects Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Review",
@@ -4625,7 +5115,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Operations Manager"
+    "state": "Review by Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Approval Request",
@@ -4640,7 +5131,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Site Supervisor"
+    "state": "Review by Site Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Approval Request",
@@ -4655,7 +5147,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Review by Projects Manager"
+    "state": "Review by Projects Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Review",
@@ -4670,9 +5163,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Operations Site",
   "workflow_state_field": "workflow_state"
  },
@@ -4688,6 +5183,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4697,10 +5193,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4710,10 +5208,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4723,10 +5223,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -4736,7 +5238,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4753,7 +5256,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -4768,7 +5272,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -4783,9 +5288,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Shift Permission",
   "workflow_state_field": "workflow_state"
  },
@@ -4801,6 +5308,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4810,10 +5318,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4823,7 +5333,8 @@
     "parenttype": "Workflow",
     "state": "Approved by Management",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4840,9 +5351,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "GP Letter Request WF",
   "workflow_state_field": "workflow_state"
  },
@@ -4858,6 +5371,7 @@
   "states": [
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4867,7 +5381,8 @@
     "parenttype": "Workflow",
     "state": "Submission for approval",
     "update_field": "customer",
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4884,9 +5399,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submission for approval"
+    "state": "Submission for approval",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Inovice",
   "workflow_state_field": "workflow_state"
  },
@@ -4902,6 +5419,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4911,10 +5429,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -4924,7 +5444,8 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -4941,7 +5462,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -4956,9 +5478,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Item Request WF",
   "workflow_state_field": "workflow_state"
  },
@@ -4974,6 +5498,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4983,10 +5508,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -4996,10 +5523,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Financial",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5009,10 +5538,12 @@
     "parenttype": "Workflow",
     "state": "Rejected by Financial",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5022,10 +5553,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Management",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5035,7 +5568,8 @@
     "parenttype": "Workflow",
     "state": "Rejected by Management",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5052,7 +5586,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -5067,7 +5602,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -5082,7 +5618,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Financial"
+    "state": "Approved by Financial",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -5097,9 +5634,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Financial"
+    "state": "Approved by Financial",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Purchase Request WF",
   "workflow_state_field": "workflow_state"
  },
@@ -5115,6 +5654,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5124,10 +5664,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5137,10 +5679,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Financial",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5150,10 +5694,12 @@
     "parenttype": "Workflow",
     "state": "Rejected by Financial",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5163,10 +5709,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Management",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5176,7 +5724,8 @@
     "parenttype": "Workflow",
     "state": "Rejected by Management",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5193,7 +5742,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -5208,7 +5758,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -5223,7 +5774,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Financial"
+    "state": "Approved by Financial",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -5238,9 +5790,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Financial"
+    "state": "Approved by Financial",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Supplier Purchase Order WF",
   "workflow_state_field": "workflow_state"
  },
@@ -5256,6 +5810,7 @@
   "states": [
    {
     "allow_edit": "System Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5265,10 +5820,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "System Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5278,10 +5835,12 @@
     "parenttype": "Workflow",
     "state": "Investigation Started",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "System Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5291,7 +5850,8 @@
     "parenttype": "Workflow",
     "state": "Investigation Completed",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5308,7 +5868,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Complete Investigation",
@@ -5323,9 +5884,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Investigation Started"
+    "state": "Investigation Started",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Legal Investigation",
   "workflow_state_field": "workflow_state"
  },
@@ -5341,6 +5904,7 @@
   "states": [
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 1,
     "message": null,
@@ -5350,10 +5914,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5363,10 +5929,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval from Operations Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5376,10 +5944,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Operations Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5389,10 +5959,12 @@
     "parenttype": "Workflow",
     "state": "Rejected by Operations Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5402,10 +5974,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Finance",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5415,10 +5989,12 @@
     "parenttype": "Workflow",
     "state": "Rejected by Finance",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Accounts Manager",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -5428,7 +6004,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5445,7 +6022,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -5460,7 +6038,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval from Operations Manager"
+    "state": "Pending Approval from Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -5475,7 +6054,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval from Operations Manager"
+    "state": "Pending Approval from Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -5490,7 +6070,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Operations Manager"
+    "state": "Approved by Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -5505,7 +6086,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Operations Manager"
+    "state": "Approved by Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -5520,9 +6102,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Finance"
+    "state": "Approved by Finance",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Sales Invoice",
   "workflow_state_field": "workflow_state"
  },
@@ -5538,6 +6122,7 @@
   "states": [
    {
     "allow_edit": "Stock User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5547,10 +6132,12 @@
     "parenttype": "Workflow",
     "state": "Received At Warehouse",
     "update_field": "",
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock User",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5560,10 +6147,12 @@
     "parenttype": "Workflow",
     "state": "Transferred From Warehouse",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock User",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -5573,7 +6162,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5590,7 +6180,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Received At Warehouse"
+    "state": "Received At Warehouse",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -5605,9 +6196,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Transferred From Warehouse"
+    "state": "Transferred From Warehouse",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Asset",
   "workflow_state_field": "workflow_state"
  },
@@ -5623,6 +6216,7 @@
   "states": [
    {
     "allow_edit": "Stock User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5632,10 +6226,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5645,10 +6241,12 @@
     "parenttype": "Workflow",
     "state": "Transferred",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Stock Manager",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -5658,7 +6256,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5675,7 +6274,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -5690,9 +6290,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Transferred"
+    "state": "Transferred",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Asset Movement",
   "workflow_state_field": "workflow_state"
  },
@@ -5708,6 +6310,7 @@
   "states": [
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5717,10 +6320,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5730,10 +6335,12 @@
     "parenttype": "Workflow",
     "state": "Pending By Supervisor",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Finance User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5743,10 +6350,12 @@
     "parenttype": "Workflow",
     "state": "Pending By Finance",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5756,7 +6365,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5773,7 +6383,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to Finance",
@@ -5788,7 +6399,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Supervisor"
+    "state": "Pending By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -5803,9 +6415,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Finance"
+    "state": "Pending By Finance",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "PIFSS Monthly Deduction",
   "workflow_state_field": "workflow_state"
  },
@@ -5821,6 +6435,7 @@
   "states": [
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5830,10 +6445,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "status",
-    "update_value": "Open"
+    "update_value": "Open",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Operator",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5843,10 +6460,12 @@
     "parenttype": "Workflow",
     "state": "Pending By Operator",
     "update_field": "status",
-    "update_value": "Pending By Operator"
+    "update_value": "Pending By Operator",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5856,10 +6475,12 @@
     "parenttype": "Workflow",
     "state": "Pending By Supervisor",
     "update_field": "status",
-    "update_value": "Pending By Supervisor"
+    "update_value": "Pending By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5869,10 +6490,12 @@
     "parenttype": "Workflow",
     "state": "Approved By Supervisor",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -5882,10 +6505,12 @@
     "parenttype": "Workflow",
     "state": "Rejected By Supervisor",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "GRD Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -5895,7 +6520,8 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": "status",
-    "update_value": "Completed"
+    "update_value": "Completed",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -5912,7 +6538,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to GRD Supervisor",
@@ -5927,7 +6554,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Operator"
+    "state": "Pending By Operator",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -5942,7 +6570,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Supervisor"
+    "state": "Pending By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -5957,7 +6586,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending By Supervisor"
+    "state": "Pending By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Save",
@@ -5972,7 +6602,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Rejected By Supervisor"
+    "state": "Rejected By Supervisor",
+    "workflow_builder_id": null
    },
    {
     "action": "Done",
@@ -5987,9 +6618,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved By Supervisor"
+    "state": "Approved By Supervisor",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "PIFSS Monthly Deduction Tool",
   "workflow_state_field": "workflow_state"
  },
@@ -6005,6 +6638,7 @@
   "states": [
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6014,10 +6648,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "status",
-    "update_value": "Draft"
+    "update_value": "Draft",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Projects Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6027,10 +6663,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": "status",
-    "update_value": "Pending"
+    "update_value": "Pending",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6040,10 +6678,12 @@
     "parenttype": "Workflow",
     "state": "Request Accepted",
     "update_field": "status",
-    "update_value": "Accepted"
+    "update_value": "Accepted",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6053,7 +6693,8 @@
     "parenttype": "Workflow",
     "state": "Request Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -6070,7 +6711,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Accept",
@@ -6085,7 +6727,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -6100,9 +6743,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Overtime Request",
   "workflow_state_field": "workflow_state"
  },
@@ -6118,6 +6763,7 @@
   "states": [
    {
     "allow_edit": "Site Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6127,10 +6773,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Line Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6140,10 +6788,12 @@
     "parenttype": "Workflow",
     "state": "Approved by Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Line Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6153,10 +6803,12 @@
     "parenttype": "Workflow",
     "state": "Rejected by Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6166,10 +6818,12 @@
     "parenttype": "Workflow",
     "state": "Approved by HR Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "HR Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6179,7 +6833,8 @@
     "parenttype": "Workflow",
     "state": "Rejected by HR Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -6196,7 +6851,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -6211,7 +6867,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -6226,7 +6883,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved by Manager"
+    "state": "Approved by Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -6241,9 +6899,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Rejected by Manager"
+    "state": "Rejected by Manager",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Employee Incentive",
   "workflow_state_field": "workflow_state"
  },
@@ -6259,6 +6919,7 @@
   "states": [
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6268,10 +6929,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6281,10 +6944,12 @@
     "parenttype": "Workflow",
     "state": "Inform Applicant",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6294,10 +6959,12 @@
     "parenttype": "Workflow",
     "state": "Applicant Attended",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6307,10 +6974,12 @@
     "parenttype": "Workflow",
     "state": "Work Contract",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6320,10 +6989,12 @@
     "parenttype": "Workflow",
     "state": "Duty Commencement",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6333,10 +7004,12 @@
     "parenttype": "Workflow",
     "state": "Bank Account",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6346,10 +7019,12 @@
     "parenttype": "Workflow",
     "state": "Mobile App Enrolment",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6359,10 +7034,12 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -6372,7 +7049,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -6389,7 +7067,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Applicant Attended",
@@ -6404,7 +7083,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Inform Applicant"
+    "state": "Inform Applicant",
+    "workflow_builder_id": null
    },
    {
     "action": "Work Contract",
@@ -6419,7 +7099,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Attended"
+    "state": "Applicant Attended",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit",
@@ -6434,7 +7115,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Attended"
+    "state": "Applicant Attended",
+    "workflow_builder_id": null
    },
    {
     "action": "Duty Commencement",
@@ -6449,7 +7131,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Work Contract"
+    "state": "Work Contract",
+    "workflow_builder_id": null
    },
    {
     "action": "Open Bank Account",
@@ -6464,7 +7147,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Duty Commencement"
+    "state": "Duty Commencement",
+    "workflow_builder_id": null
    },
    {
     "action": "Mobile App Enrolment",
@@ -6479,7 +7163,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Duty Commencement"
+    "state": "Duty Commencement",
+    "workflow_builder_id": null
    },
    {
     "action": "Mobile App Enrolment",
@@ -6494,7 +7179,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Bank Account"
+    "state": "Bank Account",
+    "workflow_builder_id": null
    },
    {
     "action": "Mark Completed",
@@ -6509,7 +7195,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Mobile App Enrolment"
+    "state": "Mobile App Enrolment",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6524,7 +7211,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Inform Applicant"
+    "state": "Inform Applicant",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6539,7 +7227,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Applicant Attended"
+    "state": "Applicant Attended",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6554,7 +7243,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Work Contract"
+    "state": "Work Contract",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6569,7 +7259,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Duty Commencement"
+    "state": "Duty Commencement",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6584,7 +7275,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Bank Account"
+    "state": "Bank Account",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6599,7 +7291,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Mobile App Enrolment"
+    "state": "Mobile App Enrolment",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6614,9 +7307,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 1,
     "skip_multiple_action": 0,
-    "state": "Completed"
+    "state": "Completed",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Onboard Employee",
   "workflow_state_field": "workflow_state"
  },
@@ -6625,13 +7320,14 @@
   "doctype": "Workflow",
   "document_type": "Contracts",
   "is_active": 1,
-  "modified": "2023-12-28 23:02:28.963066",
+  "modified": "2024-02-12 15:17:55.576872",
   "name": "Contracts",
   "override_status": 0,
   "send_email_alert": 0,
   "states": [
    {
     "allow_edit": "Finance User",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6641,10 +7337,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Finance Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6654,10 +7352,12 @@
     "parenttype": "Workflow",
     "state": "Active",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Finance Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6667,7 +7367,8 @@
     "parenttype": "Workflow",
     "state": "Inactive",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -6684,7 +7385,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Set Inactive",
@@ -6699,9 +7401,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Active"
+    "state": "Active",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Contracts",
   "workflow_state_field": "workflow_state"
  },
@@ -6717,6 +7421,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6726,10 +7431,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6739,10 +7446,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6752,10 +7461,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6765,10 +7476,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -6778,10 +7491,12 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6791,7 +7506,8 @@
     "parenttype": "Workflow",
     "state": "Update Request",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -6808,7 +7524,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -6823,7 +7540,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -6838,7 +7556,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -6853,7 +7572,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Update Request",
@@ -6868,7 +7588,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -6883,9 +7604,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Update Request"
+    "state": "Update Request",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Shift Request",
   "workflow_state_field": "workflow_state"
  },
@@ -6901,6 +7624,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6910,10 +7634,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6923,10 +7649,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -6936,10 +7664,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6949,10 +7679,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -6962,10 +7694,12 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -6975,7 +7709,8 @@
     "parenttype": "Workflow",
     "state": "Update Request",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -6992,7 +7727,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -7007,7 +7743,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7022,7 +7759,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval"
+    "state": "Pending Approval",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7037,7 +7775,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Update Request",
@@ -7052,7 +7791,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -7067,7 +7807,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Update Request"
+    "state": "Update Request",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7082,9 +7823,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Update Request"
+    "state": "Update Request",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Attendance Request",
   "workflow_state_field": "workflow_state"
  },
@@ -7100,6 +7843,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7109,10 +7853,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Leave Approver",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7122,10 +7868,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": "status",
-    "update_value": "Approved"
+    "update_value": "Approved",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Leave Approver",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7135,10 +7883,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -7148,7 +7898,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": "status",
-    "update_value": "Cancelled"
+    "update_value": "Cancelled",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -7165,7 +7916,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7180,7 +7932,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7195,7 +7948,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7210,9 +7964,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Rejected"
+    "state": "Rejected",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Leave Application",
   "workflow_state_field": "workflow_state"
  },
@@ -7228,6 +7984,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7237,10 +7994,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7250,10 +8009,12 @@
     "parenttype": "Workflow",
     "state": "Open",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7263,10 +8024,12 @@
     "parenttype": "Workflow",
     "state": "Submitted",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7276,10 +8039,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": "status",
-    "update_value": "Submitted"
+    "update_value": "Submitted",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7289,10 +8054,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -7302,7 +8069,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": "",
-    "update_value": ""
+    "update_value": "",
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -7319,7 +8087,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit",
@@ -7334,7 +8103,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -7349,7 +8119,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7364,7 +8135,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Open"
+    "state": "Open",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7379,7 +8151,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7394,7 +8167,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Rejected"
+    "state": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7409,9 +8183,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Submitted"
+    "state": "Submitted",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Timesheet",
   "workflow_state_field": "workflow_state"
  },
@@ -7427,6 +8203,7 @@
   "states": [
    {
     "allow_edit": "Employee",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7436,10 +8213,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7449,10 +8228,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7462,10 +8243,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -7475,7 +8258,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -7492,7 +8276,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7507,7 +8292,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7522,9 +8308,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Employee Checkin Issue",
   "workflow_state_field": "workflow_state"
  },
@@ -7540,6 +8328,7 @@
   "states": [
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7549,10 +8338,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Shift Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7562,10 +8353,12 @@
     "parenttype": "Workflow",
     "state": "Pending Approval from Operations Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7575,10 +8368,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7588,10 +8383,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -7601,7 +8398,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -7618,7 +8416,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -7633,7 +8432,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval from Operations Manager"
+    "state": "Pending Approval from Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7648,7 +8448,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Approval from Operations Manager"
+    "state": "Pending Approval from Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7663,7 +8464,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 1,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7678,9 +8480,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 1,
     "skip_multiple_action": 0,
-    "state": "Rejected"
+    "state": "Rejected",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Incident Form",
   "workflow_state_field": "workflow_state"
  },
@@ -7696,6 +8500,7 @@
   "states": [
    {
     "allow_edit": "Operations Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7705,10 +8510,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7718,10 +8525,12 @@
     "parenttype": "Workflow",
     "state": "Pending Operations Manager",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7731,10 +8540,12 @@
     "parenttype": "Workflow",
     "state": "Pending Onboarding Officer",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7744,10 +8555,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 1,
     "message": null,
@@ -7757,10 +8570,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7770,10 +8585,12 @@
     "parenttype": "Workflow",
     "state": "Return",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -7783,7 +8600,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -7800,7 +8618,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Submit to Onboarding Officer",
@@ -7815,7 +8634,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Operations Manager"
+    "state": "Pending Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Return",
@@ -7830,7 +8650,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Operations Manager"
+    "state": "Pending Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7845,7 +8666,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Operations Manager"
+    "state": "Pending Operations Manager",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -7860,7 +8682,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Onboarding Officer"
+    "state": "Pending Onboarding Officer",
+    "workflow_builder_id": null
    },
    {
     "action": "Return",
@@ -7875,7 +8698,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Onboarding Officer"
+    "state": "Pending Onboarding Officer",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -7890,7 +8714,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending Onboarding Officer"
+    "state": "Pending Onboarding Officer",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -7905,9 +8730,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Approved"
+    "state": "Approved",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Subcontract Staff Shortlist",
   "workflow_state_field": "workflow_state"
  },
@@ -7923,6 +8750,7 @@
   "states": [
    {
     "allow_edit": "Operations Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7932,10 +8760,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7945,10 +8775,12 @@
     "parenttype": "Workflow",
     "state": "Pending",
     "update_field": "status",
-    "update_value": "Pending"
+    "update_value": "Pending",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -7958,10 +8790,12 @@
     "parenttype": "Workflow",
     "state": "Approved",
     "update_field": "status",
-    "update_value": "Approved"
+    "update_value": "Approved",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Manager",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 1,
     "message": null,
@@ -7971,10 +8805,12 @@
     "parenttype": "Workflow",
     "state": "Rejected",
     "update_field": "status",
-    "update_value": "Rejected"
+    "update_value": "Rejected",
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Operations Supervisor",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -7984,7 +8820,8 @@
     "parenttype": "Workflow",
     "state": "Return",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -8001,7 +8838,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Approve",
@@ -8016,7 +8854,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Reject",
@@ -8031,7 +8870,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Pending"
+    "state": "Pending",
+    "workflow_builder_id": null
    },
    {
     "action": "Return",
@@ -8046,9 +8886,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Rejected"
+    "state": "Rejected",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Subcontract Staff Request",
   "workflow_state_field": "workflow_state"
  },
@@ -8064,6 +8906,7 @@
   "states": [
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -8073,10 +8916,12 @@
     "parenttype": "Workflow",
     "state": "Draft",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
     "message": null,
@@ -8086,10 +8931,12 @@
     "parenttype": "Workflow",
     "state": "In Progress",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
@@ -8099,10 +8946,12 @@
     "parenttype": "Workflow",
     "state": "Completed",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 1,
     "message": null,
@@ -8112,10 +8961,12 @@
     "parenttype": "Workflow",
     "state": "Stopped",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    },
    {
     "allow_edit": "Onboarding Officer",
+    "avoid_status_override": 0,
     "doc_status": "2",
     "is_optional_state": 0,
     "message": null,
@@ -8125,7 +8976,8 @@
     "parenttype": "Workflow",
     "state": "Cancelled",
     "update_field": null,
-    "update_value": null
+    "update_value": null,
+    "workflow_builder_id": null
    }
   ],
   "transitions": [
@@ -8142,7 +8994,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Draft"
+    "state": "Draft",
+    "workflow_builder_id": null
    },
    {
     "action": "Complete",
@@ -8157,7 +9010,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "In Progress"
+    "state": "In Progress",
+    "workflow_builder_id": null
    },
    {
     "action": "Stop",
@@ -8172,7 +9026,8 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "In Progress"
+    "state": "In Progress",
+    "workflow_builder_id": null
    },
    {
     "action": "Cancel",
@@ -8187,9 +9042,11 @@
     "parenttype": "Workflow",
     "skip_creation_of_workflow_action": 0,
     "skip_multiple_action": 0,
-    "state": "Completed"
+    "state": "Completed",
+    "workflow_builder_id": null
    }
   ],
+  "workflow_data": null,
   "workflow_name": "Onboard Subcontract Employee",
   "workflow_state_field": "workflow_state"
  }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- GRD Supervisor not able to view GRD section after accept(Workflow) the ERF by the line manager

## Solution description
- Updated the workflow state with GRD Supervisor role

## Areas affected and ensured
- `one_fm/fixtures/workflow.json`

## Is there any existing behavior change of other features due to this code change?
Yes. GRD Supervisor can access the GRD section in ERF after Accept the ERF by the line manager

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
