### PR TITLE
fix: Send Shift request notification email to approvers

### DIFF
--- a/one_fm/overrides/shift_request.py
+++ b/one_fm/overrides/shift_request.py
@@ -492,6 +492,6 @@ def send_shift_request_mail(doc, method=None):
             )
             msg = frappe.render_template('one_fm/templates/emails/shift_request_notification.html', context=context)
             recipients = [approver.user for approver in doc.custom_shift_approvers]
-            frappe.enqueue(sendemail, recipients=recipients, subject=title, content=msg, at_front=True, is_async=True)
+            sendemail(recipients=recipients, subject=title, content=msg)
         except:
             frappe.log_error(frappe.get_traceback(), "Error while sending shift request notification")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Fix notification sending to all shift request approvers

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data



## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
