### PR TITLE
fix: (ON-149) Timesheet/Employee Permission

### DIFF
--- a/one_fm/permissions.py
+++ b/one_fm/permissions.py
@@ -36,8 +36,7 @@ def extend_user_permission(user: str) -> list:
 
     # Direct reports
     direct_reports = frappe.get_all("Employee", filters={
-        'reports_to': employee_id,
-        'status': 'Active'
+        'reports_to': employee_id
     }, fields=["name"])
     employee_ids.update(emp["name"] for emp in direct_reports)
 
@@ -52,8 +51,7 @@ def extend_user_permission(user: str) -> list:
         values = get_manager(doctype, employee_id) or []
         if values:
             related_employees = frappe.get_all("Employee", filters={
-                field: ['in', values],
-                'status': 'Active'
+                field: ['in', values]
             }, fields=["name"])
             employee_ids.update(emp["name"] for emp in related_employees)
 

--- a/one_fm/permissions.py
+++ b/one_fm/permissions.py
@@ -19,25 +19,45 @@ from one_fm.utils import (
 
 
 
-def extend_user_permission(user):
-	"""
-		Extend the user permissions of the 
-	Args:
-		data (_type_): _description_
-	"""
-	
-	employee_set = []
-	employee_id = get_employee_doc(user)
-	shifts = get_manager('Operations Shift',employee_id)
-	if shifts:
-		employee_set+= frappe.get_all("Employee",{'shift':['in',shifts]})
-	sites = get_manager('Operations Site',employee_id)
-	if sites:
-		employee_set+= frappe.get_all("Employee",{'site':['in',sites]})
-	projects = get_manager('Project',employee_id)
-	if projects:
-		employee_set+= frappe.get_all("Employee",{'project':['in',projects]})
-	return employee_set
+def extend_user_permission(user: str) -> list:
+    """
+    Extend the user permissions to include all active employees
+    that report to the user's employee ID, or are part of the shifts,
+    sites, or projects managed by the user.
+
+    Args:
+        user (str): The system user.
+
+    Returns:
+        list: A list of unique employee names.
+    """
+    employee_ids = set()
+    employee_id = get_employee_doc(user)
+
+    # Direct reports
+    direct_reports = frappe.get_all("Employee", filters={
+        'reports_to': employee_id,
+        'status': 'Active'
+    }, fields=["name"])
+    employee_ids.update(emp["name"] for emp in direct_reports)
+
+    # Related fields to check
+    related_fields = {
+        'Operations Shift': 'shift',
+        'Operations Site': 'site',
+        'Project': 'project'
+    }
+
+    for doctype, field in related_fields.items():
+        values = get_manager(doctype, employee_id) or []
+        if values:
+            related_employees = frappe.get_all("Employee", filters={
+                field: ['in', values],
+                'status': 'Active'
+            }, fields=["name"])
+            employee_ids.update(emp["name"] for emp in related_employees)
+
+    return list(employee_ids)
 	
 
 def get_employee_doc(user):
@@ -102,7 +122,7 @@ def get_custom_user_permissions(user=None):
 			if out.get("Employee"):
 				if data:
 					for each in data:
-						out['Employee'].append({'doc':each.name,'applicable_for':None,'is_default':0})
+						out['Employee'].append({'doc':each,'applicable_for':None,'is_default':0})
 		frappe.cache().hset("user_permissions", user, out)
 		
 	except frappe.db.SQLError as e:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/920

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

I updated the extend_user_permission function to initially filter Employee records using the reports_to field by default. Additionally, if the session user is a supervisor, the function further includes Employee records associated with any shifts, sites, or projects that the user supervises.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
