### PR TITLE
feat: add context to github issue from HD Ticket

### DIFF
--- a/one_fm/public/js/doctype_js/hd_ticket.js
+++ b/one_fm/public/js/doctype_js/hd_ticket.js
@@ -38,18 +38,21 @@ const add_github_issue_button = (frm) => {
                 fieldname: "steps_to_reproduce",
                 fieldtype: "Text Editor",
                 reqd: 1,
+                default: `<p>1. [First step] </p><p><br></p><p>2. [Second step] </p><p><br></p><p>3. [Specific action that causes the issue] </p>`
               },
               {
                 label: __("Expected Result"),
                 fieldname: "expected_result",
                 fieldtype: "Text Editor",
                 reqd: 1,
+                default: "<p>[What you expected to happen]</p>"
               },
               {
                 label: __("Actual Result"),
                 fieldname: "actual_result",
                 fieldtype: "Text Editor",
                 reqd: 1,
+                default: "<p>[What actually happens - include error messages/screenshots]</p>"
               },
               {
                 label: __("Technical Context"),
@@ -60,11 +63,13 @@ const add_github_issue_button = (frm) => {
                 label: __("Affected DocType(s)"),
                 fieldname: "affected_doctypes",
                 fieldtype: "Small Text",
+                default: "[Specific ERPNext doctypes involved]"
               },
               {
                 label: __("Affected Files"),
                 fieldname: "affected_files",
                 fieldtype: "Small Text",
+                default: "[If known - specific Python/JS files]"
               },
               {
                 label: __("Additional Information"),
@@ -75,52 +80,55 @@ const add_github_issue_button = (frm) => {
                 label: __("Error Logs"),
                 fieldname: "error_logs",
                 fieldtype: "Text Editor",
+                default: "<p>[Paste relevant error logs]</p>"
               },
               {
                 label: __("Browser/System Info"),
                 fieldname: "browser_system_info",
                 fieldtype: "Text Editor",
+                default: "<p>[If frontend issue]</p>"
               },
               {
                 label: __("DataContext"),
                 fieldname: "data_context",
                 fieldtype: "Text Editor",
+                default: "<p>[Specific records/data involved]</p>"
               },
             ],
             primary_action_label: __("Create Issue"),
             primary_action(values) {
               const description = `
-### Environment:
-${values.environment}
+                ### Environment:
+                ${values.environment}
 
-### Problem Description:
-${values.problem_description}
+                ### Problem Description:
+                ${values.problem_description}
 
-### Steps to Reproduce:
-${values.steps_to_reproduce}
+                ### Steps to Reproduce:
+                ${values.steps_to_reproduce}
 
-### Expected Result:
-${values.expected_result}
+                ### Expected Result:
+                ${values.expected_result}
 
-### Actual Result:
-${values.actual_result}
+                ### Actual Result:
+                ${values.actual_result}
 
-### Technical Context:
-**Affected DocType(s):** ${values.affected_doctypes}
-**Affected Files:** ${values.affected_files}
+                ### Technical Context:
+                **Affected DocType(s):** ${values.affected_doctypes}
+                **Affected Files:** ${values.affected_files}
 
-### Additional Information:
-**Error Logs:**
-\`\`\`
-${values.error_logs}
-\`\`\`
+                ### Additional Information:
+                **Error Logs:**
+                \`\`\`
+                ${values.error_logs}
+                \`\`\`
 
-**Browser/System Info:**
-${values.browser_system_info}
+                **Browser/System Info:**
+                ${values.browser_system_info}
 
-**DataContext:**
-${values.data_context}
-`;
+                **DataContext:**
+                ${values.data_context}
+              `;
 
               frappe.call({
                 method: "one_fm.overrides.hd_ticket.create_github_issue",

--- a/one_fm/public/js/doctype_js/hd_ticket.js
+++ b/one_fm/public/js/doctype_js/hd_ticket.js
@@ -17,14 +17,119 @@ const add_github_issue_button = (frm) => {
       frm.add_custom_button(
         "GitHub Issue",
         () => {
-          frappe.confirm(
-            "Are you sure you want to create a GitHub issue?",
-            () => {
+          let d = new frappe.ui.Dialog({
+            title: __("New GitHub Issue"),
+            fields: [
+              {
+                label: __("Environment"),
+                fieldname: "environment",
+                fieldtype: "Select",
+                options: ["Production", "Staging", "Test Production"],
+                reqd: 1,
+              },
+              {
+                label: __("Problem Description"),
+                fieldname: "problem_description",
+                fieldtype: "Text Editor",
+                default: frm.doc.description,
+              },
+              {
+                label: __("Steps to Reproduce"),
+                fieldname: "steps_to_reproduce",
+                fieldtype: "Text Editor",
+                reqd: 1,
+              },
+              {
+                label: __("Expected Result"),
+                fieldname: "expected_result",
+                fieldtype: "Text Editor",
+                reqd: 1,
+              },
+              {
+                label: __("Actual Result"),
+                fieldname: "actual_result",
+                fieldtype: "Text Editor",
+                reqd: 1,
+              },
+              {
+                label: __("Technical Context"),
+                fieldname: "technical_context",
+                fieldtype: "Section Break",
+              },
+              {
+                label: __("Affected DocType(s)"),
+                fieldname: "affected_doctypes",
+                fieldtype: "Small Text",
+              },
+              {
+                label: __("Affected Files"),
+                fieldname: "affected_files",
+                fieldtype: "Small Text",
+              },
+              {
+                label: __("Additional Information"),
+                fieldname: "additional_information",
+                fieldtype: "Section Break",
+              },
+              {
+                label: __("Error Logs"),
+                fieldname: "error_logs",
+                fieldtype: "Text Editor",
+              },
+              {
+                label: __("Browser/System Info"),
+                fieldname: "browser_system_info",
+                fieldtype: "Text Editor",
+              },
+              {
+                label: __("DataContext"),
+                fieldname: "data_context",
+                fieldtype: "Text Editor",
+              },
+            ],
+            primary_action_label: __("Create Issue"),
+            primary_action(values) {
+              const description = `
+### Environment:
+${values.environment}
+
+### Problem Description:
+${values.problem_description}
+
+### Steps to Reproduce:
+${values.steps_to_reproduce}
+
+### Expected Result:
+${values.expected_result}
+
+### Actual Result:
+${values.actual_result}
+
+### Technical Context:
+**Affected DocType(s):** ${values.affected_doctypes}
+**Affected Files:** ${values.affected_files}
+
+### Additional Information:
+**Error Logs:**
+\`\`\`
+${values.error_logs}
+\`\`\`
+
+**Browser/System Info:**
+${values.browser_system_info}
+
+**DataContext:**
+${values.data_context}
+`;
+
               frappe.call({
                 method: "one_fm.overrides.hd_ticket.create_github_issue",
                 freeze: true,
                 freeze_message: "Creating GitHub Issue",
-                args: { name: frm.doc.name, description: frm.doc.description },
+                args: {
+                  name: frm.doc.name,
+                  description: description,
+                },
                 callback: function (r) {
                   if (r.message.status == "success") {
                     frappe.msgprint("GitHub issue created successfully");
@@ -33,9 +138,10 @@ const add_github_issue_button = (frm) => {
                   }
                 },
               });
+              d.hide();
             },
-            () => null
-          );
+          });
+          d.show();
         },
         "Create"
       );


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
Add a new action button called “Github Issue” which appears after clicking on “Create” action button in HD ticket. 
On clicking Github Issue, a popup dialog opens up which asks the bug buster to add the information as per the format attached below. Fields of popup mentioned in https://onefm.atlassian.net/browse/OFP-157

## Output screenshots (optional)

https://github.com/user-attachments/assets/2691de3d-8e2f-4780-bae4-03b35dee8c40

## Areas affected and ensured
- `one_fm/public/js/doctype_js/hd_ticket.js`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome