### PR TITLE
CHORE: SET USERS CAN NOT CREATE FOR CERTAIN DOCTYPES

### DIFF
--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
@@ -127,9 +127,10 @@
    "options": "User"
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-25 10:57:14.741275",
+ "modified": "2025-04-16 17:05:09.907972",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Roster Employee Actions",

--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.json
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.json
@@ -124,9 +124,10 @@
    "options": "Post Types OverFilled"
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-18 09:04:55.840709",
+ "modified": "2025-04-16 17:04:43.288091",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Roster Post Actions",

--- a/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.json
+++ b/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.json
@@ -119,9 +119,10 @@
    "options": "User"
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-30 23:36:05.824419",
+ "modified": "2025-04-16 17:05:51.826819",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Post Scheduler Checker",

--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.json
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.json
@@ -101,9 +101,10 @@
    "options": "User"
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-16 14:50:23.755706",
+ "modified": "2025-04-16 17:05:32.285607",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Roster Day Off Checker",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [X] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Set users can not create to true for , the following doctypes
Roster Post Action
Roster Employee Action
Day Off Checker
Post Schedule Checker
Default Shift Checker

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Set users can not create to true, from the form

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Post Action
Roster Employee Action
Day Off Checker
Post Schedule Checker
Default Shift Checker

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
