### PR TITLE
fix: bug buster creates git hub issue

### DIFF
--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -8,6 +8,7 @@ from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import HDTicket
 from one_fm.processor import sendemail
 from one_fm.api.doc_events import get_employee_user_id
 from one_fm.utils import response
+from frappe.utils.password import get_decrypted_password
 
 class HDTicketOverride(HDTicket):
     def before_insert(self):
@@ -464,7 +465,7 @@ def get_github_api_token(user=None):
     if not agent_for_user:
         frappe.msgprint("No active HD Agent found for user")
         return None
-    token = frappe.db.get_value("HD Agent", {"user": user, "is_active": 1}, "github_api_token")
+    token = get_decrypted_password("HD Agent", agent_for_user, 'github_api_token', raise_exception=True)
     if not token:
         frappe.msgprint("No GitHub API token found for user, please set it in your HD Agent profile. Follow <a href='https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token'>this link</a> for more details")
         return None


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
This pull request updates the way GitHub API tokens are retrieved for HD Agents to improve security and ensure encrypted storage. The main change is switching from fetching the token directly from the database to using the decrypted password utility, which handles encrypted values.

**Security improvements:**

* Updated the `get_github_api_token` function in `one_fm/overrides/hd_ticket.py` to use `get_decrypted_password` for retrieving the `github_api_token`, ensuring tokens are securely handled and decrypted when needed.
* Added an import for `get_decrypted_password` from `frappe.utils.password` in `one_fm/overrides/hd_ticket.py` to support the new secure token retrieval method.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Which browser(s) did you use for testing?
- [x] Chrome