### PR TITLE
fix: updated patch to update operation post start dates only

### DIFF
--- a/one_fm/patches/v15_0/update_operation_post_start_and_end_date.py
+++ b/one_fm/patches/v15_0/update_operation_post_start_and_end_date.py
@@ -8,17 +8,28 @@ def execute():
     operations_posts = frappe.get_all("Operations Post", filters={"project": ["!=", ""]}, fields=["name", "project"])
 
     for op in operations_posts:
-        project = frappe.db.get_value(
-            "Project",
-            op.project,
-            ["expected_start_date", "expected_end_date"],
-            as_dict=True
+        target_contract = frappe.db.get_value("Contracts", { "project": op.project }, ["name", "start_date"], as_dict=True)
+
+        if not target_contract:
+            continue 
+
+        # Try to fetch the first date from the dates child table of Contract
+        child_start_date = frappe.get_all(
+            "Contracts Date",
+            filters={"parent": target_contract.name},
+            fields=["contract_start_date"],
+            order_by="idx asc",
+            limit=1
         )
 
-        if project:
-            frappe.db.set_value("Operations Post", op.name, {
-                "start_date": project.expected_start_date,
-                "end_date": project.expected_end_date
-            })
+        if child_start_date:
+            start_date = child_start_date[0].contract_start_date
+        else:
+            # Fallback to the contract start date
+            start_date = target_contract.start_date
+
+        if start_date:
+            frappe.db.set_value("Operations Post", op.name, "start_date", start_date)
 
     frappe.db.commit()
+


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Need to update onlt Operation Post Start Date and that too from Contract doctype

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated patch to update start date only
Fetch start date from Contracts doctype

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Operations Post

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
