### PR TITLE
fix: no buttons for approval/rejection in shift permission assignment rule email

### DIFF
--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -141,7 +141,10 @@ class ShiftPermission(Document):
 
 				else:
 					if self.leaving_time:
-						date_time = datetime.strptime(self.date + " " + self.leaving_time, '%Y-%m-%d %H:%M:%S')
+						date_time = datetime.strptime(
+    								self.date.strftime('%Y-%m-%d') + " " + str(self.leaving_time),
+    								'%Y-%m-%d %H:%M:%S'
+									)						
 						frappe.db.sql("""
 										UPDATE `tabShift Assignment`
 										SET end_datetime = %s


### PR DESCRIPTION
## Clearly and concisely describe the feature, chore or bug.

- Functional workflow buttons should show up in shift permission notification email

Story link: https://one-fm.atlassian.net/jira/software/projects/ON/boards/2?selectedIssue=ON-85
(Was developed pre-Jira so branch name is different)

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description

- Adjusted line of code in shift_permission.py that was causing a TypeError


## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured

- `one_fm/operations/doctype/shift_permission/shift_permission.py`

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

- No

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created?
    - [*] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox

