### PR TITLE
fix: remove conditions from shift permission workflow

### DIFF
--- a/one_fm/custom/workflow/shift_permission.json
+++ b/one_fm/custom/workflow/shift_permission.json
@@ -1,5 +1,4 @@
 {
-  "name": "Shift Permission",
   "workflow_name": "Shift Permission",
   "document_type": "Shift Permission",
   "is_active": 1,
@@ -8,16 +7,92 @@
   "workflow_state_field": "workflow_state",
   "doctype": "Workflow",
   "states": [
-    { "state": "Draft", "doc_status": "0", "is_optional_state": 0, "avoid_status_override": 0, "allow_edit": "Employee", "doctype": "Workflow Document State" },
-    { "state": "Pending Approver", "doc_status": "0", "is_optional_state": 0, "avoid_status_override": 0, "allow_edit": "Shift Supervisor", "doctype": "Workflow Document State" },
-    { "state": "Approved", "doc_status": "1", "is_optional_state": 0, "avoid_status_override": 0, "allow_edit": "Shift Supervisor", "doctype": "Workflow Document State" },
-    { "state": "Rejected", "doc_status": "1", "is_optional_state": 0, "avoid_status_override": 0, "allow_edit": "Shift Supervisor", "doctype": "Workflow Document State" }
+    {
+      "state": "Draft",
+      "doc_status": "0",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Employee",
+      "doctype": "Workflow Document State"
+    },
+    {
+      "state": "Pending Approver",
+      "doc_status": "0",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Shift Supervisor",
+      "doctype": "Workflow Document State"
+    },
+    {
+      "state": "Approved",
+      "doc_status": "1",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Shift Supervisor",
+      "doctype": "Workflow Document State"
+    },
+    {
+      "state": "Rejected",
+      "doc_status": "1",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Shift Supervisor",
+      "doctype": "Workflow Document State"
+    }
   ],
   "transitions": [
-    { "state": "Draft", "action": "Submit for Review", "next_state": "Pending Approver", "allowed": "Employee", "allow_self_approval": 1, "allowed_user_field": "owner", "skip_multiple_action": 0, "skip_creation_of_workflow_action": 0, "custom_confirm_transition": 0, "custom_requires_frontend_input": 0, "condition": "", "doctype": "Workflow Transition" },
-    { "state": "Pending Approver", "action": "Return To Draft", "next_state": "Draft", "allowed": "Shift Supervisor", "allow_self_approval": 1, "allowed_user_field": "shift_supervisor", "skip_multiple_action": 0, "skip_creation_of_workflow_action": 0, "custom_confirm_transition": 0, "custom_requires_frontend_input": 0, "condition": "frappe.session.user in [doc.approver_user_id, 'abdullah@one-fm.com']", "doctype": "Workflow Transition" },
-    { "state": "Pending Approver", "action": "Approve", "next_state": "Approved", "allowed": "Shift Supervisor", "allow_self_approval": 1, "allowed_user_field": "shift_supervisor", "skip_multiple_action": 0, "skip_creation_of_workflow_action": 0, "custom_confirm_transition": 0, "custom_requires_frontend_input": 0, "condition": "frappe.session.user in [doc.approver_user_id, 'abdullah@one-fm.com']", "doctype": "Workflow Transition" },
-    { "state": "Pending Approver", "action": "Reject", "next_state": "Rejected", "allowed": "Shift Supervisor", "allow_self_approval": 1, "allowed_user_field": "shift_supervisor", "skip_multiple_action": 0, "skip_creation_of_workflow_action": 0, "custom_confirm_transition": 0, "custom_requires_frontend_input": 0, "condition": "frappe.session.user in [doc.approver_user_id, 'abdullah@one-fm.com']", "doctype": "Workflow Transition" },
-    { "state": "Pending Approver", "action": "Approve", "next_state": "Approved", "allowed": "Administrator", "allow_self_approval": 1, "skip_multiple_action": 0, "skip_creation_of_workflow_action": 0, "custom_confirm_transition": 0, "custom_requires_frontend_input": 0, "doctype": "Workflow Transition" }
+    {
+      "state": "Draft",
+      "action": "Submit for Review",
+      "next_state": "Pending Approver",
+      "allowed": "Employee",
+      "allow_self_approval": 1,
+      "allowed_user_field": "employee",
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "condition": "",
+      "doctype": "Workflow Transition"
+    },
+    {
+      "state": "Pending Approver",
+      "action": "Return To Draft",
+      "next_state": "Draft",
+      "allowed": "Shift Supervisor",
+      "allow_self_approval": 1,
+      "allowed_user_field": "shift_supervisor",
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "doctype": "Workflow Transition"
+    },
+    {
+      "state": "Pending Approver",
+      "action": "Approve",
+      "next_state": "Approved",
+      "allowed": "Shift Supervisor",
+      "allow_self_approval": 1,
+      "allowed_user_field": "shift_supervisor",
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "doctype": "Workflow Transition"
+    },
+    {
+      "state": "Pending Approver",
+      "action": "Reject",
+      "next_state": "Rejected",
+      "allowed": "Shift Supervisor",
+      "allow_self_approval": 1,
+      "allowed_user_field": "shift_supervisor",
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "doctype": "Workflow Transition"
+    }
   ]
 }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -134,9 +134,9 @@ one_fm.patches.v15_0.add_task_custom_field # Task field update
 one_fm.patches.v15_0.create_google_task_sync_process_task
 one_fm.patches.v15_0.create_daily_employee_action_check
 one_fm.patches.v15_0.assign_responsibilities_to_reliever
+one_fm.patches.v15_0.update_shift_permission_workflow_conditions
 
 [post_model_sync]
 one_fm.patches.v15_0.create_attendance_check_process_task #re run again
 one_fm.patches.v15_0.add_task_assignment_rule
 one_fm.patches.v15_0.attendance_check_create
-one_fm.patches.v15_0.update_shift_permission_workflow_conditions

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -139,4 +139,4 @@ one_fm.patches.v15_0.assign_responsibilities_to_reliever
 one_fm.patches.v15_0.create_attendance_check_process_task #re run again
 one_fm.patches.v15_0.add_task_assignment_rule
 one_fm.patches.v15_0.attendance_check_create
-
+one_fm.patches.v15_0.update_shift_permission_workflow_conditions

--- a/one_fm/patches/v15_0/update_shift_permission_workflow_conditions.py
+++ b/one_fm/patches/v15_0/update_shift_permission_workflow_conditions.py
@@ -1,0 +1,4 @@
+from one_fm.custom.workflow.workflow import get_workflow_json_file, create_workflow
+
+def execute():
+    create_workflow(get_workflow_json_file("shift_permission.json"))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Shift Permission workflow action buttons are not showing up in notification email sent to supervisors due to conditions in workflow table not evaluating to 'True'. Removed conditions from workflow.json file in order to stop them from coming back with every site migration.

Also removed 'Approve' action for role 'Administrator' from workflow transitions table.



## Solution description
Removed the condition from the relevant actions in the Shift Permission workflow.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No

## Output screenshots (optional)
<img width="1320" height="647" alt="Screenshot 2025-08-26 at 8 35 09 AM" src="https://github.com/user-attachments/assets/da4cdb51-b69b-4847-a1e1-9f5adfaf60d4" />
<img width="1171" height="647" alt="Screenshot 2025-08-26 at 8 36 33 AM" src="https://github.com/user-attachments/assets/08df034d-a82d-4197-881f-282296248b53" />


## Areas affected and ensured


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
