### PR TITLE
hof-fix: removed unique contraint from routine task coordination method

### DIFF
--- a/one_fm/operations/doctype/routine_task_coordination_method/routine_task_coordination_method.json
+++ b/one_fm/operations/doctype/routine_task_coordination_method/routine_task_coordination_method.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:coordination_method",
  "creation": "2023-04-26 22:19:28.006436",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -16,18 +15,16 @@
    "in_list_view": 1,
    "label": "Coordination Method",
    "options": "Coordination Method",
-   "reqd": 1,
-   "unique": 1
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-04-26 22:19:28.006436",
+ "modified": "2024-05-30 12:08:03.618588",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Routine Task Coordination Method",
- "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Unable to create routine task with previously selected coordination method

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Removed unique constraint from "coordination_method" field
- Replaced naming rule (from fieldname to default)

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Routine Task
Routine Task Coordination Method

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
