### PR TITLE
feat: apply preset filters to roster page

### DIFF
--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -95,6 +95,9 @@
                                 <option value="">Filter Relievers</option>
                             </select>
                         </div>
+                        <div class="col-sm-12 col-md-3 mb20 d-flex align-items-center">
+                            <div class="align-items-center colorblue cursorpointer clear_roster_filters"><i class="fas fa-close mr-2"></i>Clear Filters</div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -25,6 +25,7 @@ function load_js(page) {
 	window.isMonth = 1;
 	window.classgrtw = [];
 	window.classgrt = [];
+
 	setup_staff_filters(page);
 	setup_topbar_events(page);
 
@@ -163,9 +164,7 @@ function load_js(page) {
 			get_post_data(page);
 		});
 		$(".basicRosterClick").click(basicRosterClick);
-		$(".otRosterClick").click(
-
-			otRosterClick);
+		$(".otRosterClick").click(otRosterClick);
 
 		//week view click jquery
 		$('.postmonthviewclick').click(function () {
@@ -630,6 +629,93 @@ function load_js(page) {
 	});
 	//table custom accordian click
 
+	setup_preset_filters(page)
+}
+
+function get_preset_filters () {
+	const { main_view, sub_view, roster_type, staff_view_mode, employee_id, employee_name,...pageFilters } = frappe.utils.get_query_params();
+
+	return {
+		view: { main_view, sub_view, roster_type, staff_view_mode },
+		employee: { employee_id, employee_name },
+		page: pageFilters
+	} 
+}
+
+// Setup and populate preset filters set via query params
+function setup_preset_filters (page) {
+	// To avoid re-rendering of roster page
+	if(window.preset_filters_applied) return
+
+	const { view: viewFilters, page: pageFilters, employee: employeeFilters } = get_preset_filters()
+
+	const { main_view: mainView, sub_view: subView, roster_type: rosterType, staff_view_mode: staffViewMode } = viewFilters
+
+	if (mainView) {
+		setTimeout(() => {
+		  $("#page-roster")
+			.find(`.redirect_route[data-route="${mainView}"]`)
+			.click();
+		}, 500);
+	}
+
+	function toggle_between_views() {
+		if(mainView === 'roster') {
+			if(subView === 'roster') {
+				setTimeout(() => {
+					$(".rosterviewclick").click()
+				  }, 1000);
+			}
+			if(subView === 'post') {
+				setTimeout(() => {
+					$(".postviewclick").click()
+				  }, 1000);
+			}
+			if(rosterType === 'basic') {
+				setTimeout(() => {
+					$(".basicRosterClick").click()
+				  }, 1000);
+			}
+			if(rosterType === 'ot') {
+				setTimeout(() => {
+					$(".otRosterClick").click()
+				  }, 1000);
+			}
+		}
+	}
+
+	function populate_values() {
+		if (mainView === 'roster') {
+			setTimeout(() => {
+				const { employee_id: employeeID, employee_name: employeeName } = employeeFilters;
+
+			    let wrapper_element = get_wrapper_element();
+				if (employeeID) {
+					$(wrapper_element).find(".search-employee-id").val(employeeID);
+				}
+			    if (employeeName) {
+					$(wrapper_element).find(".search-employee-name").val(employeeName);
+				}
+			}, 1000);
+		} else if (mainView === 'staff') {
+			setTimeout(() => {
+				const { company, project, site, shift, department, designation } = pageFilters;
+			    if(company) $('.staff-company-dropdown').html(company)
+			    if(project) $('.staff-project-dropdown').html(project)
+			    if(site) $('.staff-site-dropdown').html(site)
+			    if(shift) $('.staff-shift-dropdown').html(shift)
+			    if(department) $('.staff-department-dropdown').html(department)
+			    if(designation) $('.staff-designation-dropdown').html(designation)
+
+				render_staff(staffViewMode || "list")
+			}, 1000);
+		}
+	}
+
+	toggle_between_views()
+	populate_values()
+
+	window.preset_filters_applied = true	  
 }
 
 // Show popups on clicking edit options in Roster view
@@ -649,6 +735,14 @@ function setup_topbar_events(page) {
 
 	$('.dayoff').on('click', function () {
 		dayoff(page);
+	});
+
+	$('.clear_roster_filters').on('click', function () {
+		clear_roster_filters(page);
+	});
+
+	$('.clear_staff_filters').on('click', function () {
+		clear_staff_filters(page);
 	});
 
 	$('.clear_selection').on('click', function () {
@@ -1076,7 +1170,7 @@ function get_roster_data(page, isOt) {
 	let { project, site, shift, department, operations_role, designation, relievers } = page.filters;
 	let { limit_start, limit_page_length } = page.pagination;
 	if (project || site || shift || department || operations_role || designation || relievers){
-
+		$(".clear_roster_filters").removeClass("d-none")
 		$('#cover-spin').show(0);
 		frappe.call({
 			method: "one_fm.one_fm.page.roster.roster.get_roster_view", //dotted path to server method
@@ -1091,6 +1185,8 @@ function get_roster_data(page, isOt) {
 				render_roster(res.data, page, isOt);
 			}
 		});
+	} else {
+		$(".clear_roster_filters").addClass("d-none")
 	}
 }
 // Function responsible for Rendering the Table
@@ -1772,6 +1868,11 @@ function get_projects(page) {
 			parent.empty().trigger("change");
 			parent.select2({ data: project_data });
 
+			const selectedProject = page.filters['project'];
+            if (selectedProject) {
+	           parent.val(selectedProject).trigger("change");
+            }
+
 			$(parent).on('select2:select', function (e) {
 				page.filters.project = $(this).val();
 				get_sites(page);
@@ -1796,6 +1897,11 @@ function get_sites(page) {
 			});
 			parent.empty().trigger("change");
 			parent.select2({ data: site_data });
+
+			const selectedSite = page.filters['site'];
+            if (selectedSite) {
+	           parent.val(selectedSite).trigger("change");
+            }
 
 			$(parent).on('select2:select', function (e) {
 				page.filters.site = $(this).val();
@@ -1823,6 +1929,11 @@ function get_shifts(page) {
 			parent.empty().trigger("change");
 			parent.select2({ data: shift_data });
 
+			const selectedShift = page.filters['shift'];
+            if (selectedShift) {
+	           parent.val(selectedShift).trigger("change");
+            }
+
 			$(parent).on('select2:select', function (e) {
 				page.filters.shift = $(this).val();
 				let element = get_wrapper_element().slice(1);
@@ -1847,6 +1958,12 @@ function get_operations_posts(page) {
 				operations_role_data.push({ 'id': name, 'text': name });
 			});
 			parent.select2({ data: operations_role_data });
+
+			const selectedOperationsRole = page.filters['operations_role'];
+            if (selectedOperationsRole) {
+	           parent.val(selectedOperationsRole).trigger("change");
+            }
+
 			$(parent).on('select2:select', function (e) {
 				page.filters.operations_role = $(this).val();
 				let element = get_wrapper_element().slice(1);
@@ -1868,6 +1985,12 @@ function get_departments(page) {
 				department_data.push({ 'id': name, 'text': name });
 			});
 			parent.select2({ data: department_data });
+
+			const selectedDepartment = page.filters['department'];
+            if (selectedDepartment) {
+	           parent.val(selectedDepartment).trigger("change");
+            }
+			
 			$(parent).on('select2:select', function (e) {
 				page.filters.department = $(this).val();
 				let element = get_wrapper_element().slice(1);
@@ -1889,6 +2012,12 @@ function get_designations(page){
 				designation_data.push({ 'id': name, 'text': name });
 			});
 			parent.select2({ data: designation_data });
+
+			const selectedDesignation = page.filters['designation'];
+            if (selectedDesignation) {
+	           parent.val(selectedDesignation).trigger("change");
+            }
+			
 			$(parent).on('select2:select', function (e) {
 				page.filters.designation = $(this).val();
 				let element = get_wrapper_element().slice(1);
@@ -1900,6 +2029,7 @@ function get_designations(page){
 			;
 		})
 }
+
 function get_relievers(page){
 	let parent = $('[data-page-route="roster"] #rosteringrelieverselect');
 	let reliever_data = [
@@ -1907,6 +2037,12 @@ function get_relievers(page){
 		{'id': 'False', 'text': 'Non Relievers Only'},
 	];
 	parent.select2({ data: reliever_data });
+
+	const selectedReliverStatus = page.filters['relievers'];
+    if (selectedReliverStatus) {
+	    parent.val(selectedReliverStatus).trigger("change");
+    }
+
 	$(parent).on('select2:select', function (e) {
 		page.filters.relievers = $(this).val();
 		let element = get_wrapper_element().slice(1);
@@ -2248,6 +2384,15 @@ function notificationmsg(title, message) {
 
 function render_staff(view) {
 	let filters = cur_page.page.page.filters;
+
+	const { project, site, shift, department, operations_role, designation } = filters
+
+	if (project || site || shift || department || operations_role || designation){
+		$(".clear_staff_filters").removeClass("d-none")
+	} else {
+		$(".clear_staff_filters").addClass("d-none")
+	}
+
 	frappe.xcall('one_fm.one_fm.page.roster.roster.get_staff', filters)
 		.then(res => {
 			if (res) {
@@ -2449,18 +2594,20 @@ function render_staff_card_view(data) {
 }
 
 function setup_staff_filters(page) {
+	const { page: pageFilters, employee: employeeFilters } = get_preset_filters()
+
 	let filters = {
-		assigned: 1,
-		company: '',
-		project: '',
-		site: '',
-		shift: '',
-		department: '',
-		designation: '',
-		operations_role: '',
-		employee_search_name: '',
-		employee_search_id: '',
-		relievers: ''
+		assigned: pageFilters.assigned === '0' ? 0 : 1,
+		company: pageFilters.company || '',
+		project: pageFilters.project || '',
+		site: pageFilters.site || '',
+		shift: pageFilters.shift || '',
+		department: pageFilters.department || '',
+		designation: pageFilters.designation || '',
+		operations_role: pageFilters.operations_role || '',
+		employee_search_name: employeeFilters.employee_name || '',
+		employee_search_id: employeeFilters.employee_id || '',
+		relievers: pageFilters.relievers || '',
 	};
 	let pagination = {
 		limit_start: 0,
@@ -2469,6 +2616,8 @@ function setup_staff_filters(page) {
 	if (page) {
 		page.filters = filters;
 		page.pagination = pagination;
+		page.employee_search_id = employeeFilters.employee_id || ''
+	    page.employee_search_name = employeeFilters.employee_name || ''
 	} else {
 		cur_page.page.page.filters = filters;
 		cur_page.page.page.pagination = pagination;
@@ -3241,6 +3390,30 @@ async function updateEmployeeDefaults(employees, data) {
     }
 }
 
+
+function clear_roster_filters(page) {
+	window.history.replaceState({}, document.title, window.location.origin + window.location.pathname);
+
+	page.filters = {}
+	cur_page.page.page.filters = {}
+
+	$('#page-roster').empty().append(frappe.render_template('roster'));
+	load_js(page)
+}
+
+function clear_staff_filters(page) {
+	window.history.replaceState({}, document.title, window.location.origin + window.location.pathname);
+
+	page.filters = {}
+	cur_page.page.page.filters = {}
+
+	$(".assigneddrpval").html("Assigned");
+	["company", "project", "site", "shift", "department", "designation"].forEach(item => {
+		$(`a[data-filter-type=${item}]`).click()
+	})
+
+	render_staff($(".layoutSidenav_content").attr("data-view"));
+}
 
 function clear_selection(page) {
 	classgrt = [];

--- a/one_fm/one_fm/page/roster/staff.html
+++ b/one_fm/one_fm/page/roster/staff.html
@@ -519,7 +519,7 @@
                                     <a href="#"
                                         class="dropdown-toggle fitertext text-decoration-none customdrodownicon " id=""
                                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        <div class="dropdowncustomres">Company</div>
+                                        <div class="dropdowncustomres staff-company-dropdown">Company</div>
                                     </a>
                                     <div class="dropdown-menu customredropdown dropdown-menu-right customselect">
                                         <div class="customdropdownheight company-dropdown" data-filter-type="company">
@@ -539,7 +539,7 @@
                                     <a href="#"
                                         class="dropdown-toggle fitertext text-decoration-none customdrodownicon " id=""
                                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        <div class="dropdowncustomres">Project</div>
+                                        <div class="dropdowncustomres staff-project-dropdown">Project</div>
                                     </a>
                                     <div class="dropdown-menu customredropdown dropdown-menu-right customselect">
                                         <div class="customdropdownheight project-dropdown" data-filter-type="project">
@@ -559,7 +559,7 @@
                                     <a href="#"
                                         class="dropdown-toggle fitertext text-decoration-none customdrodownicon " id=""
                                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        <div class="dropdowncustomres">Site</div>
+                                        <div class="dropdowncustomres staff-site-dropdown">Site</div>
                                     </a>
                                     <div class="dropdown-menu customredropdown dropdown-menu-right customselect">
                                         <div class="customdropdownheight site-dropdown" data-filter-type="site">
@@ -579,7 +579,7 @@
                                     <a href="#"
                                         class="dropdown-toggle fitertext text-decoration-none customdrodownicon " id=""
                                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        <div class="dropdowncustomres">Shift</div>
+                                        <div class="dropdowncustomres staff-shift-dropdown">Shift</div>
                                     </a>
                                     <div class="dropdown-menu customredropdown dropdown-menu-right customselect">
                                         <div class="customdropdownheight shift-dropdown" data-filter-type="shift">
@@ -599,7 +599,7 @@
                                     <a href="#"
                                         class="dropdown-toggle fitertext text-decoration-none customdrodownicon " id=""
                                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        <div class="dropdowncustomres">Department</div>
+                                        <div class="dropdowncustomres staff-deprtment-dropdown">Department</div>
                                     </a>
                                     <div class="dropdown-menu customredropdown dropdown-menu-right customselect">
                                         <div class="customdropdownheight department-dropdown"
@@ -620,7 +620,7 @@
                                     <a href="#"
                                         class="dropdown-toggle fitertext text-decoration-none customdrodownicon " id=""
                                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        <div class="dropdowncustomres"> Designation</div>
+                                        <div class="dropdowncustomres staff-designation-dropdown"> Designation</div>
                                     </a>
                                     <div class="dropdown-menu customredropdown dropdown-menu-right customselect">
                                         <div class="customdropdownheight designation-dropdown"

--- a/one_fm/one_fm/page/roster/staff.html
+++ b/one_fm/one_fm/page/roster/staff.html
@@ -490,6 +490,9 @@
                                 <span><i class="fas fa-times"></i></span>
                                 <span class="pl8 d-md-none d-lg-inline">Clear All Filter</span>
                             </div>
+                            <div class="mb-2 mb-lg-0 mlsm-0 mr-2">
+                                <div class="align-items-center colorblue cursorpointer clear_staff_filters"><i class="fas fa-close mr-2"></i>Clear Filters</div>
+                            </div>
                             <div class="mb-2 mb-lg-0 mlsm-0 customiconhover">
                                 <div class="btn-group">
                                     <a href="#"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As a Roster user
I want to have the roster opened in a new tab with filters applied
so that I do not have to do it

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Added params for all filters (including toggling between views)
- Apply preset filters to roster page
- Added clear filters button

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Page

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
