### PR TITLE
feat: Create Leave Handover from Leave Application

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, ONE FM and contributors
+# Copyright (c) 2024, one_fm and contributors
 # For license information, please see license.txt
 
 # import frappe
@@ -7,3 +7,66 @@ from frappe.model.document import Document
 
 class LeaveHandover(Document):
 	pass
+
+@frappe.whitelist()
+def get_handover_data(leave_application):
+	handover_items = []
+	leave_application_doc = frappe.get_doc("Leave Application", leave_application)
+	employee = leave_application_doc.employee
+
+	# Fetch projects
+	projects = frappe.get_all(
+		"Project",
+		filters={"status": "Open", "account_manager": employee},
+		fields=["name"],
+	)
+	for project in projects:
+		handover_items.append({
+			"reference_doctype": "Project",
+			"reference_docname": project.name,
+		})
+
+	# Fetch operations sites
+	sites = frappe.get_all(
+		"Operations Site",
+		filters={"status": "Active", "account_supervisor": employee},
+		fields=["name"],
+	)
+	for site in sites:
+		handover_items.append({
+			"reference_doctype": "Operations Site",
+			"reference_docname": site.name,
+		})
+
+	# Fetch process tasks
+	tasks = frappe.get_all(
+		"Process Task",
+		filters={"is_active": 1, "employee": employee},
+		fields=["name"],
+	)
+	for task in tasks:
+		handover_items.append({
+			"reference_doctype": "Process Task",
+			"reference_docname": task.name,
+		})
+
+	# Fetch employees reporting to the leave applicant
+	employees = frappe.get_all(
+		"Employee",
+		filters={"status": ("in", ["Active", "Vacation"]), "reports_to": employee},
+		fields=["name"],
+	)
+	for emp in employees:
+		handover_items.append({
+			"reference_doctype": "Employee",
+			"reference_docname": emp.name,
+		})
+
+	return {
+		"employee": leave_application_doc.employee,
+		"employee_name": leave_application_doc.employee_name,
+		"leave_application": leave_application_doc.name,
+		"leave_start_date": leave_application_doc.from_date,
+		"resumption_date": leave_application_doc.resumption_date,
+		"handover_items": handover_items,
+	}

--- a/one_fm/public/js/doctype_js/leave_application.js
+++ b/one_fm/public/js/doctype_js/leave_application.js
@@ -108,6 +108,39 @@ frappe.ui.form.on("Leave Application", {
         }
         updateCustomIsPaidVisibility(frm)
         manage_leave_extension(frm)
+
+		if (frm.doc.status == 'Approved') {
+			frm.add_custom_button(__('Create Leave Handover'), function() {
+				frappe.call({
+					method: 'one_fm.one_fm.doctype.leave_handover.leave_handover.get_handover_data',
+					args: {
+						leave_application: frm.doc.name
+					},
+					callback: function(r) {
+						if (r.message) {
+							frappe.model.with_doctype('Leave Handover', function() {
+								var doc = frappe.model.get_new_doc('Leave Handover');
+								doc.employee = r.message.employee;
+								doc.employee_name = r.message.employee_name;
+								doc.leave_application = r.message.leave_application;
+								doc.leave_start_date = r.message.leave_start_date;
+								doc.resumption_date = r.message.resumption_date;
+								if (r.message.handover_items) {
+									r.message.handover_items.forEach(item => {
+										var child = frappe.model.add_child(doc, 'Handover Item', 'handover_items');
+										child.reference_doctype = item.reference_doctype;
+										child.reference_docname = item.reference_docname;
+									});
+								}
+								frappe.set_route('Form', 'Leave Handover', doc.name);
+							});
+						}
+					},
+					freeze: true,
+					freeze_message: __("Creating Leave Handover...")
+				});
+			}, __('Create'));
+		}
     },
     onload: function(frm) {
         $.each(frm.fields_dict, function(fieldname, field) {


### PR DESCRIPTION
Adds a "Create Leave Handover" button to the "Leave Application" form when the status is "Approved".

Clicking the button creates a new "Leave Handover" document and pre-fills it with the following information:
- Employee details from the Leave Application.
- Open projects where the employee is the Project Manager.
- Active Operations Sites where the employee is the Site Supervisor.
- Active Process Tasks assigned to the employee.
- Active employees who report to the employee on leave.