### PR TITLE
feat: erp process routine task with assignment rule

### DIFF
--- a/one_fm/operations/doctype/routine_task/routine_task.js
+++ b/one_fm/operations/doctype/routine_task/routine_task.js
@@ -37,7 +37,7 @@ var remove_task_and_auto_repeat = function(frm) {
 };
 
 var set_task_and_auto_repeat = function(frm) {
-	if (!frm.doc.task_reference && !frm.doc.auto_repeat_reference){
+	if (!frm.doc.task_reference && !frm.doc.auto_repeat_reference && !frm.doc.is_erp_process){
 		frm.add_custom_button(__("Set Task and Auto Repeat"), function() {
 			if(frm.is_dirty()){
 				frappe.throw(__('Please Save the Document and Continue .!'))

--- a/one_fm/operations/doctype/routine_task/routine_task.json
+++ b/one_fm/operations/doctype/routine_task/routine_task.json
@@ -12,7 +12,8 @@
   "employee",
   "column_break_ecn7a",
   "employee_name",
-  "column_break_hppoh",
+  "employee_user",
+  "column_break_pwlz",
   "department",
   "process_section",
   "process_name",
@@ -83,6 +84,7 @@
    "reqd": 1
   },
   {
+   "description": "Set number of hours take for the task in the frequency",
    "fieldname": "hours_per_frequency",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -102,10 +104,6 @@
    "fieldtype": "Data",
    "label": "Employee Name",
    "read_only": 1
-  },
-  {
-   "fieldname": "column_break_hppoh",
-   "fieldtype": "Column Break"
   },
   {
    "fetch_from": "employee.department",
@@ -254,11 +252,24 @@
    "fieldname": "start_date",
    "fieldtype": "Date",
    "label": "Start Date"
+  },
+  {
+   "fetch_from": "employee.user_id",
+   "fieldname": "employee_user",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Employee User",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_pwlz",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-05-30 10:34:43.472561",
+ "modified": "2024-02-18 10:04:17.560326",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Routine Task",

--- a/one_fm/operations/doctype/routine_task/routine_task.py
+++ b/one_fm/operations/doctype/routine_task/routine_task.py
@@ -6,6 +6,7 @@ from frappe.model.document import Document
 from frappe.utils import getdate
 from frappe.desk.form.assign_to import add as add_assignment, DuplicateToDoError
 from frappe import _
+from one_fm.overrides.assignment_rule import get_assignment_rule_description
 
 class RoutineTask(Document):
 	def validate(self):
@@ -104,6 +105,65 @@ class RoutineTask(Document):
 			return task.name
 		return self.task_reference
 
+	def on_update(self):
+		self.update_assignment_rule_for_doc_in_process()
+
+	def update_assignment_rule_for_doc_in_process(self):
+		if self.is_erp_process and self.process_name and self.employee_user:
+			# Get routine task process to get the documents linked with the routine task
+			rt_process = frappe.get_doc('Routine Task Process', self.process_name)
+			document_names = False
+			common_assignment_rule_linked_docs = []
+			# Iterate the documents list linked with the routine task process to update the assignment rule
+			for erp_doc in rt_process.erp_document:
+				'''
+					Check if assignment rule exists without routine task link for the document,
+					do not create the assignment rule linked with routine task for the document.
+				'''
+				if frappe.db.exists('Assignment Rule', {'document_type': erp_doc.routine_task_document, 'custom_routine_task': ['is', 'not set']}):
+					common_assignment_rule_linked_docs.append(erp_doc.routine_task_document)
+					continue
+
+				if document_names:
+					document_names += ", "+erp_doc.routine_task_document
+				else:
+					document_names = erp_doc.routine_task_document
+				# Check if assignment rule exists for the routine task and the document
+				assignment_rule_exists = frappe.db.exists('Assignment Rule', {'document_type': erp_doc.routine_task_document, 'custom_routine_task': self.name})
+				assignment_rule = False
+				'''
+					If assignment rule exists with the filters and employee got changed in the routine task,
+					then get the assignment rule object and set the users linked in assignment rule to null
+				'''
+				if assignment_rule_exists and self.has_value_changed("employee"):
+					assignment_rule = frappe.get_doc('Assignment Rule', assignment_rule_exists)
+					assignment_rule.users = []
+				# If no assignment rule exists for the filters, create new assignment rule object
+				else:
+					assignment_rule = frappe.new_doc('Assignment Rule')
+					assignment_rule.name = "{0}-{1}".format(self.name, erp_doc.routine_task_document)
+					assignment_rule.document_type = erp_doc.routine_task_document
+					assignment_rule.description = get_assignment_rule_description(erp_doc.routine_task_document)
+					assignment_rule.assign_condition = 'docstatus == 0'
+					assignment_rule.rule = 'Round Robin'
+					assignment_rule.custom_routine_task = self.name
+
+					days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+					for day in days:
+						assignment_days = assignment_rule.append('assignment_days')
+						assignment_days.day = day
+
+				# If assignment rule object exists, set user of employee selected in the routine task as the users of assignment rule and save it.
+				if assignment_rule:
+					users = assignment_rule.append('users')
+					users.user = self.employee_user
+					assignment_rule.save(ignore_permissions=True)
+					frappe.msgprint(_("Assignment rules are Updated for the document(s): {0}".format(document_names)), alert=True, indicator='green')
+
+			# Notify the user by msg print about the assignment rule not linked with routine task
+			if common_assignment_rule_linked_docs and len(common_assignment_rule_linked_docs) > 0:
+				msg = _("No Assignment Rule created for the Rotine task for the lsited documents, since common Assignment Rule linked to these documents: {0}".format(", ".join(common_assignment_rule_linked_docs)))
+				frappe.msgprint(msg, alert=True, indicator='orange')
 
 @frappe.whitelist()
 def filter_routine_document(doctype, txt, searchfield, start, page_len, filters):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- We have routine tasks that are already developed in ERPNext as a Process. For example, Attendance Check. It is happening every day. Right now the Process is assigned to Ahmed to Check. SO we want to have a way to track the number of routine tasks assigned to a person and we want the assignment to the doctype to be done automatically by taking the user from routine task

## Solution description
- We create and manage Assignment rule for doctype selected in routine task process

## Areas affected and ensured
- `one_fm/operations/doctype/routine_task/routine_task.js`
- `one_fm/operations/doctype/routine_task/routine_task.json`
- `one_fm/operations/doctype/routine_task/routine_task.py`

## Is there any existing behavior change of other features due to this code change?
Yes, erp process routine task creates assignment rule for the document selected in the process

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
