### PR TITLE
fix: updated religion field and removed duplicate options

### DIFF
--- a/one_fm/accommodation/doctype/bed/bed.json
+++ b/one_fm/accommodation/doctype/bed/bed.json
@@ -208,8 +208,9 @@
   {
    "fetch_from": "employee.one_fm_religion",
    "fieldname": "religion",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Religion",
+   "options": "Religion",
    "read_only": 1
   },
   {
@@ -366,7 +367,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-05-18 10:03:47.482957",
+ "modified": "2024-04-24 12:19:09.232912",
  "modified_by": "Administrator",
  "module": "Accommodation",
  "name": "Bed",
@@ -399,5 +400,6 @@
  ],
  "search_fields": "accommodation_name, governorate, area, bed_type, gender, status",
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/one_fm/accommodation/doctype/book_bed/book_bed.json
+++ b/one_fm/accommodation/doctype/book_bed/book_bed.json
@@ -203,8 +203,9 @@
   },
   {
    "fieldname": "religion",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Religion",
+   "options": "Religion",
    "read_only": 1
   },
   {
@@ -277,10 +278,11 @@
   }
  ],
  "links": [],
- "modified": "2020-11-16 08:47:30.735656",
+ "modified": "2024-04-24 12:08:45.893685",
  "modified_by": "Administrator",
  "module": "Accommodation",
  "name": "Book Bed",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -310,5 +312,6 @@
  ],
  "search_fields": "full_name, passport_number, civil_id, employee",
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -94,7 +94,6 @@
   "salary_certificate",
   "column_break_64",
   "iqrar",
-  "section_break_50",
   "documents_required_section",
   "documents_required",
   "amended_from",
@@ -559,8 +558,9 @@
    "allow_on_submit": 1,
    "fetch_from": "employee.one_fm_religion",
    "fieldname": "religion",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Religion",
+   "options": "Religion",
    "read_only": 1
   },
   {
@@ -668,10 +668,6 @@
   {
    "depends_on": "eval:doc.work_permit_type != \"Cancellation\" && doc.work_permit_type != \"New Kuwaiti\"",
    "fieldname": "section_break_46",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "section_break_50",
    "fieldtype": "Section Break"
   },
   {
@@ -900,7 +896,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-14 16:13:28.882651",
+ "modified": "2024-04-24 12:20:03.593026",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",

--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.json
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.json
@@ -374,9 +374,11 @@
    "label": "Date of Birth"
   },
   {
+   "fetch_from": "job_applicant.one_fm_religion",
    "fieldname": "religion",
-   "fieldtype": "Data",
-   "label": "Religion"
+   "fieldtype": "Link",
+   "label": "Religion",
+   "options": "Religion"
   },
   {
    "fieldname": "column_break_20",
@@ -1564,7 +1566,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-04 09:51:08.981949",
+ "modified": "2024-04-24 13:56:25.574043",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Onboard Employee",

--- a/one_fm/one_fm/doctype/pam_visa/pam_visa.json
+++ b/one_fm/one_fm/doctype/pam_visa/pam_visa.json
@@ -175,9 +175,9 @@
   },
   {
    "fieldname": "religion",
-   "fieldtype": "Select",
+   "fieldtype": "Link",
    "label": "Religion",
-   "options": "\nChristian\nHindu\nIslam\nParsi",
+   "options": "Religion",
    "read_only": 1
   },
   {
@@ -605,7 +605,7 @@
   }
  ],
  "links": [],
- "modified": "2022-11-03 07:20:15.600923",
+ "modified": "2024-04-24 12:12:06.605384",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "PAM Visa",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -81,3 +81,4 @@ one_fm.patches.v15_0.delete_offer_term_templates_field
 one_fm.patches.v15_0.replicate_issue_types_to_hd_ticket_types
 one_fm.patches.v15_0.update_employee_status
 one_fm.patches.v15_0.update_employee_id_qr_code_generator
+one_fm.patches.v15_0.update_religion_field_options

--- a/one_fm/patches/v15_0/update_religion_field_options.py
+++ b/one_fm/patches/v15_0/update_religion_field_options.py
@@ -1,0 +1,34 @@
+import frappe
+
+def update_religion_field(doctype, fieldname):
+    query = """
+        UPDATE `tab{}` 
+        SET `{}` = 'Muslim' 
+        WHERE `{}` = 'Islam'
+    """.format(doctype, fieldname, fieldname)
+
+    frappe.db.sql(query)
+
+def delete_religion_option(name):
+    query = """
+        DELETE FROM `tabReligion`
+        WHERE  religion = '{}'
+    """.format(name)
+
+    frappe.db.sql(query)
+
+def execute():
+    # Update religion field value from 'Islam' to 'Muslim'
+    update_religion_field('Bed', 'religion')
+    update_religion_field('Book Bed', 'religion')
+    update_religion_field('Work Permit', 'religion')
+    update_religion_field('Onboard Employee', 'religion')
+    update_religion_field('Transfer Paper', 'religion')
+    update_religion_field('Employee', 'one_fm_religion')
+    update_religion_field('Job Applicant', 'one_fm_religion')
+    update_religion_field('PAM Visa', 'religion')
+
+    # Delete 'Islam' from religion options
+    delete_religion_option('Islam')
+    
+    frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Religion field not linked to Religion doctype and has duplicate options

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- LInked all religion fields to Religion doctype
- Removed duplicate options for Religion

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
- Bed (Fetch From Employee)
- Book Bed (Data)
- Work Permit (Fetch From Employee)
- Onboard Employee (Data)
- Transfer Paper (Fetch From Job Applicant)
- Employee (Link to Religion)
- Job Applicant (Link to Religion)
- PAM Visa (Select)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Religion options are synced

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
## Was the patch test?
Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
