### PR TITLE
feat: Validate UOM in Purchase Order wrt the UOM Conversion in Item

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -220,7 +220,7 @@ doc_events = {
 			"one_fm.purchase.utils.set_po_approver",
 			"one_fm.overrides.purchase_order.validate_purchase_uom"
 		],
-		'on_update':"one_fm.purchase.utils.on_update",
+		# 'on_update':"one_fm.purchase.utils.on_update",
 		"on_update_after_submit": "one_fm.purchase.utils.set_po_letter_head"
 	},
 	"Leave Application": {

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -216,8 +216,11 @@ doc_events = {
 		"on_submit": "one_fm.purchase.doctype.request_for_material.request_for_material.update_completed_purchase_qty",
 		"on_cancel": "one_fm.purchase.doctype.request_for_material.request_for_material.update_completed_purchase_qty",
 		"after_insert": "one_fm.purchase.utils.set_quotation_attachment_in_po",
-		"validate":"one_fm.purchase.utils.set_po_approver",
-		# 'on_update':"one_fm.purchase.utils.on_update",
+		"validate":[
+			"one_fm.purchase.utils.set_po_approver",
+			"one_fm.overrides.purchase_order.validate_purchase_uom"
+		],
+		'on_update':"one_fm.purchase.utils.on_update",
 		"on_update_after_submit": "one_fm.purchase.utils.set_po_letter_head"
 	},
 	"Leave Application": {

--- a/one_fm/overrides/purchase_order.py
+++ b/one_fm/overrides/purchase_order.py
@@ -1,0 +1,44 @@
+import frappe
+from frappe import _
+
+def validate_purchase_uom(doc, method):
+    for item in doc.items:
+        query = """
+            select
+                uom
+            from
+                `tabUOM Conversion Detail`
+            where
+                parent = %s
+        """
+        uoms_list = frappe.db.sql(
+            query,
+            item.item_code,
+            as_list=True,
+        )
+        uoms = [item for sublist in uoms_list for item in sublist]
+        if uoms and len(uoms) > 0:
+            if item.uom not in uoms:
+                msg = "The selected UOM in the row {0} is not having any UOM conversion Details in the item {1}".format(item.idx, item.item_code)
+                frappe.throw(_(msg))
+
+@frappe.whitelist()
+def filter_purchase_uoms(doctype, txt, searchfield, start, page_len, filters):
+    # filter UOM in item lines by UOM Conversion Detail set in the item
+	query = """
+		select
+            uom
+        from
+            `tabUOM Conversion Detail`
+        where
+            parent = %(item_code)s
+			and uom like %(txt)s
+			limit %(start)s, %(page_len)s"""
+	return frappe.db.sql(query,
+		{
+			'item_code': filters.get("item_code"),
+			'start': start,
+			'page_len': page_len,
+			'txt': "%%%s%%" % txt
+		}
+	)

--- a/one_fm/public/js/doctype_js/purchase_order.js
+++ b/one_fm/public/js/doctype_js/purchase_order.js
@@ -7,11 +7,19 @@ frappe.ui.form.on('Purchase Order', {
 		}
 		// frm.set_df_property('quoted_delivery_date', 'hidden', (frm.doc.docstatus==1 && frappe.user.has_role("Purchase User"))?false:true);
 	},
-	refresh: function(frm) {
-
+	refresh: function(frm, cdt, cdn) {
 		hide_subscription_section(frm);
 		set_field_property_for_documents(frm);
 		set_field_property_for_other_documents(frm);
+
+		// Update filter UOM in item lines by UOM Conversion Detail set in the item
+		frm.set_query("uom", "items", function(frm, cdt, cdn) {
+			var child = locals[cdt][cdn];
+			return {
+				query: "one_fm.overrides.purchase_order.filter_purchase_uoms",
+				filters: {'item_code': child.item_code}
+			}
+		});
 	},
 	onload_post_render: function(frm){
 		frappe.call({


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Validate UOM in Purchase Order wrt the UOM Conversion in Item

## Output screenshots (optional)
![Screenshot 2024-02-20 at 10 55 36 AM](https://github.com/ONE-F-M/one_fm/assets/20554466/a8816459-357d-4da3-b834-37218b81a9c3)
![Screenshot 2024-02-20 at 11 13 40 AM](https://github.com/ONE-F-M/one_fm/assets/20554466/e11d5ec1-6fae-4621-8f22-7a890ecc2730)

## Areas affected and ensured
- `one_fm/hooks.py`
- `one_fm/public/js/doctype_js/purchase_order.js`

## Is there any existing behavior change of other features due to this code change?
Yes, user can set only UOM from the item UOM Conversion Detail

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
