### PR TITLE
CHORE: BYPASS LEAVE ALLOCATION DAYS VALIDATION, WHICH CHEKS BY PERIOD

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -508,6 +508,7 @@ override_doctype_class = {
     "Payroll Entry": "one_fm.overrides.payroll_entry.PayrollEntryOverride",
     "Salary Slip": "one_fm.overrides.salary_slip.SalarySlipOverride",
     "Interview Feedback": "one_fm.overrides.interview_feedback.InterviewFeedbackOverride",
+    "Leave Allocation": "one_fm.overrides.leave_allocation.LeaveAllocationOverride",
     
     # "User": "one_fm.overrides.user.UserOverride"
 }

--- a/one_fm/overrides/leave_allocation.py
+++ b/one_fm/overrides/leave_allocation.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+from hrms.hr.doctype.leave_allocation.leave_allocation import LeaveAllocation
+
+class LeaveAllocationOverride(LeaveAllocation):
+
+
+    def validate(self):
+        super(LeaveAllocationOverride, self).validate()
+
+    
+    def validate_leave_days_and_dates(self):
+        self.validate_back_dated_allocation()
+        self.validate_total_leaves_allocated()
+        # self.validate_leave_allocation_days()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [X] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
To bypass the Leave allocation days validation, this validation uses the leave perios, and the allocation usually cuts across, two periods, which makes it overlap

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
added an override , and commented out that particular validation

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Leave Allocation

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
