### PR TITLE
feat: update shift type details in employee schedule and shift assignment on change in operations shift

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.js
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Operations Shift', {
+	onload: function (frm) {
+		frm.__previous_shift_type = frm.doc.shift_type
+	},
 	refresh: function(frm) {
 		if(!frm.doc.__islocal){
 			frm.add_custom_button(
@@ -193,5 +196,30 @@ frappe.ui.form.on('Operations Shift', {
 				}
 			);
 		}
+	},
+	shift_type: function (frm) {
+		if (frm.__is_updating_shift_type) return;
+	
+		frm.__is_updating_shift_type = true;
+	
+		frappe.confirm(
+			__('The Shift Type Change will reflect to the existing Employee Schedules and Shift Assignment starting from today. Are you sure you want to update Shift Type?'),
+			() => {
+				frm.__is_updating_shift_type = false;
+			},
+			() => {
+				// Ensure operations execute sequentially, reducing unintended re-triggers
+				frappe.run_serially([
+					() => frm.set_value('shift_type', frm.__previous_shift_type),
+					() => frm.refresh_field('shift_type'),
+					() => {
+						setTimeout(() => {
+							frm.__is_updating_shift_type = false;
+						}, 100);
+					}
+				]);
+			}
+		);
 	}
+	
 });

--- a/one_fm/operations/doctype/operations_shift/operations_shift.py
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.py
@@ -26,8 +26,8 @@ class OperationsShift(Document):
 	def on_update(self):
 		self.clear_cache()
 		self.validate_name()
-
 		self.update_post_status()
+		self.update_employee_schedules_and_shift_assignments()
 
 	def validate_name(self):
 		#this method is updating the name of the record and sending clear message through exception if any of the records are missing
@@ -94,6 +94,15 @@ class OperationsShift(Document):
 			else:
 				queue_operation_role_inactive(operations_role_list)
 				frappe.msgprint(_("Operations Role linked to the Shift {0} is set to Inactive!".format(self.name)), alert=True, indicator='green')
+
+	def update_employee_schedules_and_shift_assignments(self):
+		if self.is_new():
+			return
+		
+		if self.has_value_changed('shift_type'):
+			frappe.enqueue(update_employee_schedule_shift_type, is_async=True, queue='long', operations_shift=self.name, new_shift_type=self.shift_type, new_start_time=self.start_time, new_end_time=self.end_time)
+			frappe.enqueue(update_shift_assignment_shift_type, is_async=True, queue='long', operations_shift=self.name, new_shift_type=self.shift_type, new_start_time=self.start_time, new_end_time=self.end_time)
+
 
 def queue_operation_role_inactive(operations_role_list):
 	for operations_role in operations_role_list:
@@ -206,3 +215,15 @@ def get_supervisor_operations_shifts(supervisor=None, project=None, site=None):
 	shifts = frappe.db.sql(query, as_dict=True)
 
 	return [shift.name for shift in shifts]
+
+def update_employee_schedule_shift_type(operations_shift, new_shift_type, new_start_time, new_end_time):
+	employee_schedules = frappe.get_all("Employee Schedule", filters={"shift": operations_shift, "date": [">=", today()]}, fields=["name", "date"])
+
+	for schedule in employee_schedules:
+		frappe.db.set_value("Employee Schedule", schedule.name, {"shift_type": new_shift_type, "start_datetime": f"{schedule.date} {new_start_time}", "end_datetime": f"{schedule.date} {new_end_time}"})
+
+def update_shift_assignment_shift_type(operations_shift, new_shift_type, new_start_time, new_end_time):
+	shift_assignments = frappe.get_all("Shift Assignment", filters={"shift": operations_shift, "start_date": [">=", today()]}, fields=["name", "start_date", "end_date", "shift_classification"])
+
+	for assignment in shift_assignments:
+		frappe.db.set_value("Shift Assignment", assignment.name, {"shift_type": new_shift_type, "start_datetime": f"{assignment.start_date} {new_start_time}", "end_datetime": f"{assignment.end_date or assignment.start_date} {new_end_time}", "shift_classification": assignment.shift_classification})


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
[Ahmed, Sivaraj] As Attendance Manager 
I want certain Operations Shifts to have a different timing (start & end) during Ramadan
so that operational needs are met

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Added confirmation popup for shift type change in operations shift
- Updated shift type related details in Employee Schedule
- Updated shift type related details in Shift Assignment

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Operations Shift
Employee Schedule
Shift Assignment

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Shift Type related details will be updated in Employee Schedule and Shift Assignment as well

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
