### PR TITLE
feat: Implement Role based permissions for Task doctype

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -111,7 +111,8 @@ doctype_js = {
     "Workflow": "public/js/doctype_js/workflow.js",
     "Stock Entry": "public/js/doctype_js/stock_entry.js",
     "Gratuity": "public/js/doctype_js/gratuity.js",
-    "Goal": "public/js/doctype_js/goal.js"
+    "Goal": "public/js/doctype_js/goal.js",
+    "Task": "public/js/doctype_js/task.js"
 }
 doctype_list_js = {
 	"Job Applicant" : "public/js/doctype_js/job_applicant_list.js",
@@ -416,6 +417,9 @@ doc_events = {
 	"Wiki Page": {
 		"after_insert": "one_fm.wiki_chat_bot.main.after_insert_wiki_page"
 	},
+    "Task": {
+        "validate": "one_fm.overrides.task.validate_task"
+	}
 	# "Additional Salary" :{
 	# 	"on_submit": "one_fm.grd.utils.validate_date"
 	# }

--- a/one_fm/overrides/task.py
+++ b/one_fm/overrides/task.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe import _
+from one_fm.api.api import get_user_roles
+
+"""
+List of fields allowed to be modified based on role mentioned.
+PROJECTS_MANAGER_FIELD_MAP = ["status", "priority", "completed_by", "completed_on", "exp_start_date", "exp_end_date"]
+PROJECTS_USER_FIELD_MAP = ["status", "priority", "completed_on"]
+"""
+USER_ALLOWED_STATUSES = ["Open", "Working", "Pending Review"]
+
+def validate_task(doc, method):
+    # Check user role and see if they have updated any values based on the field map. 
+    roles = get_user_roles()
+    if "Projects User" in roles and "Projects Manager" not in roles:
+        validate_updated_fields(doc)
+
+def validate_updated_fields(doc):
+    if doc.has_value_changed('status'):
+        if doc.status not in USER_ALLOWED_STATUSES:
+            frappe.throw(_("Insufficient permission for updating status."))
+    if doc.has_value_changed('priority') or doc.has_value_changed('completed_on'):
+        frappe.throw(_("Insufficient permission for updating {0}").format("Priority" if doc.has_value_changed('priority') else 'Completed On'))

--- a/one_fm/overrides/task.py
+++ b/one_fm/overrides/task.py
@@ -5,14 +5,14 @@ from one_fm.api.api import get_user_roles
 """
 List of fields allowed to be modified based on role mentioned.
 PROJECTS_MANAGER_FIELD_MAP = ["status", "priority", "completed_by", "completed_on", "exp_start_date", "exp_end_date"]
-PROJECTS_USER_FIELD_MAP = ["status", "priority", "completed_on"]
+PROJECTS_USER_FIELD_MAP = ["status", "completed_by", "exp_start_date", "exp_end_date"]
 """
 USER_ALLOWED_STATUSES = ["Open", "Working", "Pending Review"]
 
 def validate_task(doc, method):
-    # Check user role and see if they have updated any values based on the field map. 
     roles = get_user_roles()
-    if "Projects User" in roles and "Projects Manager" not in roles:
+    is_manager = is_project_manager(doc.project) if doc.project else False
+    if "Projects User" in roles and "Projects Manager" not in roles and not is_manager:
         validate_updated_fields(doc)
 
 def validate_updated_fields(doc):
@@ -21,3 +21,18 @@ def validate_updated_fields(doc):
             frappe.throw(_("Insufficient permission for updating status."))
     if doc.has_value_changed('priority') or doc.has_value_changed('completed_on'):
         frappe.throw(_("Insufficient permission for updating {0}").format("Priority" if doc.has_value_changed('priority') else 'Completed On'))
+
+def is_project_manager(project):
+    project_manager = frappe.get_value("Project", project, "account_manager")
+    user_employee = frappe.get_value("Employee", {"user_id": frappe.session.user}) if frappe.db.exists("Employee", {"user_id": frappe.session.user}) else None
+
+    if user_employee and project_manager and user_employee == project_manager:
+        return True
+    return False
+
+
+@frappe.whitelist()
+def get_roles_and_validate_is_manager(project=None):
+    roles = get_user_roles()
+    is_manager = is_project_manager(project) if project else False
+    return roles, is_manager

--- a/one_fm/public/js/doctype_js/task.js
+++ b/one_fm/public/js/doctype_js/task.js
@@ -18,6 +18,8 @@ function set_perms(frm){
     frappe.xcall('one_fm.api.api.get_user_roles')
     .then(roles => {
         if (roles.includes("Projects User") && !roles.includes("Projects Manager")){
+            // If task status is one of ["Open", "Working", "Pending Review"], keep the status field editable.
+            // If task status is one of ["Overdue", "Template", "Completed", "Canceled"], make the status field read_only for Projects User.
             if(USER_PERMS["status"].includes(frm.doc.status)){
                 frm.set_df_property("status", "options", USER_PERMS["status"]);
             } else {

--- a/one_fm/public/js/doctype_js/task.js
+++ b/one_fm/public/js/doctype_js/task.js
@@ -15,22 +15,28 @@ frappe.ui.form.on("Task", {
 })
 
 function set_perms(frm){
-    frappe.xcall('one_fm.api.api.get_user_roles')
-    .then(roles => {
-        if (roles.includes("Projects User") && !roles.includes("Projects Manager")){
-            // If task status is one of ["Open", "Working", "Pending Review"], keep the status field editable.
-            // If task status is one of ["Overdue", "Template", "Completed", "Canceled"], make the status field read_only for Projects User.
-            if(USER_PERMS["status"].includes(frm.doc.status)){
-                frm.set_df_property("status", "options", USER_PERMS["status"]);
-            } else {
-                frm.set_df_property("status", "read_only", 1);
-            }
-            frm.set_df_property("priority", "read_only", USER_PERMS["priority"]);
-            frm.set_df_property("completed_by", "read_only", USER_PERMS["completed_by"]);
-            frm.set_df_property("completed_on", "read_only", USER_PERMS["completed_on"]);
-            frm.set_df_property("exp_start_date", "read_only", USER_PERMS["exp_start_date"]);
-            frm.set_df_property("exp_end_date", "read_only", USER_PERMS["exp_end_date"]);                
-        } 
+    let {project} = frm.doc;
+    frappe.xcall('one_fm.overrides.task.get_roles_and_validate_is_manager', {project})
+    .then(res => {
+        if(!res.exc){
+            let roles = res[0];
+            let is_project_manager = res[1];
+            // if session user is project manager for linked project, then Projects Manager perms apply otherwise Projects User perms apply.
+            if (roles.includes("Projects User") && !roles.includes("Projects Manager") && !is_project_manager){
+                // If task status is one of ["Open", "Working", "Pending Review"], keep the status field editable.
+                // If task status is one of ["Overdue", "Template", "Completed", "Canceled"], make the status field read_only for Projects User.
+                if(USER_PERMS["status"].includes(frm.doc.status)){
+                    frm.set_df_property("status", "options", USER_PERMS["status"]);
+                } else {
+                    frm.set_df_property("status", "read_only", 1);
+                }
+                frm.set_df_property("priority", "read_only", USER_PERMS["priority"]);
+                frm.set_df_property("completed_by", "read_only", USER_PERMS["completed_by"]);
+                frm.set_df_property("completed_on", "read_only", USER_PERMS["completed_on"]);
+                frm.set_df_property("exp_start_date", "read_only", USER_PERMS["exp_start_date"]);
+                frm.set_df_property("exp_end_date", "read_only", USER_PERMS["exp_end_date"]);                
+            } 
+        }
     })
 }
 

--- a/one_fm/public/js/doctype_js/task.js
+++ b/one_fm/public/js/doctype_js/task.js
@@ -1,0 +1,31 @@
+const USER_PERMS = {
+    status: ["Open", "Working", "Pending Review"],
+    priority: true,
+    completed_by: false,
+    completed_on: true,
+    exp_start_date: false,
+    exp_end_date: false,
+    //due date - no such field
+}
+
+frappe.ui.form.on("Task", {
+    refresh: function (frm) {
+        set_perms(frm);  
+        }
+})
+
+function set_perms(frm){
+    frappe.xcall('one_fm.api.api.get_user_roles')
+    .then(roles => {
+        if (roles.includes("Projects User") && !roles.includes("Projects Manager")){
+            frm.set_df_property("status", "options", USER_PERMS["status"]);
+            frm.set_df_property("priority", "read_only", USER_PERMS["priority"]);
+            frm.set_df_property("completed_by", "read_only", USER_PERMS["completed_by"]);
+            frm.set_df_property("completed_on", "read_only", USER_PERMS["completed_on"]);
+            frm.set_df_property("exp_start_date", "read_only", USER_PERMS["exp_start_date"]);
+            frm.set_df_property("exp_end_date", "read_only", USER_PERMS["exp_end_date"]);                
+        } 
+    })
+}
+
+

--- a/one_fm/public/js/doctype_js/task.js
+++ b/one_fm/public/js/doctype_js/task.js
@@ -18,7 +18,11 @@ function set_perms(frm){
     frappe.xcall('one_fm.api.api.get_user_roles')
     .then(roles => {
         if (roles.includes("Projects User") && !roles.includes("Projects Manager")){
-            frm.set_df_property("status", "options", USER_PERMS["status"]);
+            if(USER_PERMS["status"].includes(frm.doc.status)){
+                frm.set_df_property("status", "options", USER_PERMS["status"]);
+            } else {
+                frm.set_df_property("status", "read_only", 1);
+            }
             frm.set_df_property("priority", "read_only", USER_PERMS["priority"]);
             frm.set_df_property("completed_by", "read_only", USER_PERMS["completed_by"]);
             frm.set_df_property("completed_on", "read_only", USER_PERMS["completed_on"]);


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Implement field based permissions based on the below
![image](https://github.com/ONE-F-M/one_fm/assets/20857931/0a582bb6-6d61-4209-98d4-b7bce204e6e6)

## Solution description
Custom script and backend changes to implement field permissions based on role. 

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No

## Areas affected and ensured
List out the areas affected by your code changes.

> one_fm/hooks.py
> one_fm/overrides/task.py
> one_fm/public/js/doctype_js/task.js


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [] Yes
    - [x] No
        
## Is patch required?
- [] Yes
- [x] No
 

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
