### PR TITLE
feat: prompt count fields in hd ticket

### DIFF
--- a/one_fm/custom/custom_field/hd_ticket.py
+++ b/one_fm/custom/custom_field/hd_ticket.py
@@ -36,6 +36,20 @@ def get_hd_ticket_custom_fields():
                 "fetch_from": "custom_process.process_owner",
                 "read_only": 1,
                 "in_list_view": 1
+            },
+            {
+                "fieldname": "planning_prompts_count",
+                "fieldtype": "Int",
+                "label": "Planning Prompts Count",
+                "insert_after": "resolution_date",
+                "depends_on": "eval:doc.ticket_type == 'Bug'"
+            },
+            {
+                "fieldname": "execution_prompt_count",
+                "fieldtype": "Int",
+                "label": "Execution Prompt Count",
+                "insert_after": "planning_prompts_count",
+                "depends_on": "eval:doc.ticket_type == 'Bug'"
             }
         ]
     }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -144,6 +144,7 @@ one_fm.patches.v15_0.update_shift_permission_workflow_conditions
 one_fm.patches.v15_0.update_shift_request_purpose_field
 one_fm.patches.v15_0.unset_mobile_no_disabled_user
 one_fm.patches.v15_0.update_shift_request_assignment_rule
+one_fm.patches.v15_0.update_hd_ticket_prompt_fields
 
 
 [post_model_sync]

--- a/one_fm/patches/v15_0/update_hd_ticket_prompt_fields.py
+++ b/one_fm/patches/v15_0/update_hd_ticket_prompt_fields.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+    custom_fields = {
+        "HD Ticket": [
+            {
+                "fieldname": "planning_prompts_count",
+                "fieldtype": "Int",
+                "label": "Planning Prompts Count",
+                "insert_after": "resolution_date",
+                "depends_on": "eval:doc.ticket_type == 'Bug'"
+            },
+            {
+                "fieldname": "execution_prompt_count",
+                "fieldtype": "Int",
+                "label": "Execution Prompt Count",
+                "insert_after": "planning_prompts_count",
+                "depends_on": "eval:doc.ticket_type == 'Bug'"
+            }
+        ]
+    }
+    create_custom_fields(custom_fields)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
Any HD ticket for which PR is created using open swe need to have the below fields logged. 
Planning prompts count
Execution prompt count

## Solution description
Add two custom fields in HD ticket using patch

## Areas affected and ensured
- `one_fm/custom/custom_field/hd_ticket.py`
- `one_fm/patches.txt`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome