### PR TITLE
fix: Limit daily annual earned leave to 3 precision points

### DIFF
--- a/one_fm/overrides/leave_allocation.py
+++ b/one_fm/overrides/leave_allocation.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.utils import getdate
+from frappe.utils import getdate, rounded
 from frappe import _
 from hrms.hr.doctype.leave_allocation.leave_allocation import LeaveAllocation
 
@@ -24,6 +24,7 @@ def get_annual_leave_allocation(from_date, leave_policy_assignment, employee):
     annual_leave_allocation = frappe.get_value("Leave Policy Detail", {"parent": leave_policy, "leave_type": "Annual Leave"}, "annual_allocation")
 
     days_passed = getdate() - getdate(from_date)
+    daily_earned_allocation = rounded((annual_leave_allocation / 365), precision=3)
+    calculated_leave_allocation =  daily_earned_allocation * days_passed.days
 
-    calculated_leave_allocation = (annual_leave_allocation / 365) * days_passed.days
     return calculated_leave_allocation


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Limit daily earned leave to 3 precision points
Daily earned leave = (30 days earned in a year / 365 days)

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
