### PR TITLE
fix: the create document label

### DIFF
--- a/one_fm/public/js/doctype_js/hd_ticket.js
+++ b/one_fm/public/js/doctype_js/hd_ticket.js
@@ -12,7 +12,7 @@ const add_pathfinder_log_button = (frm) => {
     frappe.user.has_role("Business Analyst")
   ) {
     frm.add_custom_button(
-      "Create Pathfinder Log",
+      "Pathfinder Log",
       () => {
         frappe.call({
           method: "one_fm.overrides.hd_ticket.create_pathfinder_log",

--- a/one_fm/public/js/doctype_js/leave_application.js
+++ b/one_fm/public/js/doctype_js/leave_application.js
@@ -110,7 +110,7 @@ frappe.ui.form.on("Leave Application", {
         manage_leave_extension(frm)
 
 		if (frm.doc.status == 'Approved') {
-			frm.add_custom_button(__('Create Leave Handover'), function() {
+			frm.add_custom_button(__('Leave Handover'), function() {
 				frappe.call({
 					method: 'one_fm.one_fm.doctype.leave_handover.leave_handover.get_handover_data',
 					args: {


### PR DESCRIPTION
This pull request makes minor UI improvements by updating the labels of custom buttons in two forms to be more concise and user-friendly.

- UI Improvements:
  * Changed the custom button label from "Create Pathfinder Log" to "Pathfinder Log" in the `hd_ticket.js` file.
  * Changed the custom button label from "Create Leave Handover" to "Leave Handover" in the `leave_application.js` file.