### PR TITLE
chore: merged shift request controller methods in override

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -392,12 +392,12 @@ doc_events = {
 		"before_insert": "one_fm.api.doc_methods.help_article.before_insert",
 		# "on_update": "one_fm.api.doc_methods.help_article.on_update",
 	},
-	"Shift Request":{
-		"before_save":[
-			"one_fm.overrides.shift_request.fill_to_date",
-			"one_fm.overrides.shift_request.send_shift_request_mail",
-			"one_fm.overrides.shift_request.validate_from_date"
-		],
+	# "Shift Request":{
+		# "before_save":[
+		# 	"one_fm.overrides.shift_request.fill_to_date",
+		# 	"one_fm.overrides.shift_request.send_shift_request_mail",
+		# 	"one_fm.overrides.shift_request.validate_from_date"
+		# ],
 		# "on_update_after_submit":[
 			# "one_fm.overrides.shift_request.on_update_after_submit",
 		# ],
@@ -409,7 +409,7 @@ doc_events = {
         #     "one_fm.overrides.shift_request.validate",
         # ]
 
-	},
+	# },
 	"Customer": {
 		"on_update":"one_fm.tasks.erpnext.customer.on_update",
 	},

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -401,13 +401,13 @@ doc_events = {
 		# "on_update_after_submit":[
 			# "one_fm.overrides.shift_request.on_update_after_submit",
 		# ],
-		"on_update": [
-            "one_fm.overrides.shift_request.on_update",
-        	# "one_fm.overrides.shift_request.process_shift_assignemnt",
-		],
-        "validate": [
-            "one_fm.overrides.shift_request.validate",
-        ]
+		# "on_update": [
+        #     "one_fm.overrides.shift_request.on_update",
+        # 	"one_fm.overrides.shift_request.process_shift_assignemnt",
+		# ],
+        # "validate": [
+        #     "one_fm.overrides.shift_request.validate",
+        # ]
 
 	},
 	"Customer": {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug

## Clearly and concisely describe the feature, chore or bug.
Controller methods are used twice in Shift Request

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Moved three controller methods (validate, before_save, on_update) from hooks to Shift Request override

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Shift Request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
