### PR TITLE
[CHORE][Add leave policy patch]

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -149,6 +149,7 @@ one_fm.patches.v15_0.update_hd_ticket_prompt_fields
 one_fm.patches.v15_0.create_absentees_report_process_task
 one_fm.patches.v15_0.add_github_issue_url_in_hd_ticket
 one_fm.patches.v15_0.create_enrollment_status_process_task
+one_fm.patches.v15_0.update_expired_leave_policy_assignments
 
 [post_model_sync]
 one_fm.patches.v15_0.create_attendance_check_process_task #re run again

--- a/one_fm/patches/v15_0/update_expired_leave_policy_assignments.py
+++ b/one_fm/patches/v15_0/update_expired_leave_policy_assignments.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import frappe
 from frappe.utils import getdate, add_days, add_years, today
 
@@ -6,7 +5,7 @@ def execute():
     """
     Update expired leave policy assignments for active employees.
     """
-    frappe.log_error("Leave Policy Patch Started", "Leave Policy")
+    print("Leave Policy Patch Started")
     today_date = getdate(today())
 
     active_employees = frappe.get_all("Employee", filters={"status": "Active"}, pluck="name")
@@ -72,10 +71,10 @@ def execute():
                         leave_policy_assignment.leaves_allocated = False
                         leave_policy_assignment.save(ignore_permissions=True)
                         leave_policy_assignment.submit()
-                        frappe.log_error(f"Created new Leave Policy Assignment for {doc.employee} from {effective_from} to {new_effective_to}", "Leave Policy")
+                        print(f"Created new Leave Policy Assignment for {doc.employee} from {effective_from} to {new_effective_to}")
 
                     effective_to = new_effective_to
 
         except Exception as e:
-            frappe.log_error(f"Failed to create leave policy assignment for employee {doc.employee}: {e}", "Leave Policy Error")
+            print(f"Failed to create leave policy assignment for employee {doc.employee}: {e}")
             continue

--- a/one_fm/patches/v15_0/update_expired_leave_policy_assignments.py
+++ b/one_fm/patches/v15_0/update_expired_leave_policy_assignments.py
@@ -1,0 +1,81 @@
+from __future__ import unicode_literals
+import frappe
+from frappe.utils import getdate, add_days, add_years, today
+
+def execute():
+    """
+    Update expired leave policy assignments for active employees.
+    """
+    frappe.log_error("Leave Policy Patch Started", "Leave Policy")
+    today_date = getdate(today())
+
+    active_employees = frappe.get_all("Employee", filters={"status": "Active"}, pluck="name")
+
+    if not active_employees:
+        return
+
+    latest_assignments = frappe.db.sql("""
+        SELECT
+            lpa.name,
+            lpa.employee,
+            lpa.effective_to,
+            lpa.leave_policy,
+            lpa.carry_forward
+        FROM
+            `tabLeave Policy Assignment` AS lpa
+        WHERE
+            lpa.employee IN %(employees)s
+            AND lpa.docstatus = 1
+        ORDER BY
+            lpa.employee, lpa.effective_to DESC
+    """, {"employees": active_employees}, as_dict=1)
+
+    latest_assignment_map = {}
+    for assignment in latest_assignments:
+        if assignment.employee not in latest_assignment_map:
+            latest_assignment_map[assignment.employee] = assignment
+
+    for employee, doc in latest_assignment_map.items():
+        try:
+            effective_to = getdate(doc.effective_to)
+
+            if effective_to < today_date:
+                while effective_to < today_date:
+                    effective_from = add_days(effective_to, 1)
+                    new_effective_to = add_days(add_years(effective_from, 1), -1)
+
+                    # Check for future carry-forward leave allocations
+                    leave_types = frappe.get_all("Leave Policy Detail", filters={"parent": doc.leave_policy}, pluck="leave_type")
+                    if leave_types:
+                        future_allocation_exists = frappe.db.exists("Leave Allocation", {
+                            "employee": doc.employee,
+                            "leave_type": ("in", leave_types),
+                            "from_date": (">", new_effective_to),
+                            "docstatus": 1,
+                            "carry_forward": 1
+                        })
+                        if future_allocation_exists:
+                            break
+
+                    if not frappe.db.exists("Leave Policy Assignment", {
+                        "employee": doc.employee,
+                        "effective_from": effective_from,
+                        "effective_to": new_effective_to,
+                        "docstatus": 1
+                    }):
+                        leave_policy_assignment = frappe.new_doc('Leave Policy Assignment')
+                        leave_policy_assignment.employee = doc.employee
+                        leave_policy_assignment.effective_from = effective_from
+                        leave_policy_assignment.effective_to = new_effective_to
+                        leave_policy_assignment.leave_policy = doc.leave_policy
+                        leave_policy_assignment.carry_forward = doc.carry_forward
+                        leave_policy_assignment.leaves_allocated = False
+                        leave_policy_assignment.save(ignore_permissions=True)
+                        leave_policy_assignment.submit()
+                        frappe.log_error(f"Created new Leave Policy Assignment for {doc.employee} from {effective_from} to {new_effective_to}", "Leave Policy")
+
+                    effective_to = new_effective_to
+
+        except Exception as e:
+            frappe.log_error(f"Failed to create leave policy assignment for employee {doc.employee}: {e}", "Leave Policy Error")
+            continue


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
This patch addresses expired leave policy assignments for active employees by creating consecutive one-year policy assignments to bring their policies up-to-date.

Adds a database patch to automatically update expired leave policy assignments
Implements logic to create new consecutive policy assignments until current date
Includes safety checks to prevent conflicts with existing allocations

## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
<img width="1042" height="447" alt="Screenshot 2025-09-09 at 9 00 09 AM" src="https://github.com/user-attachments/assets/a23c1905-189c-4211-850c-61a6a55f7bc4" />


## Areas affected and ensured
Leave policy assignment and Leave allocation 

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - No
    
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
Yes


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
