### PR TITLE
BUG: SHIFT REQUEST DAY OFF OT, SHIFT ASSIGNMENT NOT GETTING CREATED

### DIFF
--- a/one_fm/overrides/shift_assignment.py
+++ b/one_fm/overrides/shift_assignment.py
@@ -108,7 +108,7 @@ def has_overlapping_timings(self) -> bool:
     """
     Accepts two shift types and checks whether their timings are overlapping
     """
-    if datetime.strptime(str(self.start_datetime), '%Y-%m-%d %H:%M:%S').date()>datetime.strptime(today(), '%Y-%m-%d').date():
+    if datetime.strptime(str(self.start_datetime), '%Y-%m-%d %H:%M:%S').date() > datetime.strptime(today(), '%Y-%m-%d').date():
         frappe.throw(f"Shift cannot be created for date greater than today. Today is {today()}, you requested {self.start_date}")
 
     existing_shift = frappe.db.sql(f"""

--- a/one_fm/overrides/shift_request.py
+++ b/one_fm/overrides/shift_request.py
@@ -526,6 +526,8 @@ def create_shift_assignment_from_request(shift_request, submit=True,day_off_ot =
     assignment_doc.check_in_site = shift_request.check_in_site
     assignment_doc.check_out_site = shift_request.check_out_site
     assignment_doc.custom_day_off_ot = 1 if day_off_ot else 0
+    if day_off_ot:
+        assignment_doc.flags.ignore_validate = True
     if shift_request.operations_role:
         assignment_doc.operations_role = shift_request.operations_role
     


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Shift assignments not getting created, after approval of day off OT

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a block to exempt day off shift request , from the validation

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Shift assignment
shift request

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
