### PR TITLE
added roster type in unscheduling staff

### DIFF
--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -125,7 +125,7 @@
                         <a href="#" class="responsivebluebtn ml-0 dayoff">Day Off</a>
                         <!--<a href="#" class="responsivebluebtn scheduleleave">Leaves</a>-->
                         <a href="#" class="responsivebluebtn changepost">Schedule/Change Post</a>
-                        <a href="#" class="responsivebluebtn assignchangemodal">Unschedule/Post Staff</a>
+                        <a href="#" class="responsivebluebtn assignchangemodal">Change Employee Schedule</a>
                     </div>
                     <div>
                         <a href="#" class="clear_selection"><i class="fas fa-close mr-2"></i>Clear Selection</a>

--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -124,8 +124,8 @@
                     <div>
                         <a href="#" class="responsivebluebtn ml-0 dayoff">Day Off</a>
                         <!--<a href="#" class="responsivebluebtn scheduleleave">Leaves</a>-->
-                        <a href="#" class="responsivebluebtn changepost">Schedule/Change Post</a>
-                        <a href="#" class="responsivebluebtn assignchangemodal">Change Employee Schedule</a>
+                        <a href="#" class="responsivebluebtn changepost">Change Employee Schedule</a>
+                        <a href="#" class="responsivebluebtn assignchangemodal">Unschedule/Post Staff</a>
                     </div>
                     <div>
                         <a href="#" class="clear_selection"><i class="fas fa-close mr-2"></i>Clear Selection</a>

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -3041,6 +3041,9 @@ function unschedule_staff(page) {
 		'title': 'Unschedule Staff',
 		'fields': [
 			{
+				'label': 'Roster Type', 'fieldname': 'roster_type', 'fieldtype': 'Select', 'options': 'Basic\nOver-Time', 'default': 'Basic'
+			},
+			{
 				'label': 'Selected Days Only', 'fieldname': 'selected_days_only', 'fieldtype': 'Check', 'default': 0, onchange: function () {
 					let val = d.get_value('selected_days_only');
 					if (val) {
@@ -3094,18 +3097,12 @@ function unschedule_staff(page) {
 		],
 		primary_action: function () {
 			$('#cover-spin').show(0);
-			let { selected_days_only, start_date, end_date, never_end } = d.get_values();
-			let element = get_wrapper_element();
-			if (element == ".rosterOtMonth") {
-				otRoster = true;
-			} else if (element == ".rosterMonth") {
-				otRoster = false;
-			}
+			let { roster_type, selected_days_only, start_date, end_date, never_end } = d.get_values();
 
 			frappe.call({
 				method: "one_fm.one_fm.page.roster.roster.unschedule_staff",
 				type: "POST",
-				args: { employees, otRoster, start_date, end_date, never_end, selected_days_only },
+				args: { employees, roster_type, start_date, end_date, never_end, selected_days_only },
 				callback: function(res) {
 					d.hide();
 					error_handler(res);

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -875,9 +875,8 @@ def schedule_leave(employees, leave_type, start_date, end_date):
         return frappe.utils.response.report_error(e.http_status_code)
 
 @frappe.whitelist(allow_guest=True)
-def unschedule_staff(employees, otRoster,start_date=None, end_date=None, never_end=0, selected_days_only=0):
+def unschedule_staff(employees, roster_type, start_date=None, end_date=None, never_end=0, selected_days_only=0):
     try:
-        roster_type = "Over-Time" if otRoster == 'true' else "Basic"
         _start_date = getdate(start_date) if start_date else None
         stop_date = getdate(end_date) if end_date else None
 
@@ -895,6 +894,9 @@ def unschedule_staff(employees, otRoster,start_date=None, end_date=None, never_e
         if end_date:
             employees = [i for i in employees if getdate(i['date'])<=stop_date]
 
+        # If roster type is "Basic" then delete Basic/Over-Time schedules otherwise delete only target roster type schedules
+        roster_type_query = "roster_type in ('Basic', 'Over-Time')" if roster_type == "Basic" else f"roster_type = '{roster_type}'"
+
         # check if no end date
         if cint(never_end) == 1:
             employees_to_delete = []
@@ -904,12 +906,12 @@ def unschedule_staff(employees, otRoster,start_date=None, end_date=None, never_e
             # delete all schedules greater than start date
             employees_to_delete=str(tuple(employees_to_delete)).replace(',)', ')')
             frappe.db.sql(f"""
-                DELETE FROM `tabEmployee Schedule` WHERE employee IN {employees_to_delete} and date>='{start_date}' and roster_type ='{roster_type}'
+                DELETE FROM `tabEmployee Schedule` WHERE employee IN {employees_to_delete} and date>='{start_date}' and {roster_type_query}
             """)
         else:
             for i in employees:
                 frappe.db.sql(f"""
-                    DELETE FROM `tabEmployee Schedule` WHERE employee='{i['employee']}' and date='{i['date']}' and roster_type ='{roster_type}'
+                    DELETE FROM `tabEmployee Schedule` WHERE employee='{i['employee']}' and date='{i['date']}' and {roster_type_query}
                 """)
         response("Success", 200, {'message':'Staff(s) unscheduled successfully'})
     except Exception as e:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As Operations User I want to Unschedule Staff from the Roster
https://one-fm.atlassian.net/browse/ROS-23?atlOrigin=eyJpIjoiODIxMDEzMjhiZGQ2NDBhMTllNTVmOTFmMjU3ZjVhNTkiLCJwIjoiaiJ9

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Added roster type in staff unscheduling
- Deleted OT schedule as well if 'basic' is selected otherwise schedule will be deleted as per roster type

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
