### PR TITLE
feat: job offer-validate shift project in a la carte hiring

### DIFF
--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -126,11 +126,13 @@ class JobOfferOverride(JobOffer):
 
     def validate_job_offer_mandatory_fields(self):
         if self.workflow_state == 'Submit for Candidate Response':
+            applicant_details = frappe.db.get_value('Job Applicant', self.job_applicant, ['one_fm_hiring_method'], as_dict=1)
             mandatory_field_required = False
-            fields = ['Project', 'Base', 'Salary Structure'] if not self.attendance_by_timesheet else ['Base', 'Salary Structure']
+            fields = ['Base', 'Salary Structure']
             if not self.shift_working and not self.reports_to:
                 fields.append("Reports to")
-            if not self.attendance_by_timesheet:
+            if not self.attendance_by_timesheet and applicant_details.one_fm_hiring_method != 'Bulk Recruitment':
+                fields.append('Project')
                 fields.append('Operations Shift')
                 if self.shift_working:
                     fields.append('Operations Site')


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Validate Shift Allocation and Project if the hiring method is A la carte Recruitment in Job Offer

## Areas affected and ensured
- `one_fm/overrides/job_offer.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome