### PR TITLE
Refactor: Move ToDo filtering to client-side in Employee Weekly Action

### DIFF
--- a/one_fm/one_fm/doctype/employee_weekly_action/employee_weekly_action.js
+++ b/one_fm/one_fm/doctype/employee_weekly_action/employee_weekly_action.js
@@ -15,8 +15,7 @@ frappe.ui.form.on("Employee Weekly Action", {
       frm.events.clear_plans_table(frm)
       if(frm.doc.employee){
         fetch_employee_reports_to(frm);
-        load_todos(frm, true);
-        load_todos(frm, false);
+        load_todos(frm);
       }
     },
     clear_plans_table(frm) {
@@ -55,29 +54,52 @@ const get_week_and_year = () => {
     return { week: weekNumber, year: adjustedDate.getFullYear() };
 };
 
-const load_todos = (frm, is_current) => {
+const load_todos = (frm) => {
     frappe.call({
         method: "one_fm.one_fm.doctype.employee_weekly_action.employee_weekly_action.fetch_todos",
-        args: { employee:frm.doc.employee, is_current:is_current },
+        args: { employee:frm.doc.employee },
         callback: function (r) {
             if (r && r.status_code === 200 && Array.isArray(r.data)) {
-                const fieldname = is_current ? 'project_progress_and_plans' : 'next_week_task_plan';
+                const getWeekDateRange = (offset = 0) => {
+                    const now = new Date();
+                    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+                    const dayOfWeek = today.getDay(); // 0 for Sunday
+                    const firstDay = new Date(today);
+                    firstDay.setDate(today.getDate() - dayOfWeek + (offset * 7));
+                    const lastDay = new Date(firstDay);
+                    lastDay.setDate(firstDay.getDate() + 6);
+
+                    const formatDate = d => d.toISOString().split('T')[0];
+                    return { start: formatDate(firstDay), end: formatDate(lastDay) };
+                }
+
+                const thisWeek = getWeekDateRange(0);
+                const nextWeek = getWeekDateRange(1);
 
                 r.data.forEach(item => {
                     let description = "";
                     if (item.description){
                       description = item.description.replace(/<[^>]*>/g, "").trim();
                     }
-                    const row = frm.add_child(fieldname);
-                    row.project = item.project;
-                    row.todo = item.name;
-                    row.todo_title = description;
-                    if (!is_current && item.date) {
+
+                    if (item.date <= thisWeek.end) {
+                        const row = frm.add_child('project_progress_and_plans');
+                        row.project = item.project;
+                        row.todo = item.name;
+                        row.todo_title = description;
+                    }
+
+                    if (item.date >= nextWeek.start && item.date <= nextWeek.end) {
+                        const row = frm.add_child('next_week_task_plan');
+                        row.project = item.project;
+                        row.todo = item.name;
+                        row.todo_title = description;
                         row.due_date = item.date;
                     }
                 });
 
-                frm.refresh_field(fieldname);
+                frm.refresh_field('project_progress_and_plans');
+                frm.refresh_field('next_week_task_plan');
             } else {
                 console.warn('No data returned from fetch_todos:', r);
             }

--- a/one_fm/one_fm/doctype/employee_weekly_action/employee_weekly_action.py
+++ b/one_fm/one_fm/doctype/employee_weekly_action/employee_weekly_action.py
@@ -50,14 +50,13 @@ def get_week_dates(offset=0):
     return start_of_week.strftime('%Y-%m-%d'), end_of_week.strftime('%Y-%m-%d')
 
 @frappe.whitelist()
-def fetch_todos(employee: str, is_current: bool = True):
+def fetch_todos(employee: str):
     try:
-        start_date, end_date = get_week_dates(offset=0 if is_current else 1)
         allocated_to = frappe.db.get_value("Employee", employee, "user_id")
         if not allocated_to:
             return response("User Not Found", 404)
 
-        week_todos = get_to_do_linked_projects(start_date, end_date, allocated_to)
+        week_todos = get_to_do_linked_projects(allocated_to)
         return response("Success", 200, week_todos)
 
     except Exception:
@@ -67,14 +66,13 @@ def fetch_todos(employee: str, is_current: bool = True):
         )
         return response("Error", 400)
 
-def get_to_do_linked_projects(start_date, end_date, allocated_to):
+def get_to_do_linked_projects(allocated_to):
     query = '''
         select
             p.name as project, t.name as todo, t.type, t.description, t.date, t.reference_name, t.reference_type
         from
             `tabProject` p, `tabToDo` t
         where
-            t.reference_type = "Project" and t.reference_name = p.name and t.date between '{0}' and '{1}'
-            and t.allocated_to = '{2}' and t.status='Open'
+            t.reference_type = "Project" and t.reference_name = p.name and t.allocated_to = '{0}' and t.status='Open'
     '''
-    return frappe.db.sql(query.format(start_date, end_date, allocated_to), as_dict=True)
+    return frappe.db.sql(query.format(allocated_to), as_dict=True)


### PR DESCRIPTION
- Modified the backend to fetch all open To-Dos for an employee, removing the date-based filtering from the SQL query.
- Updated the JavaScript frontend to perform client-side filtering, distributing the To-Dos into the correct tables ('project_progress_and_plans' and 'next_week_task_plan') based on their due dates.
- This change improves efficiency by reducing the number of server calls from two to one.


https://github.com/user-attachments/assets/114e8a27-106c-42da-8551-76a95019b0b3