### PR TITLE
FIX: CHECKIN WAS NOT GETTING CREATED IF IT DOES NOT EXIST

### DIFF
--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -131,13 +131,24 @@ class ShiftPermission(Document):
 										SET start_datetime = %s
 										WHERE name = %s
 									""", (date_time, self.assigned_shift))
+						if frappe.db.exists("Employee Checkin", {"shift_assignment": self.assigned_shift, "log_type": self.log_type}):
 
-						frappe.db.sql("""
-										UPDATE `tabEmployee Checkin`
-										SET shift_actual_start = %s, late_entry = 0
-										WHERE shift_assignment = %s
-										AND log_type = %s
-									""", (date_time, self.assigned_shift, self.log_type))
+							frappe.db.sql("""
+											UPDATE `tabEmployee Checkin`
+											SET shift_actual_start = %s, late_entry = 0
+											WHERE shift_assignment = %s
+											AND log_type = %s
+										""", (date_time, self.assigned_shift, self.log_type))
+						else:
+							self.create_checkin(
+								data=dict(
+									shift_assignment=self.assigned_shift,
+									log_type=self.log_type,
+									late_entry=0,
+									shift_actual_start=date_time,
+									employee=self.employee
+								)
+							)
 
 				else:
 					if self.leaving_time:
@@ -147,15 +158,33 @@ class ShiftPermission(Document):
 										SET end_datetime = %s
 										WHERE name = %s
 									""", (date_time, self.assigned_shift))
-
-						frappe.db.sql("""
-										UPDATE `tabEmployee Checkin`
-										SET shift_actual_end = %s, early_exit = 0
-										WHERE shift_assignment = %s
-										AND log_type = %s
-									""", (date_time, self.assigned_shift, self.log_type))
+						
+						if frappe.db.exists("Employee Checkin", {"shift_assignment": self.assigned_shift, "log_type": self.log_type}):
+							frappe.db.sql("""
+											UPDATE `tabEmployee Checkin`
+											SET shift_actual_end = %s, early_exit = 0
+											WHERE shift_assignment = %s
+											AND log_type = %s
+										""", (date_time, self.assigned_shift, self.log_type))
+						else:
+							self.create_checkin(
+								data=dict(
+									shift_assignment=self.assigned_shift,
+									log_type=self.log_type,
+									early_exit=0,
+									shift_actual_end=date_time,
+									employee=self.employee
+								)
+							)
 
 			frappe.db.commit()
+
+	def create_checkin(self, data: dict) -> None:
+		data.update({"doctype": "Employee Checkin"})
+		doc = frappe.get_doc(data)
+		doc.insert(ignore_permissions=True)
+		frappe.db.commit()
+		
 
 	def assign_to_owner(self):
 		# Assign back to owner if Shift permission is Returned to Draft state from Pending Approver

--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -132,7 +132,6 @@ class ShiftPermission(Document):
 										WHERE name = %s
 									""", (date_time, self.assigned_shift))
 						if frappe.db.exists("Employee Checkin", {"shift_assignment": self.assigned_shift, "log_type": self.log_type}):
-
 							frappe.db.sql("""
 											UPDATE `tabEmployee Checkin`
 											SET shift_actual_start = %s, late_entry = 0
@@ -140,15 +139,7 @@ class ShiftPermission(Document):
 											AND log_type = %s
 										""", (date_time, self.assigned_shift, self.log_type))
 						else:
-							self.create_checkin(
-								data=dict(
-									shift_assignment=self.assigned_shift,
-									log_type=self.log_type,
-									late_entry=0,
-									shift_actual_start=date_time,
-									employee=self.employee
-								)
-							)
+							create_checkin(self)
 
 				else:
 					if self.leaving_time:
@@ -167,24 +158,10 @@ class ShiftPermission(Document):
 											AND log_type = %s
 										""", (date_time, self.assigned_shift, self.log_type))
 						else:
-							self.create_checkin(
-								data=dict(
-									shift_assignment=self.assigned_shift,
-									log_type=self.log_type,
-									early_exit=0,
-									shift_actual_end=date_time,
-									employee=self.employee
-								)
-							)
+							create_checkin(self)
 
 			frappe.db.commit()
 
-	def create_checkin(self, data: dict) -> None:
-		data.update({"doctype": "Employee Checkin"})
-		doc = frappe.get_doc(data)
-		doc.insert(ignore_permissions=True)
-		frappe.db.commit()
-		
 
 	def assign_to_owner(self):
 		# Assign back to owner if Shift permission is Returned to Draft state from Pending Approver


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [X] Bug


## Clearly and concisely describe the feature, chore or bug.
When shift permission were getting approved, if the checkin does not exist it does not get created

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a check to confirm if ti exist then it creates it if it does not exist

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Shift Permission
Employee checkin

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
