### PR TITLE
fix: Add docstatus check when getting current shift of employee

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3278,7 +3278,7 @@ def get_current_shift(employee):
     """
     sql = f"""
         SELECT * FROM `tabShift Assignment`
-        WHERE employee="{employee}" AND status="Active" AND
+        WHERE employee="{employee}" AND status="Active" AND docstatus=1 AND
         ('{now()}' BETWEEN start_datetime AND end_datetime)
     """
     shift = frappe.db.sql(sql, as_dict=1)
@@ -3289,7 +3289,7 @@ def get_current_shift(employee):
         curtime_plus_1 = dt + timedelta(hours=1)
         sql = f"""
             SELECT * FROM `tabShift Assignment`
-            WHERE employee="{employee}" AND status="Active" AND
+            WHERE employee="{employee}" AND status="Active" AND docstatus=1 AND
             ('{curtime_plus_1}' BETWEEN start_datetime AND end_datetime)
         """
         shift = frappe.db.sql(sql, as_dict=1)
@@ -3299,7 +3299,7 @@ def get_current_shift(employee):
             curtime_plus_1 = dt + timedelta(hours=-1)
             sql = f"""
                 SELECT * FROM `tabShift Assignment`
-                WHERE employee="{employee}" AND status="Active" AND
+                WHERE employee="{employee}" AND status="Active" AND docstatus=1 AND
                 ('{curtime_plus_1}' BETWEEN start_datetime AND end_datetime)
             """
             shift = frappe.db.sql(sql, as_dict=1)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Added docstatus check so that only "Active" and "Submitted" shift assignment is returned when getting current shift of employee.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
