### PR TITLE
[FEAT Dump Backup Files to Specific Server]

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -29,7 +29,7 @@ jobs:
           cd /home/frappe          
           pip3 install --upgrade frappe-bench
           cd /home/frappe/frappe-bench
-          # bench setup requirements
+          bench setup requirements
           bench migrate # sync database
           bench restart #${{secrets.PASSKEY}}
           # we remove any unused dependencies

--- a/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.js
+++ b/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2024, omar jaber and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("File Transfer Wizard", {
+	refresh(frm) {
+        if(frm.doc.transfer_status =="Ready"){
+            frm.add_custom_button(`Hey ${frappe.session.user} ! Click me to start`,()=>{
+                frappe.call({
+                    doc: frm.doc,
+                    method: 'initiate_transfers',
+                    callback: function(r) {
+                        if(!r.exc){
+                            frappe.show_alert(`Files are being copied over to  <b>${frm.doc.directory} </b> in  <b> ${frm.doc.url || frm.doc.ip_address} </b>`)
+                        }
+                    }
+                });
+            })
+        }
+	},
+});

--- a/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.js
+++ b/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.js
@@ -4,7 +4,8 @@
 frappe.ui.form.on("File Transfer Wizard", {
 	refresh(frm) {
         if(frm.doc.transfer_status =="Ready"){
-            frm.add_custom_button(`Hey ${frappe.session.user} ! Click me to start`,()=>{
+            frm.add_custom_button(`Hey ${frappe.session.user_fullname.split(' ')[0]
+        }! Click me to start the upload`,()=>{
                 frappe.call({
                     doc: frm.doc,
                     method: 'initiate_transfers',

--- a/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.json
+++ b/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.json
@@ -1,0 +1,141 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "FTZ-.YYYY.-.MM. -.####",
+ "creation": "2024-03-14 10:10:11.005923",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "recipient_details_section",
+  "server_id",
+  "ip_address",
+  "username",
+  "password",
+  "column_break_mchs",
+  "fetch_ip_from_url",
+  "url",
+  "transfer_public_and_private_files",
+  "directory",
+  "create_directory_if_missing",
+  "transfer_status",
+  "section_break_vpib",
+  "updates"
+ ],
+ "fields": [
+  {
+   "fieldname": "server_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Server ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "ip_address",
+   "fieldtype": "Data",
+   "label": "IP Address",
+   "mandatory_depends_on": "eval:doc.fetch_ip_from_url == 0",
+   "read_only_depends_on": "eval:doc.fetch_ip_from_url"
+  },
+  {
+   "default": "0",
+   "fieldname": "fetch_ip_from_url",
+   "fieldtype": "Check",
+   "label": "Fetch IP from URL"
+  },
+  {
+   "depends_on": "eval:doc.fetch_ip_from_url",
+   "fieldname": "url",
+   "fieldtype": "Data",
+   "label": "URL",
+   "mandatory_depends_on": "eval:doc.fetch_ip_from_url",
+   "options": "URL"
+  },
+  {
+   "fieldname": "recipient_details_section",
+   "fieldtype": "Section Break",
+   "label": "Recipient Details"
+  },
+  {
+   "fieldname": "column_break_mchs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Username to access the server",
+   "fieldname": "username",
+   "fieldtype": "Data",
+   "label": "Username",
+   "reqd": 1
+  },
+  {
+   "description": "Password to access the server",
+   "fieldname": "password",
+   "fieldtype": "Password",
+   "label": "Password",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "description": "Copy the attached files backups ",
+   "fieldname": "transfer_public_and_private_files",
+   "fieldtype": "Check",
+   "label": "Transfer Public and Private Files"
+  },
+  {
+   "description": "The full file path to the directory where the backup files will be copied",
+   "fieldname": "directory",
+   "fieldtype": "Data",
+   "label": "Directory",
+   "reqd": 1
+  },
+  {
+   "fieldname": "transfer_status",
+   "fieldtype": "Select",
+   "label": "Transfer Status",
+   "options": "Pending\nReady\nInitiated\nSuccessful\nFailed",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "create_directory_if_missing",
+   "fieldtype": "Check",
+   "label": "Create Directory If Missing"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_vpib",
+   "fieldtype": "Section Break",
+   "label": "Progress"
+  },
+  {
+   "fieldname": "updates",
+   "fieldtype": "Long Text",
+   "label": "Updates",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-03-14 22:22:00.946363",
+ "modified_by": "Administrator",
+ "module": "Developer",
+ "name": "File Transfer Wizard",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.json
+++ b/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.json
@@ -91,7 +91,7 @@
    "fieldname": "transfer_status",
    "fieldtype": "Select",
    "label": "Transfer Status",
-   "options": "Pending\nReady\nInitiated\nSuccessful\nFailed",
+   "options": "Pending\nReady\nSuccessful\nFailed",
    "read_only": 1
   },
   {
@@ -115,7 +115,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-14 22:22:00.946363",
+ "modified": "2024-03-16 12:00:32.147161",
  "modified_by": "Administrator",
  "module": "Developer",
  "name": "File Transfer Wizard",

--- a/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.py
+++ b/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2024, omar jaber and contributors
+# For license information, please see license.txt
+
+import frappe,socket,paramiko
+from frappe.model.document import Document
+from frappe.integrations.offsite_backup_utils import get_latest_backup_file
+
+
+class FileTransferWizard(Document):
+    def validate(self):
+        self.set_ip_address()
+        self.validate_folder_location()
+        
+        
+    @frappe.whitelist()
+    def initiate_transfers(self):
+        frappe.enqueue(self.transfer_files, timeout=1200)
+        
+        
+    
+    def transfer_files(self):
+        try:
+            self.get_connection()
+            # self.sftp_client.put
+            last_backups = self.get_last_backups()
+            if last_backups.get('db'): #ensure that a database backup is available before proceeding
+                for one in last_backups.keys():
+                    if last_backups.get(one):
+                        old_update = self.updates or ""
+                        file_name = last_backups.get(one).split('/')[-1]
+                        self.db_set('updates',old_update+f"<br/> Uploading {file_name}......")
+                        self.sftp_client.put(last_backups.get(one),self.directory+'/'+file_name)
+                        self.db_set('updates',old_update+f"<br/> Uploaded {file_name}")
+        except Exception as e:
+            frappe.log_error(title = "Error Uploading File",message = frappe.get_traceback())
+            
+    
+    
+    def get_connection(self):
+        try:
+            self.client = paramiko.SSHClient()
+            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # Handle unknown host keys (carefully!)
+            self.client.connect(hostname=self.ip_address, username=self.username,password = self.get_password('password'),allow_agent=False, look_for_keys=False)
+            self.sftp_client = self.client.open_sftp()
+        except paramiko.AuthenticationException:
+            frappe.throw("Invalid Credentials! <br> Please review the username and password provided")
+        except Exception as e:
+            frappe.log_error(title = "Error accessing server",message = frappe.get_traceback())
+        
+
+    def validate_folder_location(self):
+        """ Ensure that the credentials provided to access the server are correct
+        """
+        try:
+            self.get_connection()
+            try:
+                self.sftp_client.stat(self.directory)
+                
+            except FileNotFoundError:
+                if self.create_directory_if_missing:
+                    self.sftp_client.mkdir(self.directory)
+                    self.db_set('transfer_status',"Ready")
+                    frappe.db.commit()
+                else:
+                    self.db_set('transfer_status',"Pending")
+                    frappe.db.commit()
+                    frappe.throw(f"Folder path {self.directory} not found")
+                self.client.close()
+                self.sftp_client.close()
+            self.client.close()
+            self.sftp_client.close()
+            self.db_set('transfer_status',"Ready")
+            frappe.db.commit()
+        except Exception as e:
+            frappe.log_error(title = "Error Validating Folder Location",message = frappe.get_traceback())
+            
+            
+
+    
+    
+    def get_last_backups(self):
+        db_filename, site_config, files_filename, private_files = None,None,None,None
+        if self.transfer_public_and_private_files:
+            db_filename, site_config, files_filename, private_files = get_latest_backup_file(with_files=1)
+        else:
+            db_filename, site_config = get_latest_backup_file()
+            
+        return {'db':db_filename,'site_config':site_config,'files_filename':files_filename,'private_files':private_files}
+    
+    def set_ip_address(self):
+        """
+            Set  the IP address if URL is set
+        """
+        try:
+            if self.fetch_ip_from_url:
+                url = self.url.split('//')[-1] #get the last item in the list
+                ip_address = socket.gethostbyname(url)
+                if ip_address != self.ip_address:
+                    self.ip_address = ip_address
+        except socket.error as e:
+    
+            frappe.log_error(title = "Error Fetching IP Address",message = e.strerror)
+            
+            frappe.throw("An error occured while fetching the IP address")
+
+

--- a/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.py
+++ b/one_fm/developer/doctype/file_transfer_wizard/file_transfer_wizard.py
@@ -31,7 +31,13 @@ class FileTransferWizard(Document):
                         self.db_set('updates',old_update+f"<br/> Uploading {file_name}......")
                         self.sftp_client.put(last_backups.get(one),self.directory+'/'+file_name)
                         self.db_set('updates',old_update+f"<br/> Uploaded {file_name}")
+                self.db_set("transfer_status",'Successful')
+                self.client.close()
+                self.sftp_client.close()
         except Exception as e:
+            self.db_set("transfer_status",'Failed')
+            self.client.close()
+            self.sftp_client.close()
             frappe.log_error(title = "Error Uploading File",message = frappe.get_traceback())
             
     

--- a/one_fm/developer/doctype/file_transfer_wizard/test_file_transfer_wizard.py
+++ b/one_fm/developer/doctype/file_transfer_wizard/test_file_transfer_wizard.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, omar jaber and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestFileTransferWizard(FrappeTestCase):
+	pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -238,3 +238,4 @@ xlrd==2.0.1
 yarl==1.9.2
 zopfli==0.2.3
 zxcvbn==4.4.28
+paramiko==3.4.0


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [*] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Automate backup files being dumped on specific servers

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Setup a feature that automate backup files being dumped on specific servers
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1431" alt="image" src="https://github.com/ONE-F-M/one_fm/assets/38866184/17f14492-0153-4cac-987b-e33bb453bd9e">
<img width="1431" alt="image" src="https://github.com/ONE-F-M/one_fm/assets/38866184/b66a6ea8-8865-4728-80f8-7f6f71a6743c">


## Areas affected and ensured
List out the areas affected by your code changes.
Created New Doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Database files can be dumped directly on remote servers

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? NO
    - [] is attachment required?
        did you test attachment
## Did you delete custom field? NO
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
