### PR TITLE
chore: added "other" tickets in HD ticket weekly summary report

### DIFF
--- a/one_fm/one_fm/report/hd_ticket_weekly_summary/hd_ticket_weekly_summary.py
+++ b/one_fm/one_fm/report/hd_ticket_weekly_summary/hd_ticket_weekly_summary.py
@@ -27,6 +27,8 @@ def execute(filters=None):
 		"status": "Resolved"
 	})
 
+	other_tickets_count = total_tickets_count - (open_tickets_count + closed_tickets_count + resolved_tickets_count)
+
 	columns = [
 		{
 			"fieldname": "total",
@@ -52,6 +54,12 @@ def execute(filters=None):
 			"label": "Resolved",
 			"width": 200
 		},
+		{
+			"fieldname": "other",
+			"fieldtype": "Data",
+			"label": "Other",
+			"width": 200
+		},
 	]
 	
 	data = [
@@ -60,20 +68,21 @@ def execute(filters=None):
 			"open": open_tickets_count,
 			"closed": closed_tickets_count,
 			"resolved": resolved_tickets_count,
+			"other": other_tickets_count,
 		}
 	]
 
 	chart = {
 		"data": {
-			"labels": ["Open","Closed","Resolved"],
+			"labels": ["Open","Closed","Resolved","Other"],
 			"datasets": [
 				{
 					"name": "HD Ticket Weekly Summary",
-					"values": [open_tickets_count,closed_tickets_count,resolved_tickets_count]
+					"values": [open_tickets_count, closed_tickets_count, resolved_tickets_count, other_tickets_count]
 				}
 			]
 		},
 		"type": "pie",
-    	"colors": ['#FF8C00', '#808080', '#228B22']
+    	"colors": ['#AACCFF', '#4CBB17', '#90EE90', '#FF9933']
 	}
 	return columns, data, None, chart, None


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Statuses other than (Open, Closed and Resolved) are not handled in report

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Add "Others" column in report to manage all other statuses

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2024-06-04 14-42-25](https://github.com/ONE-F-M/one_fm/assets/157605708/32a54925-d0c5-4261-b19d-d2f2434b835e)


## Areas affected and ensured
List out the areas affected by your code changes.
HD Ticket Weekly Summary Report

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
