### PR TITLE
feat: Default Shift checker for relievers

### DIFF
--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
@@ -15,6 +15,8 @@
   "enable_face_recognition_endpoint",
   "roster_settings_section",
   "default_shift_checker_threshold",
+  "column_break_tusm",
+  "reliever_default_shift_checker_threshold",
   "section_break_2",
   "zenquote_keyword_category",
   "zenquotes_api_key",
@@ -214,11 +216,22 @@
    "fieldname": "sync_google_tasks_btn",
    "fieldtype": "Button",
    "label": "Sync Google Tasks"
+  },
+  {
+   "fieldname": "column_break_tusm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Any reliever assigned to the same shift up to this number of times will be reported in Default Shift Checker",
+   "fieldname": "reliever_default_shift_checker_threshold",
+   "fieldtype": "Int",
+   "label": "Reliever Default Shift Checker Threshold ",
+   "reqd": 1
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2025-01-21 18:09:17.133524",
+ "modified": "2025-04-25 09:56:02.132468",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ONEFM General Setting",

--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.json
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.json
@@ -11,6 +11,7 @@
   "column_break_fxzs",
   "start_date",
   "end_date",
+  "is_reliever",
   "default_operations_role_allocation",
   "actions_section",
   "status",
@@ -23,7 +24,9 @@
   "new_operations_role_allocation",
   "section_break_yzvl",
   "assigned_shifts_outside_default_shift",
-  "amended_from"
+  "amended_from",
+  "section_break_wkho",
+  "reliever_assigned_to_the_same_shift"
  ],
  "fields": [
   {
@@ -111,6 +114,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.is_reliever==0",
    "fieldname": "assigned_shifts_outside_default_shift",
    "fieldtype": "Table",
    "label": "Assigned Shifts Outside Default Shift",
@@ -155,12 +159,29 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_reliever",
+   "fieldtype": "Check",
+   "label": "Is Reliever"
+  },
+  {
+   "fieldname": "section_break_wkho",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval:doc.is_reliever==1",
+   "fieldname": "reliever_assigned_to_the_same_shift",
+   "fieldtype": "Table",
+   "label": "Reliever Assigned to the Same Shift",
+   "options": "Default Shift Checker Shift"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-17 13:34:20.758495",
+ "modified": "2025-04-25 09:59:52.031906",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Default Shift Checker",

--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.py
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.py
@@ -8,100 +8,124 @@ from frappe.query_builder.functions import Count
 from frappe.utils import getdate, get_last_day
 
 class DefaultShiftChecker(Document):
-    def on_submit(self):
-        self.update_employee_shift_details()
+	def on_submit(self):
+		self.update_employee_shift_details()
 
-    def update_employee_shift_details(self):
-        """
-            Updates the employee's shift or reliever status based on the action type.
-        """
-        employee = frappe.get_doc("Employee", self.employee)
+	def update_employee_shift_details(self):
+		"""
+			Updates the employee's shift or reliever status based on the action type.
+		"""
+		employee = frappe.get_doc("Employee", self.employee)
 
-        field_updates = {
-            "Shift Allocation Update": {
-                "shift": self.new_shift_allocation,
-                "custom_operations_role_allocation": self.new_operations_role_allocation
-            },
-            "Mark Employee as Reliever": {
-                "custom_is_reliever": 1
-            }
-        }
+		field_updates = {
+			"Shift Allocation Update": {
+				"shift": self.new_shift_allocation,
+				"custom_operations_role_allocation": self.new_operations_role_allocation
+			},
+			"Mark Employee as Reliever": {
+				"custom_is_reliever": 1
+			}
+		}
 
-        if self.action_type in field_updates:
-            employee.update(field_updates[self.action_type])
-            employee.save()
+		if self.action_type in field_updates:
+			employee.update(field_updates[self.action_type])
+			employee.save()
 
-        self.db_set("status", "Completed")
+		self.db_set("status", "Completed")
 
 
 def create_default_shift_checker():
-    start_date = getdate()
-    last_day_of_month = get_last_day(start_date)
+	start_date = getdate()
+	last_day_of_month = get_last_day(start_date)
 
-    threshold =  frappe.db.get_single_value("ONEFM General Setting", "default_shift_checker_threshold")
+	# For normal employees
+	create_checker(start_date, last_day_of_month, is_reliever=False)
+	# For relievers
+	create_checker(start_date, last_day_of_month, is_reliever=True)
 
-    Employee = DocType("Employee")
-    EmployeeSchedule = DocType("Employee Schedule")
-    Project = DocType("Project")
 
-    query = (
-        frappe.qb.from_(Employee)
-        .join(EmployeeSchedule)
-        .on(Employee.name == EmployeeSchedule.employee)
-        .left_join(Project)
-        .on(Employee.project == Project.name)
-        .select(
-            Employee.name.as_("employee"),
-            Employee.shift.as_("default_shift"),
-            Employee.site.as_("default_site")
-        )
-        .where(
-            (Employee.status == "Active")
-            & (Employee.shift_working == 1)
-            & (Employee.custom_is_reliever != 1)
-            & (Employee.shift.isnotnull())
-            & (Employee.shift != EmployeeSchedule.shift)
-            & (EmployeeSchedule.employee_availability == "Working")
-            & (EmployeeSchedule.roster_type == "Basic")
-            & (EmployeeSchedule.date[start_date:last_day_of_month])
-            & (Project.custom_exclude_from_default_shift_checker != 1) 
-        )
-        .groupby(Employee.name)
-        .having(Count(EmployeeSchedule.shift) > threshold)
-    )
+def create_checker(start_date, last_day_of_month, is_reliever=False):
+	"""
+	Unified function to create Default Shift Checker records for both regular employees and relievers
+	"""
+	Employee = frappe.qb.DocType("Employee")
+	EmployeeSchedule = frappe.qb.DocType("Employee Schedule")
+	Project = frappe.qb.DocType("Project")
 
-    result = query.run(as_dict=1)
+	# Configuration for threshold and fieldname
+	threshold_type = "reliever_default_shift_checker_threshold" if is_reliever else "default_shift_checker_threshold"
+	threshold = frappe.db.get_single_value("ONEFM General Setting", threshold_type) or 0
+	field_name = "reliever_assigned_to_the_same_shift" if is_reliever else "assigned_shifts_outside_default_shift"
 
-    for item in result:
-        try:
-            default_shift_checker = frappe.new_doc("Default Shift Checker")
-            default_shift_checker.employee = item['employee']
-            default_shift_checker.start_date = start_date
-            default_shift_checker.end_date = last_day_of_month
-            default_shift_checker.site_supervisor = frappe.db.get_value("Operations Site", item['default_site'], "account_supervisor")
+	# Fetch list of employees
+	query = (
+		frappe.qb.from_(Employee)
+		.join(EmployeeSchedule).on(Employee.name == EmployeeSchedule.employee)
+		.left_join(Project).on(Employee.project == Project.name)
+		.select(
+			Employee.name.as_("employee"),
+			Employee.shift.as_("default_shift"),
+			Employee.site.as_("default_site")
+		)
+		.where(
+			(Employee.status == "Active")
+			& (Employee.shift_working == 1)
+			& (Employee.custom_is_reliever == (1 if is_reliever else 0))
+			& (Employee.shift.isnotnull())
+			& (EmployeeSchedule.shift == Employee.shift if is_reliever else EmployeeSchedule.shift != Employee.shift)
+			& (EmployeeSchedule.employee_availability == "Working")
+			& (EmployeeSchedule.roster_type == "Basic")
+			& (EmployeeSchedule.date[start_date:last_day_of_month])
+			& (Project.custom_exclude_from_default_shift_checker != 1)
+		)
+		.groupby(Employee.name)
+		.having(Count(EmployeeSchedule.shift) > threshold)
+	)
 
-            shifts_assigned_outside = (
-                frappe.qb.from_(EmployeeSchedule)
-                .select(
-                    EmployeeSchedule.shift,
-                    Count(EmployeeSchedule.shift).as_("operations_shift_count"),
-                )
-                .where(
-                    (EmployeeSchedule.employee == item["employee"])
-                    & (EmployeeSchedule.shift != item["default_shift"])
-                    & (EmployeeSchedule.employee_availability == "Working")
-                    & (EmployeeSchedule.roster_type == "Basic")
-                    & (EmployeeSchedule.date[start_date:last_day_of_month])
-                )
-                .groupby(EmployeeSchedule.shift)
-            ).run(as_dict=1)
+	# Create default shift checker
+	for employee in query.run(as_dict=True):
+		try:
+			doc = frappe.new_doc("Default Shift Checker")
+			doc.employee = employee.employee
+			doc.start_date = start_date
+			doc.end_date = last_day_of_month
+			doc.site_supervisor = frappe.db.get_value("Operations Site", employee.default_site, "account_supervisor")
+			
+			if is_reliever:
+				doc.is_reliever = 1
 
-            for schedule in shifts_assigned_outside:
-                default_shift_checker.append("assigned_shifts_outside_default_shift", {
-                    "operations_shift": schedule.shift,
-                    "count": schedule.operations_shift_count
-                })
-            default_shift_checker.save()
-        except Exception as e:
-            frappe.log_error("Default Shift Checker", frappe.get_traceback())
-            continue
+			# Get shiftwise count for each employee
+			shift_condition = (EmployeeSchedule.shift == employee.default_shift) if is_reliever else (EmployeeSchedule.shift != employee.default_shift)
+			shifts = get_shift_assignments(
+				employee.employee, shift_condition, 
+				start_date, last_day_of_month, EmployeeSchedule
+			)
+
+			for shift in shifts:
+				doc.append(field_name, {
+					"operations_shift": shift.shift,
+					"count": shift.operations_shift_count
+				})
+
+			doc.insert()
+		except Exception as e:
+			frappe.log_error("Default Shift Checker Error", str(e))
+			continue
+
+
+def get_shift_assignments(employee_id, shift_condition, start_date, end_date, EmployeeSchedule):
+	return (
+		frappe.qb.from_(EmployeeSchedule)
+		.select(
+			EmployeeSchedule.shift,
+			Count(EmployeeSchedule.shift).as_("operations_shift_count")
+		)
+		.where(
+			(EmployeeSchedule.employee == employee_id)
+			& shift_condition
+			& (EmployeeSchedule.employee_availability == "Working")
+			& (EmployeeSchedule.roster_type == "Basic")
+			& (EmployeeSchedule.date[start_date:end_date])
+		)
+		.groupby(EmployeeSchedule.shift)
+	).run(as_dict=True)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As Operations Admin I want to see relievers who have been assigned to the same shift in Default Shift checker.

## Solution description
`Reliever Assigned to the Same Shift` child table added to Default Shift Checker doctype. 
If the employee is a reliever, this table will be populated with data otherwise `Assigned Shifts Outside Default Shift` will be populated with data. 

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)
Threshold field added in ONEFM General Setting
![image](https://github.com/user-attachments/assets/4aa0d78c-1cd5-45bc-8d39-299fe40ac421)

Default shift checker of Reliever:
![image](https://github.com/user-attachments/assets/b211b4bc-977f-466a-95a2-1767516120c8)

Default shift checker of Non-reliever employee:
![image](https://github.com/user-attachments/assets/26c9e358-5d55-4b24-9416-4923d9891402)



## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
Yes 

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
