### PR TITLE
hotfix: Don't fetch cancelled Shift Assignment when updating Attendance Check

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -207,7 +207,7 @@ class AttendanceCheck(Document):
                         att.shift_assignment = self.shift_assignment
                     else:
                         shift_assignment = frappe.db.exists("Shift Assignment", {
-                                'employee':self.employee, 'start_date':self.date, 'roster_type':self.roster_type
+                                'docstatus': 1, 'employee':self.employee, 'start_date':self.date, 'roster_type':self.roster_type
                             })
                         if shift_assignment:
                             att.shift_assignment = shift_assignment


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Don't fetch cancelled Shift Assignment when updating Attendance Check


## Is there a business logic within a doctype?
    - [x] Yes
    - [] No



## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
