### PR TITLE
feat(leave-handover): Implement revert functionality

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.js
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.js
@@ -2,6 +2,28 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Leave Handover", {
+	refresh(frm) {
+		if (frm.doc.docstatus === 1 && frm.doc.status === "Transferred") {
+			frm.add_custom_button(__("Revert"), () => {
+				frappe.confirm(
+					__("You are about to replace the reliever with the Leave Applicant in each of the documents referenced in the table. Do you want to proceed?"),
+					() => {
+						frappe.call({
+							method: "one_fm.one_fm.doctype.leave_handover.leave_handover.revert_handover",
+							args: {
+								docname: frm.doc.name
+							},
+							callback: function(r) {
+								if (!r.exc) {
+									frm.reload_doc();
+								}
+							}
+						});
+					}
+				);
+			}).addClass("btn-primary");
+		}
+	},
 	after_save(frm) {
 		frm.dashboard.clear_headline();
 		if (frm.doc.handover_items && frm.doc.handover_items.length > 0) {

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.js
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.js
@@ -8,11 +8,8 @@ frappe.ui.form.on("Leave Handover", {
 				frappe.confirm(
 					__("You are about to replace the reliever with the Leave Applicant in each of the documents referenced in the table. Do you want to proceed?"),
 					() => {
-						frappe.call({
-							method: "one_fm.one_fm.doctype.leave_handover.leave_handover.revert_handover",
-							args: {
-								docname: frm.doc.name
-							},
+						frm.call({
+							method: "revert_handover",
 							callback: function(r) {
 								if (!r.exc) {
 									frm.reload_doc();

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -49,22 +49,21 @@ class LeaveHandover(Document):
 			if field_to_update:
 				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, item.reliever)
 
-@frappe.whitelist()
-def revert_handover(docname):
-	leave_handover = frappe.get_doc("Leave Handover", docname)
-	for item in leave_handover.handover_items:
-		field_to_update = {
-			"Project": "account_manager",
-			"Operations Site": "account_supervisor",
-			"Process Task": "employee",
-			"Employee": "reports_to",
-		}.get(item.reference_doctype)
+	@frappe.whitelist()
+	def revert_handover(self):
+		for item in self.handover_items:
+			field_to_update = {
+				"Project": "account_manager",
+				"Operations Site": "account_supervisor",
+				"Process Task": "employee",
+				"Employee": "reports_to",
+			}.get(item.reference_doctype)
 
-		if field_to_update:
-			frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, leave_handover.employee)
-			frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
+			if field_to_update:
+				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, self.employee)
+				frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
 
-	leave_handover.db_set("status", "Reverted")
+		self.db_set("status", "Reverted")
 
 @frappe.whitelist()
 def get_handover_data(leave_application):

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -50,6 +50,23 @@ class LeaveHandover(Document):
 				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, item.reliever)
 
 @frappe.whitelist()
+def revert_handover(docname):
+	leave_handover = frappe.get_doc("Leave Handover", docname)
+	for item in leave_handover.handover_items:
+		field_to_update = {
+			"Project": "account_manager",
+			"Operations Site": "account_supervisor",
+			"Process Task": "employee",
+			"Employee": "reports_to",
+		}.get(item.reference_doctype)
+
+		if field_to_update:
+			frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, leave_handover.employee)
+			frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
+
+	leave_handover.db_set("status", "Reverted")
+
+@frappe.whitelist()
 def get_handover_data(leave_application):
 	handover_items = []
 	leave_application_doc = frappe.get_doc("Leave Application", leave_application)


### PR DESCRIPTION
This commit introduces a "Revert" button for the Leave Handover doctype. The button is visible only when the document is submitted and the status is "Transferred".

Clicking the button triggers a confirmation dialog. Upon confirmation, the `revert_handover` method is called, which reverts the changes made during the handover process. The status of the Leave Handover and its items are updated to "Reverted".