### PR TITLE
feat: populate employee, from_date and to_date fields automatically when creating a new attendance request record

### DIFF
--- a/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
+++ b/one_fm/one_fm/doctype/roster_employee_actions/roster_employee_actions.json
@@ -144,6 +144,7 @@
   {
    "fieldname": "project_manager",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Project Manager",
    "options": "Employee",
    "read_only": 1
@@ -152,6 +153,7 @@
    "fetch_from": "project_manager.employee_name",
    "fieldname": "project_manager_name",
    "fieldtype": "Data",
+   "ignore_user_permissions": 1,
    "label": "Project Manager Name",
    "read_only": 1
   },
@@ -177,7 +179,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-05 15:31:05.731428",
+ "modified": "2025-05-15 16:32:55.572646",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Roster Employee Actions",

--- a/one_fm/public/js/doctype_js/attendance_request.js
+++ b/one_fm/public/js/doctype_js/attendance_request.js
@@ -5,6 +5,33 @@ frappe.ui.form.on('Attendance Request', {
   validate: (frm) => {
     validate_from_date(frm);
   },
+  onload: function(frm) {
+    if (frm.is_new()) {
+        // Set employee field based on current user
+        if (!frm.doc.employee) {
+            frappe.call({
+                method: "frappe.client.get_value",
+                args: {
+                    doctype: "Employee",
+                    filters: {
+                        user_id: frappe.session.user
+                    },
+                    fieldname: "name"
+                },
+                callback: function(response) {
+                    if (response.message) {
+                        frm.set_value("employee", response.message.name);
+                    }
+                }
+            });
+        }
+
+      // Set from_date and to_date to today's date
+      const today = frappe.datetime.get_today();
+      if (!frm.doc.from_date) frm.set_value("from_date", today);
+      if (!frm.doc.to_date) frm.set_value("to_date", today);
+  }
+},
   check_workflow: (frm)=>{
     if(frm.doc.workflow_state=='Pending Approval'){
       // Disable action button/worklow if not approver


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
employee, from_date and to_date fields in attendance request doctype are automatically filled in with the current session user and today's date when creating a new record.

Link: https://one-fm.atlassian.net/jira/software/projects/ON/boards/2?selectedIssue=ON-86

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Add a client-side `onload` event to pre-fill default values when a new form is opened.


## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/user-attachments/assets/269c6529-c952-49e4-acf8-d87cfd69c119



## Areas affected and ensured
`one_fm/one_fm/public/js/doctype_js/attendance_request.js`


## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Was child table created?
No


## Did you delete custom field?
    - [] Yes
    - [x] No


## Is patch required?
- [] Yes
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
