### PR TITLE
CHORE : As OneFM I want to indicate the Operation Shifts which can be automatically rostered so that automated rostering is only done for specific Operations Shifts

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.js
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.js
@@ -165,5 +165,18 @@ frappe.ui.form.on('Operations Shift', {
 				}
 			).addClass('btn-primary');
 		}
-	}
+	},
+	automate_roster: function (frm) {
+        // Check if the checkbox is checked
+        if (frm.doc.automate_roster) {
+            frappe.confirm(
+				__('Are you sure you want to enable this feature?'),
+                () => {
+                },
+                () => {
+                    frm.set_value('automate_roster', 0);
+                }
+            );
+        }
+    }
 });

--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -60,10 +60,12 @@
    "options": "Shift Type"
   },
   {
-    "fieldname": "automate_roster",
-    "fieldtype": "Check",
-    "label": "Automate Roster"
-   },
+   "default": "0",
+   "description": "If checked, the system automatically creates Employee Schedules for all Employees having this as their default shift.",
+   "fieldname": "automate_roster",
+   "fieldtype": "Check",
+   "label": "Automate Roster"
+  },
   {
    "fieldname": "section_break_12",
    "fieldtype": "Section Break"
@@ -174,7 +176,7 @@
    "link_fieldname": "shift"
   }
  ],
- "modified": "2024-05-08 21:24:18.202969",
+ "modified": "2024-12-17 16:34:20.846883",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Shift",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Chore

## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="498" alt="Screenshot 2024-12-17 at 4 41 50 PM" src="https://github.com/user-attachments/assets/72c1cf26-b7d2-481b-9dae-369ad5091cf9" />
<img width="750" alt="Screenshot 2024-12-17 at 4 42 29 PM" src="https://github.com/user-attachments/assets/1e625336-3906-4ddc-ab45-978ee3ba8c40" />



## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    - 
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
