### PR TITLE
BUG: DUPLICATE NOTIFIACTIONS FOR ROSTER POST ACTIONS

### DIFF
--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
@@ -15,7 +15,7 @@ from frappe.permissions import get_doctype_roles
 from one_fm.one_fm.page.roster.roster import get_current_user_details
 
 class RosterPostActions(Document):
-    ...
+    pass
 
 
 

--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
@@ -15,17 +15,7 @@ from frappe.permissions import get_doctype_roles
 from one_fm.one_fm.page.roster.roster import get_current_user_details
 
 class RosterPostActions(Document):
-    def after_insert(self):
-        # send notification to supervisor
-        user_id = frappe.db.get_value("Employee", self.supervisor, ["user_id"])
-        if user_id:
-            link = get_link_to_form(self.doctype, self.name)
-            subject = _("New Action Required")
-            message = _("""
-				You have been issued a Roster Post Action.<br>
-				Please review the Post Type for the specified date in the roster, take necessary actions and update the status.<br>
-				Link: {link}""".format(link=link))
-            sendemail([user_id], subject=subject, message=message, reference_doctype=self.doctype, reference_name=self.name)
+    ...
 
 
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [X] Bug


## Clearly and concisely describe the feature, chore or bug.
A notification from assignment rule was being sent out and aother from the system, 
https://one-fm.com/app/hd-ticket/1154

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Removed the notification from the codebase, and allowed the assignment rule to be the only one being used

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Roster Post Actions

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
