### PR TITLE
Feat: validates that the Defaults Purchase UoM is used

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -216,7 +216,10 @@ doc_events = {
 		"on_submit": "one_fm.purchase.doctype.request_for_material.request_for_material.update_completed_purchase_qty",
 		"on_cancel": "one_fm.purchase.doctype.request_for_material.request_for_material.update_completed_purchase_qty",
 		"after_insert": "one_fm.purchase.utils.set_quotation_attachment_in_po",
-		"validate":"one_fm.purchase.utils.set_po_approver",
+		"validate":[
+			"one_fm.purchase.utils.set_po_approver",
+			"one_fm.purchase.utils.validate_purchase_item_uom"
+		],
 		'on_update':"one_fm.purchase.utils.on_update",
 		"on_update_after_submit": "one_fm.purchase.utils.set_po_letter_head"
 	},

--- a/one_fm/purchase/utils.py
+++ b/one_fm/purchase/utils.py
@@ -67,6 +67,16 @@ def set_po_approver(doc,ev):
     if not doc.department_manager:
         doc.department_manager = get_approving_user(doc)
 
+def validate_purchase_item_uom(doc,method):
+    check_list = []
+    for d in doc.get("items"):
+        if d.qty:
+            default_qty = frappe.get_value("UOM Conversion Detail", {'parent':d.item_code, 'uom':d.uom}, ['conversion_factor'])
+            if d.qty != default_qty:
+                frappe.throw(
+                    _("Conversion factor for default Unit of Measure must be {0} in row {1}").format(default_qty, d.idx)
+                )
+
 def get_users_with_role(role):
     """
     Get the users with the role


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- Validate the quantity of the Purchase Order Item with the item's default conversion factor.

## Solution description
- Validate the quantity of the Purchase Order Item with the item's default conversion factor.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (

https://github.com/ONE-F-M/one_fm/assets/29017559/3f21a06e-dd2b-4edf-933a-ab677d8f67e0




## Areas affected and ensured
- Purchase Order Item table validation.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [x ] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
