### PR TITLE
feat: Toggle between selected cells vs whole row selection in Roster

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -709,6 +709,15 @@ function bind_events(page) {
 		//let $rosterWeek = $('.rosterWeek');
 		let $postWeek = $('.postWeek');
 		$postMonth.find(".hoverselectclass").on("click", function () {
+            // Loop through all rows and if there is a checked row, unselect all cells in that row.
+            $(this).closest("tbody").children("tr").each(function (i, cell) {
+                const checked_row = $(cell).find('input[name="selectallcheckbox"]:checked');
+                if (checked_row.length > 0) {
+                    $(checked_row).prop('checked', false);
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });
+
 			$(this).toggleClass("selectclass");
 			// If the id is not already in the array, add it. If it is, remove it
 
@@ -723,6 +732,15 @@ function bind_events(page) {
 		});
 
 		$postWeek.find(".hoverselectclass").on("click", function () {
+            // Loop through all rows and if there is a checked row, unselect all cells in that row.
+            $(this).closest("tbody").children("tr").each(function (i, cell) {
+                const checked_row = $(cell).find('input[name="selectallcheckbox"]:checked');
+                if (checked_row.length > 0) {
+                    $(checked_row).prop('checked', false);
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });
+
 			$(this).toggleClass("selectclass");
 			// If the id is not already in the array, add it. If it is, remove it
 
@@ -736,10 +754,20 @@ function bind_events(page) {
 			}
 		});
 
+
 		//add array on each of data select from calender
 		$rosterMonth.find(".hoverselectclass").on("click", function () {
-			$(this).toggleClass("selectclass");
+           // Loop through all rows and if there is a checked row, unselect all cells in that row.
+           $(this).closest("tbody").children("tr").each(function (i, cell) {
+                const checked_row = $(cell).find('input[name="selectallcheckbox"]:checked');
+                if (checked_row.length > 0) {
+                    $(checked_row).prop('checked', false);
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });
 
+            // select cell
+            $(this).toggleClass("selectclass");
 			//Show Day Off and Schedule Leave button if hidden for basic roster
 			if ($(".dayoff").is(":hidden")) {
 				$(".dayoff").show();
@@ -760,7 +788,16 @@ function bind_events(page) {
 		});
 
 		$rosterOtMonth.find(".hoverselectclass").on("click", function () {
-			$(this).toggleClass("selectclass");
+            // Loop through all rows and if there is a checked row, unselect all cells in that row.
+            $(this).closest("tbody").children("tr").each(function (i, cell) {
+                const checked_row = $(cell).find('input[name="selectallcheckbox"]:checked');
+                if (checked_row.length > 0) {
+                    $(checked_row).prop('checked', false);
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });
+
+            $(this).toggleClass("selectclass");
 
 			//Hide Day Off and schedule leave button for OT Roster
 			$(".dayoff").hide();
@@ -793,35 +830,44 @@ function bind_events(page) {
 
 		/*on checkbox select change*/
 		$postWeek.find(`input[name="selectallcheckbox"]`).on("change", function () {
-			if ($(this).is(":checked")) {
-				$(this).parent().parent().parent().children("td").children().not("label").each(function (i, v) {
+            let $checked_employee = $(this);
+            let selected_employee = $checked_employee.parent().parent().parent().attr('data-name');
+			if ($checked_employee.is(":checked")) {
+				$checked_employee.parent().parent().parent().children("td").children().not("label").each(function (i, v) {
 					let date = $(v).attr('data-date');
 					if (moment(date).isAfter(moment())) {
 						$(v).addClass("selectclass");
 					}
 				});
-				$(this).parent().parent().parent().children("td").children().not("label").removeClass("hoverselectclass");
+				$checked_employee.parent().parent().parent().children("td").children().not("label").removeClass("hoverselectclass");
 				$(".Postfilterhideshow").removeClass("d-none");
 
 			}
 			else {
-				$(this).parent().parent().parent().children("td").children().not("label").addClass("hoverselectclass");
-				$(this).closest('tr').children("td").children().not("label").each(function (i, v) {
+				$checked_employee.parent().parent().parent().children("td").children().not("label").addClass("hoverselectclass");
+				$checked_employee.closest('tr').children("td").children().not("label").each(function (i, v) {
 					classgrt.splice(classgrt.indexOf($(v).attr('data-selectid')), 1);
 				});
-				$(this).parent().parent().parent().children("td").children().not("label").removeClass("selectclass");
+				$checked_employee.parent().parent().parent().children("td").children().not("label").removeClass("selectclass");
 				$(".Postfilterhideshow").addClass("d-none");
 			}
-			$(".selectclass").map(function () {
+            
+            // Check for rows that are not selected full and unselect cells in that row.
+            $checked_employee.closest("tbody").children("tr").each(function (i, cell) {
+                const unchecked_row = $(cell).find('input[name="selectallcheckbox"]:not(:checked)');
+                if (unchecked_row.length > 0) {
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });
 
+			$(".selectclass").map(function () {
 				classgrt.push($(this).attr("data-selectid"));
 				classgrt = [... new Set(classgrt)];
-
 			});
 		});
 		/*on checkbox select change*/
 		$postMonth.find(`input[name="selectallcheckbox"]`).on("change", function () {
-			if ($(this).is(":checked")) {
+          	if ($(this).is(":checked")) {
 				$(this).parent().parent().parent().children("td").children().not("label").each(function (i, v) {
 					let date = $(v).attr('data-date');
 					if (moment(date).isAfter(moment())) {
@@ -839,6 +885,16 @@ function bind_events(page) {
 				$(this).parent().parent().parent().children("td").children().not("label").removeClass("selectclass");
 				$(".Postfilterhideshow").addClass("d-none");
 			}
+
+            // Check for rows that are not selected full and unselect cells in that row.
+            $(this).closest("tbody").children("tr").each(function (i, cell) {
+                const unchecked_row = $(cell).find('input[name="selectallcheckbox"]:not(:checked)');
+                if (unchecked_row.length > 0) {
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });
+
+
 			$(".selectclass").map(function () {
 
 			    classgrt.push($(this).attr("data-selectid"));
@@ -880,8 +936,10 @@ function bind_events(page) {
 		// 		// }
 		// 	});
 		// });
-		//on checkbox select change
-		$rosterMonth.find(`input[name="selectallcheckbox"]`).on("change", function () {
+		//on checkbox select change        
+        $rosterMonth.find(`input[name="selectallcheckbox"]`).on("change", function () {
+            let $checked_employee = $(this);
+            let selected_employee = $checked_employee.parent().parent().parent().attr('data-name');
 
 			//Show Day Off and Schedule Leave button if hidden for basic roster
 			if ($(".dayoff").is(":hidden")) {
@@ -891,8 +949,8 @@ function bind_events(page) {
 				$(".scheduleleave").show();
 			}
 
-			if ($(this).is(":checked")) {
-				$(this).closest('tr').children("td").children().not("label").each(function (i, v) {
+			if ($checked_employee.is(":checked")) {
+                $checked_employee.closest('tr').children("td").children().not("label").each(function (i, v) {
 					
 					let [employee, date] = $(v).attr('data-selectid').split('|');
 					classgrt.push($(v).attr('data-selectid'));
@@ -907,12 +965,22 @@ function bind_events(page) {
 				$(".filterhideshow").removeClass("d-none");
 			}
 			else {
-				$(this).closest('tr').children("td").children().not("label").each(function (i, v) {
+				$checked_employee.closest('tr').children("td").children().not("label").each(function (i, v) {
 					classgrt.splice(classgrt.indexOf($(v).attr('data-selectid')), 1);
 				});
-				$(this).closest('tr').children("td").children().not("label").removeClass("selectclass");
+				$checked_employee.closest('tr').children("td").children().not("label").removeClass("selectclass");
 				$(".filterhideshow").addClass("d-none");
 			}
+            
+            // Check for rows that are not selected full and unselect cells in that row.
+            $checked_employee.closest("tbody").children("tr").each(function (i, cell) {
+                const unchecked_row = $(cell).find('input[name="selectallcheckbox"]:not(:checked)');
+                if (unchecked_row.length > 0) {
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });;
+
+
 			$(".selectclass").map(function () {
 
 				classgrt.push($(this).attr("data-selectid"));
@@ -930,7 +998,8 @@ function bind_events(page) {
 			});
 		});
 		$rosterOtMonth.find(`input[name="selectallcheckbox"]`).on("change", function () {
-
+            let $checked_employee = $(this);
+            
 			//Hide Day Off and schedule leave button for OT Roster
 			$(".dayoff").hide();
 			$(".scheduleleave").hide();
@@ -954,6 +1023,15 @@ function bind_events(page) {
 				$(this).closest('tr').children("td").children().not("label").removeClass("selectclass");
 				$(".filterhideshow").addClass("d-none");
 			}
+            
+            // Check for rows that are not selected full and unselect cells in that row.
+            $(this).closest("tbody").children("tr").each(function (i, cell) {
+                const unchecked_row = $(cell).find('input[name="selectallcheckbox"]:not(:checked)');
+                if (unchecked_row.length > 0) {
+                    $(cell).find("div").removeClass("selectclass");
+                }
+            });
+
 			$(".selectclass").map(function () {
 
 				classgrt.push($(this).attr("data-selectid"));


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
1. If whole row is selected, unselect any single cells selected.
2. If single cell is selected, unselect any whole row(s) selected. 

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Areas affected and ensured
Roster - roster.js

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
