### PR TITLE
fix: Fetch active posts to check the overfill

### DIFF
--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.py
@@ -86,7 +86,7 @@ class EmployeeSchedule(Document):
 def is_operations_post_overfill(date, operations_shift, new_roster=0):
 	operations_post_overfill = False
 	# Fetch total number of active operations post for the operations shift
-	no_of_posts = frappe.db.count("Operations Post", {'site_shift': operations_shift})
+	no_of_posts = frappe.db.count("Operations Post", {'site_shift': operations_shift, 'status': 'Active'})
 
 	# Fetch employee scedules for the operations_shift and date
 	staffs_rostered = frappe.db.count("Employee Schedule",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
- Fetch active posts to check the overfill

## Areas affected and ensured
- `one_fm/operations/doctype/employee_schedule/employee_schedule.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
