### PR TITLE
Feat :As a recruiter I want to assign to the Career History whenever a Career History is created so that I can plan the career history verification interview with the candidate

### DIFF
--- a/one_fm/fixtures/assignment_rule.json
+++ b/one_fm/fixtures/assignment_rule.json
@@ -1161,5 +1161,69 @@
       }
     ],
   "users": []
- }
+ },
+ {
+    "assign_condition": "status == 'Submitted'",
+    "assignment_days": [
+     {
+      "day": "Monday",
+      "parent": "Career History",
+      "parentfield": "assignment_days",
+      "parenttype": "Assignment Rule"
+     },
+     {
+      "day": "Tuesday",
+      "parent": "Career History",
+      "parentfield": "assignment_days",
+      "parenttype": "Assignment Rule"
+     },
+     {
+      "day": "Wednesday",
+      "parent": "Career History",
+      "parentfield": "assignment_days",
+      "parenttype": "Assignment Rule"
+     },
+     {
+      "day": "Thursday",
+      "parent": "Career History",
+      "parentfield": "assignment_days",
+      "parenttype": "Assignment Rule"
+     },
+     {
+      "day": "Friday",
+      "parent": "Career History",
+      "parentfield": "assignment_days",
+      "parenttype": "Assignment Rule"
+     },
+     {
+      "day": "Saturday",
+      "parent": "Career History",
+      "parentfield": "assignment_days",
+      "parenttype": "Assignment Rule"
+     },
+     {
+      "day": "Sunday",
+      "parent": "Career History",
+      "parentfield": "assignment_days",
+      "parenttype": "Assignment Rule"
+     }
+    ],
+    "close_condition": null,
+    "custom_routine_task": null,
+    "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Job Applicant</td>\n                <td style=\"padding: 10px;\">{{job_applicant}}</td>\n            </tr>\n            </tbody></table><p></p>",
+    "disabled": 0,
+    "docstatus": 0,
+    "doctype": "Assignment Rule",
+    "document_type": "Career History",
+    "due_date_based_on": null,
+    "field": "recruiter_assigned",
+    "is_assignment_rule_with_workflow": 0,
+    "last_user": null,
+    "modified": "2025-04-14 15:28:18.291148",
+    "name": "Career History",
+    "priority": 0,
+    "rule": "Based on Field",
+    "unassign_condition": null,
+    "users": []
+   }
 ]

--- a/one_fm/one_fm/doctype/career_history/career_history.json
+++ b/one_fm/one_fm/doctype/career_history/career_history.json
@@ -13,6 +13,7 @@
   "column_break_5",
   "hiring_method",
   "validated_by_recruiter_on",
+  "recruiter_assigned",
   "section_break_8",
   "calculate_promotions_and_experience_automatically",
   "total_years_of_experience",
@@ -164,14 +165,22 @@
    "options": "Career History",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fetch_from": "erf.recruiter_assigned",
+   "fieldname": "recruiter_assigned",
+   "fieldtype": "Link",
+   "label": "Recruiter Assigned",
+   "options": "User"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-03-12 13:19:49.870457",
+ "modified": "2025-04-14 16:13:06.996885",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Career History",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -222,6 +231,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "applicant_name",
  "track_changes": 1
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature

## Clearly and concisely describe the feature.
https://www.pivotaltracker.com/story/show/189050809

## Analysis and design (optional)
Added assignment rule for career history doctype and a field for Recruiter Assigned

## Solution description
Added assignment rule for career history doctype and a field for Recruiter Assigned

## Is there a business logic within a doctype?
    - [] No

## Areas affected and ensured
None

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - No
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
