### PR TITLE
fix: clear employee schedules when relieving date is set

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -218,16 +218,17 @@ class EmployeeOverride(EmployeeMaster):
                     frappe.throw(message)
 
 
-    def clear_schedules(doc):
+    def clear_schedules(self):
         # clear future employee schedules
-        if doc.status == 'Left':
-            frappe.db.sql(f"""
-                DELETE FROM `tabEmployee Schedule` WHERE employee='{doc.name}'
-                AND date>'{doc.relieving_date}'
-            """)
-            frappe.msgprint(f"""
-                Employee Schedule cleared for {doc.employee_name} starting from {add_days(doc.relieving_date, 1)}
-            """)
+        if(self.has_value_changed('relieving_date') or self.has_value_changed('status')):
+            if self.status == 'Left' or self.relieving_date:
+                frappe.db.sql(f"""
+                    DELETE FROM `tabEmployee Schedule` WHERE employee = '{self.name}'
+                    AND date > '{self.relieving_date}'
+                """)
+                frappe.msgprint(f"""
+                    Employee Schedule cleared for {self.employee_name} starting from {add_days(self.relieving_date, 1)}
+                """)
 
 def validate_leaves(self):
     if self.status=='Vacation':


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.atlassian.net/browse/ON-168

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Used 'clear_schedule' method of Employee Override to clear schedules for active employee whose relieving date is set

## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Employee
Employee Schedule

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Employee Schedules will be deleted after the relieving date when set for employee

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
