### PR TITLE
fix: fixed timesheet start date validation

### DIFF
--- a/one_fm/overrides/timesheet.py
+++ b/one_fm/overrides/timesheet.py
@@ -22,16 +22,13 @@ class TimesheetOveride(Timesheet):
         self.validate_start_date()
 
     def validate_start_date(self):
-        if frappe.session.user != "Administrator":
-            start_date = getdate(self.start_date)
-            if start_date > getdate():
-                frappe.throw(_("Please note that Timesheets cannot be created for a future date"), title="Invalid Start Date")
-            if start_date < getdate():
-                if self.is_new():
-                    msg = _("Please note that Timesheets cannot be created for a past date")
-                else:
-                    msg = _("Please note that Timesheets cannot be updated for a past date")
-                frappe.throw(msg, title="Invalid Start Date")
+        if frappe.session.user == "Administrator":
+            return
+
+        today = get_datetime_in_timezone("Asia/Kuwait").date()
+
+        if self.has_value_changed("start_date") and getdate(self.start_date) != today:
+            frappe.throw(_("Please note that timesheet should not be of past/future date"),title="Invalid Start Date")
 
     def before_save(self):
         if not self.is_new():


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Unable to approve timesheets for past dates

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Fixed start date validation for timesheet

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Timesheet Override

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
TImesheets for past will be able to approve

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
