### PR TITLE
chore: Remove keep_days_off check from OT popup

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2389,8 +2389,6 @@ function change_ot_schedule(page) {
 					};
 				}
 			},
-			{ "label": "Keep Days Off", "fieldname": "keep_days_off", "fieldtype": "Check", default: 0},
-
 		],
 		primary_action: function () {
 			let values = d.get_values();


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Removed below check
![image](https://github.com/user-attachments/assets/7d63dbea-45b2-42ff-8284-c51871ba4ed6)


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data



## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
