### PR TITLE
feat: Transfer approvals to reliever + Refactor of doctype

### DIFF
--- a/one_fm/one_fm/doctype/reliever_assignment/reliever_assignment.json
+++ b/one_fm/one_fm/doctype/reliever_assignment/reliever_assignment.json
@@ -10,6 +10,7 @@
   "leave_application",
   "assignment_period_start",
   "assignment_period_end",
+  "status",
   "column_break_yubw",
   "on_leave_employee",
   "on_leave_employee_name",
@@ -102,6 +103,16 @@
    "label": "Assigned Documents",
    "options": "Reliever Assignment Document",
    "read_only": 1
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Pending\nTransferred\nReverted",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -111,7 +122,7 @@
    "link_fieldname": "name"
   }
  ],
- "modified": "2024-10-29 13:02:58.788519",
+ "modified": "2024-11-25 07:03:47.799466",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Reliever Assignment",
@@ -133,5 +144,18 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [
+  {
+   "color": "Orange",
+   "title": "Pending"
+  },
+  {
+   "color": "Green",
+   "title": "Transferred"
+  },
+  {
+   "color": "Blue",
+   "title": "Reverted"
+  }
+ ]
 }

--- a/one_fm/one_fm/doctype/reliever_assignment/reliever_assignment.py
+++ b/one_fm/one_fm/doctype/reliever_assignment/reliever_assignment.py
@@ -3,16 +3,21 @@
 
 import json, time
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
-from frappe.utils import now, validate_email_address
+from frappe.utils import now, validate_email_address, getdate
 from pypika.terms import Case
 from one_fm.api.doc_events import get_employee_user_id
 
+
 class RelieverAssignment(Document):
 	def validate(self):
+		self.validate_leave_application()
 		self.set_user_ids()
+
+	def after_insert(self):
 		self.assign_roles()
 		self.assign_reportees()
 		self.assign_todos()
@@ -20,7 +25,21 @@ class RelieverAssignment(Document):
 		self.assign_operations_site()
 		self.assign_routine_tasks()
 		self.get_single_doctypes()
+		self.get_approval_doctypes()
+		# Update status after transferring responsibilities
+		self.update_status("Transferred")
+		self.save()
 
+	def update_status(self, status):
+		self.status = status
+
+	def validate_leave_application(self):
+		leave_application = frappe.get_value("Leave Application", self.leave_application, ["workflow_state", "from_date", "to_date", "custom_reliever_"], as_dict=1)
+
+		if not ( leave_application.workflow_state == "Approved" and 
+			(leave_application.from_date <= getdate() <= leave_application.to_date) and 
+			(leave_application.custom_reliever_ is not None)):
+			frappe.throw(_(f"Reliever Assignment record cannot be created for <b>Leave Application - {self.leave_application}</b>"))
 
 	def set_user_ids(self):
 		self._employee_user_id = get_employee_user_id(self.on_leave_employee)
@@ -240,6 +259,26 @@ class RelieverAssignment(Document):
 					Singles.doctype == record.doctype
 				).run()
 
+
+	def get_approval_doctypes(self):
+		# For now, only Department Approver child table needs to be checked
+		DepartmentApprover = DocType("Department Approver")
+		approvers = (
+			frappe.qb.from_(DepartmentApprover)
+			.select(DepartmentApprover.name, DepartmentApprover.approver, DepartmentApprover.parent, DepartmentApprover.parentfield)
+			.where(
+				(DepartmentApprover.approver == self._employee_user_id)
+			)
+		).run(as_dict=True)
+
+		if len(approvers) > 0:
+			# Log data for reversal
+			self.add_assigned_documents("Department Approver", "Docname", approvers, reference_docname="Department Approver")
+			for approver in approvers: 
+				frappe.qb.update(DepartmentApprover) 	\
+				.set(DepartmentApprover.approver, self._reliever_user_id) \
+				.set(DepartmentApprover.modified, now()) \
+				.where(DepartmentApprover.name == approver.name).run()
 
 
 def assign_responsibilities(leave_application):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug

## Clearly and concisely describe the feature, chore or bug.
1. Transfer approvals to reliever. For now, only Department Approver table was being skipped from the work done till now. 
2. Added a status field with options Pending, Transferred, Reverted. 

## Solution description
Refactor transferring responsibilities from validate to after_insert since we only want to transfer them one time on creation.

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Is patch required?
- [] Yes
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
