### PR TITLE
[FEAT ROS-9 Restrict Disabling Operations Shift with Future Schedules without deleting schedules]

### DIFF
--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-from frappe.utils import today, add_days, get_url, time_diff_in_hours, cstr, getdate
+from frappe.utils import today, add_days, get_url, time_diff_in_hours, cstr, getdate,nowdate
 from frappe.integrations.offsite_backup_utils import get_latest_backup_file, send_email, validate_file_size, get_chunk_site
 from one_fm.api.notification import create_notification_log
 from frappe.utils.user import get_users_with_role
@@ -521,4 +521,41 @@ def validate_store_keeper_project_supervisor_roles(doc):
     except Exception as e:
         frappe.log_error(e, "Validate Purchase Order(store keeper)")
         return False
-   
+@frappe.whitelist()
+def has_linked_schedules(field,value):
+    """
+        Returns true if there are linked  employee schedules for days after today 
+    """
+    today = getdate()
+    if field not in ['Operations Site','Operations Shift']:
+        return False
+    doctype_field_dict = {
+        'Operations Site':'site',
+        'Operations Shift':'shift'
+    }
+    doctype_field = doctype_field_dict.get(field)
+    if not doctype_field:
+        return False
+    
+    employee_schedules = frappe.db.exists("Employee Schedule",{doctype_field:value,'date':['>',today]})
+    return True if bool(employee_schedules) else False
+
+
+@frappe.whitelist()
+def delete_linked_schedules(field,value):
+    """
+        Delete all  future schedules linked to the site
+    
+    """
+    if field not in ['Operations Site','Operations Shift']:
+        return False
+    doctype_field_dict = {
+        'Operations Site':'site',
+        'Operations Shift':'shift'
+    }
+    doctype_field = doctype_field_dict.get(field)
+    if not doctype_field:
+        return False
+    query = f" DELETE FROM `tabEmployee Schedule`  WHERE {doctype_field} = '{value}' AND date > '{nowdate()}' "
+    frappe.db.sql(query)
+    frappe.db.commit()

--- a/one_fm/one_fm/utils.py
+++ b/one_fm/one_fm/utils.py
@@ -529,7 +529,7 @@ def has_linked_schedules(field,value):
         Returns true if there are linked  employee schedules for days after today 
     """
     today = getdate()
-    if field not in ['Operations Site']:
+    if field not in ['Operations Site','Operations Shift']:
         return False
     doctype_field_dict = {
         'Operations Site':'site',
@@ -549,7 +549,7 @@ def delete_linked_schedules(field,value):
         Delete all  future schedules linked to the site
     
     """
-    if field not in ['Operations Site']:
+    if field not in ['Operations Site','Operations Shift']:
         return False
     doctype_field_dict = {
         'Operations Site':'site',

--- a/one_fm/operations/doctype/operations_shift/operations_shift.js
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.js
@@ -5,6 +5,7 @@ frappe.ui.form.on('Operations Shift', {
 	onload: function (frm) {
 		frm.__previous_shift_type = frm.doc.shift_type
 	},
+
 	refresh: function(frm) {
 		if(!frm.doc.__islocal){
 			frm.add_custom_button(
@@ -169,6 +170,9 @@ frappe.ui.form.on('Operations Shift', {
 			).addClass('btn-primary');
 		}
 	},
+	before_save: function(frm) {
+		validate_linked_schedules(frm);
+	},
 	automate_roster: function(frm) {
 		// If the flag is set, do nothing to prevent looping
 		if (frm.__is_resetting_value) {
@@ -223,3 +227,44 @@ frappe.ui.form.on('Operations Shift', {
 	}
 	
 });
+
+function  validate_linked_schedules(frm){
+	if (frm.doc.status =="Inactive" && !frm.__confirmed_inactive && !frm.is_new()){
+		frappe.call({
+			method:"one_fm.one_fm.utils.has_linked_schedules",
+			args:{
+				field: "Operations Shift",
+				value: frm.doc.name,
+			},
+			callback: (response) => {
+				
+				if(response.message==true){
+					frappe.confirm(
+						"The future Employee Schedules linked to the Operations Shift will be deleted on confirmation. Do you want to proceed?",
+						()=>{
+							console.log("CALLING O")
+							frappe.call({
+								method:"one_fm.one_fm.utils.delete_linked_schedules",
+								args:{
+									field: "Operations Shift",
+									value: frm.doc.name
+								},
+								
+								callback: (response) => {
+									frm.__confirmed_inactive = true;
+									frm.save();
+								}
+							})
+						},
+						()=>{
+							frappe.validated=false
+							frm.reload_doc();
+						}
+					)
+				}
+				frappe.validated=false
+			}})			
+		
+	}
+
+}

--- a/one_fm/operations/doctype/operations_site/operations_site.js
+++ b/one_fm/operations/doctype/operations_site/operations_site.js
@@ -25,7 +25,7 @@ frappe.ui.form.on('Operations Site', {
 				}
 			}
 		}
-		console.log(changes);
+		
 		if(changes && ids){
 			frm.add_custom_button(
 				__('Review Changes'),
@@ -146,7 +146,7 @@ function quick_entry_shifts_and_posts(frm){
 									callback: function(r) {
 										if(!r.exc) {
 											let {designations, skills} = r.message;
-											console.log(designations, skills);
+											
 											post_dialog.fields_dict["skills"].grid.remove_all();
 											post_dialog.fields_dict["designations"].grid.remove_all();
 
@@ -198,7 +198,7 @@ function quick_entry_shifts_and_posts(frm){
 							],
 							data: [],
 							get_data: function() {
-								console.log(this);
+								
 								return this.data;
 							},
 						},
@@ -232,7 +232,7 @@ function quick_entry_shifts_and_posts(frm){
 								},
 							],
 							get_data: function() {
-								console.log(this);
+								
 								return this.data;
 							},
 							data: [],
@@ -242,7 +242,7 @@ function quick_entry_shifts_and_posts(frm){
 					],
 					primary_action: function(){
 						let values = post_dialog.get_values();
-						console.log(values);
+						
 						let {qty, post_names} = values;
 						if(post_names === undefined || qty !== post_names.length){frappe.msgprint(__('Please make sure the number of posts and Post names are same.'))};
 						frappe.call({
@@ -271,7 +271,7 @@ function changes_action(frm, action, ids){
 	frappe.call('one_fm.operations.doctype.operations_site.operations_site.changes_action', {
 		action, ids, parent: frm.doc.name
 	}).then((r) => {
-		console.log(r);
+		
 		frm.reload_doc();
 	});
 }
@@ -313,7 +313,7 @@ function get_contact(doc){
 
 function set_contact(doc){
 	let {email_ids, phone_nos} = doc;
-	console.log(email_ids, phone_nos);
+	
 	let contact_details = ``;
 	for(let i=0; i<email_ids.length;i++){
 		contact_details += `<p>Email: ${email_ids[i].email_id}</p>\n`;
@@ -322,6 +322,6 @@ function set_contact(doc){
 	for(let j=0; j<phone_nos.length;j++){
 		contact_details += `<p>Phone: ${phone_nos[j].phone}</p>\n`;
 	}
-	console.log(contact_details);
+	
 	$('div[data-fieldname="contact_html"]').empty().append(`<div class="address-box">${contact_details}</div>`);
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [*] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.atlassian.net/browse/ROS-9?atlOrigin=eyJpIjoiYTUyY2JiZGVkYjc1NDU5NDkyYWQ1NjEyNzEzYmJmYTMiLCJwIjoiaiJ9
Restrict Disabling Operations Shift with Future Schedules without deleting schedules

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Restrict Disabling Operations Shift with Future Schedules without deleting schedules
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
https://www.loom.com/share/e33ba187f8a245ba99013079d84acf95?sid=b40cac51-4abc-4549-94a1-a1ba95554639

## Areas affected and ensured
List out the areas affected by your code changes.
Operations Shift

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? NO
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
