### PR TITLE
feat: Add Client Day Off option in Roster and Employee Schedule

### DIFF
--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -452,6 +452,12 @@
                             </div>
                             <div class="col-sm-12 col-md-4 custompageselecttype mb10">
                                 <div class="d-flex">
+                                    <div class="legendboxview silverboxcolor"></div>
+                                    <div class="pl10 font16 cardtitlecolor">Client Day Off</div>
+                                </div>
+                            </div>
+                            <div class="col-sm-12 col-md-4 custompageselecttype mb10">
+                                <div class="d-flex">
                                     <div class="legendboxview blueboxcolor"></div>
                                     <div class="pl10 font16 cardtitlecolor">Planned</div>
                                 </div>

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1230,6 +1230,7 @@ function get_roster_data(page, isOt) {
 let classmap = {
 	'Working': 'bluebox',
 	'Day Off': 'greyboxcolor',
+	'Client Day Off': 'silverboxcolor',
 	'Sick Leave': 'purplebox',
 	'Emergency Leave': 'purplebox',
 	'Annual Leave': 'purplebox',
@@ -1238,6 +1239,7 @@ let classmap = {
 };
 let leavemap = {
 	'Day Off': 'DO',
+	'Client Day Off': 'CDO',
 	'Sick Leave': 'SL',
 	'Annual Leave': 'AL',
 	'Emergency Leave': 'EL',
@@ -3608,6 +3610,7 @@ function dayoff(page) {
 		'fields': [
 			{ 'label': 'Selected days only', 'fieldname': 'selected_dates', 'fieldtype': 'Check', 'default': 0 },
 			{ 'label': 'Set Reliever', 'fieldname': 'set_reliever', 'fieldtype': 'Check', 'default': 0 },
+			{ 'label': 'Client Day Off', 'fieldname': 'client_day_off', 'fieldtype': 'Check', 'default': 0 },
 			{ 'label': 'Reliever', 'fieldname': 'selected_reliever', 'fieldtype': 'Select', 'options': reliever_options,'depends_on': 'eval:doc.set_reliever==1' },
 			{ 'label': 'Repeat', 'fieldname': 'repeat', 'fieldtype': 'Select', 'depends_on': 'eval:doc.selected_dates==0', 'options': 'Does not repeat\nWeekly\nMonthly' },
 			{ 'fieldtype': 'Section Break', 'fieldname': 'sb1', 'depends_on': 'eval:doc.repeat=="Weekly" && doc.selected_dates==0' },
@@ -3629,10 +3632,11 @@ function dayoff(page) {
 			let week_days = [];
 			let args = {};
 			let repeat_freq = '';
-			let { selected_dates,set_reliever,selected_reliever, repeat, sunday, monday, tuesday, wednesday, thursday, friday, saturday, repeat_till, project_end_date } = d.get_values();
+			let { selected_dates, client_day_off, set_reliever, selected_reliever, repeat, sunday, monday, tuesday, wednesday, thursday, friday, saturday, repeat_till, project_end_date } = d.get_values();
 			args["selected_dates"] = selected_dates;
 			args["set_reliever"] = set_reliever;
 			args["employees"] = employees;
+			args["client_day_off"] = client_day_off;
 
 			if(set_reliever == 0){
 				args['selected_reliever']=""

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -165,11 +165,9 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
         if isOt:
             employee_filters.update({"employee_availability" : "Working"})
             reliever_filter = f"and custom_is_reliever={strtobool(relievers)}" if relievers else ""
-            all_active_employees = frappe.db.sql(f"SELECT name from `tabEmployee` where status in ('Active','Vacation') and attendance_by_timesheet = '0' and shift_working= '1' {reliever_filter}",as_dict =1)
-            all_active_employee_ids = [i.name for i in all_active_employees]
+            all_active_employee_ids = frappe.db.sql_list(f"SELECT name from `tabEmployee` where status in ('Active','Vacation') and attendance_by_timesheet = '0' and shift_working= '1' {reliever_filter}")
             employee_filters.update({"employee":[ "In", all_active_employee_ids]})
-
-            employees = frappe.db.get_list("Employee Schedule", employee_filters, ["distinct employee", "employee_name"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
+            employees = frappe.db.get_list("Employee Schedule", employee_filters, ["distinct employee", "employee_name"], limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
             master_data.update({"total" : len(employees)})
             employees.extend(exited_employees)
             employees = filter_redundant_employees(employees)
@@ -184,7 +182,6 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
             employee_filters.update({"attendance_by_timesheet": 0})
             if designation:
                 employee_filters.update({"designation" : designation})
-
             employees = frappe.db.get_list("Employee", employee_filters, ["employee", "employee_name", "day_off_category", "number_of_days_off"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
             employees.extend(exited_employees)
             employees = filter_redundant_employees(employees)
@@ -1299,7 +1296,7 @@ def delete_existing_post_schedules(date,post):
         frappe.log_error("Error Deleting Post Schedules",frappe.get_traceback())
 
 @frappe.whitelist()
-def dayoff(employees, selected_dates=0,selected_reliever=None, repeat=0, repeat_freq=None, week_days=[], repeat_till=None, project_end_date=None):
+def dayoff(employees, client_day_off=0, selected_dates=0, selected_reliever=None, repeat=0, repeat_freq=None, week_days=[], repeat_till=None, project_end_date=None):
     """
         Set days of done with sql query for instant response
     """
@@ -1307,6 +1304,7 @@ def dayoff(employees, selected_dates=0,selected_reliever=None, repeat=0, repeat_
         creation = now()
         owner = frappe.session.user
         roster_type = "Basic"
+        employee_availability = "Client Day Off" if cint(client_day_off) else "Day Off"
 
         id_list = []
         query = """
@@ -1341,7 +1339,7 @@ def dayoff(employees, selected_dates=0,selected_reliever=None, repeat=0, repeat_
                     id_list.append(name)
                     querycontent += f"""(
                         "{name}", "{employee["employee"]}", "{date}", "", "", "",
-                        '', "Day Off", "", "", "Basic",
+                        '', "{employee_availability}", "", "", "Basic",
                         0, "{owner}", "{owner}", "{creation}", "{creation}"
                     ),"""
                     update_day_off_ot = frappe.db.get_value("Employee Schedule",
@@ -1374,7 +1372,7 @@ def dayoff(employees, selected_dates=0,selected_reliever=None, repeat=0, repeat_
                                 id_list.append(name)
                                 querycontent += f"""(
                                     "{name}", "{employee["employee"]}", "{date.date()}", "", "", "",
-                                    '', "Day Off", "", "", "Basic",
+                                    '', "{employee_availability}", "", "", "Basic",
                                     0, "{owner}", "{owner}", "{creation}", "{creation}"
                                 ),"""
                                 emp_query = f"""
@@ -1414,7 +1412,7 @@ def dayoff(employees, selected_dates=0,selected_reliever=None, repeat=0, repeat_
                                 id_list.append(name)
                                 querycontent += f"""(
                                     "{name}", "{employee["employee"]}", "{date.date()}", "", "", "",
-                                    '', "Day Off", "", "", "Basic",
+                                    '', "{employee_availability}", "", "", "Basic",
                                     0, "{owner}", "{owner}", "{creation}", "{creation}"
                                 ),"""
                                 emp_query = f"""
@@ -1454,7 +1452,7 @@ def dayoff(employees, selected_dates=0,selected_reliever=None, repeat=0, repeat_
                 shift_type = "",
                 day_off_ot = 0,
                 roster_type = "Basic",
-                employee_availability = "Day Off"
+                employee_availability = "{employee_availability}"
             """
             frappe.db.sql(query, values=[], as_dict=1)
             frappe.db.commit()

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.json
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.json
@@ -62,7 +62,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Employee Availability",
-   "options": "Working\nDay Off\nSick Leave\nAnnual Leave\nEmergency Leave",
+   "options": "Working\nDay Off\nClient Day Off\nSick Leave\nAnnual Leave\nEmergency Leave",
    "reqd": 1
   },
   {
@@ -219,7 +219,7 @@
   }
  ],
  "links": [],
- "modified": "2024-05-31 10:39:39.670488",
+ "modified": "2025-05-14 11:22:13.245469",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Employee Schedule",

--- a/one_fm/www/css/site.css
+++ b/one_fm/www/css/site.css
@@ -1033,6 +1033,9 @@ body[data-route="roster"] .redboxcolor {
 body[data-route="roster"] .greyboxcolor {
   background: #7f7f7f;
 }
+body[data-route="roster"] .silverboxcolor {
+  background: #b1b1b1;
+}
 body[data-route="roster"] .lightblueboxcolor {
   background: #63a8f8;
 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As Operations Admin I want to indicate Employees who are who are supposed to be working but the client is having a Day Off so that they can be deployed to other duties if needed
https://one-fm.atlassian.net/browse/ROS-10


## Solution description
1. Addition of “Client Day Off” option in the “Employee Availability” field in the “Employee Schedule” doctype.

2. Addition of “Client Day Off” checkbox in the day off setting modal of the Staff View in Roster.

3. If “Client Day Off” is checked when assigning Day Off, set Employee Availability to “Client Day Off”, otherwise, set it to “Day Off”.

4. Creation of Client Day Off card (CDO) in Roster in silver color to the Legend area

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)
Client Day Off in Roster and Legend
![image](https://github.com/user-attachments/assets/756af495-d1e0-445c-874d-46ead0e9d1b6)

Client day off checkbox in Day Off popup dialog
![image](https://github.com/user-attachments/assets/dfedc408-c18a-4fdf-b3cf-d23d669791a5)


## Areas affected and ensured
Employee Schedule doctype
Roster 


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
