### PR TITLE
feat: Add On-Hold attendance employees to Missing payroll information doctype for review

### DIFF
--- a/one_fm/overrides/payroll_entry.py
+++ b/one_fm/overrides/payroll_entry.py
@@ -48,7 +48,6 @@ class PayrollEntryOverride(PayrollEntry):
 		# Custom method to fetch Bank Details and update employee list
 		set_bank_details(self, employees)
 
-
 		self.set("employees", employees)
 		self.number_of_employees = len(self.employees)
 
@@ -77,7 +76,8 @@ class PayrollEntryOverride(PayrollEntry):
 			project=project,
 			custom_payroll_cycle_start_date=getdate(self.start_date).day,
 			custom_payroll_cycle_end_date=getdate(self.end_date).day,
-			payroll_type=self.payroll_type
+			payroll_type=self.payroll_type,
+			payroll_entry=self.name
 		)
 
 		if not self.salary_slip_based_on_timesheet:
@@ -91,7 +91,7 @@ def get_start_end_dates(payroll_frequency, start_date=None, company=None):
 	start_date, end_date = None, None
 	if payroll_frequency == "Monthly":
 		#fetch Payroll date's day
-		date = frappe.db.get_single_value('HR and Payroll Additional Settings', 'payroll_date')
+		date = frappe.db.get_single_value("HR and Payroll Additional Settings", "payroll_date")
 		year = getdate().year - 1 if getdate().day < cint(date) and  getdate().month == 1 else getdate().year
 		month = getdate().month if getdate().day >= cint(date) else getdate().month - 1
 
@@ -124,6 +124,18 @@ def get_employee_list(
 		return []
 
 	emp_list = get_filtered_employees(
+		sal_struct,
+		filters,
+		searchfield,
+		search_string,
+		fields,
+		as_dict=as_dict,
+		limit=limit,
+		offset=offset,
+		ignore_match_conditions=ignore_match_conditions,
+	)
+
+	set_on_hold_employees(
 		sal_struct,
 		filters,
 		searchfield,
@@ -229,7 +241,6 @@ def set_filter_conditions(query, filters, qb_object):
 	return query
 
 
-@frappe.whitelist()
 def set_bank_details(self, employee_details):
 	"""This Funtion Sets the bank Details of an employee. The data is fetched from Bank Account Doctype.
 
@@ -240,22 +251,11 @@ def set_bank_details(self, employee_details):
 		employee_details ([dict): Sets the bank account IBAN code and Bank Code.
 	"""
 	employee_missing_detail = []
-	# missing_ssa = []
-	# employee_list = ', '.join(['"{}"'.format(employee.employee) for employee in employee_details])
-	# if employee_list:
-	# 	missing_ssa = frappe.db.sql("""
-	# 		SELECT employee from `tabEmployee` E
-	# 		WHERE E.status = 'Active'
-	# 		AND E.employment_type != 'Subcontractor'
-	# 		AND E.name NOT IN (
-	# 			SELECT employee from `tabSalary Structure Assignment` SE
-	# 		)
-	# 		""".format(employee_list), as_dict=True)
 
 	for employee in employee_details:
 		try:
 			bank_account = frappe.db.get_value("Bank Account",{"party":employee.employee},["iban","bank", "bank_account_no"])
-			salary_mode = frappe.db.get_value("Employee", {'name': employee.employee}, ["salary_mode"])
+			salary_mode = frappe.db.get_value("Employee", {"name": employee.employee}, ["salary_mode"])
 			if bank_account:
 				iban, bank, bank_account_no = bank_account
 			else:
@@ -263,63 +263,152 @@ def set_bank_details(self, employee_details):
 
 			if not salary_mode:
 				employee_missing_detail.append(frappe._dict(
-				{'employee':employee.employee, 'salary_mode':'', 'issue':'No salary mode'}))
-			elif(salary_mode=='Bank' and bank is None):
+				{"employee":employee.employee, "salary_mode":"", "issue":"No salary mode"}))
+			elif(salary_mode=="Bank" and bank is None):
 				employee_missing_detail.append(frappe._dict(
-					{'employee':employee.employee, 'salary_mode':salary_mode, 'issue':'No bank account'}))
+					{"employee":employee.employee, "salary_mode":salary_mode, "issue":"No bank account"}))
 			elif(salary_mode=="Bank" and bank_account_no is None):
 				employee_missing_detail.append(frappe._dict(
-					{'employee':employee.employee, 'salary_mode':salary_mode, 'issue':'No account no.'}))
+					{"employee":employee.employee, "salary_mode":salary_mode, "issue":"No account no."}))
 			employee.salary_mode = salary_mode
 			employee.iban_number = iban or bank_account_no
-			bank_code = frappe.db.get_value("Bank", {'name': bank}, ["bank_code"])
+			bank_code = frappe.db.get_value("Bank", {"name": bank}, ["bank_code"])
 			employee.bank_code = bank_code
 		except Exception as e:
-			frappe.log_error(str(e), 'Payroll Entry')
+			frappe.log_error(str(e), "Payroll Entry")
 			frappe.throw(str(e))
-
-	# if len(missing_ssa) > 0:
-	# 	for e in missing_ssa:
-	# 		employee_missing_detail.append(frappe._dict(
-	# 			{'employee':e.employee, 'salary_mode':'', 'issue':'No Salary Structure Assignment'}))
 
 	# check for missing details, log and report
 	if len(employee_missing_detail) > 0:
 		missing_detail = []
 		for i in employee_missing_detail:
 			missing_detail.append({
-				'employee':i.employee,
-				'salary_mode':i.salary_mode,
-				'issue': i.issue
+				"employee":i.employee,
+				"salary_mode":i.salary_mode,
+				"issue": i.issue
 			})
 
-		mpi_exists = frappe.db.exists("Missing Payroll Information",{'payroll_entry': self.name})
+		mpi_exists = frappe.db.exists("Missing Payroll Information",{"payroll_entry": self.name})
 		
 		if mpi_exists:
-			mpi = frappe.get_doc('Missing Payroll Information', mpi_exists)
+			mpi = frappe.get_doc("Missing Payroll Information", mpi_exists)
 
 			# delete previous table data
-			frappe.db.sql(f"""
-				DELETE FROM `tabMissing Payroll Information Detail`
-				WHERE parent="{mpi.name}"
-			;""")
-			mpi.reload()
+			# frappe.db.sql(f"""
+			# 	DELETE FROM `tabMissing Payroll Information Detail`
+			# 	WHERE parent="{mpi.name}"
+			# ;""")
+			# mpi.reload()
 			for i in missing_detail:
-				mpi.append('missing_payroll_information_detail', i)
+				mpi.append("missing_payroll_information_detail", i)
 			mpi.save(ignore_permissions=True)
 			frappe.db.commit()
 		else:
 			mpi = frappe.get_doc({
-				'doctype':"Missing Payroll Information",
-				'payroll_entry': self.name,
-				'missing_payroll_information_detail':missing_detail
+				"doctype":"Missing Payroll Information",
+				"payroll_entry": self.name,
+				"missing_payroll_information_detail":missing_detail
 			}).insert(ignore_permissions=True)
 			frappe.db.commit()
 
 		# generate html template to show to user screen
 		message = frappe.render_template(
-			'one_fm/api/doc_methods/templates/payroll/bank_issue.html',
-			context={'employees':employee_missing_detail, 'mpi':mpi}
+			"one_fm/api/doc_methods/templates/payroll/bank_issue.html",
+			context={"employees":employee_missing_detail, "mpi":mpi}
 		)
 		frappe.throw(_(message))
 	return employee_details
+
+
+@frappe.whitelist()
+def set_on_hold_employees(
+	sal_struct,
+	filters,
+	searchfield=None,
+	search_string=None,
+	fields=None,
+	as_dict=False,
+	limit=None,
+	offset=None,
+	ignore_match_conditions=False,
+) -> list:
+	SalaryStructureAssignment = frappe.qb.DocType("Salary Structure Assignment")
+	Employee = frappe.qb.DocType("Employee")
+	Attendance = frappe.qb.DocType("Attendance")
+
+	attendance_sub_query = None
+	if filters.payroll_type == "Basic":
+		attendance_sub_query = Employee.employee.isin(
+			frappe.qb.from_(Attendance)
+			.select(Attendance.employee)
+			.where(
+				(Attendance.attendance_date[filters.start_date:filters.end_date])
+				& (Attendance.status == "On Hold")
+				& (Attendance.roster_type == filters.payroll_type)
+			)
+		)
+	elif filters.payroll_type == "Over-Time":
+		attendance_sub_query = Employee.employee.isin(
+			frappe.qb.from_(Attendance)
+			.select(Attendance.employee)
+			.where(
+				(Attendance.attendance_date[filters.start_date:filters.end_date])
+				& (Attendance.status == "On Hold")
+				& (Attendance.roster_type == filters.payroll_type)
+			)
+		)
+
+	query = (
+	frappe.qb.from_(Employee)
+	.join(SalaryStructureAssignment)
+	.on(Employee.name == SalaryStructureAssignment.employee)
+	.where(
+		(SalaryStructureAssignment.docstatus == 1)
+		& (Employee.status.isin(["Active", "Vacation"]))
+		& (Employee.company == filters.company)
+		& ((Employee.date_of_joining <= filters.end_date) | (Employee.date_of_joining.isnull()))
+		& ((Employee.relieving_date >= filters.start_date) | (Employee.relieving_date.isnull()))
+		& (SalaryStructureAssignment.salary_structure.isin(sal_struct))
+		& (SalaryStructureAssignment.payroll_payable_account == filters.payroll_payable_account)
+		& (filters.end_date >= SalaryStructureAssignment.from_date)
+		& (attendance_sub_query)
+	))
+
+	query = set_fields_to_select(query, fields)
+	query = set_searchfield(query, searchfield, search_string, qb_object=Employee)
+	query = set_filter_conditions(query, filters, qb_object=Employee)
+
+	if not ignore_match_conditions:
+		query = set_match_conditions(query=query, qb_object=Employee)
+
+	if limit:
+		query = query.limit(limit)
+
+	if offset:
+		query = query.offset(offset)
+
+	employees = query.run(as_dict=as_dict)
+	mpi_exists = frappe.db.exists("Missing Payroll Information", { "payroll_entry": filters.payroll_entry})
+	
+	missing_payroll_info = []
+	for employee in employees:
+		missing_payroll_info.append({
+			"employee": employee.employee,
+			"salary_mode": "N/A",
+			"issue": "On-Hold attendance records"
+		})
+
+	if mpi_exists:
+		mpi = frappe.get_doc("Missing Payroll Information", mpi_exists)
+		for info in missing_payroll_info:
+			mpi.append("missing_payroll_information_detail", info)
+		mpi.save(ignore_permissions=True)
+
+	else:
+		mpi = frappe.get_doc({
+			"doctype":"Missing Payroll Information",
+			"payroll_entry": filters.payroll_entry,
+			"missing_payroll_information_detail": missing_payroll_info
+		}).insert(ignore_permissions=True)
+	
+	frappe.db.commit()

--- a/one_fm/overrides/payroll_entry.py
+++ b/one_fm/overrides/payroll_entry.py
@@ -336,27 +336,15 @@ def set_on_hold_employees(
 	Employee = frappe.qb.DocType("Employee")
 	Attendance = frappe.qb.DocType("Attendance")
 
-	attendance_sub_query = None
-	if filters.payroll_type == "Basic":
-		attendance_sub_query = Employee.employee.isin(
-			frappe.qb.from_(Attendance)
-			.select(Attendance.employee)
-			.where(
-				(Attendance.attendance_date[filters.start_date:filters.end_date])
-				& (Attendance.status == "On Hold")
-				& (Attendance.roster_type == filters.payroll_type)
-			)
+	attendance_sub_query = Employee.employee.isin(
+		frappe.qb.from_(Attendance)
+		.select(Attendance.employee)
+		.where(
+			(Attendance.attendance_date[filters.start_date:filters.end_date])
+			& (Attendance.status == "On Hold")
+			& (Attendance.roster_type == filters.payroll_type)
 		)
-	elif filters.payroll_type == "Over-Time":
-		attendance_sub_query = Employee.employee.isin(
-			frappe.qb.from_(Attendance)
-			.select(Attendance.employee)
-			.where(
-				(Attendance.attendance_date[filters.start_date:filters.end_date])
-				& (Attendance.status == "On Hold")
-				& (Attendance.roster_type == filters.payroll_type)
-			)
-		)
+	)
 
 	query = (
 	frappe.qb.from_(Employee)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Add employees which match the filters selected and have "On-Hold" attendance during the selected payroll cycle to Missing Payroll Information doctype so that the person processing the payroll can review it. 

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![image](https://github.com/user-attachments/assets/ec9840c2-0717-48f3-872a-5df14172fdf9)


## Areas affected and ensured
> one_fm/overrides/payroll_entry.py


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
