### PR TITLE
feat: skip supervisor notification if employee has shift permission even in pending state

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -260,7 +260,7 @@ def notify_supervisor_about_late_entry(checkin):
 	try:
 		auto_attendance_employee = frappe.get_value("Employee", {'name':checkin.employee}, ['auto_attendance'])
 		if auto_attendance_employee == 0:
-			shift_permission = frappe.db.sql(f""" select name from `tabShift Permission` where employee = '{checkin.employee}' and date = '{now_datetime().date()}' and log_type = 'IN' and permission_type = 'Arrive Late' and workflow_state = 'Approved' ;  """)
+			shift_permission = frappe.db.sql(f""" select name from `tabShift Permission` where employee = '{checkin.employee}' and date = '{now_datetime().date()}' and log_type = 'IN' and permission_type = 'Arrive Late' and workflow_state IN ('Pending','Approved') ;  """)
 			checkin_shift_assignment = False
 			if checkin.shift_assignment:
 				checkin_shift_assignment = last_shift_assignment = checkin.shift_assignment


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Don't notify supervisor if has shift permission in draft/pending

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Add pending/approved status filter is shift permission fetching

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Shift Permission notification

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
