### PR TITLE
chore: mark site and supervisor field as mandatory depending on project type in MOM

### DIFF
--- a/one_fm/operations/doctype/mom/mom.json
+++ b/one_fm/operations/doctype/mom/mom.json
@@ -42,6 +42,7 @@
    "fieldtype": "Link",
    "hidden": 1,
    "label": "Site",
+   "mandatory_depends_on": "eval:doc.project_type == 'External'",
    "options": "Operations Site"
   },
   {
@@ -199,6 +200,7 @@
    "fieldname": "supervisor",
    "fieldtype": "Link",
    "label": "Supervisor",
+   "mandatory_depends_on": "eval:doc.project_type == 'External'",
    "options": "Employee"
   },
   {
@@ -216,7 +218,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-30 14:17:34.273265",
+ "modified": "2024-10-01 12:49:10.048427",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "MOM",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As General Manager
I want the site and supervisor fields mandatory on the MOM form if Project Type is external
so that the values are always set.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Marked site and supervisor as mandatory when project type is 'External'

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
MOM

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
