### PR TITLE
fix: google sheet data export

### DIFF
--- a/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/exporter.py
@@ -42,7 +42,8 @@ def export_data(
 	google_sheet_id=None,
 	sheet_name=None,
 	owner=None,
-	client_id = None
+	client_id=None,
+	name=None
 ):
 	_doctype = doctype
 	if isinstance(_doctype, list):
@@ -66,7 +67,8 @@ def export_data(
 		google_sheet_id=google_sheet_id,
 		sheet_name=sheet_name,
 		owner=owner,
-		client_id = client_id
+		client_id=client_id,
+		name=name
 	)
 	result = exporter.build_response()
 
@@ -86,7 +88,8 @@ class DataExporter:
 		google_sheet_id=None,
 		sheet_name=None,
 		owner=None,
-		client_id = None
+		client_id=None,
+		name=None
 	):
 		self.doctype = doctype
 		self.parent_doctype = parent_doctype
@@ -100,6 +103,7 @@ class DataExporter:
 		self.owner = owner
 		self.cell_colour = []
 		self.client_id = client_id
+		self.name = name
 
 		api = self.initialize_service()
 		self.service = api["service"]
@@ -193,7 +197,7 @@ class DataExporter:
 				_("No Data"), _("There is no data to be exported"), indicator_color="orange"
 			)
 		result = {"google_sheet_id":self.google_sheet_id, "link":self.link,"sheet_name":self.sheet_name}
-		frappe.db.set_value("Google Sheet Data Export", {"reference_doctype": self.doctype}, "last_execution_date", nowdate())
+		frappe.db.set_value("Google Sheet Data Export", self.name, "last_execution_date", nowdate())
 
 		return result
 
@@ -583,6 +587,7 @@ def update_google_sheet_daily():
 			sheet_name= doc.sheet_name,
 			owner= doc.owner,
 			client_id= doc.client_id,
+			name= doc.name,
 			is_async=True, queue="long", timeout=9000)
 
 @frappe.whitelist()

--- a/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.js
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.js
@@ -6,10 +6,10 @@ frappe.ui.form.on('Google Sheet Data Export', {
 		if(!frm.is_new()){
 			frm.add_custom_button(__('Export Sheet'), function(){
 				export_data(frm);
-			});	
+			});
 			const doctype = frm.doc.reference_doctype;
 			if (doctype) {
-				frappe.model.with_doctype(doctype, () => set_filters_and_field(frm));	
+				frappe.model.with_doctype(doctype, () => set_filters_and_field(frm));
 			}
 		}
 		if(frm.doc.reference_doctype == null){
@@ -41,9 +41,9 @@ frappe.ui.form.on('Google Sheet Data Export', {
 		columns[dt] = options;
 		});
 		let filters = frm.filter_list.get_filters().map((filter) => filter.slice(1, 4))
-		
+
 		frm.set_value('filter_cache',  JSON.stringify(filters) )
-		frm.set_value('field_cache',  JSON.stringify(columns))	
+		frm.set_value('field_cache',  JSON.stringify(columns))
 		frappe.call({
 			method: "one_fm.one_fm.doctype.google_sheet_data_export.exporter.get_client_id",
 			callback: function(r) {
@@ -53,7 +53,7 @@ frappe.ui.form.on('Google Sheet Data Export', {
 			}
 		});
 	},
-	
+
 	reference_doctype: (frm) => {
 		const doctype = frm.doc.reference_doctype;
 		if (doctype) {
@@ -104,7 +104,7 @@ const export_data = (frm) => {
 		filters = JSON.parse(frm.doc.filter_cache)
 		select_columns = frm.doc.field_cache;
 	}
-	
+
 	frappe.call({
 		method: "one_fm.one_fm.doctype.google_sheet_data_export.exporter.export_data",
 		args: {
@@ -116,7 +116,8 @@ const export_data = (frm) => {
 			google_sheet_id: frm.doc.google_sheet_id,
 			sheet_name: frm.doc.sheet_name,
 			owner:frm.doc.owner,
-			client_id: frm.doc.client_id
+			client_id: frm.doc.client_id,
+			name: frm.doc.name
 		},
 		freeze: true,
 		freeze_message: __("Exporting Data to the Sheet"),
@@ -133,10 +134,6 @@ const export_data = (frm) => {
 				}
 			}
 		});
-	
-	
-	
-	
 };
 
 const reset_filter_and_field = (frm) => {
@@ -166,9 +163,9 @@ const set_filters_and_field = (frm) => {
 	filters.forEach((filter) => {
 		frm.filter_list.add_filter(doctype, filter[0],filter[1],filter[2])
 	})
-	
+
 	// Add 'Select All' and 'Unselect All' button
-	
+
 	make_multiselect_buttons(parent_wrapper);
 	frm.fields_multicheck = {};
 	related_doctypes.forEach((dt) => {
@@ -181,7 +178,7 @@ const set_field_options = (frm) => {
 	const filter_wrapper = frm.fields_dict.filter_list.$wrapper;
 	const doctype = frm.doc.reference_doctype;
 	const related_doctypes = get_doctypes(doctype);
-	
+
 	parent_wrapper.empty();
 	filter_wrapper.empty();
 
@@ -251,7 +248,7 @@ const add_doctype_field_multicheck_control = (frm, doctype, parent_wrapper) => {
 		for (const [key, value] of Object.entries(selected_fields)) {
 			let c = selected_fields[key]
 			if(key == df.parent && c.includes(df.fieldname)){
-				check = 1 
+				check = 1
 			}
 		}
 		return {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
Google sheet data export was updating all the referenced google data export record
Updating the google sheet last execution date by reference doctypefrappe.db.set_value("Google Sheet Data Export", {"reference_doctype": self.doctype}, "last_execution_date", nowdate())it updates all the sheets refer to the doctype.

## Solution description
Update the google sheet data export based on the record name

## Areas affected and ensured
- `one_fm/one_fm/doctype/google_sheet_data_export/exporter.py`
- `one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.js`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome