### PR TITLE
hotfix: Allow task owner to update Task status and priority if no project is linked

### DIFF
--- a/one_fm/overrides/task.py
+++ b/one_fm/overrides/task.py
@@ -12,7 +12,7 @@ USER_ALLOWED_STATUSES = ["Open", "Working", "Pending Review"]
 def validate_task(doc, method):
     roles = get_user_roles()
     is_manager = is_project_manager(doc.project) if doc.project else False
-    if "Projects User" in roles and "Projects Manager" not in roles and not is_manager:
+    if "Projects User" in roles and "Projects Manager" not in roles and not is_manager and (doc.project or doc.owner != frappe.session.user):
         validate_updated_fields(doc)
 
 def validate_updated_fields(doc):

--- a/one_fm/public/js/doctype_js/task.js
+++ b/one_fm/public/js/doctype_js/task.js
@@ -21,8 +21,9 @@ function set_perms(frm){
         if(!res.exc){
             let roles = res[0];
             let is_project_manager = res[1];
-            // if session user is project manager for linked project, then Projects Manager perms apply otherwise Projects User perms apply.
-            if (roles.includes("Projects User") && !roles.includes("Projects Manager") && !is_project_manager){
+            // if project is linked and session user is project manager, then Projects Manager perms apply otherwise Projects User perms apply.
+            // if there is no project, then only the doc.owner can change the task status and priority.
+            if (roles.includes("Projects User") && !roles.includes("Projects Manager") && !is_project_manager && (project || (frm.doc.owner != frappe.session.user))){
                 // If task status is one of ["Open", "Working", "Pending Review"], keep the status field editable.
                 // If task status is one of ["Overdue", "Template", "Completed", "Canceled"], make the status field read_only for Projects User.
                 if(USER_PERMS["status"].includes(frm.doc.status)){


### PR DESCRIPTION
…ject linked

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
1. If a task has no project linked, task owner can update status and priority of the task. 

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
No

## Did you delete custom field?
- [] Yes
- [x] No
 
## Is patch required?
- [] Yes
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
