### PR TITLE
feat: remove password access on employee exit

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -85,17 +85,25 @@ class EmployeeOverride(EmployeeMaster):
         if "one_fm_password_management" not in frappe.get_installed_apps():
             return
         if self.relieving_date and self.user_id:
-            is_owner = frappe.db.exists(
+            owner_credentials = frappe.get_all(
                 "Password Management",
                 {
                     "credentials_owner": self.user_id,
                     "docstatus": ("!=", 2) # Not cancelled
-                }
+                },
+                as_list=1
             )
-            if is_owner:
-                frappe.throw(
-                    _("Employee is still listed as Credentials Owner in Password Management Records. Please reassign ownership before setting Relieving Date.")
+            if owner_credentials:
+                links = [
+                    f"<a href='{get_url_to_form('Password Management', cred[0])}' target='_blank'>[{cred[0]}]</a>"
+                    for cred in owner_credentials
+                ]
+                message = (
+                    "Employee is still listed as Credentials Owner in the following Password Management Records:<br/>"
+                    + ", ".join(links) +
+                    "<br/><br/>Please reassign ownership before setting Relieving Date."
                 )
+                frappe.throw(message)
 
     def before_save(self):
         self.assign_role_profile_based_on_designation()

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -51,7 +51,7 @@ class EmployeeOverride(EmployeeMaster):
                     "Employee", self.name, existing_user_id)
         employee_validate_attendance_by_timesheet(self, method=None)
         validate_leaves(self)
-
+        self.validate_relieving_date()
 
     def toggle_auto_attendance(self):
         try:
@@ -62,8 +62,6 @@ class EmployeeOverride(EmployeeMaster):
                         frappe.throw("You Are Not Permitted To Toggle Auto-Attendance")
         except Exception as e:
             frappe.log_error(title = f"{str(e)}", message = frappe.get_traceback())
-
-
 
     def set_employee_id_based_on_residency(self):
         if self.employee_id:
@@ -83,10 +81,25 @@ class EmployeeOverride(EmployeeMaster):
             if prev_enrollment != self.enrolled:
                 frappe.throw(f"Enrollment field is read-only and cannot be modified.")
 
+    def validate_relieving_date(self):
+        if "one_fm_password_management" not in frappe.get_installed_apps():
+            return
+        if self.relieving_date and self.user_id:
+            is_owner = frappe.db.exists(
+                "Password Management",
+                {
+                    "credentials_owner": self.user_id,
+                    "docstatus": ("!=", 2) # Not cancelled
+                }
+            )
+            if is_owner:
+                frappe.throw(
+                    _("Employee is still listed as Credentials Owner in Password Management Records. Please reassign ownership before setting Relieving Date.")
+                )
+
     def before_save(self):
         self.assign_role_profile_based_on_designation()
         # get_assurance_level_of_employee(self)
-
 
     def after_insert(self):
         employee_after_insert(self, method=None)
@@ -132,8 +145,7 @@ class EmployeeOverride(EmployeeMaster):
         self.update_subcontract_onboard()
         self.inform_employee_id_update()
         self.notify_employee_id_update()
-
-
+        self.remove_user_on_employee_left()
 
     def inform_employee_id_update(self):
         """
@@ -248,6 +260,27 @@ class EmployeeOverride(EmployeeMaster):
         subcontract_onboard = frappe.db.exists("Onboard Subcontract Employee", {"employee": self.name, "enrolled": ['!=', '1']})
         if subcontract_onboard and self.enrolled:
             frappe.db.set_value("Onboard Subcontract Employee", subcontract_onboard, "enrolled", self.enrolled)
+
+    def remove_user_on_employee_left(self):
+        if self.status != "Left":
+            return
+        if "one_fm_password_management" not in frappe.get_installed_apps():
+            return
+        # Check if status has been changed to 'Left'
+        if self.status == "Left" and self.get_doc_before_save().status != "Left":
+            if self.user_id:
+                try:
+                    frappe.db.sql("""
+                        DELETE
+                        FROM
+                            `tabPassword Management User`
+                        WHERE
+                            user = %s
+                    """, (self.user_id))
+                    frappe.msgprint(f"User {self.user_id} removed from all Password Management records.")
+                except Exception as e:
+                    message = f"Failed to remove user {self.user_id} from Password Management {user_access.parent}"
+                    frappe.log_error(message=message+f": {e}", title=message)
 
     def notify_attendance_manager_on_status_change(self):
         last_doc = self.get_doc_before_save()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
The system to validate against password ownership while setting Employee's Relieving Date, So that sensitive credentials are not retained by employees who are no longer with the organisation

## Output screenshots (optional)
<img width="1346" height="386" alt="Screenshot 2025-09-28 at 9 57 05 PM" src="https://github.com/user-attachments/assets/1e953968-65c9-4f4b-bb3b-5f6da2984b85" />
<img width="1364" height="587" alt="Screenshot 2025-09-28 at 9 44 06 PM" src="https://github.com/user-attachments/assets/1290b8a6-f4f4-43bd-86c9-013a848c7c56" />

## Areas affected and ensured
- `one_fm/overrides/employee.py`

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome