### PR TITLE
[BUG Fix RFM Permission Error]

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3288,8 +3288,8 @@ def check_employee_permission_on_doc(doc):
                     approver_list.append(approver)
 
                     if session_employee not in approver_list:
-
-                        frappe.throw("You do not have permissions to access this document.")
+                        if not doc.has_permission:
+                            frappe.throw("You do not have permissions to access this document.")
     except Exception as e:
         pass
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
When the procurement manager or anyone in the team opens the RFM the permission error pops up
<img width="512" height="189" alt="image" src="https://github.com/user-attachments/assets/5864e9ab-586b-4e75-9383-47bf6ed8c842" />


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated the process to include permission checks
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
