### PR TITLE
feat: configure doc expiry notification

### DIFF
--- a/one_fm/grd/doctype/grd_settings/grd_settings.json
+++ b/one_fm/grd/doctype/grd_settings/grd_settings.json
@@ -12,6 +12,9 @@
   "default_grd_operator_pifss",
   "default_grd_operator_transfer",
   "default_pam_operator",
+  "section_break_acel",
+  "days_before_expiry_to_notify_supervisor",
+  "column_break_fajb",
   "preparation_record_settings_section",
   "preparation_record_creation_day",
   "create_preparation_record_manually",
@@ -123,11 +126,25 @@
    "fieldtype": "Link",
    "label": "Default PAM Operator",
    "options": "User"
+  },
+  {
+   "fieldname": "section_break_acel",
+   "fieldtype": "Section Break"
+  },
+  {
+   "description": "Specify the number of days in advance the supervisor should be notified before an employee's document expires. A notification will be triggered based on this value.",
+   "fieldname": "days_before_expiry_to_notify_supervisor",
+   "fieldtype": "Int",
+   "label": "Days Before Expiry to Notify Supervisor"
+  },
+  {
+   "fieldname": "column_break_fajb",
+   "fieldtype": "Column Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-05-14 15:33:20.237365",
+ "modified": "2025-07-15 14:06:12.750452",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "GRD Settings",

--- a/one_fm/tasks/one_fm/daily.py
+++ b/one_fm/tasks/one_fm/daily.py
@@ -61,13 +61,21 @@ def notify_for_employee_docs_expiry():
             ])
         )
 
-        send_employee_doc_expiry_notification(get_employees_by_expiry_doc(), recipients)
+        if not recipients:
+            return
+
+        notify_days_before = grd_settings.days_before_expiry_to_notify_supervisor or 15
+        employees = get_employees_by_expiry_doc(notify_days_before)
+
+        if employees:
+            send_employee_doc_expiry_notification(employees, recipients)
 
     except Exception as e:
         frappe.log_error(str(e), 'Employee Docs Expiry')
 
-def get_employees_by_expiry_doc():
-    target_expiry_date = add_days(today(), 30)
+def get_employees_by_expiry_doc(notify_days_before):
+    target_expiry_date = add_days(today(), notify_days_before)
+
     expiry_fields = [
         ("work_permit_expiry_date", "Work Permit"),
         ("residency_expiry_date", "Residency"),


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
- Configure the number of days in advance the supervisor should be notified before an employee's document expires. A notification will be triggered based on this value

## Areas affected and ensured
- `one_fm/grd/doctype/grd_settings/grd_settings.json`
- `one_fm/tasks/one_fm/daily.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome