### PR TITLE
Chore : Create Interview from Job applicant make from and to time not mandatory for "A la carte Recruitment"

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -851,7 +851,9 @@ override_whitelisted_methods = {
     "frappe.desk.form.load.get_docinfo": "one_fm.permissions.get_docinfo",
 	"erpnext.controllers.accounts_controller.update_child_qty_rate":"one_fm.overrides.accounts_controller.update_child_qty_rate",
 	"hrms.hr.doctype.goal.goal.get_children":"one_fm.overrides.goal.get_childrens",
-    "hrms.payroll.doctype.payroll_entry.payroll_entry.get_start_end_dates": "one_fm.overrides.payroll_entry.get_start_end_dates"
+    "hrms.payroll.doctype.payroll_entry.payroll_entry.get_start_end_dates": "one_fm.overrides.payroll_entry.get_start_end_dates",
+    "hrms.hr.doctype.job_applicant.job_applicant.create_interview": "one_fm.overrides.job_applicant.create_interview"
+
 }
 
 

--- a/one_fm/overrides/job_applicant.py
+++ b/one_fm/overrides/job_applicant.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import json
 
 import frappe
 from frappe import _
@@ -9,6 +10,8 @@ from one_fm.processor import sendemail
 from one_fm.utils import is_scheduler_emails_enabled
 
 from one_fm.utils import production_domain
+from hrms.hr.doctype.job_applicant.job_applicant import create_interview as hrms_create_interview
+
 
 class JobApplicantOverride(JobApplicant):
 
@@ -201,3 +204,14 @@ class NotifyLocalTransfer:
 						sendemail(recipients=receivers, subject=title, content=msg)
 		except:
 			frappe.log_error(frappe.get_traceback(), "Error while sending notification of local transfer")
+
+
+@frappe.whitelist()
+def create_interview(doc,interview_round):
+	interview = hrms_create_interview(doc, interview_round)
+	if json.loads(doc)["one_fm_hiring_method"]  == "A la carte Recruitment":
+		interview.custom_hiring_method = json.loads(doc)["one_fm_hiring_method"]
+		interview.from_time = None
+		interview.to_time = None
+	return interview
+	


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Chore


## Clearly and concisely describe the chore.
Create Interview from Job applicant make from and to time not mandatory for "A la carte Recruitment"


## Analysis and design (optional)
Create Interview from Job applicant make from and to time not mandatory for "A la carte Recruitment"

## Solution description
overriding the create_interview fucntion of hrms in one_fm

## Is there a business logic within a doctype?
    - [] No

## Output screenshots (optional)

https://github.com/user-attachments/assets/61150af5-6593-4f39-827c-2603b2fbf70e


## Areas affected and ensured
Interview doctype

## Is there any existing behavior change of other features due to this code change?
No.


## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - None
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
