### PR TITLE
feat: get approver of employee

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -114,7 +114,6 @@ class EmployeeOverride(EmployeeMaster):
         approver = get_approver(self.name)
         if approver:
             return frappe.db.get_value('Employee', approver, 'user_id')
-        return False
 
     def update_subcontract_onboard(self):
         subcontract_onboard = frappe.db.exists("Onboard Subcontract Employee", {"employee": self.name, "enrolled": ['!=', '1']})

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -11,7 +11,7 @@ from one_fm.hiring.utils import (
     is_subcontract_employee
 )
 from one_fm.processor import sendemail
-from one_fm.utils import get_domain, get_standard_notification_template
+from one_fm.utils import get_domain, get_standard_notification_template, get_approver
 from six import string_types
 from frappe import _
 
@@ -111,7 +111,10 @@ class EmployeeOverride(EmployeeMaster):
             sendemail(recipients=[reports_to], subject=subject, content=msg)
 
     def get_reports_to_user(self):
-        return get_employee_reports_to_user(self)
+        approver = get_approver(self.name)
+        if approver:
+            return frappe.db.get_value('Employee', approver, 'user_id')
+        return False
 
     def update_subcontract_onboard(self):
         subcontract_onboard = frappe.db.exists("Onboard Subcontract Employee", {"employee": self.name, "enrolled": ['!=', '1']})
@@ -308,42 +311,3 @@ class NotifyAttendanceManagerOnStatusChange:
                 sendemail(recipients=the_recipient, subject=title, content=msg)
         except Exception as e:
             frappe.log_error(frappe.get_traceback(), "Error while sending mail on status change(Employee)")
-
-@frappe.whitelist()
-def get_employee_reports_to_user(employee):
-    '''
-        Method to get reports_to user of an employee with the priority
-        1. reports_to linked in the employee
-        2. If no reports_to linked in the employee, then supervisor linked in the Operation Shift(Linked in the employee)
-        3. If no shift linked in the employee or no supervisor linked in the shift,
-            then account_supervisor linked in the Operation Site(Linked in the employee)
-        4. If no Supervisor is set for the linked Operations Site,
-            then account_manager linked in the project field of the Employee site
-
-        args:
-            employee: object of Employee
-
-        return: user of the reports to employee or False
-    '''
-    reports_to = False
-    if employee.reports_to:
-        reports_to = employee.reports_to
-    if not reports_to and employee.shift:
-        shift_supervisor = frappe.db.get_value('Operations Shift', employee.shift, 'supervisor')
-        if shift_supervisor:
-            reports_to = shift_supervisor
-    if not reports_to and employee.site:
-        site_supervisor = frappe.db.get_value('Operations Site', employee.site, 'account_supervisor')
-        if site_supervisor:
-            reports_to = site_supervisor
-        if not reports_to:
-            project = frappe.db.get_value('Operations Site', employee.site, 'project')
-            if project:
-                account_manager = frappe.db.get_value('Project', project, 'account_manager')
-                if account_manager:
-                    reports_to = account_manager
-    if reports_to:
-        reports_to_user = frappe.db.get_value('Employee', reports_to, 'user_id')
-        if reports_to_user:
-            return reports_to_user
-    return False

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3066,7 +3066,7 @@ def get_approver(employee):
 
     employee_data = frappe.db.get_value('Employee', employee, ['reports_to', 'shift', 'site', 'department'], as_dict=1)
 
-    reports_to = False
+    reports_to = None
     if employee_data.reports_to:
         reports_to = employee_data.reports_to
     if not reports_to and employee_data.shift:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
Reports To Priority:
1. Set in the Employee doctype in the reports_to field  
2. The reports_to field on the Employee doctype is empty, use the supervisor field on the Operations Shift that is linked in the shift field of the Employee 
3. If no Supervisor is set for the linked Operations Shift, use the account_supervisor field on the Operations Site that is linked in the site field of the Employee  
4. If no Supervisor is set for the linked Operations Site, use the account_manager field on the Operations Site that is linked in the project field of the Employee

reports_to -> shift supervisor -> Site Supervisor(Account User) -> Site Supervisor(Account Manager)  

## Analysis and design (optional)

## Areas affected and ensured
- `one_fm/overrides/employee.py`
- `one_fm/utils.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
