### PR TITLE
fix: added reload doctype in patch

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -69,5 +69,5 @@ one_fm.patches.v14_0.set_erf_workflow_state_with_status
 one_fm.patches.v14_0.update_rejected_attendance_check
 one_fm.patches.v14_0.update_timesheet_status
 one_fm.patches.v14_0.add_super_user_role
-one_fm.patches.v15_0.convert_arabic_name_to_first_and_last_name
+one_fm.patches.v15_0.split_arabic_name_to_first_and_last_name
 one_fm.patches.v15_0.delete_duplicate_attendance

--- a/one_fm/patches/v15_0/split_arabic_name_to_first_and_last_name.py
+++ b/one_fm/patches/v15_0/split_arabic_name_to_first_and_last_name.py
@@ -1,6 +1,9 @@
 import frappe
 
 def execute():
+    # Reload doctype so that newly added fields should be added first before executing patch
+    frappe.reload_doctype("Onboard Employee")
+
     """
     Fetch and split "employee_name_in_arabic" into ("first_name_in_arabic", "second_name_in_arabic", "third_name_in_arabic", "forth_name_in_arabic", "last_name_in_arabic")
     """


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Fields were not added at the time of execution of patch

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added reload doctype to fetch latest fields before patch execution

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Fixed patch execution issue

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
