### PR TITLE
feat: customized employee list query in employee uniform

### DIFF
--- a/one_fm/overrides/queries.py
+++ b/one_fm/overrides/queries.py
@@ -67,10 +67,14 @@ def employee_query(doctype, txt, searchfield, start, page_len, filters):
     conditions = []
     fields = get_fields(doctype, ["name", "employee_name", "employee_id"])
 
+    filters = filters or {}
+    
+    if not filters.get('status'):
+        filters['status'] = ['in', ['Active', 'Vacation']]
+
     return frappe.db.sql(
         """select {fields} from `tabEmployee`
-        where (status = 'Active' or status = 'Vacation')
-            and docstatus < 2
+        where docstatus < 2
             and ({key} like %(txt)s
                 or employee_name like %(txt)s
                 or employee_id like %(txt)s)

--- a/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.js
+++ b/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.js
@@ -27,8 +27,8 @@ frappe.ui.form.on('Employee Uniform', {
 			// frappe.meta.get_docfield("Employee Uniform Item", 'quantity', frm.doc.name).label = 'Return Qty';
 		}
 	},
-	reason_for_return: function(frm) {
-
+	has_employee_left: function(frm) {
+		update_employees_list(frm)
 	},
 	get_item_data: function(frm, item) {
 		if (!item.item || frm.doc.type=='Return') return;
@@ -109,4 +109,14 @@ var set_uniform_details = function(frm) {
 			freeze_message: __('Fetching Uniform Details..')
 		});
 	}
+};
+
+var update_employees_list = function(frm) {
+	frm.set_query('employee', () => {
+		return {
+			filters: {
+				status: frm.doc.has_employee_left ? 'Left' : 'Active',
+			}
+		};
+	});
 };

--- a/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.json
+++ b/one_fm/uniform_management/doctype/employee_uniform/employee_uniform.json
@@ -11,6 +11,7 @@
   "type",
   "reason_for_return",
   "warehouse",
+  "has_employee_left",
   "employee",
   "employee_id",
   "employee_name",
@@ -174,11 +175,17 @@
    "no_copy": 1,
    "options": "Stock Entry",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "has_employee_left",
+   "fieldtype": "Check",
+   "label": "Has Employee Left"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-09 16:27:50.236905",
+ "modified": "2024-03-25 11:16:28.474036",
  "modified_by": "Administrator",
  "module": "Uniform Management",
  "name": "Employee Uniform",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Left employees cannot be selected in Employee Uniform

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added field for "Has Employee Left" and made employee query dynamic according to status

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Employee Uniform
Employee Query

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
