### PR TITLE
Bug : On submitting new leave application , need to save the application status in pending approval/pending reliever

### DIFF
--- a/one_fm/api/v1/leave_application.py
+++ b/one_fm/api/v1/leave_application.py
@@ -336,6 +336,10 @@ def new_leave_application(employee: str, from_date: str,to_date: str,leave_type:
 
     leave.leave_approver_name = frappe.db.get_value("User", leave_approver, 'full_name')
     leave.save(ignore_permissions=True)
+    if reliever:
+        leave.workflow_state = "Pending Reliever"
+    else:
+        leave.workflow_state = "Pending Approval"
     if attachments:
         _file = upload_file(leave, "", attachments['attachment_hashed_name'], "", attachments['attachment_file'], is_private=True)
         leave.append('proof_documents', {'description':attachments['attachment_name'], 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://www.pivotaltracker.com/story/show/188876824

## Analysis and design (optional)
added the workflow state after the doc is saved as we cannot change the workflow status to pending approval directly with out the draft state

## Solution description
changes in new leave application function .

## Is there a business logic within a doctype?
    - [] No

## Output screenshots (optional)
<img width="747" alt="Screenshot 2025-02-10 at 3 54 08 PM" src="https://github.com/user-attachments/assets/895a0271-812d-4523-b7e1-b23516197cb9" />


## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
