### PR TITLE
refactor: Career History - Activity Type label change

### DIFF
--- a/one_fm/templates/pages/career_history.js
+++ b/one_fm/templates/pages/career_history.js
@@ -863,7 +863,7 @@ career_history = Class.extend({
       const learningJourneyItem = `
         <div class="learning-journey-item mb-3" data-item-index="${currentItemCount + 1}">
           <div class="mb-3">
-            <label class="form-label">Activity type</label>
+            <label class="form-label">Select the  Learning Activity you have been engaged in</label>
             <select class="form-control activity_type_select_${company_no}_${currentItemCount + 1}">
               <option value="" selected disabled>None</option>
               ${activityTypes.map(type => `<option value="${type.name}">${type.name}</option>`).join('')}

--- a/one_fm/templates/pages/career_history.js
+++ b/one_fm/templates/pages/career_history.js
@@ -863,7 +863,7 @@ career_history = Class.extend({
       const learningJourneyItem = `
         <div class="learning-journey-item mb-3" data-item-index="${currentItemCount + 1}">
           <div class="mb-3">
-            <label class="form-label">Select the  Learning Activity you have been engaged in</label>
+            <label class="form-label">Select the Learning Activity you have been engaged in</label>
             <select class="form-control activity_type_select_${company_no}_${currentItemCount + 1}">
               <option value="" selected disabled>None</option>
               ${activityTypes.map(type => `<option value="${type.name}">${type.name}</option>`).join('')}


### PR DESCRIPTION
This pull request makes a small user interface improvement to the career history page. The label for the activity type selection has been updated to provide clearer instructions to users.

* Updated the label for the activity type dropdown to "Select the Learning Activity you have been engaged in" for improved clarity in the learning journey section of `career_history.js`.