### PR TITLE
feat: create post schedules on contract renewal

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -14,7 +14,6 @@ from frappe.utils import (
     get_last_day, get_datetime, flt, add_days,add_months,get_date_str
 )
 from frappe import _
-
 from one_fm.processor import sendemail
 
 class Contracts(Document):
@@ -449,6 +448,7 @@ def insert_login_credential(url, user_name, password, client):
 
 #renew contracts by one year
 def auto_renew_contracts():
+    from one_fm.operations.doctype.operations_post.operations_post import create_new_schedule_for_project
     filters = {
         'end_date' : today(),
         'is_auto_renewal' : 1,
@@ -465,6 +465,7 @@ def auto_renew_contracts():
         contract_doc.end_date = add_days(contract_doc.end_date, duration+1)
         contract_doc.save()
         frappe.db.commit()
+        create_new_schedule_for_project(contract_doc.project)
 
 def get_service_items_invoice_amounts(contract, date, current_month=False):
     # use date args instead of system date


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As Operations Admin
I want post schedules to be automatically created on auto-renewal of Contracts
so that I do not have to do it

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Created post schedules when contract is auto renewed

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
- Contracts

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
When contract will be renewed automatically then it will create post schedules for related project

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
