### PR TITLE
[BUG Extend default timeout for google sheets and update algorithm for calculating sheet range]

### DIFF
--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -3,7 +3,8 @@
 from __future__ import print_function
 
 import os.path
-
+from httplib2 import Http
+from google_auth_httplib2 import AuthorizedHttp
 import csv
 import os
 import re
@@ -113,10 +114,10 @@ class DataExporter:
 		SCOPES = ["https://www.googleapis.com/auth/spreadsheets","https://www.googleapis.com/auth/drive.file", "https://www.googleapis.com/auth/drive"]
 
 		credentials = service_account.Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
-
-		service = discovery.build('sheets', 'v4', credentials=credentials)
+		http = Http(timeout=1200)
+		authorized_http = AuthorizedHttp(credentials, http=http)
+		service = build('sheets', 'v4', http=authorized_http)
 		drive_api = build('drive', 'v3', credentials=credentials)
-		
 		return {"credentials":credentials, "service": service, "drive_api": drive_api}
 
 	def prepare_args(self):
@@ -457,6 +458,7 @@ class DataExporter:
 		Prints values from a sample spreadsheet.
 		"""
 		service = self.service
+		# service = self.service
 		try:
 			no_of_row = len(values)
 			no_of_col = len(self.column)

--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -482,7 +482,6 @@ class DataExporter:
 			return result
 		except HttpError as err:
 			frappe.log_error(title="Error Updating Google Sheet",message = err)
-			frappe.db.commit()	
 			frappe.throw("Error updating google sheet.See error log for more details")
 
 

--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -462,12 +462,8 @@ class DataExporter:
 		try:
 			no_of_row = len(values)
 			no_of_col = len(self.column)
-			if no_of_col <= 26:
-				ranges = self.sheet_name + "!A1:" + chr(ord('A') + no_of_col) + str(no_of_row)
-				ranges_ = self.sheet_name+ "!A1:" + get_column_identifier(no_of_col+1)+ str(no_of_row)
-			else:
-				ranges = self.sheet_name + "!A1:A" + chr(ord('A') + no_of_col - 26) + str(no_of_row)
-				ranges_ = self.sheet_name+ "!A1:" + get_column_identifier(no_of_col+1)+ str(no_of_row)
+			ranges = self.sheet_name+ "!A1:" + get_column_identifier(no_of_col+1)+ str(no_of_row)
+			
 
 			# clear sheet
 			
@@ -476,7 +472,7 @@ class DataExporter:
 
 			# add new value
 			result = service.spreadsheets().values().update(
-						spreadsheetId=self.google_sheet_id, range=ranges_,valueInputOption="USER_ENTERED", body={"values":values}).execute()
+						spreadsheetId=self.google_sheet_id, range=ranges,valueInputOption="USER_ENTERED", body={"values":values}).execute()
 
 			
 			# request = service.spreadsheets().values().get(spreadsheetId=SAMPLE_SPREADSHEET_ID, range="Country!A1:B22").execute()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ deep-translator==1.11.4
 firebase-admin==6.5.0
 google-cloud-core==2.3.3
 google-cloud-firestore==2.13.0
+google-auth==2.34.0
 google-cloud-storage==2.11.0
 google-cloud-vision==3.4.5
 datefinder==0.7.3


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
Google Sheets exporter encounters timeout issues when being uploading large datasets and fails to calculate the correct range for sheets with columns over 53

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated the codebase with a 20 minute timeout and updated the codebase to correctly calculate the sheet range
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

Exported the Todo doctype to this sheet
https://docs.google.com/spreadsheets/d/1I7l5Mj9F2QuyArCXLdIuzuCpbEyOz3GltpeP2xjcx_c/edit?gid=1188292813#gid=1188292813 


## Areas affected and ensured
List out the areas affected by your code changes.
Google Sheets export

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? No
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
