### PR TITLE
BUG: INACTIVE OPERATIONS SHIFT DISPLAYING NOT ACTIVE

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift_list.js
+++ b/one_fm/operations/doctype/operations_shift/operations_shift_list.js
@@ -3,7 +3,7 @@ frappe.listview_settings['Operations Shift'] = {
 		if(doc.status == "Active") {
 			return [__("Active"), "green", ];
 		} else if(doc.status == "Inactive") {
-			return [__("Inactive"), "red", ];
+			return [__("Inactive"), "gray", ];
 		}
 	}
 };

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -97,3 +97,4 @@ one_fm.patches.v15_0.update_purchase_order_according_to_new_workflow
 one_fm.patches.v15_0.update_erf_for_job_offer
 one_fm.patches.v15_0.populate_project_type_task
 one_fm.patches.v15_0.update_employees_operation_role
+one_fm.patches.v15_0.update_operations_shift_status

--- a/one_fm/patches/v15_0/update_operations_shift_status.py
+++ b/one_fm/patches/v15_0/update_operations_shift_status.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+    frappe.db.sql("""
+            UPDATE `tabOperations Shift`
+            SET status = "Inactive"
+            WHERE status = "Not Active"
+    """)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [X] Bug


## Clearly and concisely describe the feature, chore or bug.
Inactive operations shift are displaying not active, and also in red, it needs to be grey

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a patch that updates the status

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Operations Shift

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
