### PR TITLE
Chore : I want to print the RFM in a given format so that I can use it for future references

### DIFF
--- a/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
+++ b/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
@@ -103,6 +103,7 @@
    "label": "Actual Item Description",
    "oldfieldname": "description",
    "oldfieldtype": "Text",
+   "print_hide": 1,
    "print_width": "250px",
    "read_only": 1,
    "width": "250px"
@@ -211,6 +212,7 @@
    "oldfieldname": "warehouse",
    "oldfieldtype": "Link",
    "options": "Warehouse",
+   "print_hide": 1,
    "print_width": "100px",
    "width": "100px"
   },
@@ -226,6 +228,7 @@
    "label": "Required Date",
    "oldfieldname": "schedule_date",
    "oldfieldtype": "Date",
+   "print_hide": 1,
    "print_width": "100px",
    "reqd": 1,
    "width": "100px"
@@ -236,6 +239,7 @@
    "hidden": 1,
    "label": "Rate",
    "no_copy": 1,
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -244,6 +248,7 @@
    "hidden": 1,
    "label": "Amount",
    "no_copy": 1,
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -307,7 +312,8 @@
    "depends_on": "eval:doc.docstatus==1",
    "fieldname": "received_qty",
    "fieldtype": "Float",
-   "label": "Received Quantity"
+   "label": "Received Quantity",
+   "print_hide": 1
   },
   {
    "allow_on_submit": 1,
@@ -370,6 +376,7 @@
    "fieldname": "quantity_to_transfer",
    "fieldtype": "Float",
    "label": "Quantity to Transfer",
+   "print_hide": 1,
    "report_hide": 1
   },
   {
@@ -417,6 +424,7 @@
    "fieldname": "reserve_qty",
    "fieldtype": "Float",
    "label": "Reserve Quantity",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -449,7 +457,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-01-20 21:03:47.441756",
+ "modified": "2025-02-27 11:36:39.859638",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Request for Material Item",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Chore

## Clearly and concisely describe the feature, chore or bug.
https://www.pivotaltracker.com/story/show/188934185

## Solution description
Change in print hide status to 1 in the required fields of request for material docttype

## Is there a business logic within a doctype?
    - [] No

## Output screenshots (optional)
[RFM-2025-000033.pdf](https://github.com/user-attachments/files/19005388/RFM-2025-000033.pdf)

https://github.com/user-attachments/assets/10d35afc-85eb-41c6-9a3a-0cdea0b594c4

## Areas affected and ensured
Request for material print format

## Is there any existing behavior change of other features due to this code change?
 No. 

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
