### PR TITLE
fix: added doctype reload in patch to fetch latest fields

### DIFF
--- a/one_fm/patches/v15_0/update_operation_post_start_and_end_date.py
+++ b/one_fm/patches/v15_0/update_operation_post_start_and_end_date.py
@@ -1,6 +1,9 @@
 import frappe
 
 def execute():
+    # Reload doctype so that newly added fields should be added first before executing patch
+    frappe.reload_doctype("Operations Post")
+
     # Get all Operations Post records with a linked Project
     operations_posts = frappe.get_all("Operations Post", filters={"project": ["!=", ""]}, fields=["name", "project"])
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Need to reload doctype to get newly added fields

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added doctype reload to get latest changes in doctype

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2025-07-02 15-24-29](https://github.com/user-attachments/assets/250232fc-84de-4085-a7e4-e1c04c9f21b0)


## Areas affected and ensured
List out the areas affected by your code changes.
Patches

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
