### PR TITLE
fix: Modify get_supervisor_shift function

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.py
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.py
@@ -165,16 +165,20 @@ def get_shift_supervisor(shift, date=False):
 
 	for supervisor in supervisors:
 		# Return the supervisor if the supervisor working on the day
-		if frappe.db.exists(
-			"Employee Schedule",
-			{
-				"employee": supervisor.supervisor,
-				"date": date,
-				"employee_availability": "Working"
-			}
-		):
-			return supervisor.supervisor
-
+		shift_working = frappe.db.get_value("Employee", supervisor.supervisor, "shift_working")
+		if shift_working:
+			if frappe.db.exists(
+				"Employee Schedule",
+				{
+					"employee": supervisor.supervisor,
+					"date": date,
+					"employee_availability": "Working"
+				}
+			):
+				return supervisor.supervisor
+		else:
+			if not frappe.db.exists("Leave Application", {"employee": supervisor.supervisor, "status": "Approved", "from_date":["<=", date], "to_date":[">=", date]}):
+				return supervisor.supervisor
 	return None
 
 def get_supervisor_operations_shifts(supervisor=None, project=None, site=None):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Modify get_supervisor_shift so that it checks leave application is supervisor is non-shift working employee. 


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
