### PR TITLE
fix: excluded title field from assignment rule template

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -2818,7 +2818,7 @@ def get_doctype_mandatory_fields(doctype):
 	mandatory_fields = []
 	labels = {}
 	employee_fields = []
-	for d in meta.get("fields", {"reqd": 1, "fieldtype":["!=", "Table"], "fieldname":["!=", "naming_series"]}):
+	for d in meta.get("fields", {"reqd": 1, "fieldtype": ["!=", "Table"], "fieldname": ["not in", ["naming_series", "title"]]}):
 		mandatory_fields.append(d.fieldname)
 		labels[d.fieldname] = d.label
 		if d.fieldtype == "Link" and d.options=="Employee":


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
Title field is not evaluated in Assignment Rule template

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Excluded 'title' field from 'Assignment Rule' (Fetching mandatory fields of doctype)

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2024-10-31 14-43-21](https://github.com/user-attachments/assets/81b95e94-8e04-4817-8f05-61ed4ff8df73)


## Areas affected and ensured
List out the areas affected by your code changes.
Assignment Rule

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Yes, title field is eliminated from Assignment rule template

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
