### PR TITLE
CHORE: MAKE SHIFT ALLOCATION FIELD EDITABLE AFTER ONBOARD EMPLOYEE CREATION

### DIFF
--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
@@ -16,6 +16,7 @@ frappe.ui.form.on('Onboard Employee', {
 		create_custom_buttons(frm);
 		filterDefaultShift(frm);
 		set_shift_working_btn(frm);
+		set_operations_shift(frm);
 		if(frm.doc.duty_commencement_status == "Applicant Signed and Uploaded" && !frm.doc.employee && !frm.doc.company_email){
 			frm.scroll_to_field('company_email');
 		}
@@ -149,6 +150,16 @@ frappe.ui.form.on('Onboard Employee', {
 });
 
 
+const set_operations_shift = (frm) => {
+    if (frm.doc.job_offer && !frm.doc.attendance_by_timesheet && !frm.doc.operations_shift) {
+        frappe.db.get_value('Job Offer', { name: frm.doc.job_offer }, 'operations_shift')
+            .then((r) => {
+                if (r.message?.operations_shift) {
+                    frm.set_value('operations_shift', r.message.operations_shift);
+                }
+            });
+    }
+};
 
 
 var calculate_g2g_and_residency_total = function(frm) {

--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
@@ -116,6 +116,7 @@ frappe.ui.form.on('Onboard Employee', {
 					}
 				}
 			});
+			set_operations_shift(frm);
 		}
 	},
 	btn_create_bank_account: function(frm) {

--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.json
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.json
@@ -1205,7 +1205,6 @@
   {
    "allow_on_submit": 1,
    "depends_on": "eval:!doc.attendance_by_timesheet",
-   "fetch_from": "job_offer.operations_shift",
    "fetch_if_empty": 1,
    "fieldname": "operations_shift",
    "fieldtype": "Link",
@@ -1567,7 +1566,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-18 17:06:41.619717",
+ "modified": "2025-02-16 11:15:41.771341",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Onboard Employee",

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -490,6 +490,7 @@ def create_onboarding_from_job_offer(job_offer):
 			o_employee.reports_to = job_offer.reports_to
 			o_employee.date_of_joining = job_offer.estimated_date_of_joining
 			o_employee.employment_type = job_offer.employment_type
+			o_employee.operations_shift = job_offer.operations_shift
 			for d in fields:
 				o_employee.set(d, job_offer.get(d))
 			for od in one_fm_fields:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [X] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/617
To make the shift allocation field editable on the onboard employee document


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
added a method in the js that fetches the shift 

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
