### PR TITLE
feat: contracts label change

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.json
+++ b/one_fm/operations/doctype/contracts/contracts.json
@@ -462,7 +462,7 @@
   {
    "fieldname": "contract_termination_decision_period",
    "fieldtype": "Int",
-   "label": "Contract Termination Decision Period (Months)"
+   "label": "Contract Termination Decision Period (# of Months from Contract End Date)"
   },
   {
    "fieldname": "contract_termination_decision_period_date",
@@ -473,7 +473,7 @@
   {
    "fieldname": "contract_end_internal_notification",
    "fieldtype": "Int",
-   "label": "Contract End Internal Notification (Months)"
+   "label": "Contract End Internal Notification (# of Months from Contract Termination Decision Period Date)"
   },
   {
    "fieldname": "contract_end_internal_notification_date",
@@ -483,7 +483,7 @@
   }
  ],
  "links": [],
- "modified": "2023-05-28 09:50:41.365007",
+ "modified": "2025-10-20 22:49:46.777613",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contracts",
@@ -504,6 +504,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
This pull request updates the `Contracts` doctype configuration to clarify field labels related to contract termination and notification periods, and introduces a new row formatting option. The changes are primarily focused on improving the clarity and usability of contract-related fields.

Field label clarifications:

* Updated the label for `contract_termination_decision_period` to specify that the value represents the number of months from the contract end date.
* Updated the label for `contract_end_internal_notification` to specify that the value represents the number of months from the contract termination decision period date.

Configuration and formatting updates:

* Added `"row_format": "Dynamic"` to enable dynamic row formatting for the doctype.
* Updated the `modified` timestamp to reflect the latest changes.