### PR TITLE
feat: roster post off add new options selected days only and from date

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -297,6 +297,12 @@ function load_js(page) {
 							fieldtype: 'Section Break',
 							depends_on: "eval:doc.post_status == 'Post Off'",
 						},
+						{
+							label: 'Post Off From Date',
+							fieldname: 'post_off_from_date',
+							fieldtype: 'Date',
+							default: date
+						},
 						{ label: 'Repeat', fieldname: 'repeat', fieldtype: 'Select', options: 'Does not repeat\nSelected Days Only\nDaily\nWeekly\nMonthly\nYearly' },
 						{ 'fieldtype': 'Section Break', 'fieldname': 'sb1', 'depends_on': 'eval:doc.post_status=="Post Off" && doc.repeat=="Weekly"' },
 						{ 'label': 'Sunday', 'fieldname': 'sunday', 'fieldtype': 'Check' },

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -297,7 +297,7 @@ function load_js(page) {
 							fieldtype: 'Section Break',
 							depends_on: "eval:doc.post_status == 'Post Off'",
 						},
-						{ label: 'Repeat', fieldname: 'repeat', fieldtype: 'Select', options: 'Does not repeat\nDaily\nWeekly\nMonthly\nYearly' },
+						{ label: 'Repeat', fieldname: 'repeat', fieldtype: 'Select', options: 'Does not repeat\nSelected Days Only\nDaily\nWeekly\nMonthly\nYearly' },
 						{ 'fieldtype': 'Section Break', 'fieldname': 'sb1', 'depends_on': 'eval:doc.post_status=="Post Off" && doc.repeat=="Weekly"' },
 						{ 'label': 'Sunday', 'fieldname': 'sunday', 'fieldtype': 'Check' },
 						{ 'label': 'Wednesday', 'fieldname': 'wednesday', 'fieldtype': 'Check' },
@@ -308,7 +308,7 @@ function load_js(page) {
 						{ 'fieldtype': 'Column Break', 'fieldname': 'cb2' },
 						{ 'label': 'Tuesday', 'fieldname': 'tuesday', 'fieldtype': 'Check' },
 						{ 'label': 'Friday', 'fieldname': 'friday', 'fieldtype': 'Check' },
-						{ 'fieldtype': 'Section Break', 'fieldname': 'sb2', 'depends_on': 'eval:doc.post_status=="Post Off" && doc.repeat!= "Does not repeat"' },
+						{ 'fieldtype': 'Section Break', 'fieldname': 'sb2', 'depends_on': 'eval:doc.post_status=="Post Off" && doc.repeat!= "Does not repeat" && doc.repeat!= "Selected Days Only"' },
 						{ 'label': 'Repeat Till', 'fieldtype': 'Date', 'fieldname': 'repeat_till', 'depends_upon': 'eval:doc.project_end_date==0' },
 						{
 							fieldname: 'sb2',
@@ -645,7 +645,7 @@ function get_preset_filters () {
 		view: { main_view, sub_view, roster_type, staff_view_mode },
 		employee: { employee_id, employee_name },
 		page: pageFilters
-	} 
+	}
 }
 
 // Setup and populate preset filters set via query params
@@ -721,7 +721,7 @@ function setup_preset_filters (page) {
 	toggle_between_views()
 	populate_values()
 
-	window.preset_filters_applied = true	  
+	window.preset_filters_applied = true
 }
 
 // Show popups on clicking edit options in Roster view
@@ -1996,7 +1996,7 @@ function get_departments(page) {
             if (selectedDepartment) {
 	           parent.val(selectedDepartment).trigger("change");
             }
-			
+
 			$(parent).on('select2:select', function (e) {
 				page.filters.department = $(this).val();
 				let element = get_wrapper_element().slice(1);
@@ -2023,7 +2023,7 @@ function get_designations(page){
             if (selectedDesignation) {
 	           parent.val(selectedDesignation).trigger("change");
             }
-			
+
 			$(parent).on('select2:select', function (e) {
 				page.filters.designation = $(this).val();
 				let element = get_wrapper_element().slice(1);
@@ -2937,7 +2937,7 @@ function GetTodaySelectedDate() {
 
 //on next month title display on arrow click
 function rosterweekincrement() {
-	weekCalendarSettings.date.add(1, "Weeks"); 
+	weekCalendarSettings.date.add(1, "Weeks");
 	GetWeekHeaders(1);
 	displayWeekCalendar(weekCalendarSettings);
 	let element = get_wrapper_element().slice(1);
@@ -2951,7 +2951,7 @@ function rosterweekincrement() {
 
 //on previous month title display on arrow click
 function rosterweekdecrement() {
-	weekCalendarSettings.date.subtract(1, "Weeks"); 
+	weekCalendarSettings.date.subtract(1, "Weeks");
 	GetWeekHeaders(1);
 	displayWeekCalendar(weekCalendarSettings);
 	let element = get_wrapper_element().slice(1);

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -1175,7 +1175,7 @@ def insert_post_schedule(args, unique_posts_list, existing_schedules_set, end_da
                     insert_post = True
 
         if args.repeat in ['Daily', 'Weekly']:
-            for date in	pd.date_range(start=args.plan_from_date, end=end_date):
+            for date in	pd.date_range(start=args.post_off_from_date, end=end_date):
                 if args.repeat == 'Weekly' and getdate(date).strftime('%A') not in week_days: # Execute the post schedule for selected week days only
                     continue
                 date_str = cstr(date.date())

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -248,7 +248,7 @@ def get_post_view(start_date, end_date,  project=None, site=None, shift=None, op
         filters.update({'site_shift': shift})
     if operations_role:
         filters.update({'post_template': operations_role})
- 
+
     post_total = frappe.db.count("Operations Post", filters)
 
     post_filters = dict(filters)
@@ -259,7 +259,7 @@ def get_post_view(start_date, end_date,  project=None, site=None, shift=None, op
 
     filters.pop('post_template', None)
     filters.pop('site_shift', None)
-    
+
     if operations_role:
         filters['operations_role'] = operations_role
     if shift:
@@ -878,7 +878,7 @@ def edit_post(posts, values):
         if args.repeat_till and cint(args.project_end_date):
             frappe.throw(_("Cannot set both project end date and custom end date!"))
 
-        if args.repeat != "Does not repeat" and not args.repeat_till and not cint(args.project_end_date):
+        if args.repeat not in ["Does not repeat", "Selected Days Only"] and not args.repeat_till and not cint(args.project_end_date):
             frappe.throw(_("Please set an end date!"))
 
         if args.repeat == "Does not repeat" and cint(args.project_end_date):
@@ -1103,7 +1103,7 @@ def get_post_porjects(unique_posts_list):
 def get_post_schedule_end_date(args, unique_posts_list, post_projects={}):
     end_date = args.repeat_till if args.repeat_till and not cint(args.project_end_date) else None
 
-    if args.repeat == 'Does not repeat':
+    if args.repeat in ['Does not repeat', 'Selected Days Only']:
         end_date = get_last_day(args.plan_from_date)
 
     # If project_end_date is set, get contract end dates in bulk
@@ -1145,7 +1145,7 @@ def insert_post_schedule(args, unique_posts_list, existing_schedules_set, end_da
     delete_post = False
     week_days = get_week_days(args)
     post_date_map = {}
-    if args.repeat in ['Monthly', 'Yearly', 'Does not repeat']:
+    if args.repeat in ['Monthly', 'Yearly', 'Does not repeat', 'Selected Days Only']:
         post_date_map = get_post_date_map(unique_posts_list, posts)
 
     insert_query = get_insert_post_schedule_query_prefix()
@@ -1155,7 +1155,7 @@ def insert_post_schedule(args, unique_posts_list, existing_schedules_set, end_da
             previous_post = post
             post_details=get_post_details(post)
 
-        if args.repeat in ['Monthly', 'Yearly', 'Does not repeat']:
+        if args.repeat in ['Monthly', 'Yearly', 'Does not repeat', 'Selected Days Only']:
             for post_date in post_date_map[post]:
                 if args.repeat == 'Monthly':
                     for date in	month_range(post_date, end_date):
@@ -1169,7 +1169,7 @@ def insert_post_schedule(args, unique_posts_list, existing_schedules_set, end_da
                         delete_post = get_delete_posts(post, date_str, existing_schedules_set, delete_post)
                         insert_query += get_insert_post_schedule_query(post, date_str, post_details, args, owner, creation)
                         insert_post = True
-                elif args.repeat == 'Does not repeat':
+                elif args.repeat in ['Does not repeat', 'Selected Days Only']:
                     delete_post = get_delete_posts(post, post_date, existing_schedules_set, delete_post)
                     insert_query += get_insert_post_schedule_query(post, post_date, post_details, args, owner, creation)
                     insert_post = True


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- In Roster Post Off Add new Options Selected Days Only and Post Off From Date

## Output screenshots (optional)


https://github.com/user-attachments/assets/c1206625-913a-4f8b-be32-14172c5f5edc



## Areas affected and ensured
- `one_fm/one_fm/page/roster/roster.js`
- `one_fm/one_fm/page/roster/roster.py`

## Is there any existing behavior change of other features due to this code change?
Yes, Added new options on Post Off

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome