### PR TITLE
fix: change path for hd ticket document link in ticket notification email to helpdesk app instead of doctype

### DIFF
--- a/one_fm/templates/emails/notify_ticket_raiser_of_resolution.html
+++ b/one_fm/templates/emails/notify_ticket_raiser_of_resolution.html
@@ -104,7 +104,7 @@
         </tr>
         <tr>
             <th>Document Link</th>
-            <td><a href="{{ base_url }}/app/hd-ticket/{{ doc_name }}" target="_blank">Click Here</a></td>
+            <td><a href="{{ base_url }}/helpdesk/tickets/{{ doc_name }}" target="_blank">Click Here</a></td>
         </tr>
     </table>
 </body>

--- a/one_fm/templates/emails/notify_ticket_raiser_receipt.html
+++ b/one_fm/templates/emails/notify_ticket_raiser_receipt.html
@@ -100,7 +100,7 @@
         </tr>
         <tr>
             <th>Document Link</th>
-            <td><a href="{{ base_url }}/app/hd-ticket/{{ doc_name }}" target="_blank">Click Here</a></td>
+            <td><a href="{{ base_url }}/helpdesk/tickets/{{ doc_name }}" target="_blank">Click Here</a></td>
         </tr>
     </table>
 </body>


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Change path for hd ticket document link in ticket notification/resolution email to helpdesk app instead of helpdesk doctype.

Link: https://one-fm.atlassian.net/jira/software/projects/ON/boards/2?selectedIssue=ON-102


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Adjust path for HD document link in email.


## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
1. `one_fm/templates/emails/notify_ticket_raiser_receipt.html`


## Is there any existing behavior change of other features due to this code change?
No.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
No.


## Did you delete custom field?
    - [] Yes
    - [x] No
   

## Is patch required?
- [] Yes
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
