### PR TITLE
hotfix: Fix CV links in Job applicant email notification

### DIFF
--- a/one_fm/templates/emails/job_application_notification.html
+++ b/one_fm/templates/emails/job_application_notification.html
@@ -98,7 +98,7 @@
         </tr>
         <tr>
             <th>CV</th>
-            <td><a href={{ cv }}>CV Attachment</a></td>
+            <td><a href="{{ cv }}">CV Attachment</a></td>
           </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Fixes the bug where CV files with whitespace in their name were not being handled properly in template leading to broken links. 

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [] Yes
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
