### PR TITLE
FEAT: PREVENT USERS FROM CREATING ATTENDANCE REQUEST FOR PREVIOUS DATES

### DIFF
--- a/one_fm/public/js/doctype_js/attendance_request.js
+++ b/one_fm/public/js/doctype_js/attendance_request.js
@@ -3,6 +3,9 @@ frappe.ui.form.on('Attendance Request', {
       frm.trigger('check_workflow');
 			set_update_request_btn(frm);
     },
+	validate: (frm) => {
+		validate_from_date(frm);
+	},
     check_workflow: (frm)=>{
       if(frm.doc.workflow_state=='Pending Approval'){
         // Disable action button/worklow if not approver
@@ -25,6 +28,9 @@ frappe.ui.form.on('Attendance Request', {
 				}
 			})
 		}
+	},
+	from_date: (frm) =>{
+		validate_from_date(frm);
 	}
 });
 
@@ -77,3 +83,9 @@ function update_request(frm) {
 	});
 	dialog.show();
 };
+
+validate_from_date = (frm) => {
+	if (frm.doc.from_date < frappe.datetime.now_date()){
+		frappe.throw("Atendance Request can not be created for past dates.")
+	}
+}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [X] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To prevent users from createing attendance request for previous dates

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a validation check to the js file to check for previous dates

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2024-02-25 19-12-07](https://github.com/ONE-F-M/one_fm/assets/99317649/528a6155-b484-4c6d-9c46-bb4b15b55f01)


## Areas affected and ensured
List out the areas affected by your code changes.
Attendance Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
