### PR TITLE
feat: considered operation post dates while creating post scheduler checker

### DIFF
--- a/one_fm/operations/doctype/operations_post/operations_post.json
+++ b/one_fm/operations/doctype/operations_post/operations_post.json
@@ -155,7 +155,6 @@
    "reqd": 1
   },
   {
-   "default": "Today",
    "fetch_from": "project.expected_end_date",
    "fetch_if_empty": 1,
    "fieldname": "end_date",

--- a/one_fm/operations/doctype/operations_post/operations_post.json
+++ b/one_fm/operations/doctype/operations_post/operations_post.json
@@ -14,12 +14,13 @@
   "post_template",
   "column_break_4",
   "status",
+  "start_date",
+  "end_date",
   "priority_level",
   "allow_staff_rotation",
   "day_off_priority",
   "post_location",
   "gender",
-  "section_break_6",
   "section_break_12",
   "post_description",
   "section_break_14",
@@ -66,10 +67,6 @@
   {
    "fieldname": "column_break_4",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "section_break_6",
-   "fieldtype": "Section Break"
   },
   {
    "fieldname": "post_location",
@@ -149,10 +146,25 @@
    "fieldtype": "Select",
    "label": "Status",
    "options": "Active\nInactive"
+  },
+  {
+   "default": "Today",
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": "Start Date",
+   "reqd": 1
+  },
+  {
+   "default": "Today",
+   "fetch_from": "project.expected_end_date",
+   "fetch_if_empty": 1,
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date"
   }
  ],
  "links": [],
- "modified": "2023-05-04 23:00:47.784960",
+ "modified": "2025-05-31 23:40:47.812880",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Post",

--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -102,6 +102,7 @@ class OperationsPost(Document):
         #     frappe.throw(f"Operations Role ({self.post_template}) does not belong to selected shift ({self.site_shift})")
 
         self.validate_operations_role_status()
+        self.validate_dates()
         # check if operations site inactive
         if (self.status=='Active' and frappe.db.exists("Operations Site", {'name':self.site, 'status':'Inactive'})):frappe.throw(f"You cannot make this post active because Operations Site '{self.site}' is Inactive.")
 
@@ -115,6 +116,28 @@ class OperationsPost(Document):
         condition = self.post_name+"-"+self.gender+"|"+self.site_shift
         if condition != self.name:
             rename_doc(doctype=self.doctype, old=self.name, new=condition, force=True, doc=self)
+
+    def validate_dates(self):
+        project_expected_start_date, project_expected_end_date = frappe.db.get_value("Project", self.project, fieldname=["expected_start_date", "expected_end_date"])
+
+        start_date = getdate(self.start_date) if self.start_date else None
+        end_date = getdate(self.end_date) if self.end_date else None
+
+        # Validate that end date is after start date
+        if start_date and end_date:
+            if end_date < start_date:
+                frappe.throw(_("End date should be after start date"))
+
+        # Validate that start date is not before project expected start date
+        if project_expected_start_date and start_date:
+            if start_date < getdate(project_expected_start_date):
+                frappe.throw(_("Start date should not be before project expected start date"))
+
+        # Validate that end date is not after project expected end date
+        if project_expected_end_date and end_date:
+            if end_date > getdate(project_expected_end_date):
+                frappe.throw(_("End date should not be after project expected end date"))
+
 
     def on_update(self):
         self.validate_name()

--- a/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
+++ b/one_fm/operations/doctype/post_scheduler_checker/post_scheduler_checker.py
@@ -61,41 +61,32 @@ class PostSchedulerChecker(Document):
 
 
 	def fill_items(self):
-		current_date = getdate()
-		contracts_project = frappe.db.get_value("Contracts", self.contract, "project")
-		project_date_details = frappe.db.get_value("Project", contracts_project, ["expected_start_date", "expected_end_date"],as_dict=1)
-		last_day = getdate(get_last_day(current_date)) 
-		first_day = getdate(get_first_day(current_date))
-		
-		# Use project's expected dates if they fall within the current month
-		if project_date_details.expected_start_date and project_date_details.expected_start_date > first_day:
-			first_day = getdate(project_date_details.expected_start_date)
-		if project_date_details.expected_end_date and project_date_details.expected_end_date < last_day:
-			last_day = getdate(project_date_details.expected_end_date)
-			
+		current_date = getdate()			
 		week_range = get_week_start_end(str(getdate()))
-		datediff = date_diff(last_day, first_day) + 1
 
 		contract = frappe.get_doc("Contracts", self.contract)
+
 		for item in contract.items:
-			message = """"""
-			expected = 0
-			if not item.no_of_days_off:item.no_of_days_off = 0
-			else:item.no_of_days_off=int(item.no_of_days_off)
+
+			message = ""
+
+			if not item.no_of_days_off: item.no_of_days_off = 0
+			else: item.no_of_days_off=int(item.no_of_days_off)
+
 			if item.subitem_group == "Service" and item.rate_type=='Monthly':
 				roles = [i.name for i in frappe.db.sql(f"""
 					SELECT name FROM `tabOperations Role`
 					WHERE sale_item="{item.item_code}" AND project="{self.project}"
 				""", as_dict=1)]
-				roles_dict = {}
-				schedule_count = 0
+
 				operations_post = frappe.db.get_list(
 					"Operations Post",
 					filters={
 						'project': self.project,
 						'post_template': ['in', roles],
 						"status": "Active"
-					}
+					},
+					fields=["name", "start_date", "end_date"]
 				)
 				if not roles:
 					message += f"""No operations roles created with sale item {item.item_code} in project {contract.project}, for contract {contract.name} in items row {item.idx}\n\n"""
@@ -106,68 +97,47 @@ class PostSchedulerChecker(Document):
 				elif len(operations_post)<item.count:
 					message += f"""Less operations post created, expected: {item.count}, created: {len(operations_post)} for roles {roles}\n\n"""
 
-				# create final records
-				if item.rate_type == 'Monthly':
+				for post in operations_post:
 					expected = 0
-					no_of_days_off = 0
-					if item.rate_type_off == 'Full Month':
-						#instead of a full month if the project starts or ends within the  month use the difference between the start and end date
-						if project_date_details.expected_start_date and project_date_details.expected_start_date > first_day:
-							first_day = getdate(project_date_details.expected_start_date)
-						if project_date_details.expected_end_date and project_date_details.expected_end_date < last_day:
-							last_day = getdate(project_date_details.expected_end_date)
-						expected = date_diff(last_day, first_day) + 1
-						no_of_days_off = 0
-					elif item.rate_type_off == 'Days Off':
-						if item.days_off_category == 'Monthly':
-							expected = (date_diff(last_day, first_day) + 1) - item.no_of_days_off
-							no_of_days_off = item.no_of_days_off
-						elif item.days_off_category == 'Weekly':
-							first_day = getdate(week_range.start)
-							last_day = getdate(week_range.end)
-							# Use project's expected dates if they fall within the week range
-							if project_date_details.expected_start_date and project_date_details.expected_start_date > first_day:
-								first_day = getdate(project_date_details.expected_start_date)
-							if project_date_details.expected_end_date and project_date_details.expected_end_date < last_day:
-								last_day = getdate(project_date_details.expected_end_date)
-							expected = (date_diff(last_day, first_day) + 1) - item.no_of_days_off
-							no_of_days_off = item.no_of_days_off
-					for post in operations_post:
-						post_schedules = get_post_schedules(project=contract.project, post=post, first_day=first_day, last_day=last_day)
-						if not post_schedules:
-							message += f"""No post schedules created for Post  ({post.name})\n\n"""
-						elif post_schedules > expected:
-							message += f"""More post schedules created, expected: {expected}, created: {post_schedules} for post {post.name}\n\n"""
-						elif post_schedules < expected:
-							message += f"""Less post schedules created, expected: {expected}, created: {post_schedules} for post {post.name}\n\n"""
 
-					if message:
-						self.append('items', {
-							'item': item.item_code,
-							'from_date': first_day,
-							'to_date': last_day,
-							'rate_type': item.rate_type,
-							'rate_type_off': item.rate_type_off,
-							'no_of_days_off': item.no_of_days_off,
-							'days_off_category': item.days_off_category,
-							'comment': message
-						})
-				else:
+					if item.rate_type_off == 'Days Off' and item.days_off_category and item.days_off_category == 'Weekly':
+						first_day = getdate(week_range.start)
+						last_day = getdate(week_range.end)
+					else:
+						first_day = getdate(get_first_day(current_date))
+						last_day = getdate(get_last_day(current_date))
+
+					# Instead of a full month if the post starts or ends within the month/week use the difference between the start and end date
+					if post.start_date and post.start_date > first_day:
+						first_day = getdate(post.start_date)
+					if post.end_date and post.end_date < last_day:
+						last_day = getdate(post.end_date)
+
+					expected = date_diff(last_day, first_day) + 1
+						
+					if item.rate_type_off == 'Days Off':
+						expected = expected - item.no_of_days_off
+
+					post_schedules = get_post_schedules(project=contract.project, post=post, first_day=first_day, last_day=last_day)
+					if not post_schedules:
+						message += f"""No post schedules created for Post  ({post.name})\n\n"""
+					elif post_schedules > expected:
+						message += f"""More post schedules created from {first_day} to {last_day}, expected: {expected}, created: {post_schedules} for post {post.name}\n\n"""
+					elif post_schedules < expected:
+						message += f"""Less post schedules created from {first_day} to {last_day}, expected: {expected}, created: {post_schedules} for post {post.name}\n\n"""
+
+				if message:
 					self.append('items', {
-							'item': item.item_code,
-							'from_date': first_day,
-							'to_date': last_day,
-							'rate_type': item.rate_type,
-							'rate_type_off': '',
-							'no_of_days_off': 0,
-							'comment': "Hourly rate_type."
-						})
-			last_day = getdate(get_last_day(current_date))
-			if last_day > project_date_details.expected_end_date:
-				last_day = project_date_details.expected_end_date
-			first_day = getdate(get_first_day(current_date))
-			if first_day < project_date_details.expected_start_date:
-				first_day = project_date_details.expected_start_date
+						'item': item.item_code,
+						'from_date': first_day,
+						'to_date': last_day,
+						'rate_type': item.rate_type,
+						'rate_type_off': item.rate_type_off,
+						'no_of_days_off': item.no_of_days_off,
+						'days_off_category': item.days_off_category,
+						'comment': message
+					})
+
 
 def schedule_roster_checker():
 	contracts = frappe.db.sql(""" SELECT c.name from `tabContracts` c JOIN `tabProject` p ON p.name = c.project WHERE c.workflow_state = 'Active'

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -117,3 +117,4 @@ one_fm.patches.v15_0.update_designation_disabled_field
 one_fm.patches.v15_0.update_hr_settings_leave_threshold
 one_fm.patches.v15_0.add_roster_index
 one_fm.patches.v15_0.delete_all_roaster_day_off_checker_records
+one_fm.patches.v15_0.update_operation_post_start_and_end_date

--- a/one_fm/patches/v15_0/update_operation_post_start_and_end_date.py
+++ b/one_fm/patches/v15_0/update_operation_post_start_and_end_date.py
@@ -1,0 +1,21 @@
+import frappe
+
+def execute():
+    # Get all Operations Post records with a linked Project
+    operations_posts = frappe.get_all("Operations Post", filters={"project": ["!=", ""]}, fields=["name", "project"])
+
+    for op in operations_posts:
+        project = frappe.db.get_value(
+            "Project",
+            op.project,
+            ["expected_start_date", "expected_end_date"],
+            as_dict=True
+        )
+
+        if project:
+            frappe.db.set_value("Operations Post", op.name, {
+                "start_date": project.expected_start_date,
+                "end_date": project.expected_end_date
+            })
+
+    frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As Operations Admin I want Post Scheduler Checker date range to be based on the Operations Post so that the Operations Post Start Date and End Date are taken into consideration

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Updated Operations Post doctype
- Added patch to update start and end dates for existing operation posts
- Considered operation post dates while creating post scheduler checker

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Post Scheduler Checker
Operations Post

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Post Schedules will be fetched according post start and end date in Post Scheduler Checker

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
