### PR TITLE
fix: (ON-41) Days off notification issue

### DIFF
--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
@@ -114,7 +114,8 @@ def validate_offs(employee):
 		# Calculate no of off days
 		od = frappe.db.sql(frappe.qb.from_(EmployeeSchedule)        
 			.select(Count("name").as_("off_days"))
-			.where(employee_schedule_date & employee_name & employee_day_off_ot & employee_availability), 
+			.where(employee_schedule_date & employee_name & employee_day_off_ot & employee_availability)
+			.groupby(EmployeeSchedule.shift), 
 		as_dict=1) 
 		off_days = od[0].off_days if len(od) > 0 else 0 
 

--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
@@ -114,16 +114,14 @@ def validate_offs(employee):
 		# Calculate no of off days
 		od = frappe.db.sql(frappe.qb.from_(EmployeeSchedule)        
 			.select(Count("name").as_("off_days"))
-			.where(employee_schedule_date & employee_name & employee_day_off_ot & employee_availability)
-			.groupby(EmployeeSchedule.shift), 
+			.where(employee_schedule_date & employee_name & employee_day_off_ot & employee_availability), 
 		as_dict=1) 
 		off_days = od[0].off_days if len(od) > 0 else 0 
 
 		# Calculate no of ot days
 		ot = frappe.db.sql( frappe.qb.from_(EmployeeSchedule)
 			.select(Count("name").as_("ot_days"))
-			.where( employee_name & employee_schedule_date & (EmployeeSchedule.day_off_ot == 1))
-			.groupby(EmployeeSchedule.shift), as_dict=1) 
+			.where( employee_name & employee_schedule_date & (EmployeeSchedule.day_off_ot == 1)), as_dict=1) 
 		ot_days = ot[0].ot_days if len(ot) > 0 else 0 
 
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/838

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)

Currently, the query is grouped by shift. So, if an employee is rostered for day-off OT on two different shift, it returns something like [{ 'ot_days': 1 }, { 'ot_days': 1 }]. However, only the first item is used, which causes the supervisor to keep receiving day-off notifications even after assigning day-off OT to the employee.

I removed the GROUP BY clause so that the query returns a combined result like [{ 'ot_days': 2 }].


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
