### PR TITLE
[CHORE fix set_employee_from_the_session_user for cancelled docs]

### DIFF
--- a/one_fm/operations/doctype/shift_permission/shift_permission.js
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.js
@@ -27,7 +27,7 @@ frappe.ui.form.on('Shift Permission', {
 });
 
 function set_employee_from_the_session_user(frm) {
-	if(frappe.session.user != 'Administrator' && frm.is_new()){
+	if(frappe.session.user != 'Administrator' && frm.is_new() && !frm.doc.amended_from){
 		frappe.db.get_value('Employee', {'user_id': frappe.session.user} , 'name', function(r) {
 			if(r && r.name){
 				frm.set_value('employee', r.name);


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [*] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
fix set_employee_from_the_session_user for cancelled docs method, set the employee ID only for new records

## Analysis and design (optional)
Analyse and attach the design documentation
fix set_employee_from_the_session_user for cancelled docs method, set the employee ID only for new records

## Solution description
Describe your code changes in detail for reviewers.
fix set_employee_from_the_session_user for cancelled docs method, set the employee ID only for new records
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [* No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
