### PR TITLE
hot-fix: fixed exit employee in roster according to relieving date

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1329,7 +1329,7 @@ function render_roster(res, page) {
 			let tooltiptext = ``;
 			let bgclass = ``;
 
-			let is_relieved_this_day = employee_relieving_date && current_day_iter.isSameOrAfter(employee_relieving_date);
+			let is_relieved_this_day = employee_relieving_date && current_day_iter.isAfter(employee_relieving_date);
 
 			if (employees_data[employee_key][date_key] && employees_data[employee_key][date_key].length > 0) {
 				for (let k = 0; k < employees_data[employee_key][date_key].length; k++) {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Need to show employee as exit from the date after relieving date and onwards

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Updated exit employee condition check in roster

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1311" height="901" alt="Screenshot from 2025-07-22 13-00-18" src="https://github.com/user-attachments/assets/175e232d-4987-48c5-b618-2f8b9722f20c" />
<img width="1797" height="665" alt="Screenshot from 2025-07-22 13-00-34" src="https://github.com/user-attachments/assets/1d4f8df7-3504-455a-b8b5-705efc48fbb7" />

## Areas affected and ensured
List out the areas affected by your code changes.
Roster

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
