### PR TITLE
chore: allowed only procurement manager to make updates in PO at all stages

### DIFF
--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -1459,7 +1459,7 @@
   "send_email_alert": 0,
   "states": [
    {
-    "allow_edit": "Purchase Officer",
+    "allow_edit": "Procurement Manager",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -1474,7 +1474,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Purchase Manager",
+    "allow_edit": "Procurement Manager",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -1483,13 +1483,13 @@
     "parent": "Purchase Order",
     "parentfield": "states",
     "parenttype": "Workflow",
-    "state": "Pending Purchase Manager",
+    "state": "Procurement Manager",
     "update_field": null,
     "update_value": null,
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Finance PO Approver",
+    "allow_edit": "Procurement Manager",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -1504,7 +1504,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Purchase User",
+    "allow_edit": "Procurement Manager",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -1519,7 +1519,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Purchase User",
+    "allow_edit": "Procurement Manager",
     "avoid_status_override": 0,
     "doc_status": "1",
     "is_optional_state": 0,

--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -1459,7 +1459,7 @@
   "send_email_alert": 0,
   "states": [
    {
-    "allow_edit": "Procurement Manager",
+    "allow_edit": "Purchase Officer",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Only Procurement Manager should be allowed to make changes in PO at all stages

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added required changes in workflow

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
PO Wokflow

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Only Procurement Manager will be allowed to make any updates in PO

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
