### PR TITLE
Feat : As OneFM I want to auto-fetch All non-external project users in to the MOM General Attendance table so that their Attendance can be marked

### DIFF
--- a/one_fm/operations/doctype/mom/mom.js
+++ b/one_fm/operations/doctype/mom/mom.js
@@ -10,6 +10,24 @@ frappe.ui.form.on('MOM', {
 		frm.refresh_fields("attendees");
 	},
 	project: function(frm) {
+		if(frm.doc.project_type != "External"){
+			frappe.call({
+                method: "one_fm.operations.doctype.mom.mom.get_project_users",
+                args: {
+                    project: frm.doc.project
+                },
+                callback(r) {
+                    if (r.message) {
+                        frm.clear_table("general_attendance");
+                        r.message.forEach(user => {
+                            let row = frm.add_child("general_attendance");
+                            row.attendee_name = user;
+                        });
+                        frm.refresh_field("general_attendance");
+                    }
+                }
+            });
+        }
 		if(!frm.doc.site){
 			frm.clear_table("attendees");
 		}

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -141,3 +141,9 @@ def fetch_designation_of_users(list_of_users: list = []):
 							""",(tuple(loads(list_of_users)), ) ,as_dict=1)
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), "Error encountered while fetching users designation (MOM)")
+
+
+@frappe.whitelist()
+def get_project_users(project):
+    doc = frappe.get_doc("Project", project)
+    return [u.full_name for u in doc.users]


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature

## Clearly and concisely describe the feature.
https://www.pivotaltracker.com/story/show/189075666

## Is there a business logic within a doctype?
    - [] No


## Output screenshots (optional)

https://github.com/user-attachments/assets/26b73a73-9db2-429a-a338-7c5236af1001


## Areas affected and ensured
MOM Creation

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - None
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
