### PR TITLE
Hotfix BUG : Resolved creating duplicate entries for items while updating the record in Post Scheduler Checker

### DIFF
--- a/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
+++ b/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
@@ -19,13 +19,14 @@ class PostSchedulerChecker(Document):
 	def validate(self):
 		if not self.check_date:
 			self.check_date = getdate()
-		self.fill_items()
 		self.__get_shift_supervisor()
 		self.get_site_supervisor()
-		if not self.items:
-			frappe.throw('No issues found.')
+
 
 	def after_insert(self):
+		self.fill_items()
+		if not self.items:
+			frappe.throw('No issues found.')
 		frappe.db.commit()
 
 	def __get_shift_supervisor(self):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Bug


## Clearly and concisely describe the bug.
Resolved creating duplicate entries for items while updating the record in Post Scheduler Checker

## Analysis and design (optional)
added the get_fill() function inside the after_insert()

## Solution description
added the get_fill() function inside the after_insert()

## Is there a business logic within a doctype?
    - [] No


## Output screenshots (optional)

https://github.com/user-attachments/assets/af8114fe-c3a9-445a-b516-6001c535ed9c


## Areas affected and ensured
Post_Scheduler_Checker.py 

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
