### PR TITLE
Feat : I would like to change the location of the [Provide Accommodation by Company] field in the Employee Doctype to be under Address & Contacts Tab under Address section and not in the Connections

### DIFF
--- a/one_fm/fixtures/property_setter.json
+++ b/one_fm/fixtures/property_setter.json
@@ -9950,5 +9950,21 @@
   "property_type": null,
   "row_name": null,
   "value": "eval: doc.status == \"Completed\" || doc.status == \"Pending Review\""
- }
+ },
+ {
+    "default_value": null,
+    "doc_type": "Employee",
+    "docstatus": 0,
+    "doctype": "Property Setter",
+    "doctype_or_field": "DocField",
+    "field_name": "current_accommodation_type",
+    "is_system_generated": 0,
+    "modified": "2025-05-01 00:20:59.686747",
+    "module": null,
+    "name": "Employee-current_accommodation_type-depends_on",
+    "property": "depends_on",
+    "property_type": "Data",
+    "row_name": null,
+    "value": "eval:cur_frm.doc.one_fm_provide_accommodation_by_company == 0"
+   }
 ]

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -129,7 +129,7 @@ const set_current_address = (frm) => {
         frappe.call({
             method: "one_fm.overrides.employee.fetch_accomodation_name",
             args: { name: frm.doc.name },
-            callback: (r) => {r.data.accomodation
+            callback: (r) => {
                 if (r.message && r.data.accomodation) {
                     frm.set_value("current_address", r.data.accomodation);
                 }

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -129,9 +129,9 @@ const set_current_address = (frm) => {
         frappe.call({
             method: "one_fm.overrides.employee.fetch_accomodation_name",
             args: { name: frm.doc.name },
-            callback: (r) => {
-                if (r.message && r.message.accommodation) {
-                    frm.set_value("current_address", r.message.accommodation);
+            callback: (r) => {r.data.accomodation
+                if (r.message && r.data.accomodation) {
+                    frm.set_value("current_address", r.data.accomodation);
                 }
             }
         });


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature

## Clearly and concisely describe the feature.
https://one-fm.atlassian.net/jira/software/projects/ON/boards/2?selectedIssue=ON-7

## Analysis and design (optional)
Changing the depends on status and modifying the data of response.

## Solution description
Changing the depends on status and modifying the data of response.

## Is there a business logic within a doctype?
    - [] No

## Output screenshots (optional)

https://github.com/user-attachments/assets/1e8f4edc-abee-4a91-ac3f-bb1e9093772c

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [] Existing Data

## Was child table created?
    - None
    
## Did you delete custom field?
    - [] No

## Is patch required?
- [] No

## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
