### PR TITLE
chore: Configuration in App Service doctype to restrict service for Timesheet/Non-timesheet employees

### DIFF
--- a/one_fm/api/v1/configuration.py
+++ b/one_fm/api/v1/configuration.py
@@ -73,8 +73,15 @@ def app_service() -> dict:
 		}
 	"""
 	try:
+		employee_id = frappe.db.get_value("Employee", {"user_id":frappe.session.user}, ["name", "attendance_by_timesheet"], as_dict=1)
+		filters = {}
+		if employee_id.attendance_by_timesheet:
+			filters["assign_to_timesheet_employees"] = 1
+		else:
+			filters["assign_to_non_timesheet_employees"] = 1
+
 		app_service = frappe.db.get_all("App Service", 
-			filters={},
+			filters=filters,
 			fields=["name", "icon", "status", "service_group"])
 		return response("Success", 200, app_service)
 	except Exception as error:
@@ -96,13 +103,20 @@ def user_app_service() -> dict:
 	"""
 	try:
 		if not frappe.db.exists("User App Service", {"user":frappe.session.user}):
-			employee_id = frappe.db.get_value("Employee", {"user_id":frappe.session.user}, "name")
+			employee_id = frappe.db.get_value("Employee", {"user_id":frappe.session.user}, ["name", "attendance_by_timesheet"], as_dict=1)
+			filters = {"auto_assign": 1}
+			if employee_id.attendance_by_timesheet:
+				filters["assign_to_timesheet_employees"] = 1
+			else:
+				filters["assign_to_non_timesheet_employees"] = 1
+
 			auto_assign_services = frappe.db.get_list("App Service", 
-				filters={"auto_assign":1},
+				filters=filters,
 			)
+
 			frappe.get_doc({
 				"doctype": "User App Service",
-				"employee": employee_id,
+				"employee": employee_id.name,
 				"user":frappe.session.user,
 				"service_detail": [{"service":i.name} for i in auto_assign_services]
             }).insert(ignore_permissions=True)

--- a/one_fm/one_fm/doctype/app_service/app_service.json
+++ b/one_fm/one_fm/doctype/app_service/app_service.json
@@ -10,7 +10,9 @@
   "icon",
   "column_break_iidf",
   "status",
-  "auto_assign"
+  "auto_assign",
+  "assign_to_timesheet_employees",
+  "assign_to_non_timesheet_employees"
  ],
  "fields": [
   {
@@ -54,10 +56,22 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Auto Assign"
+  },
+  {
+   "default": "0",
+   "fieldname": "assign_to_timesheet_employees",
+   "fieldtype": "Check",
+   "label": "Assign to timesheet employees"
+  },
+  {
+   "default": "0",
+   "fieldname": "assign_to_non_timesheet_employees",
+   "fieldtype": "Check",
+   "label": "Assign to non timesheet employees"
   }
  ],
  "links": [],
- "modified": "2024-04-26 00:02:30.868707",
+ "modified": "2025-02-18 09:53:30.765357",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "App Service",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Configure App service for timesheet and non-timesheet employees so that they are shown in mobile app based on this configuration.


## Solution description
1. Added `Assign to timesheet employees` and `Assign to timesheet employees` checkbox field. 
2. Modified APIs to check if current user has `attendance_by_timesheet = 1`, then they will be shown all the app service that have `Assign to timesheet employees` checked. 


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d5f669f2-4944-4392-96b1-222a213f719b)

## Is there any existing behavior change of other features due to this code change?
Yes. 
After updating App service, they will be fetched based on logged in user's attendance_by_timesheet value. 

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
