### PR TITLE
FEAT : As OneFM I want to indicate the Operation Shifts which can be automatically rostered so that automated rostering is only done for specific Operations Shifts

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -15,6 +15,7 @@
   "shift_details_section",
   "shift_number",
   "shift_type",
+  "automate_roster",
   "supervisor",
   "supervisor_name",
   "column_break_8",
@@ -58,6 +59,11 @@
    "label": "Shift Type",
    "options": "Shift Type"
   },
+  {
+    "fieldname": "automate_roster",
+    "fieldtype": "Check",
+    "label": "Automate Roster"
+   },
   {
    "fieldname": "section_break_12",
    "fieldtype": "Section Break"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature

## Clearly and concisely describe the feature
[SS]As OneFM
I want to indicate the Operation Shifts which can be automatically rostered
so that automated rostering is only done for specific Operations Shifts


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] No


## Output screenshots (optional)
<img width="535" alt="Screenshot 2024-12-15 at 10 13 59 AM" src="https://github.com/user-attachments/assets/e7c69dc2-e8ba-4d47-8266-b8b58860ee38" />


## Areas affected and ensured
List out the areas affected by your code changes.
operations_shift.json


## Is there any existing behavior change of other features due to this code change?
No. 


## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    - 
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
