### PR TITLE
hajj check changes

### DIFF
--- a/one_fm/fixtures/doctype_layout.json
+++ b/one_fm/fixtures/doctype_layout.json
@@ -741,13 +741,6 @@
     "parenttype": "DocType Layout"
    },
    {
-    "fieldname": "went_to_hajj",
-    "label": "Went to Hajj",
-    "parent": "Employee",
-    "parentfield": "fields",
-    "parenttype": "DocType Layout"
-   },
-   {
     "fieldname": "leave_policy",
     "label": "Leave Policy",
     "parent": "Employee",
@@ -1009,6 +1002,13 @@
    {
     "fieldname": "one_fm_religion",
     "label": "Religion",
+    "parent": "Employee",
+    "parentfield": "fields",
+    "parenttype": "DocType Layout"
+   },
+   {
+    "fieldname": "went_to_hajj",
+    "label": "Went to Hajj",
     "parent": "Employee",
     "parentfield": "fields",
     "parenttype": "DocType Layout"

--- a/one_fm/overrides/leave_allocation.py
+++ b/one_fm/overrides/leave_allocation.py
@@ -15,7 +15,6 @@ class LeaveAllocationOverride(LeaveAllocation):
             frappe.throw("Maternity Leave allocation is only allowed for female workers.")
 
     def validate_hajj_leave(self):
-        print("samdaniii")
         employee_info = frappe.db.get_value("Employee", self.employee, ["one_fm_religion", "went_to_hajj"], as_dict=True)
         religion = employee_info.get("one_fm_religion")
         went_to_hajj = employee_info.get("went_to_hajj")

--- a/one_fm/overrides/leave_allocation.py
+++ b/one_fm/overrides/leave_allocation.py
@@ -7,11 +7,21 @@ class LeaveAllocationOverride(LeaveAllocation):
     def validate(self):
         super().validate()
         self.validate_employee_gender()
+        self.validate_hajj_leave()
     
     def validate_employee_gender(self):
         gender  = frappe.db.get_value("Employee", self.employee, "gender")
         if gender == "Male" and self.leave_type == "Maternity Leave":
             frappe.throw("Maternity Leave allocation is only allowed for female workers.")
+
+    def validate_hajj_leave(self):
+        print("samdaniii")
+        employee_info = frappe.db.get_value("Employee", self.employee, ["one_fm_religion", "went_to_hajj"], as_dict=True)
+        religion = employee_info.get("one_fm_religion")
+        went_to_hajj = employee_info.get("went_to_hajj")
+        if religion != "Muslim" or (religion == "Muslim" and went_to_hajj  == True):
+            frappe.throw("Hajj Leave allocation is only allowed for a muslim staff Who has not performed Hajj before.")
+
 
 
 @frappe.whitelist()

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -49,6 +49,10 @@ frappe.ui.form.on('Employee', {
 	onload: function(frm) {
         frm.trigger('mandatory_reports_to');
 		is_employee_master(frm);
+		frm.trigger('check_religion_for_hajj');
+    },
+	one_fm_religion: function(frm) {
+        frm.trigger('check_religion_for_hajj');
     },
 	designation: function(frm) {
 		frm.trigger('mandatory_reports_to');
@@ -63,6 +67,15 @@ frappe.ui.form.on('Employee', {
             frm.set_df_property("reports_to", "reqd", 1);
         }
 	},
+	check_religion_for_hajj: function(frm) {
+        var religion = frm.doc.one_fm_religion;
+        if (religion === "Muslim") {
+            frm.set_df_property('went_to_hajj', 'read_only', 0);
+        } else {
+            frm.set_df_property('went_to_hajj', 'read_only', 1);
+            frm.set_value('went_to_hajj', 0);
+        }
+    },
 	under_company_residency: function(frm){
 		if(frm.doc.employee_id){
 			update_employee_id_based_on_residency(frm);


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- Story


## Clearly and concisely describe the feature, chore or bug.
          [] I want to allocate Hajj leave only to Muslim staff members who have not performed Hajj before so that unqualified employees are not allocated Hajj leave
        
        Acceptance Criteria
        Given that a leave allocation is being created or edited and the leave type is "Hajj Leave"
        when the user clicks save
        then the system validates that the Employee is a muslim who has not performed Hajj. If these 2 conditions are not met, a message is shown and the process is aborted
        
        Notes:
        -Hajj Leave allocation is only allowed for a muslim staff Who has not performed Hajj before.
        -[Religion] and [Went to Hajj] are fields in the Employee doctype
        
        Consider moving [Went to Hajj] to "Personal" tab, after Religion and it should only be editable if [Religion] is set as "Muslim" (Depends on: eval: Religion == "Muslim").


## Analysis and design (optional)
[Analyse and attach the design documentation
](https://lucid.app/lucidchart/37a0e91b-1f10-40d0-bb6c-e7126f57eb57/edit?page=2tkbzzr9QS2v#)


## Solution description
---  Code changes in employee.js file of docstype.js ,added a check to religion if muslim to enable the went to hajj checkbox else to disable it .
--- Code changes in leave_allocation.py file for checking if religion is muslim to allocate the leave for that specific employee

## Is there a business logic within a doctype?
    - [] No


## Output screenshots (optional)
<img width="427" alt="Screenshot 2024-10-14 at 11 21 27 AM" src="https://github.com/user-attachments/assets/d4b5f02e-595e-4c29-a9ef-e126b50ad138">
<img width="531" alt="Screenshot 2024-10-14 at 11 21 39 AM" src="https://github.com/user-attachments/assets/e2ba5165-575b-40e6-a6b9-58716da8d092">
<img width="683" alt="Screenshot 2024-10-14 at 11 22 34 AM" src="https://github.com/user-attachments/assets/4073ca15-0464-4b7d-8a65-8d6d87cafb90">


##List out the areas affected by your code changes.
  -- Employee.js and leave_allocation.py file


## Is there any existing behavior change of other features due to this code change?
 Yes - The went to hajj field is been shifted to the personal details from the attedance in the employee profile page

## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
