### PR TITLE
BUG: GOOGLE SHEET EXPORT KEEPS EXPORTING DOCFIELD EVEN WHEN IT IS NOT SELECTED

### DIFF
--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -53,6 +53,9 @@ def export_data(
 		filters=filters,
 		method=parent_doctype,
 	)
+	
+	print(select_columns, 3444444444444444444)
+
 	exporter = DataExporter(
 		doctype=doctype,
 		parent_doctype=parent_doctype,
@@ -167,6 +170,12 @@ class DataExporter:
 
 		self.column = self.labelrow
 		values = self.add_data()
+
+		with open("yaga_output.csv", mode="w", newline="") as file:
+			writer = csv.writer(file)
+			
+			# Writing each array (row) into the file
+			writer.writerows(values)
 
 		if self.with_data and not values:
 			frappe.msgprint(
@@ -285,6 +294,7 @@ class DataExporter:
 		self.data = frappe.get_list(
 			self.doctype, fields=["*"], filters=self.filters, limit_page_length=None, order_by=order_by
 		)
+
 		cell_colour = []
 		row_index = 0
 		for doc in self.data:
@@ -295,19 +305,20 @@ class DataExporter:
 			if self.all_doctypes:
 				# add child tables
 				for c in self.child_doctypes:
-					child_doctype_table = DocType(c["doctype"])
-					data_row = (
-						frappe.qb.from_(child_doctype_table)
-						.select("*")
-						.where(child_doctype_table.parent == doc.name)
-						.where(child_doctype_table.parentfield == c["parentfield"])
-						.where(child_doctype_table.parenttype == self.doctype)
-						.orderby(child_doctype_table.idx)
-					)
-					for ci, child in enumerate(data_row.run(as_dict=True)):
-						if ci > 0:
-							self.add_data_row(rows, self.doctype, None, doc, ci, cell_colour, row_index)
-						self.add_data_row(rows, c["doctype"], c["parentfield"], child, ci, cell_colour, row_index)
+					if self.select_columns.get(c.get("doctype")):
+						child_doctype_table = DocType(c["doctype"])
+						data_row = (
+							frappe.qb.from_(child_doctype_table)
+							.select("*")
+							.where(child_doctype_table.parent == doc.name)
+							.where(child_doctype_table.parentfield == c["parentfield"])
+							.where(child_doctype_table.parenttype == self.doctype)
+							.orderby(child_doctype_table.idx)
+						)
+						for ci, child in enumerate(data_row.run(as_dict=True)):
+							if ci > 0:
+								self.add_data_row(rows, self.doctype, None, doc, ci, cell_colour, row_index)
+							self.add_data_row(rows, c["doctype"], c["parentfield"], child, ci, cell_colour, row_index)
 
 			for row in rows:
 				data.append(row)

--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -53,8 +53,7 @@ def export_data(
 		filters=filters,
 		method=parent_doctype,
 	)
-	
-	print(select_columns, 3444444444444444444)
+
 
 	exporter = DataExporter(
 		doctype=doctype,
@@ -170,12 +169,6 @@ class DataExporter:
 
 		self.column = self.labelrow
 		values = self.add_data()
-
-		with open("yaga_output.csv", mode="w", newline="") as file:
-			writer = csv.writer(file)
-			
-			# Writing each array (row) into the file
-			writer.writerows(values)
 
 		if self.with_data and not values:
 			frappe.msgprint(


### PR DESCRIPTION

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [X] Bug


## Clearly and concisely describe the feature, chore or bug.
The exporter keeps exporting docfield wven when it is not exported, and it mixes up the whole data

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a check to filter out the child doctypes that were not selected


## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
BEFORE
![image](https://github.com/user-attachments/assets/4d1b4567-735c-487e-ac99-8268af4cb58a)

AFTER
![image](https://github.com/user-attachments/assets/59f7ab02-d165-48c4-85d2-455ec8231b9e)


## Areas affected and ensured
List out the areas affected by your code changes.
Google Data sheet Export

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
