### PR TITLE
feat: Validate post overfill on rostering

### DIFF
--- a/one_fm/api/doc_methods/shift_request.py
+++ b/one_fm/api/doc_methods/shift_request.py
@@ -10,6 +10,7 @@ from frappe.utils import getdate, today, cstr, add_to_date, nowdate, add_days
 from frappe.model.workflow import apply_workflow
 from one_fm.utils import (workflow_approve_reject, send_workflow_action_email)
 from one_fm.api.notification import create_notification_log, get_employee_user_id
+from one_fm.operations.doctype.employee_schedule.employee_schedule import validate_operations_post_overfill
 
 class OverlappingShiftError(frappe.ValidationError):
     pass
@@ -99,6 +100,9 @@ def process_shift_assignemnt(doc, event=None):
                     end_date = es.date
                     if start_time > end_time:
                         end_date = add_days(end_date, 1)
+
+                    validate_operations_post_overfill({es.date: 1}, doc.operations_shift)
+
                     frappe.db.set_value('Employee Schedule', es.name, {
                         'shift':doc.operations_shift,
                         'shift_type':doc.shift_type,
@@ -125,6 +129,8 @@ def process_shift_assignemnt(doc, event=None):
                         if start_time > end_time:
                             end_date = add_days(end_date, 1)
 
+                        validate_operations_post_overfill({es.date: 1}, doc.operations_shift)
+
                         frappe.db.set_value('Employee Schedule', es.name, {
                             'shift':doc.operations_shift,
                             'shift_type':doc.shift_type,
@@ -140,6 +146,7 @@ def process_shift_assignemnt(doc, event=None):
                             'reference_docname': doc.name
                             }
                         )
+
                     else:
                         schedule = frappe.new_doc("Employee Schedule")
                         schedule.employee = doc.employee
@@ -349,7 +356,7 @@ def update_request(shift_request, from_date, to_date):
 def _get_employee_from_user(user):
 	employee_docname = frappe.db.get_value("Employee", {"user_id": user})
 	return employee_docname if employee_docname else None
-	
+
 
 def get_manager(doctype,employee):
     field = None
@@ -363,7 +370,7 @@ def get_manager(doctype,employee):
         values = frappe.get_all(doctype,{field:employee},['name'])
         if values:
             return [i.name for i in values]
-        
+
 
 
 @frappe.whitelist()
@@ -376,9 +383,9 @@ def get_employees(doctype, txt, searchfield, start, page_len, filters):
     """
     Return the full list of employees if current user has a HR role or Included in the Employee Master Table.
     else, it returns the full list of employees assigned to the Operations shifts,sites or projects where this user is set
-    
+
     """
-    
+
     is_master= False
     default_user_roles = None
     employee_master_roles = frappe.get_all("ONEFM Document Access Roles Detail",{'parent':"ONEFM General Setting",'parentfield':"employee_master_role"},['role'])
@@ -396,20 +403,20 @@ def get_employees(doctype, txt, searchfield, start, page_len, filters):
             #If the user has  typed anything on the employee field
             employees = frappe.db.sql(f"Select name,employee_name,employee_id from `tabEmployee` where status = 'Active' and name like '%{txt}%' or employee_name like '%{txt}%' or employee_id like '%{txt}%'   ")
             return employees
-            
+
     else:
         allowed_employees = []
         user = frappe.session.user
         if user!="Administrator":
             employee_id = _get_employee_from_user(user)
             if employee_id:
-                employee_base_query = f""" 
+                employee_base_query = f"""
                         SELECT name,employee_name,employee_id from `tabEmployee` where status = "Active"
                 """
                 cond_str = ""
                 query = None
                 allowed_employees.append(employee_id)
-                #get all reports to 
+                #get all reports to
                 reports_to = frappe.get_all("Employee",{'reports_to':employee_id,'status':"Active"},'name')
                 if reports_to:
                     allowed_employees+=[i.name for i in reports_to]
@@ -438,10 +445,10 @@ def get_employees(doctype, txt, searchfield, start, page_len, filters):
                         cond_str+=f" and (name like '%{txt}%' or employee_name like '%{txt}%' or employee_id like '%{txt}%')  "
                     query += f""" UNION SELECT name,employee_name,employee_id from `tabEmployee` where status = "Active"  {cond_str} """
                 #Check if employee is set in operations shift, operations site or project
-                
+
                 return frappe.db.sql(query)
-                
-                
+
+
             else:
                 return ()
         else:
@@ -450,13 +457,6 @@ def get_employees(doctype, txt, searchfield, start, page_len, filters):
             else:
                 return frappe.db.sql("Select name,employee_name,employee_id from `tabEmployee` where status = 'Active' and name \
                     like '%{txt}%' or employee_name like '%{txt}%' \or employee_id like '%{txt}%'  ")
-        
-        
-        
-    
-        
-        
-        
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Validate the number of assigned Employees to active posts in a shift so that that a post is not overfilled

## Output screenshots (optional)
Operations Shift have Two Posts
![Screenshot 2024-03-04 at 7 04 15 PM](https://github.com/ONE-F-M/one_fm/assets/20554466/d33de1c7-7b8a-4c27-82ac-a82ab1ff5e47)

Two Employee Schedules on date
![Screenshot 2024-03-04 at 7 05 04 PM](https://github.com/ONE-F-M/one_fm/assets/20554466/890300ba-04a7-483f-8095-3b5a82d7ffbb)

Validate on the date while creating new Employee Schedule
![Screenshot 2024-03-04 at 7 03 59 PM](https://github.com/ONE-F-M/one_fm/assets/20554466/83b5e18c-2257-495d-a92d-cb76217626ba)

Validation on Roster
1/2
https://github.com/ONE-F-M/one_fm/assets/20554466/feba4ec7-f468-442f-96bb-3a3020d4f974
2/2
https://github.com/ONE-F-M/one_fm/assets/20554466/83848e73-080c-4bdb-bcec-8ef232edf422

https://github.com/ONE-F-M/one_fm/assets/20554466/4cedce1c-5b6e-446a-a1c7-d317d03cea34

## Areas affected and ensured
- `one_fm/api/doc_methods/shift_request.py`
- `one_fm/one_fm/page/roster/roster.py`
- `one_fm/operations/doctype/employee_schedule/employee_schedule.py`

## Is there any existing behavior change of other features due to this code change?
Yes, validate post overfill on rostering

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
