### PR TITLE
chore: employee field marked as optional when process in set in process task

### DIFF
--- a/one_fm/operations/doctype/process_task/process_task.json
+++ b/one_fm/operations/doctype/process_task/process_task.json
@@ -92,8 +92,8 @@
    "in_filter": 1,
    "in_standard_filter": 1,
    "label": "Employee",
-   "options": "Employee",
-   "reqd": 1
+   "mandatory_depends_on": "eval:!doc.process_name",
+   "options": "Employee"
   },
   {
    "fetch_from": "employee.employee_name",
@@ -278,7 +278,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-03 12:50:04.815516",
+ "modified": "2025-03-24 11:22:43.775429",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Process Task",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Make Employee field non-mandatory for Process tasks 

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Marked employee field as optional when process is set in Process Task doctype

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Process Task

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
