### PR TITLE
feat: add shift details to supervisor reminder email for checkin/checkout

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -245,12 +245,16 @@ def supervisor_reminder(shift, today_datetime, now_time):
 				#for_user = get_employee_user_id(recipient.reports_to) if get_employee_user_id(recipient.reports_to) else get_notification_user(op_shift)
 				subject = _("{employee} has not checked in yet.".format(employee=recipient.employee_name))
 				action_message = _("""
+				Operations Site: {site}
+				Operations Shift: {shift_type}
+				Shift Start: {shift_start}
+				Shift End: {shift_end}
 				Submit a Shift Permission for the employee to give an excuse and not need to penalize
 				<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 				<br/><br/>
 				Issue penalty for the employee
 				<a class='btn btn-primary btn-danger no-punch-in' id='{employee}_{date}_{shift}' href="/app/penalty-issuance/new-penalty-issuance-1">Issue Penalty</a>
-				""").format(shift=recipient.shift, date=cstr(now_time), employee=recipient.name, time=checkin_time)
+				""").format(site=recipient.site, shift_type=recipient.shift_type, shift_start=recipient.start_datetime, shift_end=recipient.end_datetime, shift=recipient.shift, date=cstr(now_time), employee=recipient.name, time=checkin_time)
 				if action_user is not None:
 					send_notification(title, subject, action_message, category, [action_user])
 
@@ -275,12 +279,16 @@ def supervisor_reminder(shift, today_datetime, now_time):
 				#for_user = get_employee_user_id(recipient.reports_to) if get_employee_user_id(recipient.reports_to) else get_notification_user(op_shift)
 				subject = _('{employee} has not checked out yet.'.format(employee=recipient.employee_name))
 				action_message = _("""
+					Operations Site: {site}
+					Operations Shift: {shift_type}
+					Shift Start: {shift_start}
+					Shift End: {shift_end}
 					Submit a Shift Permission for the employee to give an excuse and not need to penalize
 					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 					<br/><br/>
 					Issue penalty for the employee
 					<a class='btn btn-primary btn-danger no-punch-in' id='{employee}_{date}_{shift}' href="/app/penalty-issuance/new-penalty-issuance-1">Issue Penalty</a>
-					""").format(shift=recipient.shift, date=cstr(now_time), employee=recipient.name, time=checkout_time)
+					""").format(site=recipient.site, shift_type=recipient.shift_type, shift_start=recipient.start_datetime, shift_end=recipient.end_datetime, shift=recipient.shift, date=cstr(now_time), employee=recipient.name, time=checkout_time)
 				if action_user is not None:
 						send_notification(title, subject, action_message, category, [action_user])
 
@@ -329,7 +337,7 @@ def checkin_checkout_query(date, shift_type, log_type):
 	else:
 		permission_type = ("Leave Early",)
 
-	query = frappe.db.sql("""SELECT DISTINCT emp.user_id, emp.name , emp.employee_name, emp.holiday_list, tSA.shift
+	query = frappe.db.sql("""SELECT DISTINCT emp.user_id, emp.name , emp.employee_name, emp.holiday_list, tSA.shift, tSA.shift_type, tSA.site, tSA.start_datetime, tSA.end_datetime
 					FROM `tabShift Assignment` tSA, `tabEmployee` emp
 					WHERE
 						tSA.employee=emp.name

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -249,6 +249,7 @@ def supervisor_reminder(shift, today_datetime, now_time):
 				Operations Shift: {shift_type}
 				Shift Start: {shift_start}
 				Shift End: {shift_end}
+				<br/>
 				Submit a Shift Permission for the employee to give an excuse and not need to penalize
 				<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 				<br/><br/>
@@ -283,6 +284,7 @@ def supervisor_reminder(shift, today_datetime, now_time):
 					Operations Shift: {shift_type}
 					Shift Start: {shift_start}
 					Shift End: {shift_end}
+					<br/>
 					Submit a Shift Permission for the employee to give an excuse and not need to penalize
 					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 					<br/><br/>

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -245,11 +245,11 @@ def supervisor_reminder(shift, today_datetime, now_time):
 				#for_user = get_employee_user_id(recipient.reports_to) if get_employee_user_id(recipient.reports_to) else get_notification_user(op_shift)
 				subject = _("{employee} has not checked in yet.".format(employee=recipient.employee_name))
 				action_message = _("""
-				Operations Site: {site}
-				Operations Shift: {shift_type}
-				Shift Start: {shift_start}
-				Shift End: {shift_end}
-				<br/>
+				<b>Operations Site:</b> {site} <br/>
+				<b>Operations Shift:</b> {shift_type} <br/>
+				<b>Shift Start:</b> {shift_start} <br/>
+				<b>Shift End:</b> {shift_end}
+				<br/><br/>
 				Submit a Shift Permission for the employee to give an excuse and not need to penalize
 				<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 				<br/><br/>
@@ -280,11 +280,11 @@ def supervisor_reminder(shift, today_datetime, now_time):
 				#for_user = get_employee_user_id(recipient.reports_to) if get_employee_user_id(recipient.reports_to) else get_notification_user(op_shift)
 				subject = _('{employee} has not checked out yet.'.format(employee=recipient.employee_name))
 				action_message = _("""
-					Operations Site: {site}
-					Operations Shift: {shift_type}
-					Shift Start: {shift_start}
-					Shift End: {shift_end}
-					<br/>
+					<b>Operations Site:</b> {site} <br/>
+					<b>Operations Shift:</b> {shift_type} <br/>
+					<b>Shift Start:</b> {shift_start} <br/>
+					<b>Shift End:</b> {shift_end}
+					<br/><br/>
 					Submit a Shift Permission for the employee to give an excuse and not need to penalize
 					<a class="btn btn-primary" href="/app/shift-permission/new-shift-permission-1">Submit Shift Permission</a>&nbsp;
 					<br/><br/>


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Added employee shift details (operations site, operations shift, shift start and shift end) to supervisor reminder email for checkin/checkout

Story link: https://one-fm.atlassian.net/browse/ON-9

## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="574" alt="Screenshot 2025-05-15 at 12 52 03 PM" src="https://github.com/user-attachments/assets/abaa52a3-87b2-45ec-bd23-95112a11aa4a" />


## Areas affected and ensured
`one_fm/api/tasks.py`

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

No


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
