### PR TITLE
feat: revoked and deleted all existing oauth bearer tokens when new token is issued

### DIFF
--- a/one_fm/api/doc_methods/oauth_bearer_token.py
+++ b/one_fm/api/doc_methods/oauth_bearer_token.py
@@ -1,14 +1,30 @@
 import frappe
-from frappe.integrations.oauth2 import revoke_token
+import requests
+from frappe.utils import get_url
+
+
+def revoke_token(access_token):
+
+    url = f"{get_url()}/api/method/frappe.integrations.oauth2.revoke_token"
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    data = {"token": access_token}
+
+    try:
+        response = requests.post(url, headers=headers, data=data)
+        response.raise_for_status()
+        return True
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error revoking token: {e}")
+        return False
+
 
 def revoke_and_delete_existing_tokens(doc, event):
     """
         Revokes and deletes all the existing tokens for the target user.
     """
-    user_existing_tokens = frappe.get_all('OAuth Bearer Token', filters={'user': doc.user}, fields=['name'])
+    user_existing_tokens = frappe.get_all('OAuth Bearer Token', filters={
+                                          'client': doc.client, 'user': doc.user, 'status': 'Active', 'name': ['!=', doc.name]}, fields=['name'])
 
     for token in user_existing_tokens:
-        # Check if its not the recently generated token
-        if(token.name != doc.name):
-            revoke_token(token=token.name)
-            frappe.delete_doc('OAuth Bearer Token', token.name,ignore_permissions=True)
+        revoke_token(token.name)

--- a/one_fm/api/doc_methods/oauth_bearer_token.py
+++ b/one_fm/api/doc_methods/oauth_bearer_token.py
@@ -1,0 +1,14 @@
+import frappe
+from frappe.integrations.oauth2 import revoke_token
+
+def revoke_and_delete_existing_tokens(doc, event):
+    """
+        Revokes and deletes all the existing tokens for the target user.
+    """
+    user_existing_tokens = frappe.get_all('OAuth Bearer Token', filters={'user': doc.user}, fields=['name'])
+
+    for token in user_existing_tokens:
+        # Check if its not the recently generated token
+        if(token.name != doc.name):
+            revoke_token(token=token.name)
+            frappe.delete_doc('OAuth Bearer Token', token.name,ignore_permissions=True)

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -420,10 +420,13 @@ doc_events = {
 	# },
     "Task": {
         "validate": "one_fm.overrides.task.validate_task"
-	}
+	},
 	# "Additional Salary" :{
 	# 	"on_submit": "one_fm.grd.utils.validate_date"
 	# }
+    "OAuth Bearer Token": {
+		"after_insert": "one_fm.api.doc_methods.oauth_bearer_token.revoke_and_delete_existing_tokens",
+	},
 }
 
 standard_portal_menu_items = [


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Revoke and delete all existing oauth bearer tokens for particular user when new token is issued

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Created a doc_method and attached it with "OAuth Bearer Token" (after_insert) hook

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
OAuth Bearer Token

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Yes, All the existing OAuth tokens for particular user will be deleted when new one will be issued

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
