### PR TITLE
feat: Assign roles on leave handover submission

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -37,6 +37,7 @@ class LeaveHandover(Document):
 				title=_("Not Accepted")
 			)
 
+		self.assign_role_on_handover()
 		self.transfer_handover()
 
 	def transfer_handover(self):
@@ -55,6 +56,46 @@ class LeaveHandover(Document):
 				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, item.reliever)
 	
 		self.db_set("status", "Transferred")
+
+	def assign_role_on_handover(self):
+		for item in self.handover_items:
+			if not item.reliever:
+				continue
+
+			reliever_user_id = frappe.db.get_value("Employee", item.reliever, "user_id")
+			if not reliever_user_id:
+				continue
+
+			# Define the roles based on the reference doctype
+			doctype_to_check = item.reference_doctype
+			if doctype_to_check not in ["Project","Operations Site","Process Task","Employee"]:
+				continue
+
+			roles_to_assign = [
+				f"{doctype_to_check} Access",
+				f"{doctype_to_check} Update"
+			]
+
+			# Get the user document and their current roles
+			reliever_user = frappe.get_doc("User", reliever_user_id)
+			user_roles = reliever_user.get_roles()
+
+			newly_assigned_roles = []
+
+			# Check and assign each role
+			for role in roles_to_assign:
+				if frappe.db.exists("Role", role) and role not in user_roles:
+					reliever_user.add_roles(role)
+					newly_assigned_roles.append(role)
+
+			# If any new roles were assigned, update the handover item
+			if newly_assigned_roles:
+				frappe.db.set_value(
+					"Handover Item",
+					item.name,
+					"roles_assigned",
+					", ".join(newly_assigned_roles)
+				)
 
 	@frappe.whitelist()
 	def revert_handover(self):

--- a/one_fm/one_fm/doctype/leave_handover/test_leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/test_leave_handover.py
@@ -1,9 +1,109 @@
 # Copyright (c) 2025, ONE FM and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import get_random_string
+
+from one_fm.one_fm.doctype.leave_handover.leave_handover import get_handover_data
 
 
 class TestLeaveHandover(FrappeTestCase):
-	pass
+	def setUp(self):
+		# Create roles if they don't exist
+		for role in ["Project Access", "Project Update"]:
+			if not frappe.db.exists("Role", role):
+				frappe.get_doc({"doctype": "Role", "role_name": role}).insert()
+
+		# Create users
+		self.user_on_leave = self.create_user("test_user_on_leave@example.com")
+		self.reliever_user = self.create_user("test_reliever_user@example.com")
+
+		# Create employees
+		self.employee_on_leave = self.create_employee(self.user_on_leave.name)
+		self.reliever_employee = self.create_employee(self.reliever_user.name)
+
+		# Create a project
+		self.project = frappe.get_doc(
+			{
+				"doctype": "Project",
+				"project_name": "Test Handover Project " + get_random_string(5),
+				"account_manager": self.employee_on_leave.name,
+				"status": "Open",
+			}
+		).insert()
+
+		# Create a leave application
+		self.leave_application = frappe.get_doc(
+			{
+				"doctype": "Leave Application",
+				"employee": self.employee_on_leave.name,
+				"from_date": "2025-10-21",
+				"to_date": "2025-10-22",
+				"leave_type": "Privilege Leave",
+				"status": "Approved",
+			}
+		).insert()
+		self.leave_application.submit()
+
+	def tearDown(self):
+		# Clean up created documents
+		frappe.db.rollback()
+
+	def create_user(self, email):
+		if frappe.db.exists("User", email):
+			return frappe.get_doc("User", email)
+		return frappe.get_doc(
+			{"doctype": "User", "email": email, "first_name": email.split("@")[0], "send_welcome_email": 0}
+		).insert()
+
+	def create_employee(self, user_id):
+		employee_name = user_id.split("@")[0]
+		if frappe.db.exists("Employee", {"user_id": user_id}):
+			return frappe.get_doc("Employee", {"user_id": user_id})
+
+		# Ensure _Test Company exists
+		if not frappe.db.exists("Company", "_Test Company"):
+			frappe.get_doc({"doctype": "Company", "company_name": "_Test Company", "default_currency": "USD"}).insert()
+
+		if not frappe.db.exists("Leave Type", "Privilege Leave"):
+			frappe.get_doc({"doctype": "Leave Type", "leave_type_name": "Privilege Leave", "max_days_allowed":30}).insert()
+
+		return frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"employee_name": employee_name.replace("_", " ").title(),
+				"company": "_Test Company",
+				"user_id": user_id,
+				"status": "Active",
+			}
+		).insert()
+
+	def test_role_assignment_on_submit(self):
+		# Create Leave Handover
+		leave_handover = frappe.get_doc(get_handover_data(self.leave_application.name))
+		leave_handover.insert()
+
+		# Update handover item with reliever and status
+		item = leave_handover.handover_items[0]
+		item.reliever = self.reliever_employee.name
+		item.status = "Accepted"
+		leave_handover.save()
+
+		# Submit the document
+		frappe.set_user(self.user_on_leave.name)  # set user to employee on leave to submit
+		leave_handover.submit()
+		frappe.set_user("Administrator")  # revert back to admin
+
+		# Assertions
+		# 1. Check if reliever user has the roles
+		reliever_user_doc = frappe.get_doc("User", self.reliever_user.name)
+		reliever_roles = [d.role for d in reliever_user_doc.roles]
+		self.assertIn("Project Access", reliever_roles)
+		self.assertIn("Project Update", reliever_roles)
+
+		# 2. Check if the roles_assigned field is updated
+		updated_handover = frappe.get_doc("Leave Handover", leave_handover.name)
+		self.assertEqual(
+			updated_handover.handover_items[0].roles_assigned, "Project Access, Project Update"
+		)


### PR DESCRIPTION
This commit introduces a new feature that automates the assignment of roles to a reliever when a Leave Handover is submitted.

The `assign_role_on_handover` method has been added to the `LeaveHandover` doctype. This method iterates through the handover items and, based on the reference doctype, assigns the appropriate 'Access' and 'Update' roles to the reliever's user if they do not already have them.

The names of the newly assigned roles are stored in the `roles_assigned` field of the Handover Item.

A comprehensive test suite has been added to verify this new functionality.