### PR TITLE
fix: Employee Checkin Notification Issue

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1773,7 +1773,7 @@ def fetch_employees_not_in_checkin():
 		shift_permissions = [i.employee for i in frappe.db.sql(f"""
 			SELECT employee FROM `tabShift Permission`
 			WHERE date='{cur_date}' AND employee IN {shift_assignments_employees_tuple}
-			AND log_type='{log_type}'
+			AND log_type='{log_type}' AND workflow_state != 'Rejected'
 			GROUP BY employee
 		""", as_dict=1)]
 
@@ -1785,6 +1785,7 @@ def fetch_employees_not_in_checkin():
 			WHERE  docstatus=1
 			AND '{cur_date}' BETWEEN from_date AND to_date
 			AND employee IN {shift_assignments_employees_tuple}
+			AND workflow_state NOT IN ('Rejected', 'Canceled')
 			GROUP BY employee
 		""", as_dict=1)]
 
@@ -1805,6 +1806,7 @@ def fetch_employees_not_in_checkin():
 			SELECT employee FROM `tabShift Request`
 			WHERE  docstatus=1 AND '{cur_date}' BETWEEN from_date AND to_date
 			AND employee IN {shift_assignments_employees_tuple}
+			AND workflow_state != 'Rejected'
 		""", as_dict=1)]
 
 		employees_yet_to_checkin = [i for i in employees_yet_to_checkin if not i in shift_request]

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -269,7 +269,7 @@ def notify_supervisor_about_late_entry(checkin):
 			checkin_shift_assignment = False
 			if checkin.shift_assignment:
 				checkin_shift_assignment = last_shift_assignment = checkin.shift_assignment
-				shift_late_minutes = frappe.db.get_value("Shift Type", {"name": checkin.shift_type}, ['supervisor_reminder_shift_start', 'start_time'], as_dict=1)
+				shift_late_minutes = frappe.db.get_value("Shift Type", {"name": checkin.shift_type}, ['supervisor_reminder_shift_start', 'start_time', 'late_entry_grace_period'], as_dict=1)
 				the_roster_type = checkin.roster_type
 				op_shift = frappe.get_doc("Operations Shift", checkin.operations_shift)
 
@@ -277,7 +277,7 @@ def notify_supervisor_about_late_entry(checkin):
 				last_shift_assignment = get_shift_from_checkin(checkin)
 				if last_shift_assignment:
 					checkin_shift_assignment = last_shift_assignment.name
-					shift_late_minutes = frappe.db.get_value("Shift Type", {"name": last_shift_assignment["shift_type"]}, ['supervisor_reminder_shift_start', 'start_time'], as_dict=1)
+					shift_late_minutes = frappe.db.get_value("Shift Type", {"name": last_shift_assignment["shift_type"]}, ['supervisor_reminder_shift_start', 'start_time', 'late_entry_grace_period'], as_dict=1)
 					the_roster_type = last_shift_assignment.roster_type
 					op_shift = frappe.get_doc("Operations Shift", last_shift_assignment.shift)
 
@@ -286,7 +286,7 @@ def notify_supervisor_about_late_entry(checkin):
 				notify_late_arrival = False if exists_checkin(checkin_shift_assignment, checkin.name) else True
 
 			if last_shift_assignment and notify_late_arrival and not shift_permission:
-				if checkin.time.time() > datetime.strptime(str(shift_late_minutes["start_time"] + timedelta(minutes=shift_late_minutes['supervisor_reminder_shift_start'])), "%H:%M:%S").time():
+				if checkin.time.time() > datetime.strptime(str(shift_late_minutes["start_time"] + timedelta(minutes=shift_late_minutes['late_entry_grace_period'])), "%H:%M:%S").time():
 					time_diff = calculate_time_diffrence_for_checkin(shift_late_minutes["start_time"], checkin.time)
 					time_of_arrival = parse(str(checkin.time)).time()
 					get_reports_to = frappe.db.get_value("Employee", {"name": checkin.employee}, ['reports_to'])


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.

https://one-fm.com/app/hd-ticket/877

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description

For the first case, I discovered that the Employee Check-in notification was using the "Supervisor Reminder Shift Start" time instead of the "Late Entry Grace Period." This caused the notification to be sent after the "Supervisor Reminder Shift Start" time, even though the employee checked in between the "Late Entry Grace Period" and the "Supervisor Reminder Shift Start" time. As a result, the supervisor did not receive the notification. I have made the necessary changes to use the "Late Entry Grace Period" instead.

For the second case, I discovered that the shift permission filter was incorrect. It was excluding all employees with shift permission, without excluding only those with rejected shift permissions. I have corrected the filter accordingly.

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
