### PR TITLE
feat: Add DataTable for Client portal

### DIFF
--- a/one_fm/public/js/datatable.js
+++ b/one_fm/public/js/datatable.js
@@ -1,0 +1,3 @@
+import DataTable from "frappe-datatable";
+
+window.DataTable = DataTable;

--- a/one_fm/public/js/web.bundle.js
+++ b/one_fm/public/js/web.bundle.js
@@ -1,0 +1,1 @@
+import "./datatable.js";


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Solution description
Frappe DataTable which is otherwise restricted to desk access imported for use on Client portal. 

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
