### PR TITLE
feat: Roster - show shift start and end time in tooltip. 

### DIFF
--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -157,18 +157,17 @@ class CreateMap():
         #Noticed the trailing comma in a tuple is raising a SQL error, using this conditional to create the fetch query based on the employee
         if len(employees)==1:
             self.schedule_query  = f"""SELECT  es.employee, es.employee_name, es.date, es.operations_role, es.post_abbrv, \
-            es.shift, es.roster_type, es.employee_availability, es.day_off_ot, es.project from `tabEmployee Schedule`es  where \
+            es.shift, es.start_datetime, es.end_datetime, es.roster_type, es.employee_availability, es.day_off_ot, es.project from `tabEmployee Schedule`es  where \
                 es.employee in  ('{employees[0].employee}') and {self.str_filter} order by es.employee """
-            self.attendance_query = f"SELECT at.status, at.leave_type, at.leave_application,  at.attendance_date,at.employee,at.employee_name, at.operations_shift from `tabAttendance`at where at.employee in ('{employees[0].employee}')  and at.attendance_date between '{self.start}' and '{self.end}' and at.docstatus = 1 AND at.roster_type='{self.roster_type}' order by at.employee """
+            self.attendance_query = f"SELECT at.status, at.leave_type, at.leave_application,  at.attendance_date,at.employee,at.employee_name, at.operations_shift, osh.start_time, osh.end_time from `tabAttendance`at left join `tabOperations Shift` osh on at.operations_shift=osh.name where at.employee in ('{employees[0].employee}')  and at.attendance_date between '{self.start}' and '{self.end}' and at.docstatus = 1 AND at.roster_type='{self.roster_type}' order by at.employee """
             self.employee_query = f"SELECT name,employee_id,relieving_date, employee_name,day_off_category,number_of_days_off from `tabEmployee` where name in ('{employees[0].employee}') order by employee_name"
         else:
             self.schedule_query  = f"SELECT  es.employee, es.employee_name, es.date, es.operations_role, es.post_abbrv, \
-                es.shift, es.roster_type, es.employee_availability, es.day_off_ot, es.project from `tabEmployee Schedule`es  where \
+                es.shift,  es.start_datetime, es.end_datetime, es.roster_type, es.employee_availability, es.day_off_ot, es.project from `tabEmployee Schedule`es  where \
                     es.employee in {self.employees} and {self.str_filter}   order by es.employee "
-            self.attendance_query = f"SELECT at.status,at.leave_type,at.leave_application, at.attendance_date,at.employee,at.employee_name, at.operations_shift from `tabAttendance`at where at.employee in {self.employees}  and at.attendance_date between '{self.start}' and '{self.end}' and at.docstatus = 1 AND at.roster_type='{self.roster_type}' order by at.employee "
+            self.attendance_query = f"SELECT at.status,at.leave_type,at.leave_application, at.attendance_date,at.employee,at.employee_name, at.operations_shift, osh.start_time, osh.end_time from `tabAttendance`at  left join `tabOperations Shift` osh on at.operations_shift=osh.name where at.employee in {self.employees}  and at.attendance_date between '{self.start}' and '{self.end}' and at.docstatus = 1 AND at.roster_type='{self.roster_type}' order by at.employee "
 
             self.employee_query = f"SELECT name, employee_id,relieving_date, employee_name,day_off_category,number_of_days_off from `tabEmployee` where name in {self.employees} order by employee_name"
-
 
 
         self.schedule_set = frappe.db.sql(self.schedule_query,as_dict=1) if self.employees else []
@@ -302,7 +301,9 @@ class CreateMap():
                     'day_off_category': self.employee_period_details[row[0]].get('day_off_category'),
                     'number_of_days_off': self.employee_period_details[row[0]].get('number_of_days_off'),
                     'shift': one.operations_shift,
-                    'employee_id': self.employee_period_details[row[0]].get('employee_id')
+                    'employee_id': self.employee_period_details[row[0]].get('employee_id'),
+                    'start_time': one.start_time,
+                    'end_time': one.end_time
                 })
         except Exception as e:
             pass

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1249,10 +1249,13 @@ function render_roster(res, page, isOt) {
 			let sch = ``;
 
 
-			let { employee, employee_name, date, operations_role, post_abbrv, employee_availability, shift, actual_shift, roster_type, attendance, asa, day_off_ot,leave_type,leave_application,relieving_date } = employees_data[employee_key][i];
+			let { employee, employee_name, date, operations_role, post_abbrv, employee_availability, shift, start_datetime, end_datetime, start_time, end_time, actual_shift, roster_type, attendance, asa, day_off_ot,leave_type,leave_application,relieving_date } = employees_data[employee_key][i];
 			//OT schedule view
 			var r = Date.parse(date)
-			
+			let shift_start = moment(start_datetime, "YYYY-MM-DD HH:mm:ss").format("LT");
+			let shift_end = moment(end_datetime, "YYYY-MM-DD HH:mm:ss").format("LT");
+			start_time = moment(start_time, "HH:mm").format("LT");
+			end_time = moment(end_time, "HH:mm").format("LT");
 
 			if (isOt) {
 				if ((actual_shift && shift) && (actual_shift!=shift) && roster_type == 'Over-Time' && day_off_ot==0) {
@@ -1260,7 +1263,7 @@ function render_roster(res, page, isOt) {
 					sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
-							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
+							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}<br>Start: ${shift_start}<br>End: ${shift_end}</span></div>
 					</td>`;
 				} else if (post_abbrv && roster_type == 'Over-Time' && !asa && day_off_ot==0) {
 
@@ -1268,7 +1271,7 @@ function render_roster(res, page, isOt) {
 					sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so customtooltip"
-							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
+							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}<br>Start: ${shift_start}<br>End: ${shift_end}</span></div>
 					</td>`;
 				} else if(post_abbrv && roster_type == 'Over-Time' && asa && day_off_ot==0){
 
@@ -1284,7 +1287,7 @@ function render_roster(res, page, isOt) {
 					sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['Day Off OT']} d-flex justify-content-center align-items-center text-white so customtooltip"
-							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
+							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}<br>Start: ${shift_start}<br>End: ${shift_end}</span></div>
 					</td>`;
 				}
 				else if (employee_availability && !post_abbrv) {
@@ -1300,7 +1303,7 @@ function render_roster(res, page, isOt) {
 					sch = `
 					<td>
 						<div class="forbidden tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
-							data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
+							data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift+`<br>Start: ${start_time}<br>End: ${end_time}`}</span></div>
 					</td>`;
 				} else {
 
@@ -1333,7 +1336,7 @@ function render_roster(res, page, isOt) {
 									sch = `
 				<td>
 					<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['ASA']} d-flex justify-content-center align-items-center text-white so customtooltip"
-						data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
+						data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}<br>Start: ${shift_start}<br>End: ${shift_end}</span></div>
 				</td>`;
 				}
 				else if (post_abbrv && roster_type == 'Basic' && !asa && day_off_ot==0) {
@@ -1342,7 +1345,7 @@ function render_roster(res, page, isOt) {
 					sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap[employee_availability]} d-flex justify-content-center align-items-center text-white so customtooltip"
-							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
+							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}<br>Start: ${shift_start}<br>End: ${shift_end}</span></div>
 					</td>`;
 				}
 				else if(post_abbrv && roster_type == 'Basic' && asa && day_off_ot==0){
@@ -1359,7 +1362,7 @@ function render_roster(res, page, isOt) {
 					sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${classmap['Day Off OT']} d-flex justify-content-center align-items-center text-white so customtooltip"
-							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}</span></div>
+							data-selectid="${employee + "|" + date + "|" + operations_role + "|" + shift + "|" + employee_availability}">${post_abbrv}<span class="customtooltiptext">${shift}<br>Start: ${shift_start}<br>End: ${shift_end}</span></div>
 					</td>`;
 				}
 				else if (employee_availability && !post_abbrv) {
@@ -1375,7 +1378,7 @@ function render_roster(res, page, isOt) {
 												sch = `
 					<td>
 						<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox darkgreenbox d-flex justify-content-center align-items-center text-white so customtooltip"
-							data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
+							data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift+`<br>Start: ${start_time}<br>End: ${end_time}`}</span></div>
 					</td>`;
 					}
 					else{
@@ -1383,7 +1386,7 @@ function render_roster(res, page, isOt) {
 															sch = `
 						<td>
 							<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
-								data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
+								data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift+`<br>Start: ${start_time}<br>End: ${end_time}`}</span></div>
 						</td>`;
 							j++;
 
@@ -1392,7 +1395,7 @@ function render_roster(res, page, isOt) {
 														sch = `
 						<td>
 							<div class="forbidden tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
-								data-selectid="${employee + "|" + date + "|" + attendance}">${leavemap[leave_type]?leavemap[leave_type]:'LV'}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
+								data-selectid="${employee + "|" + date + "|" + attendance}">${leavemap[leave_type]?leavemap[leave_type]:'LV'}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift +`<br>Start: ${start_time}<br>End: ${end_time}`}</span></div>
 						</td>`;
 
 						}
@@ -1400,7 +1403,7 @@ function render_roster(res, page, isOt) {
 							sch = `
 						<td>
 							<div class="${moment().isBefore(moment(date)) ? 'hoverselectclass' : 'forbidden'} tablebox ${attendancemap[attendance]} d-flex justify-content-center align-items-center text-white so customtooltip"
-								data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift}</span></div>
+								data-selectid="${employee + "|" + date + "|" + attendance}">${attendance_abbr_map[attendance]}<span class="customtooltiptext">${leave_application ? leave_application+'|'+leave_type : shift +`<br>Start: ${start_time}<br>End: ${end_time}`}</span></div>
 						</td>`;
 
 						}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Show shift start and end times in Roster view

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Shift : 
<img width="157" alt="Shift" src="https://github.com/user-attachments/assets/212645e1-e17d-4fcc-9b36-84f8ea0de212">
Absent: 
<img width="134" alt="Absent" src="https://github.com/user-attachments/assets/f2aa6d0f-17f9-4bdd-859c-0ead390da4da">
On hold: 
<img width="149" alt="oh hold" src="https://github.com/user-attachments/assets/0d55e625-ebd0-46f0-8e0c-e7d96c49614f">




## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
