### PR TITLE
FEAT : As OneFM I want the Attendance Request with Workflow State Pending Approval to be approved automatically right before the Attendance Marking so that Employees with Valid Attendance Requests are not marked Absent

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -705,7 +705,6 @@ scheduler_events = {
 			'one_fm.api.tasks.generate_payroll'
 		],
 		"05 23 1-31 * *": [ #“At 23:05 on every day-of-month from 1 through 31.”
-			# 'one_fm.overrides.attendance_request.mark_future_attendance_request',
 			'one_fm.tasks.one_fm.daily.roster_projection_view_task',
 		],
 		"15 0 * * *": [ # create shift assignment

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -705,7 +705,7 @@ scheduler_events = {
 			'one_fm.api.tasks.generate_payroll'
 		],
 		"05 23 1-31 * *": [ #“At 23:05 on every day-of-month from 1 through 31.”
-			'one_fm.overrides.attendance_request.mark_future_attendance_request',
+			# 'one_fm.overrides.attendance_request.mark_future_attendance_request',
 			'one_fm.tasks.one_fm.daily.roster_projection_view_task',
 		],
 		"15 0 * * *": [ # create shift assignment

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -1,3 +1,4 @@
+from one_fm.overrides.attendance_request import approve_pending_attendance_request
 import pandas as pd
 import frappe, erpnext
 from frappe import _
@@ -504,6 +505,7 @@ def mark_all_attendance():
     frappe.enqueue(approve_open_shift_permission, start_date=str(start_date), end_date=str(end_date))
     frappe.enqueue(approve_pending_employee_checkin_issue)
     frappe.enqueue(mark_open_timesheet_and_create_attendance)
+    frappe.enqueue(approve_pending_attendance_request)
     frappe.enqueue(mark_daily_attendance, start_date=start_date, end_date=end_date, timeout=4000, queue='long')
 
 def mark_daily_attendance(start_date, end_date):

--- a/one_fm/overrides/attendance_request.py
+++ b/one_fm/overrides/attendance_request.py
@@ -251,3 +251,23 @@ def mark_future_attendance_request():
 			frappe.get_doc("Attendance Request", row.name).mark_attendance(str(getdate()))
 		except Exception as e:
 			frappe.log_error(str(e), 'Attendance Request')
+
+
+def approve_pending_attendance_request():
+    """
+    Get attendance requests for the future where date is today
+    and workflow state is 'Pending Approval' and approve it.
+    """
+    attendance_requests = frappe.db.sql(f"""
+        SELECT name FROM `tabAttendance Request`
+        WHERE '{getdate()}' BETWEEN from_date AND to_date
+        AND workflow_state = 'Pending Approval'
+    """, as_dict=1)
+    for row in attendance_requests:
+        try:
+            doc = frappe.get_doc("Attendance Request", row.name)
+            doc.workflow_state = 'Approved'
+            doc.save(ignore_permissions=True)
+            frappe.db.commit()
+        except Exception as e:
+            print(f"Error in {row.name}: {str(e)}")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.atlassian.net/browse/ON-5

## Is there a business logic within a doctype?
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
None

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    -None

## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
