### PR TITLE
chore: marked shifts outside default shift child table as read only

### DIFF
--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.json
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.json
@@ -118,7 +118,8 @@
    "fieldname": "assigned_shifts_outside_default_shift",
    "fieldtype": "Table",
    "label": "Assigned Shifts Outside Default Shift",
-   "options": "Default Shift Checker Shift"
+   "options": "Default Shift Checker Shift",
+   "read_only": 1
   },
   {
    "fetch_from": "employee.shift",
@@ -182,7 +183,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-28 11:43:18.267802",
+ "modified": "2025-05-06 08:24:15.457029",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Default Shift Checker",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Assigned Shifts Outside Default Shift in Default Shift Checker doctype should be read only

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Marked "Assigned Shifts Outside Default Shift" in Default Shift Checker doctype as read only

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Default Shift Checker

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
