### PR TITLE
Bug : As OneFM I want to set the last basic duty as Employee's default Operations role so that it will not be manually set in the Employee record

### DIFF
--- a/one_fm/patches/v15_0/update_employees_operation_role.py
+++ b/one_fm/patches/v15_0/update_employees_operation_role.py
@@ -30,7 +30,6 @@ def execute():
 
     # Execute bulk update if there are matching records
     if updates:
-        # Prepare the CASE statement and employee IDs for the update
         update_cases = []
         employee_ids = []
         for operations_role, employee_name in updates:

--- a/one_fm/patches/v15_0/update_employees_operation_role.py
+++ b/one_fm/patches/v15_0/update_employees_operation_role.py
@@ -31,17 +31,17 @@ def execute():
     # Execute bulk update if there are matching records
     if updates:
         # Prepare the CASE statement and employee IDs for the update
-        case_statements = []
+        update_cases = []
         employee_ids = []
         for operations_role, employee_name in updates:
-            case_statements.append(f"WHEN '{employee_name}' THEN '{operations_role}'")
+            update_cases.append(f"WHEN '{employee_name}' THEN '{operations_role}'")
             employee_ids.append(f"'{employee_name}'")
         
         # Bulk update query
         update_query = f"""
             UPDATE `tabEmployee`
             SET custom_operations_role_allocation = CASE name
-                {' '.join(case_statements)}
+                {' '.join(update_cases)}
             END
             WHERE name IN ({', '.join(employee_ids)})
         """

--- a/one_fm/patches/v15_0/update_employees_operation_role.py
+++ b/one_fm/patches/v15_0/update_employees_operation_role.py
@@ -2,7 +2,7 @@ import frappe
 
 @frappe.whitelist()
 def execute():
-    # Fetch all employees and their schedules in a single query
+    # Query to fetch employees and their schedules
     query = """
         SELECT e.name AS employee, e.shift AS current_shift, es.shift AS schedule_shift, es.operations_role
         FROM `tabEmployee` AS e
@@ -28,22 +28,24 @@ def execute():
         if schedule["schedule_shift"] and schedule["current_shift"] == schedule["schedule_shift"]:
             updates.append((schedule["operations_role"], schedule["employee"]))
 
-    # Execute bulk update if there are matching records
+    # Proceed only if there are matching records
     if updates:
-        update_query = """
-            UPDATE `tabEmployee`
-            SET custom_operations_role_allocation = CASE name
-        """
-        update_cases = []
+        # Prepare the CASE statement and employee IDs for the update
+        case_statements = []
         employee_ids = []
         for operations_role, employee_name in updates:
-            update_cases.append(f"WHEN '{employee_name}' THEN '{operations_role}'")
+            case_statements.append(f"WHEN '{employee_name}' THEN '{operations_role}'")
             employee_ids.append(f"'{employee_name}'")
         
-        # Combine the query
-        update_query += " ".join(update_cases) + " END WHERE name IN (" + ", ".join(employee_ids) + ")"
-
+        # Bulk update query
+        update_query = f"""
+            UPDATE `tabEmployee`
+            SET custom_operations_role_allocation = CASE name
+                {' '.join(case_statements)}
+            END
+            WHERE name IN ({', '.join(employee_ids)})
+        """
+        
         # Execute the query
         frappe.db.sql(update_query)
         frappe.db.commit()
-    return results

--- a/one_fm/patches/v15_0/update_employees_operation_role.py
+++ b/one_fm/patches/v15_0/update_employees_operation_role.py
@@ -2,7 +2,7 @@ import frappe
 
 @frappe.whitelist()
 def execute():
-    # Query to fetch employees and their schedules
+    # Fetch all employees and their schedules in a single query
     query = """
         SELECT e.name AS employee, e.shift AS current_shift, es.shift AS schedule_shift, es.operations_role
         FROM `tabEmployee` AS e
@@ -28,7 +28,7 @@ def execute():
         if schedule["schedule_shift"] and schedule["current_shift"] == schedule["schedule_shift"]:
             updates.append((schedule["operations_role"], schedule["employee"]))
 
-    # Proceed only if there are matching records
+    # Execute bulk update if there are matching records
     if updates:
         # Prepare the CASE statement and employee IDs for the update
         case_statements = []

--- a/one_fm/patches/v15_0/update_employees_operation_role.py
+++ b/one_fm/patches/v15_0/update_employees_operation_role.py
@@ -33,8 +33,9 @@ def execute():
         update_cases = []
         employee_ids = []
         for operations_role, employee_name in updates:
-            update_cases.append(f"WHEN '{employee_name}' THEN '{operations_role}'")
-            employee_ids.append(f"'{employee_name}'")
+            update_cases.append("WHEN %s THEN %s")
+            employee_ids.append(employee_name)  # Add employee name
+            employee_ids.append(operations_role)  # Add corresponding operation role
         
         # Bulk update query
         update_query = f"""
@@ -42,9 +43,9 @@ def execute():
             SET custom_operations_role_allocation = CASE name
                 {' '.join(update_cases)}
             END
-            WHERE name IN ({', '.join(employee_ids)})
+            WHERE name IN ({', '.join(['%s'] * len(updates))})
         """
         
         # Execute the query
-        frappe.db.sql(update_query)
+        frappe.db.sql(update_query, tuple(employee_ids + [emp[0] for emp in updates]))
         frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Bug


## Clearly and concisely describe the or bug.

Based on the logs, https://github.com/ONE-F-M/one_fm/actions/runs/12747699910/job/35526309465#step:2:122 it seems the issue arises from a syntax error in the SQL query during the update operation.The issue seems to be appears when performing the bulk update because special characters like '-,/' in the values of operation roles are not being handled properly in some cases, which causes the error.
To resolve this, I have modified the update query to use parameterized queries, ensuring that special characters are correctly handled.

## Analysis and design (optional)
[Analyse and attach the design documentation
](https://www.pivotaltracker.com/story/show/188754874)


## Solution description
The update_cases list and employee_ids list are combined into two separate lists.
The update_query is formed by joining the elements in case_statements and employee_ids using join(), simplifying the query string construction.
The check if updates: ensures that we only proceed if there are records to update. The query will be constructed and executed only when necessary.

## Is there a business logic within a doctype?
    - [] No

## Areas affected and ensured
Employee Doctype

## Is there any existing behavior change of other features due to this code change?
 No.


## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    -No

## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
