### PR TITLE
feat: Add 'Create Pathfinder Log' button to HD Ticket

### DIFF
--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -529,3 +529,26 @@ def get_github_api_token(user=None):
         frappe.msgprint("No GitHub API token found for user, please set it in your HD Agent profile. Follow <a href='https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token'>this link</a> for more details")
         return None
     return token
+
+@frappe.whitelist()
+def create_pathfinder_log(hd_ticket_name):
+    if "Business Analyst" not in frappe.get_roles():
+        frappe.throw(_("You are not authorized to create a Pathfinder Log."), title=_("Permission Denied"))
+
+    existing_log = frappe.db.exists("Pathfinder Log", {"hd_ticket": hd_ticket_name})
+    if existing_log:
+        log_url = frappe.utils.get_url_to_form("Pathfinder Log", existing_log)
+        frappe.throw(
+            _("Pathfinder Log already exists for this HD Ticket: <a href='{0}'>{1}</a>").format(
+                log_url, existing_log
+            ),
+            title=_("Exists")
+        )
+
+    hd_ticket = frappe.get_doc("HD Ticket", hd_ticket_name)
+    pathfinder_log = frappe.new_doc("Pathfinder Log")
+    pathfinder_log.process_name = hd_ticket.custom_process
+    pathfinder_log.goal_description = hd_ticket.description
+    pathfinder_log.hd_ticket = hd_ticket.name
+    pathfinder_log.save(ignore_permissions=True)
+    return pathfinder_log.name

--- a/one_fm/public/js/doctype_js/hd_ticket.js
+++ b/one_fm/public/js/doctype_js/hd_ticket.js
@@ -2,8 +2,41 @@ frappe.ui.form.on("HD Ticket", {
   refresh: function (frm) {
     add_dev_ticket_button(frm);
     add_github_issue_button(frm);
+    add_pathfinder_log_button(frm);
   },
 });
+
+const add_pathfinder_log_button = (frm) => {
+  if (
+    frm.doc.ticket_type === "Feature Request" &&
+    frappe.user.has_role("Business Analyst")
+  ) {
+    frm.add_custom_button(
+      "Create Pathfinder Log",
+      () => {
+        frappe.call({
+          method: "one_fm.overrides.hd_ticket.create_pathfinder_log",
+          args: {
+            hd_ticket_name: frm.doc.name,
+          },
+          callback: function (r) {
+            if (r.message) {
+              frappe.msgprint({
+                message: __(
+                  "Pathfinder Log <a href='/app/pathfinder-log/{0}'>{0}</a> created"
+                ).format([r.message]),
+                title: __("Pathfinder Log Created"),
+                indicator: "green",
+              });
+              frm.reload_doc();
+            }
+          },
+        });
+      },
+      "Create"
+    );
+  }
+};
 
 const add_github_issue_button = (frm) => {
   if (frm.doc.ticket_type == "Bug") {


### PR DESCRIPTION
Adds a custom button to the 'HD Ticket' form that allows users with the 'Business Analyst' role to create a 'Pathfinder Log' from a 'Feature Request' ticket.

- The button is only visible on 'Feature Request' tickets for 'Business Analyst' users.
- A server-side check prevents the creation of duplicate logs.
- The 'process_name', 'goal_description', and 'hd_ticket' fields are mapped from the HD Ticket.
- If a log already exists, a link to the existing log is displayed.