### PR TITLE
fix: Schedule staff even on overfill

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -575,7 +575,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 			VALUES
 		"""
 		can_create = False		
-		omitted_days = []
+		omitted_days = set()
 				
 		# Create a temporary structure to count new schedules per day from the current batch
 		daily_add_count = defaultdict(int)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Initialise variable as set instead of list

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
