### PR TITLE
fix: one click approval for assignment rule emails

### DIFF
--- a/one_fm/overrides/assignment_rule.py
+++ b/one_fm/overrides/assignment_rule.py
@@ -2,7 +2,7 @@ from one_fm.utils import get_doctype_mandatory_fields
 from frappe.workflow.doctype.workflow_action.workflow_action import (
 
     get_workflow_name,
-    get_workflow_action_url,
+    get_confirm_workflow_action_url,
     get_doc_workflow_state
 )
 
@@ -60,7 +60,7 @@ def get_workflow_assignment_rule_description(doc, user):
                 frappe._dict(
                     {
                         "action_name": transition.action,
-                        "action_link": get_workflow_action_url(transition.action, doc, user),
+                        "action_link": get_confirm_workflow_action_url(doc, transition.action, user),
                     }
                 )
             )


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [*] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.

- Buttons clicked on in emails sent through assignment rule apply the workflow action directly instead of directing the user to a page where the button needs to be clicked a second time before the action is applied

Extension to the following story: https://one-fm.atlassian.net/browse/ON-85?atlOrigin=eyJpIjoiYjI1YTY0MzNiMzlhNGMxOTg4M2E1OWNiZWM3ZDllNzgiLCJwIjoiaiJ9

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.


## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured

- `one_fm/overrides/assignment_rule.py`

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

- No

## Did you test with the following dataset?
- [*] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
