### PR TITLE
fix: Return 200 response instead of "404 not found" when there are no notifications

### DIFF
--- a/one_fm/api/v1/notification.py
+++ b/one_fm/api/v1/notification.py
@@ -44,7 +44,7 @@ def get_notification_list(employee_id: str = None) -> dict:
         result = []
         
         if not notification_list or len(notification_list) == 0:
-            return response("Resource not found", 404, None, "No notifications found for user {employee_id}".format(employee_id=employee_id))
+            return response("Success", 200, [{"title": "No notifications found for user {employee_id}".format(employee_id=employee_id)}])
         
         for notification in notification_list:
             notify = {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/dd7016ef-b325-4772-b859-e996499c045f)

## Areas affected and ensured
Server and app code

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
