### PR TITLE
fix: leave handover

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.js
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.js
@@ -8,8 +8,9 @@ frappe.ui.form.on("Leave Handover", {
 				frappe.confirm(
 					__("You are about to replace the reliever with the Leave Applicant in each of the documents referenced in the table. Do you want to proceed?"),
 					() => {
-						frm.call({
+						frappe.call({
 							method: "revert_handover",
+							doc: frm.doc,
 							callback: function(r) {
 								if (!r.exc) {
 									frm.reload_doc();
@@ -34,39 +35,12 @@ frappe.ui.form.on("Leave Handover", {
 			});
 
 			const message = __("Found {0}. Proceed to set the relievers", [message_parts.join(", ")]);
-			frm.dashboard.set_headline(message);
+			frappe.show_alert({ message: message, indicator: "green" });
 		}
 	},
 	before_submit(frm) {
-		if (frm.doc.__islocal) {
-			return;
-		}
 		if (frm.doc.employee_user_id !== frappe.session.user) {
 			frappe.throw(__("You are not authorized to submit this Leave Handover."));
 		}
-		frappe.confirm(
-			__("You are about to replace the Employee with the Reliever in each of the documents referenced in the table. Do you want to proceed?"),
-			() => {
-				frm.page.btn_primary.prop('disabled', true);
-				frappe.call({
-					method: 'frappe.desk.form.save.submit',
-					args: {
-						doc: frm.doc
-					},
-					callback: function(r) {
-						if(!r.exc) {
-							frm.reload_doc();
-						}
-					},
-					error: function(r) {
-						frm.page.btn_primary.prop('disabled', false);
-					}
-				});
-			},
-			() => {
-				frappe.msgprint(__("Submission cancelled."));
-			}
-		);
-		return false; // Prevent default submission
 	}
 });

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -75,7 +75,7 @@ class LeaveHandover(Document):
 
 			# Get the user document and their current roles
 			reliever_user = frappe.get_doc("User", reliever_user_id)
-			user_roles = reliever_user.get_roles()
+			user_roles = frappe.get_roles(reliever_user_id)
 
 			newly_assigned_roles = []
 
@@ -154,7 +154,7 @@ def get_user_roles_for_doctype(user, doctype):
     # List of permission fields in DocPerm
     perm_fields = [
         "read", "write", "create", "delete", "submit", "cancel", "amend",
-        "report", "import", "export", "print", "email", "share", "set_user_permissions"
+        "report", "import", "export", "print", "email", "share"
     ]
     # Create a list of OR filters to check if any permission is granted
     or_filters = [[field, "=", 1] for field in perm_fields]


### PR DESCRIPTION
This pull request includes several improvements and cleanups to the Leave Handover feature, focusing on user experience, permission logic, and code consistency. The most important changes are grouped below:

**User Interface and Experience:**

* Changed the dashboard headline to use `frappe.show_alert` for a more prominent and user-friendly notification when relievers are found.
* Updated the confirmation dialog for reverting handover to use `frappe.call` instead of `frm.call`, and explicitly passed the document in the call for better clarity and consistency.
* Removed the custom confirmation and submission logic from the `before_submit` handler, simplifying the process and relying on standard submission flow.

**Backend Logic and Permissions:**

* Standardized retrieval of user roles by switching from `get_roles()` method on the user document to the global `frappe.get_roles()` function, ensuring consistent role fetching.
* Cleaned up the permissions check by removing the `set_user_permissions` field from the list of permission fields considered in `get_user_roles_for_doctype`, aligning with intended permission checks.