### PR TITLE
fix: confirmation on submit leave handover

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.js
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.js
@@ -21,6 +21,7 @@ frappe.ui.form.on("Leave Handover", {
 				);
 			}).addClass("btn-primary");
 		}
+		set_submit_button(frm);
 	},
 	after_save(frm) {
 		frm.dashboard.clear_headline();
@@ -44,3 +45,20 @@ frappe.ui.form.on("Leave Handover", {
 		}
 	}
 });
+
+function set_submit_button(frm) {
+	if (frm.doc.docstatus === 0 && !frm.is_new()) {
+		frm.page.clear_primary_action();
+		frm.page.set_primary_action(__('Submit'), function() {
+			frappe.confirm(
+				__("You are about to replace the Employee with the Reliever in each of the documents referenced in the table. Do you want to proceed?"),
+				function() {
+					frm.save('Submit'); // proceed
+				},
+				function() {
+					frappe.msgprint(__('Submission cancelled'));
+				}
+			);
+		});
+	}
+}


### PR DESCRIPTION
This pull request updates the `Leave Handover` client-side logic to improve the submission workflow. The main change is the introduction of a custom submit button with a confirmation dialog, ensuring users are aware of the impact of their action before proceeding.

**User experience improvements:**

* Added a new `set_submit_button` function to display a custom "Submit" button when the document is in draft state and not new, prompting users with a confirmation dialog before replacing the Employee with the Reliever in referenced documents.
* Integrated the `set_submit_button` function into the form's `refresh` event to ensure the custom button is shown at the appropriate time.