### PR TITLE
feat: create GitHub issue from HD Ticket

### DIFF
--- a/one_fm/custom/custom_field/hd_ticket.py
+++ b/one_fm/custom/custom_field/hd_ticket.py
@@ -20,6 +20,13 @@ def get_hd_ticket_custom_fields():
                 "translatable": 1
             },
             {
+                "fieldname": "custom_github_issue_url",
+                "fieldtype": "Data",
+                "label": "GitHub Issue",
+                "insert_after": "custom_dev_ticket",
+                "read_only": 1,
+            },
+            {
                 "fieldname": "custom_bug_buster",
                 "fieldtype": "Link",
                 "insert_after": "ticket_split_from",

--- a/one_fm/custom/custom_field/hd_ticket.py
+++ b/one_fm/custom/custom_field/hd_ticket.py
@@ -24,7 +24,7 @@ def get_hd_ticket_custom_fields():
                 "fieldtype": "Data",
                 "label": "GitHub Issue",
                 "insert_after": "custom_dev_ticket",
-                "read_only": 1,
+                "read_only": 1
             },
             {
                 "fieldname": "custom_bug_buster",

--- a/one_fm/custom/property_setter/hd_ticket.py
+++ b/one_fm/custom/property_setter/hd_ticket.py
@@ -1,19 +1,18 @@
 def get_hd_ticket_properties():
     return [
         {
-            "doctype_or_field": "DocField",
-            "doc_type": "HD Ticket",
-            "field_name": "custom_dev_ticket",
-            "property": "read_only",
-            "property_type": "Check",
-            "value": 1
+            "doctype_or_field":"DocField",
+            "doc_type":"HD Ticket",
+            "field_name":"status",
+            "property":"options",
+            "value":"Draft\nOpen\nReplied\nOn Hold\nResolved\nClosed",
+            "default_value":"Open"
         },
         {
-            "doctype_or_field": "DocField",
-            "doc_type": "HD Ticket",
-            "field_name": "custom_dev_ticket",
-            "property": "translatable",
-            "property_type": "Check",
-            "value": 1
+            "doctype_or_field":"DocField",
+            "doc_type":"HD Ticket",
+            "field_name":"agent_group",
+            "property":"hidden",
+            "value":"1"
         }
     ]

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -326,7 +326,7 @@ def create_dev_ticket(name, description):
             return {'error': 'Dev Ticket Error', 'message': f"Dev ticket could not be created:\n{error_msg}"}
 
     except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "Dev Ticket Creation Error")
+        frappe.log_error(message=frappe.get_traceback(), title="Dev Ticket Creation Error")
         return {'error': 'Dev Ticket Error', 'message': f"Dev ticket could not be created:\n {str(e)}"}
 
 
@@ -442,9 +442,9 @@ def create_github_issue(name, description):
             return {'status': 'success', 'github_issue_url': issue_url}
         else:
             error_msg = response.json().get("message") or response.text
-            frappe.log_error(f"GitHub Issue Creation Error: {error_msg}", "GitHub Integration")
+            frappe.log_error(message=f"GitHub Issue Creation Error: {error_msg}", title="GitHub Integration")
             return {'error': 'GitHub Issue Error', 'message': f"GitHub issue could not be created:\n{error_msg}"}
 
     except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "GitHub Issue Creation Error")
+        frappe.log_error(message=frappe.get_traceback(), title="GitHub Issue Creation Error")
         return {'error': 'GitHub Issue Error', 'message': f"GitHub issue could not be created:\n {str(e)}"}

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -402,3 +402,49 @@ def get_priority():
 @frappe.whitelist()
 def get_process():
     return _fetch_list("Process")
+
+@frappe.whitelist()
+def create_github_issue(name, description):
+    """
+    Create a GitHub issue from an HD Ticket
+    """
+    try:
+        doc = frappe.get_doc("HD Ticket", name)
+        doc_link = frappe.utils.get_url(f"/app/hd-ticket/{doc.name}")
+
+        # Use fallback if description is not provided
+        description = cleanhtml(description) or doc.subject
+
+        # Get GitHub credentials from site_config.json
+        github_token = frappe.conf.get("github_api_token")
+        github_repo_owner = frappe.conf.get("github_repo_owner")
+        github_repo_name = frappe.conf.get("github_repo_name")
+
+        if not all([github_token, github_repo_owner, github_repo_name]):
+            frappe.throw("GitHub credentials not found in site_config.json")
+
+        headers = {
+            "Authorization": f"token {github_token}",
+            "Content-Type": "application/json"
+        }
+
+        data = {
+            "title": doc.subject,
+            "body": f"**From HD Ticket:** [{doc.name}]({doc_link})\n\n**Description:**\n{description}"
+        }
+
+        url = f"https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/issues"
+        response = requests.post(url, headers=headers, json=data, timeout=10)
+
+        if response.status_code == 201:
+            issue_url = response.json().get("html_url")
+            doc.db_set('custom_github_issue_url', issue_url)
+            return {'status': 'success', 'github_issue_url': issue_url}
+        else:
+            error_msg = response.json().get("message") or response.text
+            frappe.log_error(f"GitHub Issue Creation Error: {error_msg}", "GitHub Integration")
+            return {'error': 'GitHub Issue Error', 'message': f"GitHub issue could not be created:\n{error_msg}"}
+
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "GitHub Issue Creation Error")
+        return {'error': 'GitHub Issue Error', 'message': f"GitHub issue could not be created:\n {str(e)}"}

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -146,8 +146,7 @@ one_fm.patches.v15_0.unset_mobile_no_disabled_user
 one_fm.patches.v15_0.update_shift_request_assignment_rule
 one_fm.patches.v15_0.update_hd_ticket_prompt_fields
 one_fm.patches.v15_0.create_absentees_report_process_task
-
-
+one_fm.patches.v15_0.add_github_issue_url_in_hd_ticket
 
 [post_model_sync]
 one_fm.patches.v15_0.create_attendance_check_process_task #re run again

--- a/one_fm/patches/v15_0/add_github_issue_url_in_hd_ticket.py
+++ b/one_fm/patches/v15_0/add_github_issue_url_in_hd_ticket.py
@@ -1,0 +1,16 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+    custom_field = {
+        "HD Ticket": [
+            {
+                "fieldname": "custom_github_issue_url",
+                "fieldtype": "Data",
+                "label": "GitHub Issue",
+                "insert_after": "custom_dev_ticket",
+                "read_only": 1
+            }
+        ]
+    }
+    create_custom_fields(custom_field)

--- a/one_fm/patches/v15_0/update_shift_request_pending_approver_to_pending_approval.py
+++ b/one_fm/patches/v15_0/update_shift_request_pending_approver_to_pending_approval.py
@@ -7,7 +7,7 @@ def execute():
     pending_workflow = frappe.get_all(
         "Shift Request",
         filters={"workflow_state": "Pending Approver"},
-        fields=["name", "parent"]
+        fields=["name"]
     )
     if pending_workflow:
         update_existing_pending_approver_to_pending_approval(pending_workflow)

--- a/one_fm/public/js/doctype_js/hd_ticket.js
+++ b/one_fm/public/js/doctype_js/hd_ticket.js
@@ -1,8 +1,47 @@
 frappe.ui.form.on("HD Ticket", {
   refresh: function (frm) {
     add_dev_ticket_button(frm);
+    add_github_issue_button(frm);
   },
 });
+
+const add_github_issue_button = (frm) => {
+  if (frm.doc.ticket_type == "Bug") {
+    if (frm.doc.custom_github_issue_url) {
+      if (!document.querySelector("#github_issue_span")) {
+        let el = `<span id="github_issue_span">GitHub Issue has been created</span><br>
+        <a href="${frm.doc.custom_github_issue_url}" class="btn btn-primary" target="_blank">View GitHub Issue</a>`;
+        frm.dashboard.add_section(el, __("GitHub Issue"));
+      }
+    } else if (["Open", "Replied"].includes(frm.doc.status)) {
+      frm.add_custom_button(
+        "GitHub Issue",
+        () => {
+          frappe.confirm(
+            "Are you sure you want to create a GitHub issue?",
+            () => {
+              frappe.call({
+                method: "one_fm.overrides.hd_ticket.create_github_issue",
+                freeze: true,
+                freeze_message: "Creating GitHub Issue",
+                args: { name: frm.doc.name, description: frm.doc.description },
+                callback: function (r) {
+                  if (r.message.status == "success") {
+                    frappe.msgprint("GitHub issue created successfully");
+                    frm.refresh();
+                    frm.reload_doc();
+                  }
+                },
+              });
+            },
+            () => null
+          );
+        },
+        "Create"
+      );
+    }
+  }
+};
 
 const add_dev_ticket_button = (frm) => {
   if (

--- a/one_fm/public/js/doctype_js/hd_ticket.js
+++ b/one_fm/public/js/doctype_js/hd_ticket.js
@@ -13,7 +13,7 @@ const add_github_issue_button = (frm) => {
         <a href="${frm.doc.custom_github_issue_url}" class="btn btn-primary" target="_blank">View GitHub Issue</a>`;
         frm.dashboard.add_section(el, __("GitHub Issue"));
       }
-    } else if (["Open", "Replied"].includes(frm.doc.status)) {
+    } else if (["Open", "Replied"].includes(frm.doc.status) && frappe.session.user==frm.doc.custom_bug_buster) {
       frm.add_custom_button(
         "GitHub Issue",
         () => {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
Integrate HD ticket with Github API for automated github issue creation

## Solution description
Add custom field in HD ticket to capture the github issue url
Integrate with Github API to create GitHub Issues

## Areas affected and ensured
-`one_fm/custom/custom_field/hd_ticket.py`
-`one_fm/custom/property_setter/hd_ticket.py`
-`one_fm/overrides/hd_ticket.py`
-`one_fm/patches.txt`
-`one_fm/patches/v15_0/add_github_issue_url_in_hd_ticket.py`
-`one_fm/patches/v15_0/update_shift_request_pending_approver_to_pending_approval.py`
-`one_fm/public/js/doctype_js/hd_ticket.js`

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes
<img width="1079" height="212" alt="Screenshot 2025-08-30 at 12 04 39 AM" src="https://github.com/user-attachments/assets/84b719fb-a4cb-42e6-be89-a8bf9e8e957d" />

## Which browser(s) did you use for testing?
- [x] Chrome