### PR TITLE
Prevent Creation of POC Check for non external project

### DIFF
--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -76,13 +76,11 @@ class MOM(Document):
 
 				
 			
-	def on_submit(self):
-		if self.project_type=="External":
-			self.create_poc_check()
-		
+	def on_submit(self):	
 		if self.project_type != "External":
 			self.create_task_and_assign()
 		else:
+			self.create_poc_check()
 			if self.issues == "Yes":
 				self.create_task_and_assign()
 	

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -33,6 +33,7 @@ class MOM(Document):
 		"""
 			Create a POC Check if all the rows in the attendees table in a MOM record are not checked as attended
 		"""	
+		
 		table_checks  = [int(i.attended_meeting) for i in self.attendees]
 		if not any(table_checks):
 		#Create POC Check if no row in the POC table is marked
@@ -76,7 +77,8 @@ class MOM(Document):
 				
 			
 	def on_submit(self):
-		self.create_poc_check()
+		if self.project_type=="External":
+			self.create_poc_check()
 		project_type = frappe.db.get_value("Project", self.project, "project_type")
 		if project_type != "External":
 			self.create_task_and_assign()

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -79,8 +79,8 @@ class MOM(Document):
 	def on_submit(self):
 		if self.project_type=="External":
 			self.create_poc_check()
-		project_type = frappe.db.get_value("Project", self.project, "project_type")
-		if project_type != "External":
+		
+		if self.project_type != "External":
 			self.create_task_and_assign()
 		else:
 			if self.issues == "Yes":


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
Ensure that a POC Check is only created for external projects
## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Ensure that a POC Check is only created for external projects
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
MOM

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
Yes, POC CHECK WILL NOT BE CREATED FOR INTERNAL PROJECTS

## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created? NO
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
