### PR TITLE
feat: updated default shift checker w.r.t to single employee

### DIFF
--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.js
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.js
@@ -1,8 +1,16 @@
 // Copyright (c) 2024, omar jaber and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Default Shift Checker", {
-// 	refresh(frm) {
+frappe.ui.form.on("Default Shift Checker", {
+    action_type: function(frm){
+        reset_new_operations_shift_and_role_allocation(frm)
+    }
+});
 
-// 	},
-// });
+function reset_new_operations_shift_and_role_allocation(frm){
+	frm.set_value({
+        "new_shift_allocation": "",
+        "new_operations_role_allocation": ""
+    })
+    frm.refresh_fields()
+}

--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.json
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.json
@@ -1,25 +1,29 @@
 {
  "actions": [],
- "autoname": "format: {start_date} | {end_date} | Check Default Shift | {operations_shift}",
+ "autoname": "format: {start_date} | {end_date} | Check Default Shift | {employee}",
  "creation": "2024-12-20 10:44:56.021618",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "start_date",
-  "operations_shift",
+  "employee",
+  "employee_name",
+  "default_shift_allocation",
   "column_break_fxzs",
+  "start_date",
   "end_date",
+  "default_operations_role_allocation",
   "actions_section",
   "status",
-  "shift_supervisor",
-  "shift_supervisor_name",
-  "column_break_mejq",
-  "action_type",
   "site_supervisor",
   "site_supervisor_name",
   "site_supervisor_user",
+  "column_break_mejq",
+  "action_type",
+  "new_shift_allocation",
+  "new_operations_role_allocation",
   "section_break_yzvl",
-  "employees_assigned_outside_default_shift"
+  "assigned_shifts_outside_default_shift",
+  "amended_from"
  ],
  "fields": [
   {
@@ -55,19 +59,6 @@
    "options": "Pending\nCompleted\nOverdue\nCancelled"
   },
   {
-   "fieldname": "shift_supervisor",
-   "fieldtype": "Link",
-   "ignore_user_permissions": 1,
-   "label": "Shift Supervisor",
-   "options": "Employee"
-  },
-  {
-   "fetch_from": "shift_supervisor.employee_name",
-   "fieldname": "shift_supervisor_name",
-   "fieldtype": "Data",
-   "label": "Shift Supervisor Name"
-  },
-  {
    "fieldname": "column_break_mejq",
    "fieldtype": "Column Break"
   },
@@ -77,7 +68,7 @@
    "fieldtype": "Select",
    "in_standard_filter": 1,
    "label": "Action Type",
-   "options": "No Changes Made\nShift Allocation Update\nMarked Employees as Relievers\nMixed Actions"
+   "options": "No Changes Made\nShift Allocation Update\nMark Employee as Reliever"
   },
   {
    "fieldname": "site_supervisor",
@@ -97,19 +88,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "employees_assigned_outside_default_shift",
-   "fieldtype": "Table",
-   "label": "Employees Assigned Outside Default Shift",
-   "options": "Default Shift Checker Employee"
-  },
-  {
-   "fieldname": "operations_shift",
-   "fieldtype": "Link",
-   "in_standard_filter": 1,
-   "label": "Operations Shift",
-   "options": "Operations Shift"
-  },
-  {
    "fetch_from": "site_supervisor.user_id",
    "fetch_if_empty": 1,
    "fieldname": "site_supervisor_user",
@@ -117,12 +95,73 @@
    "hidden": 1,
    "label": "Site Supervisor User",
    "options": "User"
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "employee.employee_name",
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "assigned_shifts_outside_default_shift",
+   "fieldtype": "Table",
+   "label": "Assigned Shifts Outside Default Shift",
+   "options": "Default Shift Checker Shift"
+  },
+  {
+   "fetch_from": "employee.shift",
+   "fieldname": "default_shift_allocation",
+   "fieldtype": "Data",
+   "label": "Default Shift Allocation",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "employee.custom_operations_role_allocation",
+   "fieldname": "default_operations_role_allocation",
+   "fieldtype": "Data",
+   "label": "Default Operations Role Allocation",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.action_type == \"Shift Allocation Update\";",
+   "fieldname": "new_shift_allocation",
+   "fieldtype": "Link",
+   "label": "New Shift Allocation",
+   "mandatory_depends_on": "eval:doc.action_type == \"Shift Allocation Update\";",
+   "options": "Operations Shift"
+  },
+  {
+   "depends_on": "eval:!!doc.new_shift_allocation;",
+   "fieldname": "new_operations_role_allocation",
+   "fieldtype": "Link",
+   "label": "New Operations Role Allocation",
+   "mandatory_depends_on": "eval:!!doc.new_shift_allocation;",
+   "options": "Operations Role"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Default Shift Checker",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2025-02-09 12:23:52.923918",
+ "modified": "2025-02-18 12:06:18.214897",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Default Shift Checker",

--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.py
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.py
@@ -1,20 +1,41 @@
 # Copyright (c) 2024, omar jaber and contributors
 # For license information, please see license.txt
-
-from collections import defaultdict
-
 import frappe
 from frappe.model.document import Document
 from frappe import _
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
 from frappe.utils import getdate, get_last_day
-from one_fm.operations.doctype.operations_shift.operations_shift import get_shift_supervisor
 
 class DefaultShiftChecker(Document):
-    pass
+    def on_submit(self):
+        self.update_employee_shift_details()
+
+    def update_employee_shift_details(self):
+        """
+            Updates the employee's shift or reliever status based on the action type.
+        """
+        employee = frappe.get_doc("Employee", self.employee)
+
+        field_updates = {
+            "Shift Allocation Update": {
+                "shift": self.new_shift_allocation,
+                "custom_operations_role_allocation": self.new_operations_role_allocation
+            },
+            "Mark Employee as Reliever": {
+                "custom_is_reliever": 1
+            }
+        }
+
+        if self.action_type in field_updates:
+            employee.update(field_updates[self.action_type])
+            employee.save()
+
+        self.db_set("status", "Completed")
 
 
+
+@frappe.whitelist(allow_guest=True)
 def create_default_shift_checker():
     start_date = getdate()
     last_day_of_month = get_last_day(start_date)
@@ -29,12 +50,9 @@ def create_default_shift_checker():
         .join(EmployeeSchedule)
         .on(Employee.name == EmployeeSchedule.employee)
         .select(
-            Employee.name,
-            Employee.employee_name,
-            EmployeeSchedule.shift.as_("scheduled_shift"),
+            Employee.name.as_("employee"),
             Employee.shift.as_("default_shift"),
-            EmployeeSchedule.site,
-            Count(EmployeeSchedule.shift).as_("operations_shift_count"),
+            Employee.site.as_("default_site")
         )
         .where(
             (Employee.shift_working == 1)
@@ -45,34 +63,40 @@ def create_default_shift_checker():
             & (EmployeeSchedule.roster_type == "Basic")
             & (EmployeeSchedule.date[start_date:last_day_of_month])
         )
-        .groupby(Employee.name, EmployeeSchedule.shift)
+        .groupby(Employee.name)
         .having(Count(EmployeeSchedule.shift) > threshold)
     )
 
     result = query.run(as_dict=1)
 
-    grouped_data = defaultdict(list)
     for item in result:
-        grouped_data[(item["scheduled_shift"], item["site"])].append(item)
-
-    for key, employees in grouped_data.items():
-        shift, site = key
         try:
             default_shift_checker = frappe.new_doc("Default Shift Checker")
+            default_shift_checker.employee = item['employee']
             default_shift_checker.start_date = start_date
             default_shift_checker.end_date = last_day_of_month
-            default_shift_checker.operations_shift = shift
+            default_shift_checker.site_supervisor = frappe.db.get_value("Operations Site", item['default_site'], "account_supervisor")
 
-            site_supervisor = frappe.db.get_value("Operations Site", site, "account_supervisor")
-            shift_supervisor = get_shift_supervisor(shift)
-            default_shift_checker.site_supervisor = site_supervisor
-            default_shift_checker.shift_supervisor = shift_supervisor
+            shifts_assigned_outside = (
+                frappe.qb.from_(EmployeeSchedule)
+                .select(
+                    EmployeeSchedule.shift,
+                    Count(EmployeeSchedule.shift).as_("operations_shift_count"),
+                )
+                .where(
+                    (EmployeeSchedule.employee == item["employee"])
+                    & (EmployeeSchedule.shift != item["default_shift"])
+                    & (EmployeeSchedule.employee_availability == "Working")
+                    & (EmployeeSchedule.roster_type == "Basic")
+                    & (EmployeeSchedule.date[start_date:last_day_of_month])
+                )
+                .groupby(EmployeeSchedule.shift)
+            ).run(as_dict=1)
 
-            for employee in employees:
-                default_shift_checker.append("employees_assigned_outside_default_shift", {
-                    "employee": employee.name,
-                    "employee_name": employee.employee_name,
-                    "count": employee.operations_shift_count
+            for schedule in shifts_assigned_outside:
+                default_shift_checker.append("assigned_shifts_outside_default_shift", {
+                    "operations_shift": schedule.shift,
+                    "count": schedule.operations_shift_count
                 })
             default_shift_checker.save()
         except Exception as e:

--- a/one_fm/operations/doctype/default_shift_checker_shift/default_shift_checker_shift.json
+++ b/one_fm/operations/doctype/default_shift_checker_shift/default_shift_checker_shift.json
@@ -1,41 +1,26 @@
 {
  "actions": [],
  "allow_rename": 1,
- "creation": "2024-12-20 10:58:49.275676",
+ "creation": "2025-02-17 23:05:26.787232",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "employee",
-  "column_break_sulr",
-  "employee_name",
-  "column_break_pbsg",
+  "operations_shift",
+  "column_break_aepi",
   "count"
  ],
  "fields": [
   {
-   "fieldname": "employee",
+   "fieldname": "operations_shift",
    "fieldtype": "Link",
-   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "in_preview": 1,
-   "label": "Employee",
-   "options": "Employee"
+   "label": "Operations Shift",
+   "options": "Operations Shift"
   },
   {
-   "fieldname": "column_break_sulr",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fetch_from": "employee.employee_name",
-   "fieldname": "employee_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "in_preview": 1,
-   "label": "Employee Name"
-  },
-  {
-   "fieldname": "column_break_pbsg",
+   "fieldname": "column_break_aepi",
    "fieldtype": "Column Break"
   },
   {
@@ -49,10 +34,10 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-09 12:31:06.177299",
+ "modified": "2025-02-17 23:10:49.636630",
  "modified_by": "Administrator",
  "module": "Operations",
- "name": "Default Shift Checker Employee",
+ "name": "Default Shift Checker Shift",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",

--- a/one_fm/operations/doctype/default_shift_checker_shift/default_shift_checker_shift.py
+++ b/one_fm/operations/doctype/default_shift_checker_shift/default_shift_checker_shift.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2024, omar jaber and contributors
+# Copyright (c) 2025, omar jaber and contributors
 # For license information, please see license.txt
 
 # import frappe
 from frappe.model.document import Document
 
 
-class DefaultShiftCheckerEmployee(Document):
+class DefaultShiftCheckerShift(Document):
 	pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
[Sivaraj] As a Roster User
I want to be able to take necessary action from within the Default Shift Checker Doctype
so that I not have to navigate elsewhere to get it done
(https://www.pivotaltracker.com/story/show/188879121)

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Updated fields w.r.t to single employee
- Added child table to see shifts assigned outside default shift
- Updated employee details based on action type

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2025-02-18 14-36-47](https://github.com/user-attachments/assets/7f078398-6b34-4633-82c7-aab27d1848dc)


## Areas affected and ensured
List out the areas affected by your code changes.
Default Shift Checker

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Default Shift Checker will be created w.r.t single employees

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
