### PR TITLE
feat: Keep Day Off OT while scheduling staff

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2316,7 +2316,6 @@ function staff_edit_dialog() {
 			callback: function (r) {
 				if (r.message) {
 					let employee_details = r.message;
-					console.log(employee_details)
 					// Populate fields
 					d.set_value("project", employee_details.project);
 					d.set_value("site", employee_details.site);
@@ -2447,12 +2446,9 @@ function schedule_change_post(page) {
 		selected.forEach(function (i) {
 			let [employee, date] = i.split("|");
 			employees.push({ employee, date });
-			employees = [... new Set(employees)]; // This might be redundant if items are unique from classgrt
+			employees = [... new Set(employees)];
 		});
 	}
-	var hide_day_off_ot_check = 0;
-	var hide_keep_days_off_check = 0;
-	// let element = get_wrapper_element(); // element is not used here
 
 	let d = new frappe.ui.Dialog({
 		"title": "Schedule/Change Basic",
@@ -2524,9 +2520,6 @@ function schedule_change_post(page) {
 				}
 			},
 			{ "label": "Project End Date", "fieldname": "project_end_date", "fieldtype": "Check", default: 0 },
-			{ "label": "Keep Days Off", "fieldname": "keep_days_off", "fieldtype": "Check", default: 0, "hidden": hide_keep_days_off_check },
-			{ "label": "Request Employee Schedule", "fieldname": "request_employee_schedule", "fieldtype": "Check" },
-			{ "label": "Day Off OT", "fieldname": "day_off_ot", "fieldtype": "Check", "hidden": hide_day_off_ot_check },
 			{ "fieldname": "cb1", "fieldtype": "Column Break" },
 			{
 				"label": "Till Date", "fieldname": "end_date", "fieldtype": "Date", "depends_on": "eval:doc.project_end_date==0", default: 0, onchange: function () {
@@ -2542,6 +2535,17 @@ function schedule_change_post(page) {
 					}
 				}
 			},
+			{ "fieldtype": "Section Break"},
+			{ "label": "Keep Days Off", "fieldname": "keep_days_off", "fieldtype": "Check", default: 0, onchange: function () {
+				if (d.get_value("keep_days_off") == 1) d.set_value("day_off_ot", 0);
+			} },
+			{ "label": "Keep Days Off OT", "fieldname": "keep_days_off_ot", "fieldtype": "Check", default: 0, onchange: function () {
+				if (d.get_value("keep_days_off_ot") == 1) d.set_value("day_off_ot", 0);
+			} },
+			{ "label": "Day Off OT", "fieldname": "day_off_ot", "fieldtype": "Check", onchange: function () {
+				if (d.get_value("day_off_ot") == 1) d.set_value("keep_days_off", 0);
+				if (d.get_value("day_off_ot") == 1) d.set_value("keep_days_off_ot", 0);
+			}},
 		],
 		primary_action: function () {
 			let values = d.get_values();

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -364,7 +364,7 @@ def schedule_overtime(employees, shift, operations_role,start_date,end_date=None
 		# extreme schedule
 		extreme_schedule(employees=employees, start_date=start_date, end_date=end_date, shift=shift,
 			operations_role=operations_role, otRoster="true", keep_days_off=0, day_off_ot=0,
-			request_employee_schedule=0, employee_list=employee_list
+			employee_list=employee_list
 		)
 		update_roster(key="roster_view")
 
@@ -375,7 +375,7 @@ def schedule_overtime(employees, shift, operations_role,start_date,end_date=None
 
 
 @frappe.whitelist()
-def schedule_staff(employees, shift, operations_role, otRoster, start_date, project_end_date, keep_days_off=0, request_employee_schedule=0, day_off_ot=None, end_date=None, selected_days_only=0):
+def schedule_staff(employees, shift, operations_role, otRoster, start_date, project_end_date, keep_days_off=0, keep_days_off_ot=0, day_off_ot=None, end_date=None, selected_days_only=0):
 	try:
 		_start_date = getdate(start_date)
 
@@ -424,7 +424,7 @@ def schedule_staff(employees, shift, operations_role, otRoster, start_date, proj
 
 		emp_tuple = str(employee_list).replace("[", "(").replace("]",")")
 
-		if not cint(request_employee_schedule) and "Projects Manager" not in user_roles and "Operations Manager" not in user_roles:
+		if "Projects Manager" not in user_roles and "Operations Manager" not in user_roles:
 			all_employee_shift_query = frappe.db.sql("""
 				SELECT DISTINCT es.shift, s.supervisor
 				FROM `tabEmployee Schedule` es JOIN `tabOperations Shift` s ON es.shift = s.name
@@ -440,8 +440,8 @@ def schedule_staff(employees, shift, operations_role, otRoster, start_date, proj
 		else:
 			# extreme schedule
 			extreme_schedule(employees=employees, start_date=start_date, end_date=end_date, shift=shift,
-				operations_role=operations_role, otRoster=otRoster, keep_days_off=keep_days_off, day_off_ot=day_off_ot,
-				request_employee_schedule=request_employee_schedule, employee_list=employee_list
+				operations_role=operations_role, otRoster=otRoster, keep_days_off=keep_days_off, keep_days_off_ot=keep_days_off_ot, day_off_ot=day_off_ot,
+				employee_list=employee_list
 			)
 			update_roster(key="roster_view")
 
@@ -456,7 +456,7 @@ def update_roster(key):
 
 
 def extreme_schedule(employees, shift, operations_role, otRoster, start_date, end_date, keep_days_off, day_off_ot,
-	request_employee_schedule, employee_list, selected_reliever=None):
+	employee_list, selected_reliever=None, keep_days_off_ot=0):
 	if not employees:
 		frappe.throw("Please select employees before rostering")
 		return
@@ -486,7 +486,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 			employees = new_employees.copy()
 
 
-	# check keep days_off
+	# if keeps_days_off is checked
 	if cint(keep_days_off):
 		days_off_list = frappe.db.get_list("Employee Schedule", filters={
 			"employee":["IN", [i["employee"] for i in employees]],
@@ -509,6 +509,23 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 				if new_employees:
 					employees = new_employees.copy()
 
+	# if keeps_days_off_ot is checked
+	if cint(keep_days_off_ot):
+		day_off_ot_list = frappe.db.get_list("Employee Schedule", filters={
+			"employee": ["IN", [i["employee"] for i in employees]],
+			"date": ["IN", [i["date"] for i in employees]],
+			"roster_type": "Basic",
+			"day_off_ot": 1
+		}, fields=["employee", "date"])
+
+		# Build a quick lookup map for (employee, date) → True if day_off_ot is set
+		day_off_ot_map = {(i.employee, str(i.date)): True for i in day_off_ot_list}
+
+		# Inject day_off_ot = 1 into employees if Basic schedule has it
+		for i in employees:
+			if day_off_ot_map.get((i["employee"], i["date"])):
+				i["day_off_ot"] = 1
+
 	employees_list_db = frappe.db.get_list("Employee", filters={"name": ["IN", employee_list]}, fields=["name", "employee_name", "department","date_of_joining"], ignore_permissions=True)
 	employees_dict = {}
 	for i in employees_list_db:
@@ -526,8 +543,12 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 		if employee_detail and employee_detail.get("date_of_joining"):
 			if getdate(employee_detail.get("date_of_joining")) <= getdate(i.get("date")):
 				if employees_date_dict.get(i["employee"]):
-					employees_date_dict[i["employee"]].append({"date":i["date"],
-						"start_datetime": datetime.strptime(f"{i['date']} {shift_start_time}", "%Y-%m-%d %H:%M:%S"), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end_time}", "%Y-%m-%d %H:%M:%S")})
+					employees_date_dict[i["employee"]].append({
+						"date":i["date"],
+						"start_datetime": datetime.strptime(f"{i['date']} {shift_start_time}", "%Y-%m-%d %H:%M:%S"), 
+						"end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end_time}", "%Y-%m-%d %H:%M:%S"),
+						"day_off_ot": i.get("day_off_ot")
+					})
 				else:
 					employees_date_dict[i["employee"]] =[{"date":i["date"], "start_datetime": datetime.strptime(f"{i['date']} {shift_start_time}", "%Y-%m-%d %H:%M:%S"), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end_time}", "%Y-%m-%d %H:%M:%S")}]
 		else:
@@ -568,151 +589,121 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 		frappe.throw(error_head+error_msg)
 
 
-	if not cint(request_employee_schedule):
-		query = """
-			INSERT INTO `tabEmployee Schedule` (`name`, `employee`, `employee_name`, `department`, `date`, `shift`, `site`, `project`, `shift_type`, `employee_availability`,
-			`operations_role`, `post_abbrv`, `roster_type`, `day_off_ot`, `start_datetime`, `end_datetime`, `owner`, `modified_by`, `creation`, `modified`)
-			VALUES
+	query = """
+		INSERT INTO `tabEmployee Schedule` (`name`, `employee`, `employee_name`, `department`, `date`, `shift`, `site`, `project`, `shift_type`, `employee_availability`,
+		`operations_role`, `post_abbrv`, `roster_type`, `day_off_ot`, `start_datetime`, `end_datetime`, `owner`, `modified_by`, `creation`, `modified`)
+		VALUES
+	"""
+	can_create = False
+	omitted_days = set()
+
+	# Create a temporary structure to count new schedules per day from the current batch
+	daily_add_count = defaultdict(int)
+	for emp, date_values in employees_date_dict.items():
+		for dateval in date_values:
+			daily_add_count[dateval.get("date")] +=1
+
+	query_values = [] # Prepare values for bulk insert
+	skipped_ot_no_basic = []
+	skipped_ot_overlap = []
+
+
+	for employee_name_iter, date_values in employees_date_dict.items():
+		for datevalue in date_values:
+			current_processing_date = datevalue.get("date")
+
+			# For each date, check overfill status
+			post_data = validate_overfilled_post([current_processing_date], operations_shift_doc.name, operations_role_doc.name)
+			post_number = post_data.get("post_number", 0)
+			schedule_data = post_data.get("schedule_dict", {})
+
+			if roster_type == "Over-Time":
+				# Query for existing Basic schedule for this employee and date
+				basic_schedule = frappe.db.get_value(
+					"Employee Schedule",
+					{
+						"employee": employee_name_iter,
+						"date": current_processing_date,
+						"roster_type": "Basic",
+						"employee_availability": "Working"
+					},
+					["start_datetime", "end_datetime"]
+				)
+				if not basic_schedule:
+					skipped_ot_no_basic.append(f"{employee_name_iter} on {current_processing_date}")
+					continue
+
+				# Check for overlap
+				ot_start = datevalue.get("start_datetime")
+				ot_end = datevalue.get("end_datetime")
+				basic_start = basic_schedule[0]
+				basic_end = basic_schedule[1]
+
+				# If Over-Time overlaps with Basic, skip scheduling Over-Time
+				if not (ot_end <= basic_start or ot_start >= basic_end):
+					skipped_ot_overlap.append(f"{employee_name_iter} on {current_processing_date}")
+					continue
+
+			# if current_processing_date not in omitted_days:
+			already_scheduled = int(schedule_data.get(current_processing_date, 0))
+			num_to_add_this_day = daily_add_count[current_processing_date]
+
+			if already_scheduled + num_to_add_this_day > post_number:
+				omitted_days.add(current_processing_date)
+
+
+			employee_doc = employees_dict.get(employee_name_iter)
+			name = f"{datevalue['date']}_{employee_name_iter}_{roster_type}"
+			day_off_ot_val = datevalue.get('day_off_ot') or day_off_ot  
+			query_values.append(f"""
+				(
+					'{name}', '{employee_name_iter}', '{employee_doc.employee_name}', '{employee_doc.department}', '{datevalue['date']}', '{operations_shift_doc.name}',
+					'{operations_shift_doc.site}', '{operations_shift_doc.project}', '{operations_shift_doc.shift_type}', 'Working',
+					'{operations_role_doc.name}', '{operations_role_doc.post_abbrv}', '{roster_type}',
+					{day_off_ot_val}, '{datevalue.get('start_datetime')}', '{datevalue.get('end_datetime')}', '{owner}', '{owner}', '{creation}', '{creation}'
+				)""")
+			can_create = True
+
+
+	if query_values:
+		query += ",\n".join(query_values)
+		query += f"""
+			ON DUPLICATE KEY UPDATE
+			modified_by = VALUES(modified_by),
+			modified = VALUES(modified),
+			operations_role = VALUES(operations_role),
+			post_abbrv = VALUES(post_abbrv),
+			roster_type = VALUES(roster_type),
+			shift = VALUES(shift),
+			project = VALUES(project),
+			site = VALUES(site),
+			shift_type = VALUES(shift_type),
+			day_off_ot = VALUES(day_off_ot),
+			employee_availability = "Working",
+			start_datetime= VALUES(start_datetime),
+			end_datetime= VALUES(end_datetime)
 		"""
-		can_create = False
-		omitted_days = set()
-
-		# Create a temporary structure to count new schedules per day from the current batch
-		daily_add_count = defaultdict(int)
-		for emp, date_values in employees_date_dict.items():
-			for dateval in date_values:
-				daily_add_count[dateval.get("date")] +=1
-
-		query_values = [] # Prepare values for bulk insert
-		skipped_ot_no_basic = []
-		skipped_ot_overlap = []
-
-
-		for employee_name_iter, date_values in employees_date_dict.items():
-			for datevalue in date_values:
-				current_processing_date = datevalue.get("date")
-
-				# For each date, check overfill status
-				post_data = validate_overfilled_post([current_processing_date], operations_shift_doc.name, operations_role_doc.name)
-				post_number = post_data.get("post_number", 0)
-				schedule_data = post_data.get("schedule_dict", {})
-
-				if roster_type == "Over-Time":
-					# Query for existing Basic schedule for this employee and date
-					basic_schedule = frappe.db.get_value(
-						"Employee Schedule",
-						{
-							"employee": employee_name_iter,
-							"date": current_processing_date,
-							"roster_type": "Basic",
-							"employee_availability": "Working"
-						},
-						["start_datetime", "end_datetime"]
-					)
-					if not basic_schedule:
-						skipped_ot_no_basic.append(f"{employee_name_iter} on {current_processing_date}")
-						continue
-
-					# Check for overlap
-					ot_start = datevalue.get("start_datetime")
-					ot_end = datevalue.get("end_datetime")
-					basic_start = basic_schedule[0]
-					basic_end = basic_schedule[1]
-
-					# If Over-Time overlaps with Basic, skip scheduling Over-Time
-					if not (ot_end <= basic_start or ot_start >= basic_end):
-						skipped_ot_overlap.append(f"{employee_name_iter} on {current_processing_date}")
-						continue
-
-				# if current_processing_date not in omitted_days:
-				already_scheduled = int(schedule_data.get(current_processing_date, 0))
-				num_to_add_this_day = daily_add_count[current_processing_date]
-
-				if already_scheduled + num_to_add_this_day > post_number:
-					omitted_days.add(current_processing_date)
-
-
-				employee_doc = employees_dict.get(employee_name_iter)
-				name = f"{datevalue['date']}_{employee_name_iter}_{roster_type}"
-				query_values.append(f"""
-					(
-						'{name}', '{employee_name_iter}', '{employee_doc.employee_name}', '{employee_doc.department}', '{datevalue['date']}', '{operations_shift_doc.name}',
-						'{operations_shift_doc.site}', '{operations_shift_doc.project}', '{operations_shift_doc.shift_type}', 'Working',
-						'{operations_role_doc.name}', '{operations_role_doc.post_abbrv}', '{roster_type}',
-						{day_off_ot}, '{datevalue.get('start_datetime')}', '{datevalue.get('end_datetime')}', '{owner}', '{owner}', '{creation}', '{creation}'
-					)""")
-				can_create = True
-
-
-		if query_values:
-			query += ",\n".join(query_values)
-			query += f"""
-				ON DUPLICATE KEY UPDATE
-				modified_by = VALUES(modified_by),
-				modified = VALUES(modified),
-				operations_role = VALUES(operations_role),
-				post_abbrv = VALUES(post_abbrv),
-				roster_type = VALUES(roster_type),
-				shift = VALUES(shift),
-				project = VALUES(project),
-				site = VALUES(site),
-				shift_type = VALUES(shift_type),
-				day_off_ot = VALUES(day_off_ot),
-				employee_availability = "Working",
-				start_datetime= VALUES(start_datetime),
-				end_datetime= VALUES(end_datetime)
-			"""
-			if can_create:
-				frappe.db.sql(query, values=[])
-				frappe.db.commit()
-
-
-		if skipped_ot_no_basic:
-			frappe.msgprint("Over-Time schedule was not created for the following because no Basic schedule exists:<br>" + "<br>".join(skipped_ot_no_basic))
-		if skipped_ot_overlap:
-			frappe.msgprint("Over-Time schedule was not created for the following because it overlaps with Basic schedule:<br>" + "<br>".join(skipped_ot_overlap))
-
-
-		if omitted_days:
-			omitted_days_str = ", ".join(datetime.strptime(date, "%Y-%m-%d").strftime("%d-%m-%Y") for date in sorted(set(omitted_days)))
-			title = "This action has overfilled the post for the following dates."
-			msg = f"""
-			<b>Role: {operations_role_doc.post_abbrv}</b> ({operations_role_doc.name}) <br>
-			<b>Shift:</b> {operations_shift_doc.name}<br>
-			<b>Dates:</b> {omitted_days_str}
-			"""
-			frappe.msgprint(_(msg), _(title))
-
-	else: # request_employee_schedule is true
-		from_schedule = frappe.db.get_list(
-			"Employee Schedule",
-			filters={
-				"shift": shift,
-				"date": ["BETWEEN", [start_date, end_date if end_date else start_date]],
-				"employee": ["IN", employee_list]
-			},
-			fields=["shift", "site", "project", "employee", "employee_name", "operations_role"],
-			group_by="employee DESC"
-		)
-		if len(from_schedule):
-			if otRoster == "false":
-				roster_type_val = "Basic"
-			elif otRoster == "true":
-				roster_type_val = "Over-Time"
-
-			for emp_item in from_schedule:
-				req_es_doc = frappe.new_doc("Request Employee Schedule")
-				req_es_doc.employee = emp_item.employee
-				req_es_doc.from_shift = emp_item.shift
-				req_es_doc.from_operations_role = emp_item.operations_role
-				req_es_doc.to_shift = shift
-				req_es_doc.to_operations_role = operations_role_doc.name
-				req_es_doc.start_date = start_date
-				req_es_doc.end_date = end_date if end_date else start_date
-				req_es_doc.roster_type = roster_type_val
-				req_es_doc.save(ignore_permissions=True)
+		if can_create:
+			frappe.db.sql(query, values=[])
 			frappe.db.commit()
-			frappe.msgprint("Request Employee Schedule created successfully")
+
+
+	if skipped_ot_no_basic:
+		frappe.msgprint("Over-Time schedule was not created for the following because no Basic schedule exists:<br>" + "<br>".join(skipped_ot_no_basic))
+	if skipped_ot_overlap:
+		frappe.msgprint("Over-Time schedule was not created for the following because it overlaps with Basic schedule:<br>" + "<br>".join(skipped_ot_overlap))
+
+
+	if omitted_days:
+		omitted_days_str = ", ".join(datetime.strptime(date, "%Y-%m-%d").strftime("%d-%m-%Y") for date in sorted(set(omitted_days)))
+		title = "This action has overfilled the post for the following dates."
+		msg = f"""
+		<b>Role: {operations_role_doc.post_abbrv}</b> ({operations_role_doc.name}) <br>
+		<b>Shift:</b> {operations_shift_doc.name}<br>
+		<b>Dates:</b> {omitted_days_str}
+		"""
+		frappe.msgprint(_(msg), _(title))
+
 
 	frappe.enqueue(update_employee_shift, employees=list(employees_date_dict.keys()), shift=shift, owner=owner, creation=creation)
 
@@ -1510,7 +1501,6 @@ def dayoff(employees, client_day_off=0, selected_dates=0, selected_reliever=None
 
 def reliever_roster_assignment(reliver_emp_name, roster_list_arg):
 	day_off_ot = 0
-	request_employee_schedule = 0
 	keep_days_off = 0
 	employee_list_for_extreme = [reliver_emp_name]
 	otRoster = "false"
@@ -1528,11 +1518,11 @@ def reliever_roster_assignment(reliver_emp_name, roster_list_arg):
 
 			employees_for_extreme = [{"employee":reliver_emp_name,"date":date_val_str}]
 
-			extreme_schedule(employees_for_extreme, shift_val, operations_role_val, otRoster,
-				start_date_val.strftime("%Y-%m-%d"),
-				end_date_val.strftime("%Y-%m-%d"),
-				keep_days_off, day_off_ot,
-				request_employee_schedule, employee_list_for_extreme, selected_reliever=reliver_emp_name)
+			extreme_schedule(employees=employees_for_extreme, shift=shift_val, operations_role=operations_role_val, otRoster=otRoster,
+				start_date=start_date_val.strftime("%Y-%m-%d"),
+				end_date=end_date_val.strftime("%Y-%m-%d"),
+				keep_days_off=keep_days_off, day_off_ot=day_off_ot,
+				employee_list=employee_list_for_extreme, selected_reliever=reliver_emp_name)
 		else:
 			frappe.log_error(f"Skipping reliever assignment due to incomplete roster_data: {roster_data_item}", "Reliever Assignment")
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
As a roster user, I want to keep Day Off OT while updating employee schedule of staff with the changed shift and operations role details. 

- Keep Day Off OT checkbox added in popup dialog. 
- When checked, if any of the selected days of a staff have Day Off OT scheduled, the roster will keep those days as Day Off OT but will change the shift and role to the new changes. 
- Removed Request Employee Schedule checkbox and code references as it was not being used. 
- If Keep Days Off/Keep Days Off OT is checked, Day Off OT will be unchecked and vice versa. 

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
<img width="873" height="1131" alt="image" src="https://github.com/user-attachments/assets/817f26f9-4178-461c-bd87-b67af06b5e3c" />


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Is patch required?
- [] Yes
- [x] No


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
