### PR TITLE
fix: Task Doctype Permission Issue

### DIFF
--- a/one_fm/overrides/task.py
+++ b/one_fm/overrides/task.py
@@ -14,7 +14,7 @@ def validate_task(doc, method):
     # When new doc is added, then sync field after insert
     if not doc.is_new() and doc.status != "Pending Review":
         sync_assign_to_field(doc)
-    check_completed_by_and_completed_on(doc,method)
+    
 
     all_asssigned_users = doc.get_assigned_users()
     assignees = doc.custom_assigned_to 
@@ -39,6 +39,8 @@ def validate_task(doc, method):
     is_manager = is_project_manager(doc.project) if doc.project else False
     if "Projects User" in roles and "Projects Manager" not in roles and not is_manager and (doc.project or doc.owner != frappe.session.user):
         validate_updated_fields(doc)
+    
+    check_completed_by_and_completed_on(doc,method)
 
 def after_task_insert(doc, method):
     sync_assign_to_field(doc)

--- a/one_fm/public/js/doctype_js/task.js
+++ b/one_fm/public/js/doctype_js/task.js
@@ -9,20 +9,6 @@ const USER_PERMS = {
 }
 
 frappe.ui.form.on("Task", {
-    status:function (frm) {
-        if (frm.doc.status == "Pending Review" || frm.doc.status == "Completed") {
-            // Set completed_by from the first person in the 'assign_to' field
-            if (frm.doc.custom_assigned_to.length > 0) {
-                frm.set_value("completed_by", frm.doc.custom_assigned_to[0]["user"]);
-            }
-            else{
-                frm.set_value("completed_by", "");
-            }
-
-            // Set completed_on as today's date
-            frm.set_value("completed_on", frappe.datetime.get_today());
-        }
-    },
     refresh: function (frm) {
         set_perms(frm);  
         }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/817

I 

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description

The current issue is that It is preventing user to change status to "pending review" because on setting the status to "pending review" the "completed on" and "completed by" field is been set from the frontend and when saving it there is a validation on the backend that is checking not to edit "completed on" field if you are not the document owner or have "Project Manager" role

I removed the setting of "completed on" and "completed by" fields from the frontend and leave it to the backend after the permission check that if the session user is not the owner of the document and is not have "Project Manager" role not to be able to edit "completed on" field

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


https://github.com/user-attachments/assets/1ca6860c-fc22-4ecf-b4ce-7f157a584dfb



## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
