### PR TITLE
BUG : Attendance Check is created for timesheet employee even timesheet exists

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -761,9 +761,9 @@ def mark_open_timesheet_and_create_attendance():
     present_employees = frappe.db.get_list("Timesheet", filters={"start_date": the_date, "workflow_state": "Approved"}, pluck="employee")
     for obj in employee_list:
         status, message = is_holiday(employee=obj,date=the_date)
-        if obj not in present_employees:
+        if obj.name not in present_employees:
             att = frappe.new_doc("Attendance")
-            att.employee = obj
+            att.employee = obj.name
             att.attendance_date = the_date
             att.status = "Absent" if not status else "Day Off"
             att.working_hours = 0


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Bug


## Clearly and concisely describe the bug.
https://www.pivotaltracker.com/story/show/188883112

## Solution description
The employee_list returns the list of dict ,therefore the dict should be validated with key , as it was directly validating with dic it was failing and absent record was created for timesheet employee even when timesheet for present is created.

## Is there a business logic within a doctype?
    - [] No

## Areas affected and ensured
None

## Is there any existing behavior change of other features due to this code change?
No. 

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
