### PR TITLE
fix: Shift Request fixes for attendance branch

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -393,6 +393,19 @@ doc_events = {
 		"before_insert": "one_fm.api.doc_methods.help_article.before_insert",
 		# "on_update": "one_fm.api.doc_methods.help_article.on_update",
 	},
+    "Shift Request":{
+        "before_save":[
+            "one_fm.overrides.shift_request.fill_to_date",
+            "one_fm.overrides.shift_request.send_shift_request_mail",
+            "one_fm.overrides.shift_request.validate_from_date"
+        ],
+        "on_update": [
+            "one_fm.overrides.shift_request.on_update",
+        ],
+        "validate": [
+            "one_fm.overrides.shift_request.validate",
+        ]
+    },
 	"Customer": {
 		"on_update":"one_fm.tasks.erpnext.customer.on_update",
 	},

--- a/one_fm/overrides/shift_request.py
+++ b/one_fm/overrides/shift_request.py
@@ -20,41 +20,15 @@ class OverlappingShiftError(frappe.ValidationError):
     pass
 
 class ShiftRequestOverride(ShiftRequest):
-    def validate(self):
-        # ensure status is not pending
-        if self.is_new():
-            self.status='Draft'
-        if self.status=='Pending Approval':
-            self.status == 'Draft'
-
-        process_shift_assignemnt(self) # set shift assignment and employee schedule
-
     def on_submit(self):
         if self.workflow_state != 'Update Request':
             self.db_set("status", self.workflow_state) if self.workflow_state!='Pending Approval' else self.db_set("status", 'Draft')
 
-    def before_save(self):
-        # Fill 'To' date if not set
-        if not self.to_date:
-            self.to_date = self.from_date
-
-        # Validate 'From' date
-        if not self.purpose == "Assign Day Off":
-            if getdate(today()) > getdate(self.from_date):
-                frappe.throw('From Date cannot be before today.')
-        
-        send_shift_request_mail(self)
 
     def on_update(self):
         for approver in self.custom_shift_approvers:
             share_doc_with_approver(self, approver.user)
 
-        if self.workflow_state in ['Approved', 'Rejected']:
-            workflow_approve_reject(self, [get_employee_user_id(self.employee)])
-
-        if self.workflow_state == 'Draft':
-            send_workflow_action_email(self,[approver.user for approver in self.custom_shift_approvers])
-            validate_shift_overlap(self)
 
     def validate_approver(self):
         if not self.is_new() and self.workflow_state == "Approved":
@@ -683,9 +657,9 @@ def fill_to_date(doc, method):
 
 
 def validate_from_date(doc, method):
-    if doc.purpose != 'Assign Day Off' and not (frappe.session.user == get_employee_user_id(
-            frappe.db.get_single_value("ONEFM General Setting", "attendance_manager"))):
-        if getdate(today()) > getdate(doc.from_date):
+    if getdate(today()) > getdate(doc.from_date):
+        attendance_manager = get_employee_user_id(frappe.db.get_single_value("ONEFM General Setting", "attendance_manager"))
+        if doc.purpose != 'Assign Day Off' or frappe.session.user != attendance_manager:
             message = "Please note that Shift Requests cannot be created for a past date." if doc.is_new() else "Please note that Shift Requests cannot be updated to a past date."
             frappe.throw(
                 _(message),
@@ -873,7 +847,7 @@ def daterange(start_date, end_date):
         yield start_date + datetime.timedelta(n)
 
 
-def send_shift_request_mail(doc):
+def send_shift_request_mail(doc, method):
     if doc.workflow_state == 'Pending Approval':
         try:
             title = f"Urgent Notification: {doc.doctype} Requires Your Immediate Review"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
1. If session user is Attendance Manager and they select any other purpose than Assign Day Off, shift request is not getting created.
2. Attendance Manager can only update if purpose is Assign Day Off. Cannot update a shift request for a past date with any other purpose.
3. Error message needs to be changed as per lucidchart.
Title: Invalid Start Date 
Message: Please note that Shift Requests cannot be created for a past date.


## Solution description
Reverted shift request code refactor done recently on staging.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
