### PR TITLE
feat: added feature for unscheduling staff in roster for selected days as well

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -3023,14 +3023,26 @@ function unschedule_staff(page) {
 		'title': 'Unschedule Staff',
 		'fields': [
 			{
-				'label': 'Start Date', 'fieldname': 'start_date', 'fieldtype': 'Date', 'reqd': 1, 'default': date, onchange: function () {
+				'label': 'Selected Days Only', 'fieldname': 'selected_days_only', 'fieldtype': 'Check', 'default': 0, onchange: function () {
+					let val = d.get_value('selected_days_only');
+					if (val) {
+						d.set_value('start_date', '');
+						d.set_value('never_end', 0);
+						d.set_value('select_end', 0);
+						d.set_value('end_date', '');
+					}
+				}
+			},
+			{ 'fieldtype': 'Section Break', 'depends_on': "eval:doc.selected_days_only == 0" },
+			{
+				'label': 'Start Date', 'fieldname': 'start_date', 'fieldtype': 'Date', 'reqd': 1, 'mandatory_depends_on': "eval:doc.selected_days_only == 0", 'default': date, onchange: function () {
 					let start_date = d.get_value('start_date');
 					if (start_date && moment(start_date).isSameOrBefore(moment(frappe.datetime.nowdate()))) {
 						frappe.throw(__("Start Date cannot be before today."));
 					}
 				}
 			},
-			{ 'fieldtype': 'Section Break' },
+			{ 'fieldtype': 'Section Break', 'depends_on': "eval:doc.selected_days_only == 0" },
 			{
 				'label': 'Never End', 'fieldname': 'never_end', 'fieldtype': 'Check', onchange: function () {
 					let val = d.get_value('never_end');
@@ -3064,7 +3076,7 @@ function unschedule_staff(page) {
 		],
 		primary_action: function () {
 			$('#cover-spin').show(0);
-			let { start_date, end_date, never_end } = d.get_values();
+			let { selected_days_only, start_date, end_date, never_end } = d.get_values();
 			let element = get_wrapper_element();
 			if (element == ".rosterOtMonth") {
 				otRoster = true;
@@ -3075,7 +3087,7 @@ function unschedule_staff(page) {
 			frappe.call({
 				method: "one_fm.one_fm.page.roster.roster.unschedule_staff",
 				type: "POST",
-				args: { employees,otRoster, start_date, end_date, never_end },
+				args: { employees, otRoster, start_date, end_date, never_end, selected_days_only },
 				callback: function(res) {
 					// code snippet
 					d.hide();

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -770,21 +770,24 @@ def schedule_leave(employees, leave_type, start_date, end_date):
         return frappe.utils.response.report_error(e.http_status_code)
 
 @frappe.whitelist(allow_guest=True)
-def unschedule_staff(employees, otRoster,start_date, end_date=None, never_end=0):
+def unschedule_staff(employees, otRoster,start_date=None, end_date=None, never_end=0, selected_days_only=0):
     try:
-        if otRoster == 'true':
-            roster_type = "Over-Time"
-        else:
-            roster_type = "Basic"
-        _start_date = getdate(start_date)
-        if end_date:
-            stop_date = getdate(end_date)
-        else: stop_date = None
-        delete_list = []
+        roster_type = "Over-Time" if otRoster == 'true' else "Basic"
+        _start_date = getdate(start_date) if start_date else None
+        stop_date = getdate(end_date) if end_date else None
+
         employees = json.loads(employees)
+
+        print("="*200, employees)
+
         if not employees:
             response("Error", 400, None, {'message':'Employees must be selected.'})
-        employees = [i for i in employees if getdate(i['date'])>=_start_date]
+
+        if not selected_days_only and not _start_date:
+            frappe.throw("Must provide a start date if selected days are not targetted")
+        
+        if _start_date:
+            employees = [i for i in employees if getdate(i['date'])>=_start_date]
 
         if end_date:
             employees = [i for i in employees if getdate(i['date'])<=stop_date]

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -778,8 +778,6 @@ def unschedule_staff(employees, otRoster,start_date=None, end_date=None, never_e
 
         employees = json.loads(employees)
 
-        print("="*200, employees)
-
         if not employees:
             response("Error", 400, None, {'message':'Employees must be selected.'})
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
[Ahmed] As a roster user
I want to be able to unschedule staff for selected days only
so that specific days can be (un)planned
(https://www.pivotaltracker.com/story/show/188857549)

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added selected days option as well in unschedule staff form in roster

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster (Unschedule Staff)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
