### PR TITLE
Fix: Neither 'start' nor 'end' can be NaT

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -306,7 +306,7 @@ def get_employee_leave_attendance(employees,start_date):
 
 @frappe.whitelist()
 def schedule_staff(employees, shift, operations_role, otRoster, start_date, project_end_date, keep_days_off=0, request_employee_schedule=0, day_off_ot=None, end_date=None, selected_days_only=0):
-    # try:
+    try:
         _start_date = getdate(start_date)
 
         validation_logs = []
@@ -383,9 +383,9 @@ def schedule_staff(employees, shift, operations_role, otRoster, start_date, proj
 
 
             response("success", 200, {'message':'Successfully rostered employees'})
-    # except Exception as e:
-    #     frappe.log_error(frappe.get_traceback(), "Schedule Roster")
-    #     response("error", 200, None, str(e))
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "Schedule Roster")
+        response("error", 200, None, str(e))
 
 def update_roster(key):
     frappe.publish_realtime(key, "Success")

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -504,7 +504,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
         """
         can_create = False
         if not end_date:
-        end_date = start_date
+            end_date = start_date
         list_of_date = date_range(start_date, end_date)
         post_data = validate_overfilled_post(list_of_date,operations_shift.name)
         post_number = post_data.get('post_number')

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -503,8 +503,8 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
             VALUES
         """
         can_create = False
-         if not end_date:
-            end_date = start_date
+        if not end_date:
+        end_date = start_date
         list_of_date = date_range(start_date, end_date)
         post_data = validate_overfilled_post(list_of_date,operations_shift.name)
         post_number = post_data.get('post_number')

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -306,8 +306,7 @@ def get_employee_leave_attendance(employees,start_date):
 
 @frappe.whitelist()
 def schedule_staff(employees, shift, operations_role, otRoster, start_date, project_end_date, keep_days_off=0, request_employee_schedule=0, day_off_ot=None, end_date=None, selected_days_only=0):
-    try:
-
+    # try:
         _start_date = getdate(start_date)
 
         validation_logs = []
@@ -384,9 +383,9 @@ def schedule_staff(employees, shift, operations_role, otRoster, start_date, proj
 
 
             response("success", 200, {'message':'Successfully rostered employees'})
-    except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "Schedule Roster")
-        response("error", 200, None, str(e))
+    # except Exception as e:
+    #     frappe.log_error(frappe.get_traceback(), "Schedule Roster")
+    #     response("error", 200, None, str(e))
 
 def update_roster(key):
     frappe.publish_realtime(key, "Success")
@@ -504,6 +503,8 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
             VALUES
         """
         can_create = False
+         if not end_date:
+            end_date = start_date
         list_of_date = date_range(start_date, end_date)
         post_data = validate_overfilled_post(list_of_date,operations_shift.name)
         post_number = post_data.get('post_number')


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
![Screenshot_20240509_221558_Chrome](https://github.com/ONE-F-M/one_fm/assets/29017559/cb91b1e0-1fb9-43d3-8979-8e43882dd50d)


## Solution description
- Check if end_date Exists.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)
<img width="721" alt="Screen Shot 2024-05-12 at 9 54 09 AM" src="https://github.com/ONE-F-M/one_fm/assets/29017559/a97eae8e-982a-4605-aa55-b31204a419d5">


## Areas affected and ensured
Condition Checking

## Is there any existing behavior change of other features due to this code change?
no.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
