### PR TITLE
fix: create pathfinder log

### DIFF
--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -7,12 +7,13 @@
  "field_order": [
   "section_break_wx0s",
   "process_name",
-  "goal_description",
   "hd_ticket",
+  "status",
   "column_break_ojgt",
   "initiated_on",
   "type",
-  "status",
+  "section_break_pzty",
+  "goal_description",
   "stakeholders_section",
   "process_owner_user",
   "process_owner_name",
@@ -41,7 +42,7 @@
   {
    "description": "A brief description of what this update is meant to achieve.",
    "fieldname": "goal_description",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "in_list_view": 1,
    "label": "Goal Description",
    "reqd": 1
@@ -133,12 +134,16 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "section_break_pzty",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-14 10:26:35.486082",
+ "modified": "2025-10-21 08:45:01.190813",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Pathfinder Log",

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -550,5 +550,6 @@ def create_pathfinder_log(hd_ticket_name):
     pathfinder_log.process_name = hd_ticket.custom_process
     pathfinder_log.goal_description = hd_ticket.description
     pathfinder_log.hd_ticket = hd_ticket.name
+    pathfinder_log.flags.ignore_mandatory = True
     pathfinder_log.save(ignore_permissions=True)
     return pathfinder_log.name

--- a/one_fm/public/js/doctype_js/hd_ticket.js
+++ b/one_fm/public/js/doctype_js/hd_ticket.js
@@ -24,7 +24,7 @@ const add_pathfinder_log_button = (frm) => {
               frappe.msgprint({
                 message: __(
                   "Pathfinder Log <a href='/app/pathfinder-log/{0}'>{0}</a> created"
-                ).format([r.message]),
+                , [r.message]),
                 title: __("Pathfinder Log Created"),
                 indicator: "green",
               });


### PR DESCRIPTION
This pull request updates the `Pathfinder Log` doctype and related logic to improve the user experience and data structure. The most important changes include reordering fields for better logical grouping, enhancing the `goal_description` field, and ensuring smoother creation of logs from HD Tickets.

**Improvements to `Pathfinder Log` doctype structure:**

* Reordered the `field_order` in `pathfinder_log.json` to group related fields together and introduced a new `section_break_pzty` for better form organization. (`[one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.jsonL10-R16](diffhunk://#diff-d2dc8b183d09214d68c0b6be744568e4bd8e99652a5b24a7097378f4c2662ecfL10-R16)`)
* Changed the `goal_description` field type from `Small Text` to `Text Editor` to allow richer input. (`[one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.jsonL44-R45](diffhunk://#diff-d2dc8b183d09214d68c0b6be744568e4bd8e99652a5b24a7097378f4c2662ecfL44-R45)`)
* Added a new section break field definition (`section_break_pzty`) to the fields list for improved layout. (`[one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.jsonR137-R146](diffhunk://#diff-d2dc8b183d09214d68c0b6be744568e4bd8e99652a5b24a7097378f4c2662ecfR137-R146)`)

**Enhancements to log creation and user feedback:**

* Set `ignore_mandatory` flag when creating a `Pathfinder Log` from an HD Ticket to prevent validation errors during automated creation. (`[one_fm/overrides/hd_ticket.pyR553](diffhunk://#diff-10c365a1e78f38ce8af072690f76c85b7b10b61577d0d9d848f604f231f096a0R553)`)
* Fixed a bug in the JavaScript notification for Pathfinder Log creation, ensuring the log link is rendered correctly in the message. (`[one_fm/public/js/doctype_js/hd_ticket.jsL27-R27](diffhunk://#diff-6ce901e9a4990cd600c774568920108516da63b8a5891383560c2a7fa4903dbdL27-R27)`)