### PR TITLE
Fix permission error loading RFM

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -59,7 +59,6 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2 import service_account
 
 
-
 def get_common_email_args(doc):
 	doctype = doc.get("doctype")
 	docname = doc.get("name")
@@ -3289,8 +3288,8 @@ def check_employee_permission_on_doc(doc):
                     approver_list.append(approver)
 
                     if session_employee not in approver_list:
-
-                        frappe.throw("You do not have permissions to access this document.")
+                        if not doc.has_permission:
+                            frappe.throw("You do not have permissions to access this document.")
     except Exception as e:
         pass
 
@@ -3468,7 +3467,7 @@ def get_current_shift(employee):
                     order_by="time desc",
                     limit=1,
                 )
-                
+
                 if checkin:
                     last_log = checkin[0]
                     # CASE 1: Last log is IN → Shift is active
@@ -3531,7 +3530,7 @@ def check_existing():
     shift_exists = get_current_shift(employee)
     if not shift_exists:
         return response("Resource Not Found", 404, None, "No Active Shift Found")
-    
+
     if shift_exists['type'] == "On Time":
         curr_shift = shift_exists['data']
     if not curr_shift:
@@ -3706,6 +3705,7 @@ def set_employee_status():
             'status': 'Approved',
             'from_date': ['<=', current_date],
             'to_date': ['>=', add_days(current_date, -1)],
+            "leave_type": ["IN", fetch_leave_types_update_employee_status()]
         },
         fields=['employee', 'employee.status', 'from_date', 'to_date', 'custom_reliever_', 'name']  # Fetch employee status directly
     )
@@ -3728,14 +3728,6 @@ def set_employee_status():
                 frappe.db.set_value('Employee', employee, 'status', 'Vacation')
                 if reliever:
                     frappe.enqueue(assign_responsibilities, leave_application=leave_application)
-
-                frappe.db.sql(
-                    '''
-                    DELETE FROM `tabEmployee Schedule` WHERE
-                    employee = %s AND
-                    date BETWEEN %s AND %s;
-                    ''', (employee, from_date, to_date)
-                )
                 employees_set_to_vacation += 1
             elif current_date == add_days(getdate(to_date), 1) and status == "Vacation":
                 frappe.db.set_value('Employee', employee, 'status', 'Active')
@@ -3992,6 +3984,77 @@ def update_fields_in_doctypes(data):
 						doc.set(field, value)  # Re-set the actual value
 					doc.save()
 
+def get_json_file(file_name, folder):
+    """
+    Load and return JSON data from a file in the specified folder.
+
+    Args:
+        file_name (str): The name of the JSON file (must end with `.json`).
+        folder (str): The absolute path to the folder containing the JSON file.
+
+    Returns:
+        dict: Parsed JSON data from the file.
+    """
+    data = {}
+    if not file_name.endswith(".json"):
+        frappe.log_error("Only JSON files are allowed. Please ensure the file ends with '.json'.")
+
+    file_path = os.path.join(folder, file_name)
+
+    if not os.path.isfile(file_path):
+        frappe.log_error(f"File not found: {file_path}")
+
+    try:
+        with open(file_path, "r") as f:
+            data = json.load(f)
+
+    except json.JSONDecodeError as e:
+        frappe.log_error(f"Invalid JSON format in file {file_path}: {str(e)}")
+
+    except Exception as e:
+        frappe.log_error(f"An error occurred while reading the file {file_path}: {str(e)}")
+
+    return data
+
+def get_workflow_action_buttons_html(doc, user):
+    from one_fm.overrides.workflow import get_next_possible_transitions
+    doctype = doc.get('doctype')
+    workflow = get_workflow_name(doctype)
+    message_html = ""
+    if workflow:
+        transitions = get_next_possible_transitions(
+            workflow, get_doc_workflow_state(doc), doc
+        )
+
+        action_details = []
+
+        for transition in transitions:
+            if transition.get("custom_requires_frontend_input") or transition.get("require_digital_signature"):
+                action_name = f"{transition.action} (open in ERP)"
+                action_link = f"{frappe.utils.get_url()}/app/{doctype.lower().replace(' ', '-')}/{doc.name}"
+            else:
+                action_name = transition.action
+                action_link = get_confirm_workflow_action_url(doc, transition.action, user)
+
+            action_details.append(
+                frappe._dict(
+                    {
+                        "action_name": action_name,
+                        "action_link": action_link,
+                    }
+                )
+            )
+
+        if action_details and len(action_details) > 0:
+            message_html += "<div>"
+            for action in action_details:
+                message_html += '<a href="{0}" class="btn btn-primary btn-action" style="margin-right: 10px; margin-bottom: 10px">{1}</a>'.format(
+                    action.action_link, action.action_name
+                )
+            message_html += "</div>"
+
+    return message_html
 
 
-   
+def fetch_leave_types_update_employee_status():
+    return set(frappe.db.get_list("Leave Type", {"custom_update_employee_status_to_vacation": True}, pluck="name"))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
When the procurement manager or anyone in the team opens the RFM the permission error pops up
<img width="512" height="189" alt="image" src="https://github.com/user-attachments/assets/23a158c5-acce-4c04-8a1b-fbe88f36cb1e" />

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated the method to check for permission before throwing the error
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [*] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
