### PR TITLE
Chore : Changing the on_cancel hook to the class function as both the hook and the class function is defined in present

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -431,7 +431,8 @@ class LeaveApplicationOverride(LeaveApplication):
             reassign_responsiobility.reassign()
         self.create_leave_ledger_entry(submit=False)
         # notify leave applier about cancellation
-        leave_application_on_cancel()
+        method = "on_cancel"
+        leave_application_on_cancel(self,method)
         self.cancel_attendance()
         self.validate_cancel()
         send_leave_cancellation_email_to_leave_approver(self)

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -431,8 +431,7 @@ class LeaveApplicationOverride(LeaveApplication):
             reassign_responsiobility.reassign()
         self.create_leave_ledger_entry(submit=False)
         # notify leave applier about cancellation
-        method = "on_cancel"
-        leave_application_on_cancel(self,method)
+        leave_application_on_cancel(self,"on_cancel")
         self.cancel_attendance()
         self.validate_cancel()
         send_leave_cancellation_email_to_leave_approver(self)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Chore


## Clearly and concisely describe the chore .
Chore : Changing the on_cancel hook to the class function as both the hook and the class function is defined in present


## Analysis and design (optional)
Analyse and attach the design documentation
Changing the on_cancel hook to the class function as both the hook and the class function is defined in present

## Solution description
Describe your code changes in detail for reviewers.
leave_application.py file changes from hook.py file

## Is there a business logic within a doctype?
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

https://github.com/user-attachments/assets/bf76defe-ac27-4613-8d3f-294482438ce3




## Areas affected and ensured
List out the areas affected by your code changes.
leave_application.py


## Is there any existing behavior change of other features due to this code change?
No. 


## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
