### PR TITLE
[BUG Validate employee date of joining while creating the roster]

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -441,7 +441,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
                     employees = new_employees.copy()
 
     # # get and structure employee dictionary for easy hashing
-    employees_list = frappe.db.get_list("Employee", filters={'employee': ['IN', employee_list]}, fields=['name', 'employee_name', 'department'], ignore_permissions=True)
+    employees_list = frappe.db.get_list("Employee", filters={'employee': ['IN', employee_list]}, fields=['name', 'employee_name', 'department','date_of_joining'], ignore_permissions=True)
     employees_dict = {}
     for i in employees_list:
         employees_dict[i.name] = i
@@ -453,11 +453,12 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
         next_day = True
     employees_date_dict = {}
     for i in employees:
-        if employees_date_dict.get(i['employee']):
-            employees_date_dict[i['employee']].append({'date':i['date'],
-                'start_datetime': datetime.strptime(f"{i['date']} {shift_start}", '%Y-%m-%d %H:%M:%S'), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end}", '%Y-%m-%d %H:%M:%S')})
-        else:
-            employees_date_dict[i['employee']] =[{'date':i['date'], 'start_datetime': datetime.strptime(f"{i['date']} {shift_start}", '%Y-%m-%d %H:%M:%S'), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end}", '%Y-%m-%d %H:%M:%S')}]
+        if getdate(employees_dict.get(i.get('employee')).get('date_of_joining')) <= getdate(i.get('date')):
+            if employees_date_dict.get(i['employee']):
+                employees_date_dict[i['employee']].append({'date':i['date'],
+                    'start_datetime': datetime.strptime(f"{i['date']} {shift_start}", '%Y-%m-%d %H:%M:%S'), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end}", '%Y-%m-%d %H:%M:%S')})
+            else:
+                employees_date_dict[i['employee']] =[{'date':i['date'], 'start_datetime': datetime.strptime(f"{i['date']} {shift_start}", '%Y-%m-%d %H:%M:%S'), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end}", '%Y-%m-%d %H:%M:%S')}]
 
     # check for intersection schedules
     error_msg = """"""


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
Validate the employee date of joining while creating employee schedules, So that a schedule is not created for a date before 
the employee joined
## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Validate the employee date of joining while creating employee schedules, So that a schedule is not created for a date before 
the employee joined
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Employee Schedules will not be created for dates before the date of joining

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? No
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
