### PR TITLE
feat: send email to ticket raiser with details once HD ticket is created

### DIFF
--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -87,15 +87,23 @@ def validate_hd_ticket(doc, event):
 
 
 def notify_ticket_raiser_of_receipt(doc, event):
-    subject = f"HelpDesk Ticket - {doc.name}"
-    context = dict(
-        document_name=doc.name,
-        document_link=frappe.utils.get_url(doc.get_url()),
-        document_subject=doc.subject
-    )
-    msg = frappe.render_template('one_fm/templates/emails/notify_ticket_raiser_receipt.html', context=context)
-    frappe.enqueue(method=sendemail, queue="short", recipients=doc.raised_by, subject=subject, content=msg, is_external_mail=True, is_scheduler_email=True)
-    
+    try:
+        subject = f"Support Ticket Raised - Ticket No. {doc.name}"
+        employee=  frappe.db.get_value("Employee", {"user_id": doc.raised_by}, ["employee_name"], as_dict=1)
+
+        args = frappe._dict({
+            "employee_name": employee.employee_name,
+            "ticket_id": doc.name,
+            "ticket_subject": doc.subject,
+            "base_url": frappe.utils.get_url(),
+            "doc_type": doc.doctype,
+            "doc_name": doc.name
+        })
+        message = frappe.render_template('one_fm/templates/emails/notify_ticket_raiser_receipt.html', context=args)
+        frappe.enqueue(method=sendemail, queue="short", recipients=doc.raised_by, subject=subject, content=message, is_external_mail=True, is_scheduler_email=True)
+
+    except Exception as e:
+        frappe.log_error(message=frappe.get_traceback(), title="HD Ticket")
     
     
 def notify_issue_raiser_about_priority(doc, event):

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -88,12 +88,11 @@ def validate_hd_ticket(doc, event):
 
 def notify_ticket_raiser_of_receipt(doc, event):
     try:
-        subject = f"Support Ticket Raised - Ticket No. {doc.name}"
+        subject = f"HD Ticket {doc.name} Raised"
         employee=  frappe.db.get_value("Employee", {"user_id": doc.raised_by}, ["employee_name"], as_dict=1)
 
         args = frappe._dict({
             "employee_name": employee.employee_name,
-            "ticket_id": doc.name,
             "ticket_subject": doc.subject,
             "base_url": frappe.utils.get_url(),
             "doc_type": doc.doctype,
@@ -101,7 +100,6 @@ def notify_ticket_raiser_of_receipt(doc, event):
         })
         message = frappe.render_template('one_fm/templates/emails/notify_ticket_raiser_receipt.html', context=args)
         frappe.enqueue(method=sendemail, queue="short", recipients=doc.raised_by, subject=subject, content=message, is_external_mail=True, is_scheduler_email=True)
-
     except Exception as e:
         frappe.log_error(message=frappe.get_traceback(), title="HD Ticket")
     

--- a/one_fm/templates/emails/notify_ticket_raiser_receipt.html
+++ b/one_fm/templates/emails/notify_ticket_raiser_receipt.html
@@ -59,12 +59,12 @@
 </head>
 <body>
      <div class="subject-container">
-        <h1 class="title">Support Ticket Raised - Ticket No. {{ticket_id}}</h1>
+        <h1 class="title">HD Ticket {{ doc_name }} Raised</h1>
     </div>
     <table class="core-table">
         <tr>
           <th>Document Name</th>
-          <td></td>
+          <td>{{ doc_name }}</td>
         </tr>
         <tr>
             <th>Document Type</th>
@@ -90,7 +90,7 @@
                 <br><br>
                 <strong>Ticket ID: </strong>
                 <br>
-                {{ ticket_id }}
+                {{ doc_name }}
                 <br><br>
                 <strong>Ticket Subject: </strong>
                 <br>

--- a/one_fm/templates/emails/notify_ticket_raiser_receipt.html
+++ b/one_fm/templates/emails/notify_ticket_raiser_receipt.html
@@ -1,55 +1,107 @@
-<style>
-    table {
-      font-family: Arial, sans-serif;
-      border-collapse: collapse;
-      width: 100%;
-    }
-    
-    th, .notify_ticket_raiser td {
-      border: 1px solid #ddd;
-      padding: 8px;
-    }
-    
-    th {
-      background-color: #f2f2f2;
-      color: #333;
-      width: 30%;
-      text-align: left;
-    }
-    
-    tr:nth-child(even) {
-      background-color: #f9f9f9;
-    }
-    
-    tr:hover {
-      background-color: #ddd;
-    }
-    
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        /* Import Google Fonts */
+        @import url('https://fonts.googleapis.com/css2?family=Readex+Pro:wght@300&family=Noto+Naskh+Arabic:wght@400&display=swap');
+
+        /* General Styling */
+        body {
+            font-family: 'Readex Pro', sans-serif;
+            font-size: 10px;
+            color: #000;
+        }
+        /* Table Styling */
+        .core-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+            border: 1px solid #ccc;
+            background-color: #fff;
+        }
+
+        .core-table td, th {
+            border: 1px solid #ccc;
+            padding: 10px;
+            font-size: 13px;
+        }
+
+        .core-table th {
+            background-color: #f0f0f0;
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .container {
+            min-height: 100px;
+        }
+
+        a {
+            color: #007bff;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+        
+        .title {
+              font-family: 'Alexandria', sans-serif; 
+              font-style: italic;
+              font-weight: bold;
+              font-size: 18px;
+              color: black;
+              text-align: center;
+          }
     </style>
-    
-    <h3>A new Ticket has been created</h3>
-    <table>
-      <tbody class="notify_ticket_raiser">
+</head>
+<body>
+     <div class="subject-container">
+        <h1 class="title">Support Ticket Raised - Ticket No. {{ticket_id}}</h1>
+    </div>
+    <table class="core-table">
         <tr>
           <th>Document Name</th>
-          <td>{{ document_name }}</td>
+          <td></td>
         </tr>
         <tr>
-          <th>Document Type</th>
-          <td>HD Ticket</td>
+            <th>Document Type</th>
+            <td>{{ doc_type }}</td>
         </tr>
         <tr>
           <th>Description</th>
-          <td>New Ticket Created</td>
+          <td>
+            <div class="container">
+              Dear {{ employee_name }},
+              <br><br>
+              Thank you for contacting our support team. A support ticket has now been opened for your request.
+              <br><br>
+              You will be notified when a response is made by email.
+            </div>
+          </td>
         </tr>
         <tr>
-          <th>Content</th>
-          <td>The HD Ticket {{ document_name }} with Subject, {{ document_subject }} has been received, the Support team will review it soon!</td>
+            <th>Content</th>
+            <td>
+              <div class="container">
+                The details of your ticket are shown below:
+                <br><br>
+                <strong>Ticket ID: </strong>
+                <br>
+                {{ ticket_id }}
+                <br><br>
+                <strong>Ticket Subject: </strong>
+                <br>
+                {{ ticket_subject }}
+              </div>
+            </td>
         </tr>
         <tr>
-          <th>Document Link</th>
-          <td><a href={{document_link}}>Click Here</a></td>
+            <th>Document Link</th>
+            <td><a href="{{ base_url }}/app/hd-ticket/{{ doc_name }}" target="_blank">Click Here</a></td>
         </tr>
-      </tbody>
     </table>
-    
+</body>
+</html>


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Send email to ticket raiser with ticket details once HD ticket is created.

Link: https://one-fm.atlassian.net/jira/software/projects/ON/boards/2?selectedIssue=ON-102


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
1. Adjust `notify_ticket_raiser_receipt.html` template.
2. Adjust `notify_ticket_raiser_of_receipt` function to take into account new fields in template.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
<img width="732" alt="Screenshot 2025-05-26 at 1 51 32 PM" src="https://github.com/user-attachments/assets/72861d64-724f-4a80-9081-1565e14a27bd" />


## Areas affected and ensured
1. `one_fm/overrides/hd_ticket.py`
2. `one_fm/templates/emails/notify_ticket_raiser_receipt.html`

## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
    - [] Yes
    - [x] No

## Is patch required?
- [] Yes
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
