### PR TITLE
[OFP-141] Filter Operations Shift Fields in Onboard Employee and Job Offer

### DIFF
--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
@@ -4,7 +4,7 @@
 frappe.ui.form.on('Onboard Employee', {
 	
 	onload: function(frm) {
-		// using frm.set_query to set_query for the operations shift field based on active shifts
+		// using frm.set_query to filter the operations shift field based on active shifts
 		frm.set_query('operations_shift', function() {
 			return {
 				filters: {

--- a/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
+++ b/one_fm/hiring/doctype/onboard_employee/onboard_employee.js
@@ -3,7 +3,16 @@
 
 frappe.ui.form.on('Onboard Employee', {
 	
-	
+	onload: function(frm) {
+		// using frm.set_query to set_query for the operations shift field based on active shifts
+		frm.set_query('operations_shift', function() {
+			return {
+				filters: {
+					"status": "Active"
+				}
+			};
+		});
+	},
 	refresh: function(frm) {
 		show_hide_fields(frm)
 		set_progress_html(frm);

--- a/one_fm/public/js/doctype_js/job_offer.js
+++ b/one_fm/public/js/doctype_js/job_offer.js
@@ -1,5 +1,14 @@
 frappe.ui.form.on('Job Offer', {
   refresh(frm) {
+    // Ensure that only Active Shifts are shown in operations_shift field
+    frm.set_query('operations_shift', function() {
+			return {
+				filters: {
+					"status": "Active"
+				}
+			};
+		});
+
     if(frm.is_new()){
       frm.set_value('offer_date', frappe.datetime.now_date());
     }
@@ -129,6 +138,8 @@ frappe.ui.form.on('Job Offer', {
     set_filters(frm);
   },
 });
+
+
 
 var set_filters = function(frm) {
   var filters = {};


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
Ensure that Operations Shifts selected in the job offer and the onboard employee document are filtered to Active alone.

## Analysis and design (optional)
None

## Solution description
Ensure that Operations Shifts selected in the job offer and the onboard employee document are filtered to Active alone.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No

## Output screenshots (optional)
<img width="751" height="582" alt="image" src="https://github.com/user-attachments/assets/ac5bb1e0-4ab3-459e-b8b3-b220f08c4f79" />


## Areas affected and ensured
Areas affected are Job Offer and Onboard Employee.

## Is there any existing behavior change of other features due to this code change?
Only behavior that will be changed is fields in Job offer and onboard employee.

## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data

## Was child table created?
- [ ] Yes
- [x] No

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox
