### PR TITLE
feat: set default terms for job offer

### DIFF
--- a/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
+++ b/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
@@ -17,6 +17,7 @@
   "performance_profile_guid",
   "job_offer_section",
   "notify_finance_department_for_job_offer_salary_advance",
+  "default_terms_and_conditions",
   "job_applicaion_section",
   "default_hr_manager",
   "default_hr_manager_name",
@@ -136,11 +137,17 @@
    "fieldtype": "Data",
    "label": "Default HR Manager Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "default_terms_and_conditions",
+   "fieldtype": "Link",
+   "label": "Default Terms and Conditions",
+   "options": "Terms and Conditions"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-01-16 04:27:34.888456",
+ "modified": "2024-02-27 08:29:05.173163",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Hiring Settings",

--- a/one_fm/public/js/doctype_js/job_offer.js
+++ b/one_fm/public/js/doctype_js/job_offer.js
@@ -2,6 +2,7 @@ frappe.ui.form.on('Job Offer', {
   refresh(frm) {
     if(frm.is_new()){
       frm.set_value('offer_date', frappe.datetime.now_date());
+      set_default_terms_and_conditions(frm);
     }
     set_shift_working_btn(frm);
     filterDefaultShift(frm);
@@ -375,6 +376,20 @@ const filterDefaultShift = (frm) => {
             }
         }
     })
+}
+
+const set_default_terms_and_conditions = (frm) => {
+  frappe.call({
+    method: 'frappe.client.get_single_value',
+    args: {
+    doctype: 'Hiring Settings',
+    field: 'default_terms_and_conditions'
+    },
+    callback: function(r){						
+      frm.set_value('select_terms', r.message || '')
+      frm.refresh_field("select_terms")
+    }
+  });
 }
 
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Set default Job Offer Terms according to terms set in "Hiring Settings"

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Added field for default terms in "Hiring Settings"
- Set default terms according to above settings

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
- Hiring Settings
- Job Offer

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
