### PR TITLE
feat: added clear selection button in roster

### DIFF
--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -106,21 +106,29 @@
         </div>
         <div class="container-fluid pl30 pr30 d-none filterhideshow lightbluedtbg mt30">
             <div class="row py-4 py-md-4 py-lg-0">
-                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 pr-md-0">
-                    <a href="#" class="responsivebluebtn ml-0 dayoff">Day Off</a>
-                    <!--<a href="#" class="responsivebluebtn scheduleleave">Leaves</a>-->
-                    <a href="#" class="responsivebluebtn changepost">Schedule/Change Post</a>
-                    <a href="#" class="responsivebluebtn assignchangemodal">Unschedule/Post Staff</a>
-                    <a href="#" class="clear_selection"><i class="fas fa-close mr-2"></i>Clear Selection</a>
+                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 pr-md-0 d-flex justify-content-between align-items-center">
+                    <div>
+                        <a href="#" class="responsivebluebtn ml-0 dayoff">Day Off</a>
+                        <!--<a href="#" class="responsivebluebtn scheduleleave">Leaves</a>-->
+                        <a href="#" class="responsivebluebtn changepost">Schedule/Change Post</a>
+                        <a href="#" class="responsivebluebtn assignchangemodal">Unschedule/Post Staff</a>
+                    </div>
+                    <div>
+                        <a href="#" class="clear_selection"><i class="fas fa-close mr-2"></i>Clear Selection</a>
+                    </div>
                 </div>
             </div>
         </div>
         <div class="container-fluid pl30 pr30 d-none Postfilterhideshow lightbluedtbg mt30">
             <div class="row py-4 py-md-0">
-                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 pr-md-0">
-                    <a href="#" class="responsivebluebtn ml-0 editpostclassclick" data-target="#addpostmodal"
+                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 pr-md-0 d-flex justify-content-between align-items-center">
+                    <div>
+                        <a href="#" class="responsivebluebtn ml-0 editpostclassclick" data-target="#addpostmodal"
                         data-toggle="modal">Edit Post</a>
+                    </div>
+                    <div>
                         <a href="#" class="clear_selection"><i class="fas fa-close mr-2"></i>Clear Selection</a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -111,6 +111,7 @@
                     <!--<a href="#" class="responsivebluebtn scheduleleave">Leaves</a>-->
                     <a href="#" class="responsivebluebtn changepost">Schedule/Change Post</a>
                     <a href="#" class="responsivebluebtn assignchangemodal">Unschedule/Post Staff</a>
+                    <a href="#" class="clear_selection"><i class="fas fa-close mr-2"></i>Clear Selection</a>
                 </div>
             </div>
         </div>
@@ -119,6 +120,7 @@
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 pr-md-0">
                     <a href="#" class="responsivebluebtn ml-0 editpostclassclick" data-target="#addpostmodal"
                         data-toggle="modal">Edit Post</a>
+                        <a href="#" class="clear_selection"><i class="fas fa-close mr-2"></i>Clear Selection</a>
                 </div>
             </div>
         </div>

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -691,8 +691,13 @@ function setup_topbar_events(page) {
 
 		unschedule_staff(page);
 	});
+
 	$('.dayoff').on('click', function () {
 		dayoff(page);
+	});
+
+	$('.clear_selection').on('click', function () {
+		clear_selection(page);
 	});
 }
 
@@ -3326,6 +3331,20 @@ function schedule_change_post(page) {
 	});
 	d.show();
 }
+
+function clear_selection(page) {
+	classgrt = [];
+	classgrtw = [];
+
+	$(".filterhideshow").addClass("d-none");
+	$(".Postfilterhideshow").addClass("d-none");
+	
+	$("#calenderviewtable tbody").find("tr").each(function (i, row) {
+		$(row).find("input[type='checkbox']").prop("checked", false); // Uncheck the employee checkbox
+		$(row).find("div").removeClass("selectclass"); // Remove days selections
+	});
+}
+
 function update_roster_view(element, page) {
 	page[element](page);
 	frappe.realtime.on("roster_view", function (output) {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As a Roster user
I want to have the option to clear existing selection (Employees/post and days selection on both staff and post views)
so that I do not have to unselect one-by-one

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added clear selection button to clear selections

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2025-02-11 10-48-51](https://github.com/user-attachments/assets/778255c3-8d58-4216-8a66-33213da357a4)
![Screenshot from 2025-02-11 10-49-08](https://github.com/user-attachments/assets/d36f8b69-a0c6-47e5-8b0d-8fb51451b3b4)


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Page

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
