### PR TITLE
BUG: ROSTERED EMPLOYEE NOT COMING UP WHEN FILTERED WITH OPERATIONS ROLE

### DIFF
--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -163,16 +163,18 @@ class CreateMap():
         else:
             employee_tuple = tuple(employee_list)  # Format as ('HR-EMP-00081', 'HR-EMP-00082')
 
+
         # Construct the queries
         self.schedule_query = f"""
             SELECT es.employee, es.employee_name, es.date, es.operations_role, es.post_abbrv, 
                 es.shift, es.start_datetime, es.end_datetime, es.roster_type, es.employee_availability, 
                 es.day_off_ot, es.project 
             FROM `tabEmployee Schedule` es 
-            WHERE es.employee IN {employee_tuple} 
-            AND {self.str_filter} 
+            WHERE {self.str_filter} 
+            AND es.employee IN {employee_tuple}
             ORDER BY es.employee
         """
+
 
         self.attendance_query = f"""
             SELECT at.status, at.leave_type, at.leave_application, at.attendance_date, at.employee, 
@@ -220,12 +222,14 @@ class CreateMap():
 
     def start_mapping(self):
         filters = [[i.employee,i.employee_name] for i in  self.all_employees]
+        print(filters, "\n" * 8)
         #Fetch all employee details
         self.employee_details = list(map(self.create_employee_schedule,self.employee_set))
         #Create the attendance iterable for each employee using python map
         self.att_map=list(map(self.create_attendance_map,filters))
         #Create the schedule iterable for each employee using python map
         self.sch_map = list(map(self.create_schedule_map,filters))
+        print(self.sch_map, "\n" *9)
         #Combine both the attenance and schedule maps,
         self.combined_map = list(map(self.combine_maps,self.att_map,self.sch_map))
         #Add missing  calendar days
@@ -307,7 +311,7 @@ class CreateMap():
         schedule = []
         for one in self.schedule_set:
             try:
-                if one.employee==row[0]:
+                if one.employee == row[0]:
                     schedule.append(one.update(self.employee_period_details[row[0]]))
             except KeyError:
                 pass

--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -222,14 +222,12 @@ class CreateMap():
 
     def start_mapping(self):
         filters = [[i.employee,i.employee_name] for i in  self.all_employees]
-        print(filters, "\n" * 8)
         #Fetch all employee details
         self.employee_details = list(map(self.create_employee_schedule,self.employee_set))
         #Create the attendance iterable for each employee using python map
         self.att_map=list(map(self.create_attendance_map,filters))
         #Create the schedule iterable for each employee using python map
         self.sch_map = list(map(self.create_schedule_map,filters))
-        print(self.sch_map, "\n" *9)
         #Combine both the attenance and schedule maps,
         self.combined_map = list(map(self.combine_maps,self.att_map,self.sch_map))
         #Add missing  calendar days

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -88,10 +88,19 @@ def get_staff_filters_data():
     }
 
 
+def fetch_role_schedule_employees(start_date, end_date, role):
+    query  = """SELECT employee, employee_name from `tabEmployee Schedule` WHERE date BETWEEN %s AND %s AND operations_role = %s"""
+    return frappe.db.sql(query, (start_date, end_date, role), as_dict=1)
+
+
+
 @frappe.whitelist()
-def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_search_id=None, employee_search_name=None, project=None, site=None, shift=None, department=None, operations_role=None, designation=None, relievers=False, isOt=None, limit_start=0, limit_page_length=9999):
+def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_search_id=None, employee_search_name=None,
+                     project=None, site=None, shift=None, department=None, operations_role=None, designation=None, 
+                     relievers=False, isOt=None, limit_start=0, limit_page_length=9999):
     try:
         master_data, formatted_employee_data, post_count_data, employee_filters= {}, {}, {}, {}
+        role_employees = []
         operations_roles_list = []
         employees = []
         asa_filters = "em.status = 'Active' and em.attendance_by_timesheet = '0' "
@@ -101,8 +110,11 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
         str_filters = f'es.date between "{start_date}" and "{end_date}"'
         exited_employee_filters = f"""status='Left' and attendance_by_timesheet = '0' and relieving_date between '{start_date}' and '{end_date}'"""
         if operations_role:
-            filters.update({'operations_role': operations_role})
-            str_filters +=' and es.operations_role = "{}"'.format(operations_role)
+            role_value = frappe.db.get_value("Operations Post", operations_role, "post_template")
+            filters.update({'operations_role': role_value})
+            str_filters +=' and es.operations_role = "{}"'.format(role_value)
+            role_employees = fetch_role_schedule_employees(start_date=start_date, end_date=end_date, role=role_value)
+
 
         if employee_search_id:
             employee_filters.update({'employee_id': employee_search_id})
@@ -159,9 +171,11 @@ def get_roster_view(start_date, end_date, assigned=0, scheduled=0, employee_sear
             employee_filters.update({'attendance_by_timesheet':'0'})
             if designation:
                 employee_filters.update({'designation' : designation})
-				
-            employees = frappe.db.get_list("Employee", employee_filters, ["employee", "employee_name", "day_off_category", "number_of_days_off"], order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
+			
+            employees = frappe.db.get_list("Employee", employee_filters, ["employee", "employee_name", "day_off_category", "number_of_days_off"],
+                                            order_by="employee_name asc" ,limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=True)
             employees.extend(exited_employees)
+            employees.extend(role_employees) if role_employees else None
             employees = filter_redundant_employees(employees)
 
             #Conditional to ensure that the proceeding code block does not run unless Project,shift or site is queried


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [X] Bug


## Clearly and concisely describe the feature, chore or bug.
When a user is rostered to a particular role, which is different from the one on the employee document, he doesnt how up when the roster is filtered via operations role

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Fetched the correct operations role value to be used for filter purposes, and also added the employees, if filtered by employees, as the other employee query is paginated,a nd would not contain all of them

https://one-fm.com/app/hd-ticket/840


## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
