### PR TITLE
feat: (Ros 8) I want the “New Operations Role Allocation” field in the Default Shift Checker doctype to be filtered based on the selected “New Shift Allocation” so that only valid Operations roles are selected

### DIFF
--- a/one_fm/operations/doctype/default_shift_checker/default_shift_checker.js
+++ b/one_fm/operations/doctype/default_shift_checker/default_shift_checker.js
@@ -4,6 +4,15 @@
 frappe.ui.form.on("Default Shift Checker", {
     action_type: function(frm){
         reset_new_operations_shift_and_role_allocation(frm)
+    },
+    new_shift_allocation: function(frm){
+        frm.set_query("new_operations_role_allocation", function() {
+            return {
+                filters: {
+                    shift: frm.doc.new_shift_allocation
+                }
+            };
+        });
     }
 });
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.atlassian.net/jira/software/projects/ROS/boards/4?selectedIssue=ROS-8

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)

https://github.com/user-attachments/assets/0756be94-1d0f-493b-95f3-1e76b83ca128




## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
