### PR TITLE
fix: added missing method for employee annual leave calculation report

### DIFF
--- a/one_fm/one_fm/report/employee_annual_leave_calculation/employee_annual_leave_calculation.py
+++ b/one_fm/one_fm/report/employee_annual_leave_calculation/employee_annual_leave_calculation.py
@@ -8,8 +8,8 @@ from frappe.utils import getdate, date_diff, add_days, month_diff, formatdate, a
 from hrms.hr.doctype.leave_application.leave_application \
 	import get_leave_balance_on, get_leaves_for_period
 
-from hrms.hr.report.employee_leave_balance_summary.employee_leave_balance_summary \
-	import get_department_leave_approver_map
+# from hrms.hr.report.employee_leave_balance_summary.employee_leave_balance_summary \
+# 	import get_department_leave_approver_map
 
 def execute(filters=None):
 	# Get the list of  Paid annula leave Leave type
@@ -128,3 +128,26 @@ def find_year_from_no_of_days(number_of_days):
 	days = (number_of_days % 365) % 30
 	year_from_no_of_days = str(year)+" Years "+str(month)+" Months "+str(days)+" Days"
 	return year_from_no_of_days
+
+def get_department_leave_approver_map(department = None):
+	# get current department and all its child
+	department_list = frappe.get_list(
+		"Department",
+		filters={"disabled": 0},
+		or_filters={"name": department, "parent_department": department},
+		pluck="name",
+	)
+	# retrieve approvers list from current department and from its subsequent child departments
+	approver_list = frappe.get_all(
+		"Department Approver",
+		filters={"parentfield": "leave_approvers", "parent": ("in", department_list)},
+		fields=["parent", "approver"],
+		as_list=True,
+	)
+
+	approvers = {}
+
+	for k, v in approver_list:
+		approvers.setdefault(k, []).append(v)
+
+	return approvers


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Imported method (get_department_leave_approver_map) does not exist

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added the required method for getting leave approvers for department

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Employee Annual Leave Calculation Report

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
