### PR TITLE
Feat: Validate from_date in Shift Request

### DIFF
--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -330,6 +330,10 @@ def fill_to_date(doc, method):
     if not doc.to_date:
         doc.to_date = doc.from_date
 
+def validate_from_date(doc, method):
+    if not doc.assign_day_off:
+        if getdate(today()) > getdate(doc.from_date):
+            frappe.throw('From Date cannot be before today.')
 
 @frappe.whitelist()
 def update_request(shift_request, from_date, to_date):

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -384,7 +384,8 @@ doc_events = {
 	"Shift Request":{
 		"before_save":[
 			"one_fm.api.doc_methods.shift_request.fill_to_date",
-			"one_fm.utils.send_shift_request_mail"
+			"one_fm.utils.send_shift_request_mail",
+			"one_fm.api.doc_methods.shift_request.validate_from_date"
 		],
 		# "on_update_after_submit":[
 			# "one_fm.api.doc_methods.shift_request.on_update_after_submit",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
- If not assigning day_off, Employee shouldn't be able to apply for the previous date.

## Solution description
- Considering not assigning a Day Off, validate from a date not less than today.
- If so, Throw a Warning.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/ONE-F-M/one_fm/assets/29017559/0992d8ad-04cd-4056-a2f9-7089dfacd692

## Areas affected and ensured
Shift Request validation.

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
