### PR TITLE
[Update Shift from operations site Only when status is changed]

### DIFF
--- a/one_fm/operations/doctype/operations_site/operations_site.py
+++ b/one_fm/operations/doctype/operations_site/operations_site.py
@@ -89,7 +89,8 @@ class OperationsSite(Document):
 	def on_update(self):
 		self.clear_cache()
 		doc_before_save = self.get_doc_before_save()
-		self.update_shift_post_role_status()
+		if doc_before_save and doc_before_save.status != self.status: # only update if status has changed
+			self.update_shift_post_role_status()
 		if doc_before_save and doc_before_save.project != self.project:	
 			update_on_field_change(self,doc_before_save)
 		# changes = self.get_changes()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/906

Any changes made to the Operations site list are incorrectly reactivating inactive shifts

## Analysis and design (optional)
Analyse and attach the design documentation
Any changes made to the Operations site list are incorrectly reactivating inactive shifts

## Solution description
Describe your code changes in detail for reviewers.
Updated codebase to trigger changes in shift and post only when the site status is changed
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
operation site

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Operations Shifts will only be activated or disabled if the status is changed

## Did you test with the following dataset?
- [*] Existing Data
- [] New Data

## Was child table created? NO
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
