### PR TITLE
FEAT ROS-18 Restrict the disabling of Operations Site when Employees are still scheduled or assigned to that Operations Site 

### DIFF
--- a/one_fm/operations/doctype/operations_site/operations_site.js
+++ b/one_fm/operations/doctype/operations_site/operations_site.js
@@ -57,6 +57,9 @@ frappe.ui.form.on('Operations Site', {
 
 		});
 	},
+	before_save:  function(frm){
+		validate_linked_schedules(frm)
+	},
 	account_supervisor: function(frm){
 		frm.trigger("get_employee_status")
 	},
@@ -77,7 +80,46 @@ frappe.ui.form.on('Operations Site', {
 		})
 	}
 })
+function  validate_linked_schedules(frm){
+	if (frm.doc.status =="Inactive" && !frm.__confirmed_inactive && !frm.is_new()){
+		frappe.call({
+			method:"one_fm.one_fm.utils.has_linked_schedules",
+			args:{
+				field: "Operations Site",
+				value: frm.doc.name,
+			},
+			callback: (response) => {
+				
+				if(response.message==true){
+					frappe.confirm(
+						"The future Employee Schedules linked to the Operations Site will be deleted on confirmation. Do you want to proceed?",
+						()=>{
+							frappe.call({
+								method:"one_fm.one_fm.utils.delete_linked_schedules",
+								args:{
+									field: "Operations Site",
+									value: frm.doc.name
+								},
+								freeze:1,
+								freeze_message:__("Deleting Linked Schedules..."),
+								callback: (response) => {
+									frm.__confirmed_inactive = true;
+									frm.save();
+								}
+							})
+						},
+						()=>{
+							frappe.validated=false
+							frm.reload_doc();
+						}
+					)
+				}
+				frappe.validated=false
+			}})			
+		
+	}
 
+}
 function quick_entry_shifts_and_posts(frm){
 	if(!frm.doc.__islocal){
 		frm.add_custom_button(


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [*] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.atlassian.net/browse/ROS-18?atlOrigin=eyJpIjoiOWJiMjM2NzdkMWI5NDc4ZGJiMDVmYWEwZjI4ODJmZjkiLCJwIjoiaiJ9
As Operations Admin I want to restrict the disabling of Operations Site when Employees are still scheduled or assigned to that Operations Site so that only Sites without Employee Assignment and/or Employee Schedules can be set as inactive



## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
As Operations Admin I want to restrict the disabling of Operations Site when Employees are still scheduled or assigned to that Operations Site so that only Sites without Employee Assignment and/or Employee Schedules can be set as inactive


## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
https://www.loom.com/share/9d5d21eab98f48489b6ee38f667cd911?sid=d2b994b8-5737-4b11-bcd3-dce50e4bf4ea

## Areas affected and ensured
List out the areas affected by your code changes.
Operations Site

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [*] Existing Data
- [*] New Data

## Was child table created?  No
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
