### PR TITLE
fix: Employee Schedule Creation Fixes

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -1751,7 +1751,7 @@ def create_or_update_schedule_for_employee(employee, date_val, availability, ope
 		
 		existing_schedule_name = frappe.get_value( 
 			"Employee Schedule",
-			{"employee": employee.name, "date": date_str},
+			{"employee": employee.name, "date": date_str, "roster_type": "Basic", "shift_type": operations_shift_doc.shift_type},
 			"name"
 		)
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.

![image](https://github.com/user-attachments/assets/1ba97bd9-b774-41f9-b878-0f47978b96a5)


It appears that an employee can have two Employee Schedule records for the same date with the same shift type and roster type. This situation occurs because two schedules were previously created for the employee—one marked as Basic, and the other as Overtime.

When the monthly cron job runs to generate employee schedules, it finds both records. However, it only picks the most recent one and updates it, which can lead to double basic data.

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

I modify the filter

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
