### PR TITLE
feat: populate employee, from_date and to_date fields automatically when creating a new attendance request record

### DIFF
--- a/one_fm/public/js/doctype_js/attendance_request.js
+++ b/one_fm/public/js/doctype_js/attendance_request.js
@@ -5,6 +5,33 @@ frappe.ui.form.on('Attendance Request', {
   validate: (frm) => {
     validate_from_date(frm);
   },
+  onload: function(frm) {
+    if (frm.is_new()) {
+        // Set employee field based on current user
+        if (!frm.doc.employee) {
+            frappe.call({
+                method: "frappe.client.get_value",
+                args: {
+                    doctype: "Employee",
+                    filters: {
+                        user_id: frappe.session.user
+                    },
+                    fieldname: "name"
+                },
+                callback: function(response) {
+                    if (response.message) {
+                        frm.set_value("employee", response.message.name);
+                    }
+                }
+            });
+        }
+
+      // Set from_date and to_date to today's date
+      const today = frappe.datetime.get_today();
+      if (!frm.doc.from_date) frm.set_value("from_date", today);
+      if (!frm.doc.to_date) frm.set_value("to_date", today);
+  }
+},
   check_workflow: (frm)=>{
     if(frm.doc.workflow_state=='Pending Approval'){
       // Disable action button/worklow if not approver


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
employee, from_date and to_date fields in attendance request doctype are automatically filled in with the current session user and today's date when creating a new record.

Link: https://one-fm.atlassian.net/jira/software/projects/ON/boards/2?selectedIssue=ON-86


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Add a client-side `onload` event to pre-fill default values when a new form is opened.


## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
https://github.com/user-attachments/assets/c3809861-9da0-4981-87a8-2806bc92ef67



## Areas affected and ensured
`one_fm/one_fm/public/js/doctype_js/attendance_request.js`



## Is there any existing behavior change of other features due to this code change?
No


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Was child table created?
No


## Did you delete custom field?
    - [] Yes
    - [x] No


## Is patch required?
- [] Yes
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
