### PR TITLE
[ 187665461 I want to restrict same-day changes and permit changes for next day in Roster]

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -893,13 +893,14 @@ function bind_events(page) {
 
 			if ($(this).is(":checked")) {
 				$(this).closest('tr').children("td").children().not("label").each(function (i, v) {
-
+					
 					let [employee, date] = $(v).attr('data-selectid').split('|');
 					classgrt.push($(v).attr('data-selectid'));
 					var r = Date.parse(date)
 					let roster_stop_date = new Date(r);
 					roster_stop_date.setDate(roster_stop_date.getDate() - parseInt(2))
-					if (moment(roster_stop_date).isAfter(moment())) {
+					
+					if (moment(date).isAfter(moment())) {
 						$(v).addClass("selectclass");
 					}
 
@@ -1261,7 +1262,7 @@ function render_roster(res, page, isOt) {
 
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 					</td>`;
 				} else if (post_abbrv && roster_type == 'Over-Time' && !asa && day_off_ot==0) {
@@ -1269,7 +1270,7 @@ function render_roster(res, page, isOt) {
 					j++;
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 					</td>`;
 				} else if(post_abbrv && roster_type == 'Over-Time' && asa && day_off_ot==0){
@@ -1277,7 +1278,7 @@ function render_roster(res, page, isOt) {
 					j++;
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${"<strong>Scheduled:</strong> <br>" + shift + "<br>" + "<strong>Assigned:</strong> <br>" + asa}</span></div>
 					</td>`;
 				}else if(post_abbrv && roster_type == 'Over-Time' && day_off_ot==1){
@@ -1285,7 +1286,7 @@ function render_roster(res, page, isOt) {
 					j++;
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['Day Off OT']} d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['Day Off OT']} d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 					</td>`;
 				}
@@ -1293,7 +1294,7 @@ function render_roster(res, page, isOt) {
 
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so"
 							data-selectid="${employee + "|" + date + "|" + employee_availability}">${leavemap[employee_availability]}</div>
 					</td>`;
 				} else if (attendance && !employee_availability) {
@@ -1310,7 +1311,7 @@ function render_roster(res, page, isOt) {
 
 						sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkblackox d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkblackox d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">EX<span class="customtooltiptext">Exited</span></div>
 					</td>`;
 					}
@@ -1318,7 +1319,7 @@ function render_roster(res, page, isOt) {
 
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
 							data-selectid="${employee + "|" + date}"></div>
 					</td>`;
 					}
@@ -1334,7 +1335,7 @@ function render_roster(res, page, isOt) {
 			 	if ((actual_shift && shift) && (actual_shift!=shift) && day_off_ot==0) {
 									sch = `
 				<td>
-					<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
+					<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
 						data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 				</td>`;
 				}
@@ -1343,7 +1344,7 @@ function render_roster(res, page, isOt) {
 					j++;
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 					</td>`;
 				}
@@ -1352,7 +1353,7 @@ function render_roster(res, page, isOt) {
 					j++;
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${"<strong>Scheduled:</strong> <br>" + shift + "<br>" + "<strong>Assigned:</strong> <br>" + asa}</span></div>
 					</td>`;
 				}else if(post_abbrv && roster_type == 'Basic' && day_off_ot==1){
@@ -1360,7 +1361,7 @@ function render_roster(res, page, isOt) {
 					j++;
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['Day Off OT']} d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['Day Off OT']} d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
 					</td>`;
 				}
@@ -1368,7 +1369,7 @@ function render_roster(res, page, isOt) {
 
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so"
 							data-selectid="${employee + "|" + date + "|" + employee_availability}">${leavemap[employee_availability]}</div>
 					</td>`;
 				} else if (attendance && !employee_availability) {
@@ -1376,7 +1377,7 @@ function render_roster(res, page, isOt) {
 					if(day_off_ot){
 												sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkgreenbox d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkgreenbox d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
 					</td>`;
 					}
@@ -1384,7 +1385,7 @@ function render_roster(res, page, isOt) {
 												if (attendance == 'Present') {
 															sch = `
 						<td>
-							<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
+							<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
 								data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
 						</td>`;
 							j++;
@@ -1401,7 +1402,7 @@ function render_roster(res, page, isOt) {
 						else{
 							sch = `
 						<td>
-							<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
+							<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
 								data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
 						</td>`;
 
@@ -1416,7 +1417,7 @@ function render_roster(res, page, isOt) {
 
 						sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkblackox d-flex justify-content-center align-items-center text-white so customtooltip"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkblackox d-flex justify-content-center align-items-center text-white so customtooltip"
 							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">EX<span class="customtooltiptext">Exited</span></div>
 					</td>`;
 					}
@@ -1424,7 +1425,7 @@ function render_roster(res, page, isOt) {
 
 					sch = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox borderbox d-flex justify-content-center align-items-center so"
 							data-selectid="${employee + "|" + date}"></div>
 					</td>`;
 					}

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -897,8 +897,7 @@ function bind_events(page) {
 					let [employee, date] = $(v).attr('data-selectid').split('|');
 					classgrt.push($(v).attr('data-selectid'));
 					var r = Date.parse(date)
-					let roster_stop_date = new Date(r);
-					roster_stop_date.setDate(roster_stop_date.getDate() - parseInt(2))
+					
 					
 					if (moment(date).isAfter(moment())) {
 						$(v).addClass("selectclass");
@@ -940,8 +939,7 @@ function bind_events(page) {
 
 					let [employee, date] = $(v).attr('data-selectid').split('|');
 					var r = Date.parse(date)
-					let roster_stop_date = new Date(r);
-					roster_stop_date.setDate(roster_stop_date.getDate() - parseInt(2))
+					
 					if (moment(date).isAfter(moment())) {
 						$(v).addClass("selectclass");
 					}
@@ -1254,8 +1252,7 @@ function render_roster(res, page, isOt) {
 			let { employee, employee_name, date, operations_role, post_abbrv, employee_availability, shift, actual_shift, roster_type, attendance, asa, day_off_ot,leave_type,leave_application,relieving_date } = employees_data[employee_key][i];
 			//OT schedule view
 			var r = Date.parse(date)
-			let roster_stop_date = new Date(r);
-			roster_stop_date.setDate(roster_stop_date.getDate() - parseInt(2))
+			
 
 			if (isOt) {
 				if ((actual_shift && shift) && (actual_shift!=shift) && roster_type == 'Over-Time' && day_off_ot==0) {
@@ -1764,7 +1761,7 @@ function get_post_week_data(page) {
 					else {
 						schedule = `
 					<td>
-						<div class="${moment().isBefore(moment(roster_stop_date)) ? 'hoverselectclass' : 'forbidden'} hoverselectclass tablebox darkblackox d-flex justify-content-center align-items-center so"
+						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} hoverselectclass tablebox darkblackox d-flex justify-content-center align-items-center so"
 							data-selectid="${post_name + '_' + start_date.format('YYYY-MM-DD')}"
 							data-date="${start_date.format('YYYY-MM-DD')}"
 							data-post="${post_name}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ google-cloud-vision==3.4.5
 datefinder==0.7.3
 html2text==2020.1.16
 qrcode==7.4.2
+paramiko==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-firestore==2.13.0
 google-cloud-storage==2.11.0
 google-cloud-vision==3.4.5
 datefinder==0.7.3
+html2text==2020.1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mindee==3.11.1
 twilio==9.0.5
 pandas==2.1.2
 deep-translator==1.11.4
+firebase-admin==6.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ bleach-allowlist==1.0.3
 mindee==3.11.1
 twilio==9.0.5
 pandas==2.1.2
+deep-translator==1.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ twilio==9.0.5
 pandas==2.1.2
 deep-translator==1.11.4
 firebase-admin==6.5.0
+google-cloud-core==2.3.3
+google-cloud-firestore==2.13.0
+google-cloud-storage==2.11.0
+google-cloud-vision==3.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ google-cloud-core==2.3.3
 google-cloud-firestore==2.13.0
 google-cloud-storage==2.11.0
 google-cloud-vision==3.4.5
+datefinder==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ google-cloud-storage==2.11.0
 google-cloud-vision==3.4.5
 datefinder==0.7.3
 html2text==2020.1.16
+qrcode==7.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bleach==6.0.0
 bleach-allowlist==1.0.3
 mindee==3.11.1
 twilio==9.0.5
+pandas==2.1.2


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [*] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
I want to restrict same-day changes and permit changes for next day in Roster
so that supervisors make changes 1 day ahead

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated the codebase to allow modifications from the user affect the next day  schedule
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1373" alt="image" src="https://github.com/ONE-F-M/one_fm/assets/38866184/136a7c0c-bbfb-493b-87b9-6ce1feadd4df">


## Areas affected and ensured
List out the areas affected by your code changes.
Roster

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Users will be able to make changes to the roster from the next day

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? NO
    - [] is attachment required? NO
        did you test attachment
## Did you delete custom field? NO
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
