### PR TITLE
fix: Send notification to Approver in case Shift request is still open

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -2130,7 +2130,7 @@ def notify_approver_about_pending_shift_request(is_scheduled_event=True):
 												LEFT JOIN `tabOperations Shift` os ON sr.operations_shift = os.name
 									   			LEFT JOIN `tabShift Request Approvers` ap ON sr.name = ap.parent
 												WHERE sr.workflow_state = 'Pending Approver'
-									   			AND ap.parentfield="shift_request_approver"
+									   			AND ap.parentfield="custom_shift_approvers"
 												AND sr.from_date = %s 
 												AND os.start_time BETWEEN %s AND %s
 											""", (date_time.date(), date_time.time(), one_hour.time()), as_dict=1)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Send notification to Approver in case Shift request is still open 1 hour before the start of the shift

## Solution description
Wrong parentfield was being validated


## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
