### PR TITLE
chore: added workflow transition for reverting hold po to draft

### DIFF
--- a/one_fm/fixtures/workflow.json
+++ b/one_fm/fixtures/workflow.json
@@ -1624,6 +1624,24 @@
     "skip_multiple_action": 0,
     "state": "Pending Finance Approver",
     "workflow_builder_id": null
+   },
+   {
+    "action": "Revert to Draft",
+    "allow_self_approval": 1,
+    "allowed": "Procurement Manager",
+    "allowed_user_field": null,
+    "allowed_user_id": null,
+    "condition": null,
+    "custom_confirm_message": null,
+    "custom_confirm_transition": 0,
+    "next_state": "Draft",
+    "parent": "Purchase Order",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "skip_creation_of_workflow_action": 0,
+    "skip_multiple_action": 0,
+    "state": "Hold",
+    "workflow_builder_id": null
    }
   ],
   "workflow_data": null,


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Need option to revert Hold PO back to Draft

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added workflow transition to revert Hold PO back to draft

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
PO Workflow

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
