### PR TITLE
[FEAT CREATE A  POC CHECK FROM MOM]

### DIFF
--- a/one_fm/one_fm/doctype/general_attendance/general_attendance.json
+++ b/one_fm/one_fm/doctype/general_attendance/general_attendance.json
@@ -6,26 +6,15 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "attendees",
   "attendees_designation",
   "attended_meeting"
  ],
  "fields": [
   {
-   "fieldname": "attendees",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Attendees",
-   "options": "User"
-  },
-  {
-   "fetch_from": "attendees.full_name",
    "fieldname": "attendees_designation",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Attendees Full Name",
-   "read_only": 1
+   "label": "Attendees Full Name"
   },
   {
    "default": "0",
@@ -39,7 +28,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-10 20:24:55.032713",
+ "modified": "2024-11-11 12:53:50.378306",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "General Attendance",

--- a/one_fm/operations/doctype/mom/mom.json
+++ b/one_fm/operations/doctype/mom/mom.json
@@ -63,8 +63,7 @@
    "fieldname": "attendees",
    "fieldtype": "Table",
    "label": "Attendees",
-   "options": "MOM POC",
-   "read_only": 1
+   "options": "MOM POC"
   },
   {
    "fieldname": "section_break_5",
@@ -233,7 +232,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-10 08:20:30.914523",
+ "modified": "2024-11-11 13:07:53.357841",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "MOM",

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -23,17 +23,47 @@ class MOM(Document):
 		for attendee in self.attendees[:]:
 			if attendee.attended_meeting:
 				attendees_count = attendees_count + 1
-			else:
-				self.remove(attendee)
-
-		if(attendees_count < 1):
-			frappe.throw(_("Please check the attendees present."))
-
+			
 		if self.issues == "Yes" and len(self.action) < 1:
 			frappe.throw(_("Please add Action taken to the table."))
 
+	def create_poc_check(self):
+		"""
+			Create a POC Check if all the rows in the attendees table in a MOM record are not checked as attended
+		"""	
+		table_checks  = [int(i.attended_meeting) for i in self.attendees]
+		if not any(table_checks):
+		#Create POC Check if no row in the POC table is marked
+			poc_check = frappe._dict()
+			poc_check.doctype = "POC Check"
+			poc_check.project = self.project
+			poc_check.site = self.site
+			poc_check.supervisor = self.supervisor
+			poc_check.supervisor_name = self.supervisor_name
+			poc_check.mom = self.name
+			attendees_list = []
+			for each in self.attendees:
+				attendees_list.append({'poc_name':each.poc_name,'poc_designation':each.poc_designation})
+			poc_check.mom_poc_table = attendees_list
+			poc_check_doc = frappe.get_doc(poc_check)
+			poc_check_doc.save()
+			mom_user  = frappe.get_value("Employee",self.supervisor,'user_id')
+			if mom_user:
+				add_assignment({
+						'doctype': "POC Check",
+						'name': poc_check_doc.name,
+						'assign_to': [mom_user],
+						'description':f"Kindly Update this document to update the POC details for {self.project}",
+						"date": frappe.utils.getdate(),
+						"priority": "Medium"
+					})
+				frappe.db.commit()
 
+
+				
+			
 	def on_submit(self):
+		self.create_poc_check()
 		project_type = frappe.db.get_value("Project", self.project, "project_type")
 		if project_type != "External":
 			self.create_task_and_assign()

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -53,11 +53,13 @@ class MOM(Document):
 						'doctype': "POC Check",
 						'name': poc_check_doc.name,
 						'assign_to': [mom_user],
-						'description':f"Kindly Update this document to update the POC details for {self.project}",
+						'description':f"Kindly fill and submit this document to update the POC details for Site: {self.site} and Project: {self.project}",
 						"date": frappe.utils.getdate(),
 						"priority": "Medium"
 					})
 				frappe.db.commit()
+			frappe.msgprint(_(f"POC Check {poc_check_doc.name} Created!"),
+                alert=True, indicator='green')
 
 
 				

--- a/one_fm/operations/doctype/mom_poc/mom_poc.json
+++ b/one_fm/operations/doctype/mom_poc/mom_poc.json
@@ -1,42 +1,50 @@
 {
-  "creation": "2020-04-27 14:56:26.766154",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": ["poc_name", "poc_designation", "attended_meeting"],
-  "fields": [
-    {
-      "fieldname": "poc_name",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "POC Name",
-      "options": "Contact"
-    },
-    {
-      "default": "0",
-      "fieldname": "attended_meeting",
-      "fieldtype": "Check",
-      "in_list_view": 1,
-      "label": "Attended Meeting"
-    },
-    {
-      "fetch_from": "poc_name.designation",
-      "fieldname": "poc_designation",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "POC Designation",
-      "read_only": 1
-    }
-  ],
-  "istable": 1,
-  "modified": "2020-04-27 15:54:06.313386",
-  "modified_by": "Administrator",
-  "module": "Operations",
-  "name": "MOM POC",
-  "owner": "Administrator",
-  "permissions": [],
-  "quick_entry": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "track_changes": 1
+ "actions": [],
+ "creation": "2020-04-27 14:56:26.766154",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "poc_name",
+  "poc_designation",
+  "attended_meeting"
+ ],
+ "fields": [
+  {
+   "fieldname": "poc_name",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "POC Name",
+   "options": "Contact",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "attended_meeting",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Attended Meeting"
+  },
+  {
+   "fetch_from": "poc_name.designation",
+   "fieldname": "poc_designation",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "POC Designation",
+   "read_only": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2024-11-11 13:08:29.073583",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "MOM POC",
+ "owner": "Administrator",
+ "permissions": [],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/one_fm/operations/doctype/poc_check/poc_check.js
+++ b/one_fm/operations/doctype/poc_check/poc_check.js
@@ -5,6 +5,7 @@ frappe.ui.form.on("POC Check", {
 	refresh(frm) {
         if(frm.doc.docstatus ==0){
             frm.set_intro("On each row of the MOM POC Table, Update the Action field with the appropriate action for the POC",'blue')
+            frm.set_intro("Select Update POC if the contact for the Project and Site should be changed.\n Select Do Nothing If the contact for the Project and Site should be unchanged",'blue')
         }
 	},
 });

--- a/one_fm/operations/doctype/poc_check/poc_check.js
+++ b/one_fm/operations/doctype/poc_check/poc_check.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2024, omar jaber and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("POC Check", {
+	refresh(frm) {
+        if(frm.doc.docstatus ==0){
+            frm.set_intro("On each row of the MOM POC Table, Update the Action field with the appropriate action for the POC",'blue')
+        }
+	},
+});

--- a/one_fm/operations/doctype/poc_check/poc_check.json
+++ b/one_fm/operations/doctype/poc_check/poc_check.json
@@ -1,0 +1,124 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:POC-CHK-{####}",
+ "creation": "2024-11-07 13:55:11.792442",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_x1e2",
+  "project",
+  "supervisor",
+  "supervisor_name",
+  "column_break_ghof",
+  "site",
+  "amended_from",
+  "mom",
+  "section_break_mmpv",
+  "mom_poc_table"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_x1e2",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project",
+   "read_only": 1
+  },
+  {
+   "fieldname": "supervisor",
+   "fieldtype": "Link",
+   "label": "Supervisor",
+   "options": "Employee",
+   "read_only": 1
+  },
+  {
+   "fieldname": "supervisor_name",
+   "fieldtype": "Data",
+   "label": "Supervisor Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_ghof",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "site",
+   "fieldtype": "Link",
+   "label": "Site",
+   "options": "Operations Site",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "POC Check",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "mom",
+   "fieldtype": "Link",
+   "label": "MOM",
+   "options": "MOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_mmpv",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "mom_poc_table",
+   "fieldtype": "Table",
+   "label": "MOM POC Table",
+   "options": "Missing POC Attendance"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2024-11-09 13:13:43.779687",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "POC Check",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/operations/doctype/poc_check/poc_check.py
+++ b/one_fm/operations/doctype/poc_check/poc_check.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2024, omar jaber and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.desk.form.assign_to import remove
+from erpnext.crm.utils import get_open_todos
+from frappe.model.document import Document
+
+
+class POCCheck(Document):
+	def on_submit(self):
+		for each in self.mom_poc_table:
+			if each.action not in ['Do Nothing',"Update POC"]:
+				frappe.throw(f"Please set an action for row {each.idx} in MOM POC Table")
+		self.remove_assignments()
+		self.update_poc_details()
+	
+	def remove_assignments(self):
+		open_todo = get_open_todos("POC Check",self.name)
+		if open_todo:
+			for each in open_todo:
+				remove("POC Check",self.name,each.allocated_to,ignore_permissions=1)
+	
+	def update_poc_details(self):
+		for each in self.mom_poc_table:
+			if each.action == "Update POC":
+				destination_dict = {"Operations Site":["Operations Site"],'Project':['Project'],'Both':["Operations Site","Project"]}
+				if destination_dict.get(each.destination):
+					for one in destination_dict.get(each.destination):
+						try:
+							existing_row = frappe.get_doc("POC",{'parenttype':one,'parent':self.project if one == "Project" else self.site,'poc':each.poc_name})
+							if existing_row:
+								existing_row.poc = each.new_poc_name
+								existing_row.designation = each.new_poc_designation
+								existing_row.save()
+						except frappe.DoesNotExistError:
+							frappe.throw(f"Please note that <b>{each.poc_name}</b> is not set as a POC in <b>{one}</b> <b>{self.project if one=='Project' else self.site}</b>")
+					
+     
+

--- a/one_fm/operations/doctype/poc_check/poc_check.py
+++ b/one_fm/operations/doctype/poc_check/poc_check.py
@@ -8,10 +8,13 @@ from frappe.model.document import Document
 
 
 class POCCheck(Document):
-	def on_submit(self):
+	def validate_rows(self):
 		for each in self.mom_poc_table:
 			if each.action not in ['Do Nothing',"Update POC"]:
 				frappe.throw(f"Please set an action for row {each.idx} in MOM POC Table")
+    
+	def on_submit(self):
+		self.validate_rows()
 		self.remove_assignments()
 		self.update_poc_details()
 	
@@ -33,8 +36,8 @@ class POCCheck(Document):
 								existing_row.poc = each.new_poc_name
 								existing_row.designation = each.new_poc_designation
 								existing_row.save()
-						except frappe.DoesNotExistError:
+						except frappe.exceptions.DoesNotExistError:
 							frappe.throw(f"Please note that <b>{each.poc_name}</b> is not set as a POC in <b>{one}</b> <b>{self.project if one=='Project' else self.site}</b>")
 					
-     
+	 
 

--- a/one_fm/operations/doctype/poc_check/test_poc_check.py
+++ b/one_fm/operations/doctype/poc_check/test_poc_check.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, omar jaber and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPOCCheck(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [*] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As a mom user, if the POC's does not attend and General Attendance attends then the system would mark a check mark as POC Check.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated the codebase to show how the POC check is created from MOM records
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
MOM

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
POC Checks are created if no row in attendance field of poc attendees is marked

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? No
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
