### PR TITLE
feat: Add validations for setting reliever

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -125,6 +125,12 @@ class LeaveApplicationOverride(LeaveApplication):
     def validate_reliever(self):
         if self.custom_reliever_ == self.employee:
             frappe.throw("Oops! You can't assign yourself as the reliever!")
+        employee = frappe.get_value("Employee", self.employee, ["reports_to", "user_id"], as_dict=1)    
+        super_user_role = frappe.db.get_single_value("ONEFM General Setting", "super_user_role")
+        user_roles = frappe.get_roles(employee.user_id)
+        # If Reports to set or Super user role, then reliever is mandatory
+        if employee.reports_to or (super_user_role in user_roles) and not self.custom_reliever_:
+            frappe.throw(msg=_("Please ensure that a Reliever is set"), title=_("No Reliever set"))
 
     def close_shifts(self):
         #delete the shifts if a leave application is approved


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As OneFM
I want to ensure that Employees going on leave indicate a reliever where applicable
so that the work does not suffer while they are away


## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/411ecc60-f5f5-4a67-91bc-e20752c61287)


## Areas affected and ensured
> one_fm/overrides/leave_application.py

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
