### PR TITLE
feat: disable email and sync on developer mode

### DIFF
--- a/one_fm/after_migrate/execute.py
+++ b/one_fm/after_migrate/execute.py
@@ -635,3 +635,39 @@ def update_all_ticket_features():
         run_command("bench restart", cwd=bench_path)
     else:
         print("No changes detected. Skipping build and restart.")
+
+def disable_email_and_sync_on_developer_mode():
+    if not frappe.conf.get("developer_mode"):
+        return
+    disable_email_accounts_on_developer_mode()
+    disable_sync_on_developer_mode()
+
+def disable_email_accounts_on_developer_mode():
+    if not frappe.conf.get("developer_mode"):
+        return
+    email_accounts = frappe.get_all("Email Account", pluck="name")
+    for account in email_accounts:
+        frappe.db.set_value(
+            "Email Account",
+            account,
+            {
+                "enable_outgoing": 0,
+                "default_outgoing": 0,
+                "enable_incoming": 0,
+                "default_incoming": 0
+            }
+        )
+        print(f"Disabled Email Account: {account}")
+    print("All Email Accounts have been disabled.")
+
+def disable_sync_on_developer_mode():
+    if not frappe.conf.get("developer_mode"):
+        return
+    sync_ = frappe.db.get_single_value("ONEFM General Setting", "google_task_synchronization_enabled")
+    if sync_:
+        frappe.db.set_single_value(
+            "ONEFM General Setting",
+            "google_task_synchronization_enabled",
+            0
+        )
+        print(f"Disabled Google Task Synchronization")

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -852,7 +852,8 @@ after_migrate = [
     "one_fm.after_migrate.execute.comment_process_expired_allocation_in_hrms",
     "one_fm.after_migrate.execute.replace_prompt_message_in_goal",
     "one_fm.after_migrate.execute.update_all_ticket_features",
-    "one_fm.overrides.scheduled_job_type.update_scheduled_job_type_from_process_task"
+    "one_fm.overrides.scheduled_job_type.update_scheduled_job_type_from_process_task",
+    "one_fm.after_migrate.execute.disable_email_and_sync_on_developer_mode"
 ]
 
 before_migrate = [


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
Disable the email account and google task sync on developer mode to avoid unnecessary notifications to users

## Solution description
Disable all the email account and sync after migrate hook

## Output screenshots (optional)
<img width="748" height="637" alt="Screenshot 2025-08-28 at 11 53 46 PM" src="https://github.com/user-attachments/assets/314b99b1-8983-4367-9a8c-589f4d787b2e" />

## Areas affected and ensured
-`one_fm/after_migrate/execute.py`
-`one_fm/hooks.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome