### PR TITLE
fix: Default Shift checker - Only include working days for counting

### DIFF
--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.py
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.py
@@ -40,6 +40,7 @@ def create_default_shift_checker():
             (Employee.shift_working == 1)
             & (Employee.shift.isnotnull())
             & (Employee.shift != EmployeeSchedule.shift)
+            & (EmployeeSchedule.employee_availability == "Working")
             & (EmployeeSchedule.roster_type == "Basic")
             & (EmployeeSchedule.date[start_date:last_day_of_month])
         )


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Only include employee schedule with Employee Availability = "Working" while counting for creating Default Shift checker. 

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
