### PR TITLE
feat: bug buster creates git hub issue

### DIFF
--- a/one_fm/custom/custom_field/hd_agent.py
+++ b/one_fm/custom/custom_field/hd_agent.py
@@ -1,0 +1,13 @@
+def get_hd_agent_custom_fields():
+    """Return a dictionary of custom fields for the Employee document."""
+    return {
+         "HD Agent": [
+            {
+                "fieldname": "github_api_token",
+                "fieldtype": "Password",
+                "label": "GitHub API Token",
+                "insert_after": "agent_name",
+                "description": "GitHub API Token for creating issues on behalf of the user"
+            }
+        ]
+    }

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -420,11 +420,14 @@ def create_github_issue(name, description):
         description = cleanhtml(description) or doc.subject
 
         # Get GitHub credentials from site_config.json
-        github_token = frappe.conf.get("github_api_token")
+        github_token = get_github_api_token(doc.custom_bug_buster)
+        if not github_token:
+            frappe.msgprint("GitHub token not found for user, please set it in your HD Agent profile")
+            return {'error': 'GitHub Issue Error', 'message': "GitHub token not found for user, please set it in your HD Agent profile"}
         github_repo_owner = frappe.conf.get("github_repo_owner")
         github_repo_name = frappe.conf.get("github_repo_name")
 
-        if not all([github_token, github_repo_owner, github_repo_name]):
+        if not all([github_repo_owner, github_repo_name]):
             frappe.throw("GitHub credentials not found in site_config.json")
 
         headers = {
@@ -453,3 +456,16 @@ def create_github_issue(name, description):
     except Exception as e:
         frappe.log_error(message=frappe.get_traceback(), title="GitHub Issue Creation Error")
         return {'error': 'GitHub Issue Error', 'message': f"GitHub issue could not be created:\n {str(e)}"}
+
+def get_github_api_token(user=None):
+    if not user:
+        user = frappe.session.user
+    agent_for_user = frappe.db.exists("HD Agent", {"user": user, "is_active": 1})
+    if not agent_for_user:
+        frappe.msgprint("No active HD Agent found for user")
+        return None
+    token = frappe.db.get_value("HD Agent", {"user": user, "is_active": 1}, "github_api_token")
+    if not token:
+        frappe.msgprint("No GitHub API token found for user, please set it in your HD Agent profile. Follow <a href='https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token'>this link</a> for more details")
+        return None
+    return token

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -158,6 +158,7 @@ one_fm.patches.v15_0.add_loan_disbursement_assignment_rule
 one_fm.patches.v15_0.add_update_custom_field #2025-09-23
 one_fm.patches.v15_0.approve_pending_attendance_check
 one_fm.patches.v15_0.create_loan_process_task
+one_fm.patches.v15_0.add_hd_agent_custom_field_github_api_token
 
 [post_model_sync]
 one_fm.patches.v15_0.create_attendance_check_process_task #re run again

--- a/one_fm/patches/v15_0/add_hd_agent_custom_field_github_api_token.py
+++ b/one_fm/patches/v15_0/add_hd_agent_custom_field_github_api_token.py
@@ -1,0 +1,17 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+    custom_field = {
+        "HD Agent": [
+            {
+                "fieldname": "github_api_token",
+                "fieldtype": "Password",
+                "label": "GitHub API Token",
+                "insert_after": "agent_name",
+                "description": "GitHub API Token for creating issues on behalf of the user"
+            }
+            
+        ]
+    }
+    create_custom_fields(custom_field)

--- a/one_fm/setup/custom_field.py
+++ b/one_fm/setup/custom_field.py
@@ -91,6 +91,7 @@ from one_fm.custom.custom_field.email_template import get_email_template_custom_
 from one_fm.custom.custom_field.issue import get_issue_custom_fields
 from one_fm.custom.custom_field.loan_product import get_loan_product_custom_fields
 from one_fm.custom.custom_field.repayment_schedule import get_repayment_schedule_custom_fields
+from one_fm.custom.custom_field.hd_agent import get_hd_agent_custom_fields
 
 def get_custom_fields():
 	"""ONEFM specific custom fields that need to be added to the masters in ERPNext"""
@@ -186,5 +187,6 @@ def get_custom_fields():
 	custom_fields.update(get_email_template_custom_fields())
 	custom_fields.update(get_loan_product_custom_fields())
 	custom_fields.update(get_repayment_schedule_custom_fields())
+	custom_fields.update(get_hd_agent_custom_fields())
 
 	return custom_fields


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature

## Clearly and concisely describe the feature, chore or bug.
This pull request adds support for storing and retrieving GitHub API tokens on a per-HD Agent basis, allowing users to create GitHub issues with their own credentials. It introduces a new custom field for the `HD Agent` document, updates the logic for fetching the API token, and provides a patch to add the field in existing systems.

**Custom Field Addition:**
- Added a new `github_api_token` field (type: Password) to the `HD Agent` DocType, enabling each agent to store their personal GitHub API token. [[1]](diffhunk://#diff-ff2837908d7c4476b9f46a6cb2077a3ed9e9d5c558ca9297df63b060e8099e08R1-R13) [[2]](diffhunk://#diff-af2d8794d6704c7c9c71b2430176022a97a78af2bca8e1c41832d0ce6a6a6cadR1-R17)
- Registered the new custom field in the custom fields setup and included it in the patch system for automatic migration. [[1]](diffhunk://#diff-e67431d20aa420ce43ad77101b4d72bf7f65befd80358789a7985d24e4c556efR94) [[2]](diffhunk://#diff-e67431d20aa420ce43ad77101b4d72bf7f65befd80358789a7985d24e4c556efR190) [[3]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R161)

**GitHub Issue Creation Logic:**
- Updated `create_github_issue` to fetch the GitHub API token from the agent's profile using a new helper function, and added user-facing error messages when the token is missing. [[1]](diffhunk://#diff-10c365a1e78f38ce8af072690f76c85b7b10b61577d0d9d848f604f231f096a0L423-R430) [[2]](diffhunk://#diff-10c365a1e78f38ce8af072690f76c85b7b10b61577d0d9d848f604f231f096a0R459-R471)
- Implemented `get_github_api_token`, which retrieves the token for the current or specified user, checks for an active agent, and provides guidance if the token is missing.
