### PR TITLE
feat: Replicate Roster Employee Actions in Roster view

### DIFF
--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
@@ -1,15 +1,17 @@
 # Copyright (c) 2021, omar jaber and contributors
 # For license information, please see license.txt
 
+from datetime import timedelta, datetime
+from collections import OrderedDict
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import nowdate, add_to_date, cstr, cint, getdate, get_link_to_form
-from one_fm.processor import sendemail
+from frappe.utils import  add_to_date, cstr, getdate
 from frappe.permissions import get_doctype_roles
-import datetime
-from datetime import timedelta, datetime
-from collections import OrderedDict
+
+from one_fm.one_fm.page.roster.roster import get_current_user_details
+
 
 class RosterEmployeeActions(Document):
 	def autoname(self):
@@ -107,8 +109,8 @@ def create_roster_employee_actions():
 
 			for employee in employees:
 				sorted_dates = sorted(
-                [datetime.strptime(date.strip(), "%Y-%m-%d") for date in employees_not_rostered.get(employee, [])]
-            )
+				[datetime.strptime(date.strip(), "%Y-%m-%d") for date in employees_not_rostered.get(employee, [])]
+			)
 				roster_employee_actions.append('employees_not_rostered', {
 					'employee': employee,
 					"missing_dates": ", ".join([date.strftime("%Y-%m-%d") for date in sorted_dates])
@@ -144,7 +146,7 @@ def get_employees_not_rostered(start_date, end_date):
 	try:
 		employees_not_rostered_dict = OrderedDict()
 		for obj in employees_not_rostered:
-			employees_not_rostered_dict.setdefault(obj[0], []).append(obj[1])
+			employees_not_rostered_dict.setdefault(obj[0], []).append(obj[4])
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), "Error while generating missing dates(Roster Employee Actions)")
 
@@ -161,14 +163,17 @@ def get_shift_working_active_employees(start_date, end_date):
 			end_date: Date Object
 
 		Return: List of tuples.
-		Eg: [('HR-EMP-00001', '2024-04-08'), ('HR-EMP-00001', '2024-04-09'), ('HR-EMP-00001', '2024-04-10'),
-		('HR-EMP-00002', '2024-04-08'), ('HR-EMP-00002', '2024-04-09'), ('HR-EMP-00002', '2024-04-10')]
+		Eg: [('HR-EMP-00001', '2024IN093', 'John Doe', '2024-04-08'), ('HR-EMP-00001', '2024IN093', 'Jane Doe', '2024-04-09')]
 	"""
 
 	active_employees = frappe.db.sql("""
 		select
 			employee,
+			employee_id, 
+			employee_name,
+			shift as shift_allocation,
 			relieving_date
+
 		from
 			`tabEmployee`
 		where
@@ -176,12 +181,15 @@ def get_shift_working_active_employees(start_date, end_date):
 			and
 			shift_working = 1
 	""", as_dict=1)
+
 	return [
-		(employee.employee, (start_date + timedelta(days=x)).strftime('%Y-%m-%d'))
+		(employee.employee, employee.employee_id, employee.employee_name, employee.shift_allocation, (start_date + timedelta(days=x)).strftime('%Y-%m-%d'))
 		for employee in active_employees
 		for x in range((end_date - start_date).days + 1)
 		if employee.relieving_date is None or (start_date + timedelta(days=x)) < employee.relieving_date
 	]
+
+
 
 def get_rostered_employees(start_date, end_date):
 	"""
@@ -199,19 +207,22 @@ def get_rostered_employees(start_date, end_date):
 
 	employees_rostered = frappe.db.sql(f"""
 		select
-			employee, date
-        from
-			`tabEmployee Schedule`
-        where
-			date >= '{start_date}'
+			es.employee, es.date, emp.employee_id, es.employee_name, emp.shift as shift_allocation
+		from
+			`tabEmployee Schedule` es
+		join `tabEmployee` emp
+		on es.employee=emp.name
+		where
+			es.date >= '{start_date}'
 			and
-			date <= '{end_date}'
-    """, as_dict=True)
+			es.date <= '{end_date}'
+	""", as_dict=True)
 
 	return [
-		(roster.employee, (roster.date).strftime('%Y-%m-%d'))
+		(roster.employee, roster.employee_id, roster.employee_name, roster.shift_allocation, (roster.date).strftime('%Y-%m-%d'))
 		for roster in employees_rostered
 	]
+
 
 def get_employees_on_leave_in_period(start_date, end_date):
 	"""
@@ -226,13 +237,15 @@ def get_employees_on_leave_in_period(start_date, end_date):
 
 	leaves = frappe.db.sql(f"""
 		SELECT 
-			employee, from_date, to_date
+			la.employee, la.employee_name, la.from_date, la.to_date, emp.employee_id, emp.shift as shift_allocation
 		FROM 
-			`tabLeave Application`
+			`tabLeave Application` la
+		JOIN `tabEmployee` emp
+		ON la.employee=emp.name
 		WHERE 
-			(from_date >= '{start_date}' AND to_date <= '{end_date}' AND status IN ('Open', 'Approved'))
+			(la.from_date >= '{start_date}' AND la.to_date <= '{end_date}' AND la.status IN ('Open', 'Approved'))
 			OR 
-			name IN (
+			la.name IN (
 				SELECT DISTINCT leave_application 
 				FROM `tabAttendance` 
 				WHERE attendance_date >= '{start_date}'
@@ -241,11 +254,13 @@ def get_employees_on_leave_in_period(start_date, end_date):
 			)
 	""", as_dict=True)
 
+
 	return [
-		(leave.employee, (leave.from_date + timedelta(days=x)).strftime('%Y-%m-%d'))
+		(leave.employee, leave.employee_id, leave.employee_name, leave.shift_allocation, (leave.from_date + timedelta(days=x)).strftime('%Y-%m-%d'))
 		for leave in leaves
 		for x in range((leave.to_date - leave.from_date).days + 1)
 	]
+
 
 def get_supervisors_not_rostered_employees(employees_not_rostered, date):
 	"""
@@ -258,6 +273,7 @@ def get_supervisors_not_rostered_employees(employees_not_rostered, date):
 		Eg: [{'shift_supervisor': 'HR-EMP-00003', 'site': 'Site1', 'employees': 'HR-EMP-00001, HR-EMP-00002'}]
 	"""
 	employee_ids = tuple(employees_not_rostered.keys())
+
 	query = """
 		SELECT
 			COALESCE(
@@ -306,6 +322,166 @@ def get_supervisors_not_rostered_employees(employees_not_rostered, date):
 			e.name IN {1}
 			AND (oss.supervisor IS NULL OR ess.employee IS NOT NULL)
 		GROUP BY
-			shift_supervisor, os.site
+		    shift_supervisor, os.site
 	""".format(date, employee_ids)
 	return frappe.db.sql(query, as_dict=True)
+
+
+## Roster Employee Actions code for Roster view below
+@frappe.whitelist()
+def get_employees_with_missing_schedules():
+	"""
+	Returns employees with missing schedules based on current user's role
+	Returns: OrderedDict {employee: [missing_dates]}
+	"""
+	start_date = getdate(add_to_date(cstr(getdate()), days=1))  # Tomorrow
+	end_date = getdate(add_to_date(start_date, days=14))        # 14 days later
+
+	# Get current user details
+	user, user_roles, user_employee = get_current_user_details()
+
+	if not user_employee:
+		frappe.throw("No employee record linked to current user")
+
+	# Get base employee list based on role
+	if "Operations Manager" in user_roles:
+		employees = get_shift_working_active_employees(start_date, end_date)
+	elif "Project Manager" in user_roles:
+		employees = get_project_manager_employees(user_employee.name, start_date, end_date)
+	elif "Site Supervisor" in user_roles:
+		employees = get_site_supervisor_employees(user_employee.name, start_date, end_date)
+	elif "Shift Supervisor" in user_roles:
+		employees = get_shift_supervisor_employees(user_employee.name, start_date, end_date)
+	else:
+		return OrderedDict()
+
+	# Calculate scheduling gaps
+	rostered = get_rostered_employees(start_date, end_date)
+	on_leave = get_employees_on_leave_in_period(start_date, end_date)
+	
+	missing_schedules = set(employees) - set(rostered) - set(on_leave)
+	
+	# Format results
+	result = OrderedDict()
+
+	for emp, emp_id, emp_full_name, shift_allocation, date in missing_schedules:
+		if emp not in result:
+			result[emp] = {
+				"employee_id": emp_id,
+				"employee_name": emp_full_name,
+				"shift_allocation": shift_allocation,
+				"dates": []
+			}
+		result[emp]["dates"].append(date)
+
+	# Sort dates for each employee
+	for emp in result:
+		result[emp]["dates"] = sorted(result[emp]["dates"])
+	
+	html_output = render_employees_missing_schedules_html(result)
+	return html_output
+
+
+def render_employees_missing_schedules_html(missing_schedules):
+	"""
+	missing_schedules: {employee_docname: {"employee_id": ..., "employee_name": ..., "dates": [...]}}
+	"""
+	if len(missing_schedules) > 0:
+		html = "<table class='table table-bordered'>"
+		html += """<thead>
+					<tr>
+						<th>Employee ID</th>
+						<th>Employee Name</th>
+						<th>Shift Allocation</th>
+						<th>Missing Dates</th>
+						<th></th>
+					</tr>
+				</thead><tbody>"""
+		
+		for emp, info in missing_schedules.items():
+			formatted_dates = [
+				datetime.strptime(date, "%Y-%m-%d").strftime("%d-%m-%Y") for date in info["dates"]
+			]
+			dates_str = ", ".join(formatted_dates)
+			html += f"""<tr>
+							<td>{info["employee_id"]}</td>
+							<td>{info["employee_name"]}</td>
+							<td>{info["shift_allocation"]}</td>
+							<td>{dates_str}</td>
+							<td><a class="btn btn-warning" target="_blank" href="/app/roster?main_view='roster'&sub_view='basic'&roster_type='basic'&shift={info["shift_allocation"]}&employee_id={info["employee_id"]}">Take Action</a></td>
+						</tr>"""
+		html += "</tbody></table>"
+		return html
+
+	html = """
+		<div class="alert text-center" role="alert">
+			<h5 class="mb-0">No employees with missing schedules found.</h5>
+		</div>
+	"""
+	return html
+
+
+def get_project_manager_employees(user_employee, start_date, end_date):
+	"""Employees in projects managed by current user"""
+	return _get_employees_with_join(
+		join_clause="""
+			JOIN `tabOperations Shift` os ON e.shift = os.name
+			JOIN `tabOperations Site` site ON os.site = site.name 
+			JOIN `tabProject` p ON site.project = p.name
+		""",
+		where_clause="p.account_manager = %(user_employee)s",
+		user_employee=user_employee,
+		start_date=start_date,
+		end_date=end_date
+	)
+
+def get_site_supervisor_employees(user_employee, start_date, end_date):
+	"""Employees in sites managed by current user"""
+	return _get_employees_with_join(
+		join_clause="""
+			JOIN `tabOperations Shift` os ON e.shift = os.name
+			JOIN `tabOperations Site` site ON os.site = site.name
+		""",
+		where_clause="site.account_supervisor = %(user_employee)s",
+		user_employee=user_employee,
+		start_date=start_date,
+		end_date=end_date
+	)
+
+def get_shift_supervisor_employees(user_employee, start_date, end_date):
+	"""Employees in shifts managed by current user"""
+	return _get_employees_with_join(
+		join_clause="""
+			JOIN `tabOperations Shift` os ON e.shift = os.name
+			JOIN `tabOperations Shift Supervisor` oss 
+				ON os.name = oss.parent AND oss.parenttype = 'Operations Shift'
+		""",
+		where_clause="oss.supervisor = %(user_employee)s",
+		user_employee=user_employee,
+		start_date=start_date,
+		end_date=end_date
+	)
+
+def _get_employees_with_join(join_clause, where_clause, user_employee, start_date, end_date):
+	"""Generic query builder for role-based employee fetching"""
+	employees = frappe.db.sql(f"""
+		SELECT 
+			e.name as employee,
+			e.employee_id as employee_id, 
+			e.employee_name,
+			e.shift as shift_allocation,
+			e.relieving_date
+		FROM `tabEmployee` e
+		{join_clause}
+		WHERE
+			e.status = 'Active'
+			AND e.shift_working = 1
+			AND {where_clause}
+	""", {"user_employee": user_employee}, as_dict=True)
+
+	return [
+		(emp.employee, emp.employee_id, emp.employee_name, emp.shift_allocation, (start_date + timedelta(days=x)).strftime('%Y-%m-%d'))
+		for emp in employees
+		for x in range((end_date - start_date).days + 1)
+		if not emp.relieving_date or (start_date + timedelta(days=x)) < emp.relieving_date
+	]

--- a/one_fm/one_fm/page/roster/roster.css
+++ b/one_fm/one_fm/page/roster/roster.css
@@ -8,9 +8,8 @@
 @import url("/css/main.css");
 @import url("/css/material_blue.css");
 
-
 body[data-route="roster"] .page-container {
-  margin-top: 0px;
+	margin-top: 0px;
 }
 
 body[data-route="roster"] .collapse {

--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -51,7 +51,13 @@
                     <a class="flex-sm-fill text-sm-center nav-link active bg-primary basicRosterClick">Basic Roster</a>
                     <a class="flex-sm-fill text-sm-center nav-link otRosterClick">OT Roster</a>
                 </nav>
-            </div>
+				<div class="dropdown flex-column flex-sm-row mt-2">
+					<button class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">View</button>
+					<div class="dropdown-menu">
+						<a id="rosterEmployeeActions" class="dropdown-item">Employees with Missing Schedules</a>
+					</div>
+				</div>
+			</div>
         </div> 
         <div class="container-fluid borderradius8 mt-2 pl30 pr30 bg-white">
             <div class="d-flex justify-content-between align-items-center pl30 pr30">

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -754,6 +754,10 @@ function setup_topbar_events(page) {
 	$('.clear_selection').on('click', function () {
 		clear_selection(page);
 	});
+
+	$("#rosterEmployeeActions").on("click", function() {
+		roster_employee_actions(page);
+	});
 }
 
 //Bind events to Edit options in Roster/Post view
@@ -1095,6 +1099,8 @@ function bind_events(page) {
 		}
 
 	})
+
+
 }
 
 function bind_search_bar_event(page) {
@@ -3852,4 +3858,30 @@ let error_handler = (res) => {
 	} else {
 		$('#cover-spin').hide();
 	}
+}
+
+
+function roster_employee_actions(page){
+	let dialog = new frappe.ui.Dialog({
+		title: "Employee with Missing Schedules",
+		fields: [
+			{
+				fieldname: "employees_table",
+				fieldtype: "HTML",
+				options: "<div id='employees_table'></div>"
+			}
+		]
+	})
+	dialog.$wrapper.find(".modal-dialog").css("max-width", "75%");
+
+
+	frappe.call({
+		method: "one_fm.one_fm.doctype.roster_employee_actions.roster_employee_actions.get_employees_with_missing_schedules",
+		// freeze: true,
+		async: true,
+		callback: function(r) {
+			dialog.fields_dict.employees_table.$wrapper.html(r.message);
+		}
+	});
+	dialog.show();
 }

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -159,6 +159,7 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
             employee_filters.update({'attendance_by_timesheet':'0'})
             if designation:
                 employee_filters.update({'designation' : designation})
+				
             employees = frappe.db.get_list("Employee", employee_filters, ["employee", "employee_name", "day_off_category", "number_of_days_off"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
             employees.extend(exited_employees)
             employees = filter_redundant_employees(employees)

--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -164,7 +164,7 @@ def convert_html_to_plain_text(html_content):
         if table:
             rows = table.find_all("tr")
             table_content = "\n".join(
-                f"{" : ".join(td.get_text(strip=True) for td in row.find_all("td"))}" for row in rows
+                f"{' : '.join(td.get_text(strip=True) for td in row.find_all('td'))}" for row in rows
             )
             text_output += "\n\nDetails:\n" + table_content +"\n"
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://www.pivotaltracker.com/story/show/189064762

As a Roster User
I want to see Employees that are not fully rostered
so that I can fix them before it shows in Roster Employee Action

## Solution description
Replicate Roster Employee Actions functionality based on session user's role. 


## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/794825d3-7aad-459b-bf66-3040a61e1b38)
![image](https://github.com/user-attachments/assets/b46b3bb5-0d16-4023-95d9-2bfcb9b75eb3)



## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
