### PR TITLE
BUG : Late Arrival Notification on approving shift permission

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -265,7 +265,7 @@ def notify_supervisor_about_late_entry(checkin):
 	try:
 		auto_attendance_employee = frappe.get_value("Employee", {'name':checkin.employee}, ['auto_attendance'])
 		if auto_attendance_employee == 0:
-			shift_permission = frappe.db.sql(f""" select name from `tabShift Permission` where employee = '{checkin.employee}' and date = '{now_datetime().date()}' and log_type = 'IN' and permission_type = 'Arrive Late' and workflow_state IN ('Pending','Approved') ;  """)
+			shift_permission = frappe.db.sql(f""" select name from `tabShift Permission` where employee = '{checkin.employee}' and date = '{now_datetime().date()}' and log_type = 'IN' and workflow_state IN ('Pending','Approved') ;  """)
 			checkin_shift_assignment = False
 			if checkin.shift_assignment:
 				checkin_shift_assignment = last_shift_assignment = checkin.shift_assignment


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/830

## Analysis and design (optional)
We have recently implemented a new feature where, upon approving a Shift Permission, a corresponding Employee Checkin record is created. When this Checkin record is created, the after_insert method is triggered, which sends a notification to the employee’s reporting manager.

As part of the notification logic, we check if auto-attendance is disabled for the employee and whether there is an approved or pending Shift Permission for late arrival on the current date. We also check if a similar Checkin already exists. If no such Shift Permission is found and other conditions are met, the notification is triggered.

However, the query used to check for late arrival permissions relies on a permission_type field in the Shift Permission doctype

The issue is that the permission_type field was removed from the Shift Permission doctype, causing this query to return no results. As a result, the system incorrectly assumes there is no valid permission, and the supervisor is notified immediately after approval, even though the permission exists.

## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
