### PR TITLE
fix: fixed duplicate employees data in employees not rostered

### DIFF
--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.py
@@ -291,7 +291,7 @@ def get_supervisors_not_rostered_employees(employees_not_rostered, date):
 
 			os.project As project,
 			os.site AS site,
-			GROUP_CONCAT(e.name) AS employees
+			GROUP_CONCAT(DISTINCT e.name) AS employees
 		FROM
 			`tabOperations Shift` AS os
 		LEFT JOIN


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Duplicate entries in "Employee No Rostered" child table in Roster Post Actions doctype

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Modified SQL query for fetching supervisors for not rostered employees in Roster Employee Actions

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
Before
![Screenshot from 2025-05-06 12-47-52](https://github.com/user-attachments/assets/58da22ff-4a6a-4ee2-baf6-1aa1578d204b)

After
![Screenshot from 2025-05-06 12-48-32](https://github.com/user-attachments/assets/5c0f9016-0c10-42be-9d65-cdfc6ef2f910)


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Employee Actions

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
