### PR TITLE
FEAT : Allow submit the career history by the recruiter only if the 'Validate by Recruiter On' is set in Career History 

### DIFF
--- a/one_fm/one_fm/doctype/career_history/career_history.py
+++ b/one_fm/one_fm/doctype/career_history/career_history.py
@@ -15,10 +15,6 @@ class CareerHistory(Document):
 		update_interview_and_feedback(self)
 
 	def validate(self):
-		if not self.validated_by_recruiter_on:
-			frappe.throw("You can only submit Career History once 'Validate by Recruiter On' is set.")
-		elif getdate(self.validated_by_recruiter_on) > getdate(nowdate()):
-				frappe.throw("Validate by Recruiter On cannot be future date.")
 		self.validate_with_applicant()
 		if self.career_history_company and self.calculate_promotions_and_experience_automatically:
 			self.calculate_promotions_and_experience()
@@ -100,6 +96,10 @@ class CareerHistory(Document):
 			self.total_years_of_experience = total_months_of_experience/12
 
 	def	on_submit(self):
+		if not self.validated_by_recruiter_on:
+			frappe.throw("You can only submit Career History once 'Validate by Recruiter On' is set.")
+		elif getdate(self.validated_by_recruiter_on) > getdate(nowdate()):
+			frappe.throw("Validate by Recruiter On cannot be future date.")
 		self.career_history_score_action()
 		update_interview_and_feedback(self, True)
 

--- a/one_fm/one_fm/doctype/career_history/career_history.py
+++ b/one_fm/one_fm/doctype/career_history/career_history.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
 from frappe import _
-from frappe.utils import getdate, month_diff, today, now, get_link_to_form
+from frappe.utils import getdate, month_diff, today, now, get_link_to_form,nowdate
 from one_fm.utils import validate_applicant_overseas_transferable
 
 class OverlapError(frappe.ValidationError): pass
@@ -15,6 +15,10 @@ class CareerHistory(Document):
 		update_interview_and_feedback(self)
 
 	def validate(self):
+		if not self.validated_by_recruiter_on:
+			frappe.throw("You can only submit Career History once 'Validate by Recruiter On' is set.")
+		elif getdate(self.validated_by_recruiter_on) > getdate(nowdate()):
+				frappe.throw("Validate by Recruiter On cannot be future date.")
 		self.validate_with_applicant()
 		if self.career_history_company and self.calculate_promotions_and_experience_automatically:
 			self.calculate_promotions_and_experience()


### PR DESCRIPTION
…e by Recruiter On' is set in Career History

## Is this a Feature, Chore or Bug?
- [] Feature

## Clearly and concisely describe the feature.
https://www.pivotaltracker.com/story/show/189050806

## Solution description
Changes done on validation method on the career history doctype

## Is there a business logic within a doctype?
    - [] No


## Output screenshots 👍 
https://github.com/user-attachments/assets/e1997d1f-5650-4bce-9d15-5459378a0fa3


## Areas affected and ensured
Career History doctype

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    -No

## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
