### PR TITLE
fix: ignored user permissions for site supervisor

### DIFF
--- a/one_fm/operations/doctype/operations_site/operations_site.json
+++ b/one_fm/operations/doctype/operations_site/operations_site.json
@@ -70,6 +70,7 @@
   {
    "fieldname": "account_supervisor",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Site Supervisor",
    "options": "Employee"
   },
@@ -194,7 +195,7 @@
   }
  ],
  "links": [],
- "modified": "2023-05-04 21:58:18.376106",
+ "modified": "2025-08-27 18:00:27.356342",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Site",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Operations Supervisors and Facility Engineers are not having access to all Operation Sites

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Ignored user permissions for Supervisor field in Operations Site

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Operations Site

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
