### PR TITLE
feat(leave-handover): implement role and role profile reversion

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -113,7 +113,28 @@ class LeaveHandover(Document):
 				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, self.employee)
 				frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
 
+		self.revert_roles()
 		self.db_set("status", "Reverted")
+
+	def revert_roles(self):
+		for item in self.handover_items:
+			if not item.reliever:
+				continue
+
+			reliever_user_id = frappe.db.get_value("Employee", item.reliever, "user_id")
+			if not reliever_user_id:
+				continue
+
+			reliever_user = frappe.get_doc("User", reliever_user_id)
+
+			if item.roles_assigned:
+				roles_to_revert = [role.strip() for role in item.roles_assigned.split(",")]
+				for role in roles_to_revert:
+					if frappe.db.exists("Has Role", {"parent": reliever_user.name, "role": role}):
+						reliever_user.remove_roles(role)
+
+			if item.reliever_role_profile:
+				reliever_user.db_set("role_profile_name", item.reliever_role_profile)
 
 
 @frappe.whitelist()

--- a/one_fm/tests/test_leave_handover.py
+++ b/one_fm/tests/test_leave_handover.py
@@ -1,0 +1,55 @@
+import frappe
+import unittest
+from frappe.utils import random_string
+from frappe.test_runner import make_test_records
+
+class TestLeaveHandover(unittest.TestCase):
+    def setUp(self):
+        make_test_records("User")
+        make_test_records("Employee")
+        make_test_records("Leave Application")
+        make_test_records("Role")
+        make_test_records("Role Profile")
+        self.employee = frappe.get_doc("Employee", {"user_id": "test@example.com"})
+        self.reliever = frappe.get_doc("Employee", {"user_id": "test1@example.com"})
+        self.leave_application = frappe.get_doc("Leave Application", {"employee": self.employee.name})
+        self.leave_handover = create_leave_handover(self.employee.name, self.leave_application.name)
+
+    def tearDown(self):
+        frappe.db.rollback()
+
+    def test_revert_handover(self):
+        self.leave_handover.submit()
+        self.leave_handover.reload()
+        self.assertEqual(self.leave_handover.docstatus, 1)
+        self.assertEqual(self.leave_handover.status, "Transferred")
+
+        reliever_user = frappe.get_doc("User", self.reliever.user_id)
+        self.assertIn("Project Manager", reliever_user.get_roles())
+
+        self.leave_handover.revert_handover()
+        self.leave_handover.reload()
+        self.assertEqual(self.leave_handover.status, "Reverted")
+
+        reliever_user.reload()
+        self.assertNotIn("Project Manager", reliever_user.get_roles())
+        self.assertEqual(reliever_user.role_profile_name, "Test Role Profile")
+
+def create_leave_handover(employee, leave_application):
+    doc = frappe.get_doc({
+        "doctype": "Leave Handover",
+        "employee": employee,
+        "leave_application": leave_application,
+        "handover_items": [
+            {
+                "reference_doctype": "Project",
+                "reference_docname": "Test Project",
+                "reliever": "test1@example.com",
+                "status": "Accepted",
+                "roles_assigned": "Project Manager",
+                "reliever_role_profile": "Test Role Profile"
+            }
+        ]
+    })
+    doc.insert()
+    return doc


### PR DESCRIPTION
This change introduces the logic to revert roles and role profiles when a Leave Handover is reverted.

The `revert_handover` method in the `LeaveHandover` DocType now calls a new `revert_roles` method. This method iterates through the handover items, removes the assigned roles from the reliever's user account, and restores the reliever's original role profile.

A new test file, `test_leave_handover.py`, has been added to verify the functionality of the `revert_handover` method.

