### PR TITLE
feat: added staff duty to last page only on printed report

### DIFF
--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.html
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.html
@@ -188,15 +188,17 @@
           </tr>
         {% } %}
   
-        <!-- Staff on Duty -->
-        <tr class="staff-duty">
-          <th colspan="{{ empIdColSpan + empNameColSpan + shiftColSpan + 1 }}">No. of Staff on Duty</th>
-          {% for (var i = 0; i < monthDays.length; i++) { %}
-            <td>{{ pageData.reduce((count, att) => att[monthDays[i].date.toString()] === 'P' ? count + 1 : count, 0) }}</td>
-          {% } %}
-          <td colspan="2">-</td>
-          <td>-</td>
-        </tr>
+        <!-- Staff on Duty (On Last Page Only) -->
+        {% if (p == (pages.length - 1)) { %}
+          <tr class="staff-duty">
+            <th colspan="{{ empIdColSpan + empNameColSpan + shiftColSpan + 1 }}">No. of Staff on Duty</th>
+            {% for (var n = 0; n < monthDays.length; n++) { %}
+              <td>{{ data.reduce((count, att) => att[monthDays[n].date.toString()] === 'P' ? count + 1 : count, 0) }}</td>
+            {% } %}
+            <td colspan="2">{{ data.reduce((acc, rec) => acc + (rec.working_days || 0), 0) }}</td>
+            <td>{{ data.reduce((acc, rec) => acc + (rec.off_days || 0), 0) }}</td>
+          </tr>
+        {% } %}
   
         <!-- Signatures -->
         <tr class="signatures">

--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.html
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.html
@@ -17,6 +17,17 @@
     font-size: 7px !important;
     font-family: "Readex Pro", sans-serif;
   }
+
+  /* Override the existing styles */
+  .print-format td img {
+    max-height: 50px;
+    max-width: 100%;
+    height: auto !important;
+    width: auto !important;
+    object-fit: contain;
+    display: block;
+    margin: auto; 
+  }
   /* === Print Format Styles End === */
 
   .attendance-table {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://onefm.atlassian.net/browse/OFP-136

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Added Staff Duty row only on the last page
- Rendered total of working and off days as well
- Fixed header logo size

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1345" height="168" alt="Screenshot from 2025-08-26 14-16-20" src="https://github.com/user-attachments/assets/99c40c83-2652-4620-943c-ca7493444c9c" />
<img width="1341" height="102" alt="Screenshot from 2025-08-26 14-15-56" src="https://github.com/user-attachments/assets/85308a51-69ab-49a8-8a9f-7444c7276e2c" />

## Areas affected and ensured
List out the areas affected by your code changes.
Operations Monthly Attendance Report (PDF)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
