### PR TITLE
[CHORE][Prevent unnecessary attendance manager email notifications by only sending when new todos are created]

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -632,7 +632,8 @@ def assign_attendance_manager(pending_approval_attendance_checks):
         existing_todos = fetch_existing_todos(attendance_manager_user)
         filtered_pending_approval_attendance_check = [i for i in pending_approval_attendance_checks if i.name not in existing_todos ]
         create_todos(attendance_manager_user,filtered_pending_approval_attendance_check)
-        notify_manager(attendance_manager_user)
+        if filtered_pending_approval_attendance_check:
+            notify_manager(attendance_manager_user)
 
 
 def schedule_attendance_check():


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [X] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/930
This PR updates the attendance check notification logic to only send emails to the attendance manager when new todos are created. This prevents unnecessary email notifications when there are no new assignments.

Only calls notify_manager if filtered_pending_approval_attendance_check is not empty.
Reduces email volume and improves notification relevance.

## Which browser(s) did you use for testing?
  - [X] Chrome
  - [X] Safari
  - [X] Firefox
