### PR TITLE
fix: Remove date validation from Operations Post

### DIFF
--- a/one_fm/operations/doctype/operations_post/operations_post.json
+++ b/one_fm/operations/doctype/operations_post/operations_post.json
@@ -151,8 +151,7 @@
    "default": "Today",
    "fieldname": "start_date",
    "fieldtype": "Date",
-   "label": "Start Date",
-   "reqd": 1
+   "label": "Start Date"
   },
   {
    "fetch_from": "project.expected_end_date",
@@ -163,7 +162,7 @@
   }
  ],
  "links": [],
- "modified": "2025-05-31 23:40:47.812880",
+ "modified": "2025-07-04 10:48:37.464794",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Post",

--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -102,7 +102,6 @@ class OperationsPost(Document):
         #     frappe.throw(f"Operations Role ({self.post_template}) does not belong to selected shift ({self.site_shift})")
 
         self.validate_operations_role_status()
-        self.validate_dates()
         # check if operations site inactive
         if (self.status=='Active' and frappe.db.exists("Operations Site", {'name':self.site, 'status':'Inactive'})):frappe.throw(f"You cannot make this post active because Operations Site '{self.site}' is Inactive.")
 
@@ -116,27 +115,6 @@ class OperationsPost(Document):
         condition = self.post_name+"-"+self.gender+"|"+self.site_shift
         if condition != self.name:
             rename_doc(doctype=self.doctype, old=self.name, new=condition, force=True, doc=self)
-
-    def validate_dates(self):
-        project_expected_start_date, project_expected_end_date = frappe.db.get_value("Project", self.project, fieldname=["expected_start_date", "expected_end_date"])
-
-        start_date = getdate(self.start_date) if self.start_date else None
-        end_date = getdate(self.end_date) if self.end_date else None
-
-        # Validate that end date is after start date
-        if start_date and end_date:
-            if end_date < start_date:
-                frappe.throw(_("End date should be after start date"))
-
-        # Validate that start date is not before project expected start date
-        if project_expected_start_date and start_date:
-            if start_date < getdate(project_expected_start_date):
-                frappe.throw(_("Start date should not be before project expected start date"))
-
-        # Validate that end date is not after project expected end date
-        if project_expected_end_date and end_date:
-            if end_date > getdate(project_expected_end_date):
-                frappe.throw(_("End date should not be after project expected end date"))
 
 
     def on_update(self):


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Remove dates validation from Operation Post.
Remove mandatory check from start_date in Operation Post


## Is there a business logic within a doctype?
- [x] Yes
- [] No


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
