### PR TITLE
fix: adjust total years of experience calculation in Career History doctype

### DIFF
--- a/one_fm/one_fm/doctype/career_history/career_history.js
+++ b/one_fm/one_fm/doctype/career_history/career_history.js
@@ -95,9 +95,14 @@ var calculate_promotions_and_experience = function(frm) {
 		for (var company in start_date_in_company) {
 			if (start_date_in_company.hasOwnProperty(company)) {
 				var start_date = start_date_in_company[company];
-				if(end_date_in_company[company]){
-					total_years_of_experience += calculate_total_years_of_experience(start_date, end_date_in_company[company]);
+				var end_date = end_date_in_company[company];
+
+				if (!end_date)
+				{
+					end_date = new Date().toISOString().split('T')[0];
 				}
+
+				total_years_of_experience += calculate_total_years_of_experience(start_date, end_date);
 			}
 			if(promotions[company]){
 				total_number_of_promotions += promotions[company].length-1;


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Total years of experience calculation should take into consideration the date difference between the 'start_date' and the current date when the 'end_date' value in the career history table is not provided (indicating that the person is still currently employed at that company). 

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.

Career History DocType.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
