### PR TITLE
fix: update production fixes to test-production

### DIFF
--- a/one_fm/custom/property_setter/purchase_order.py
+++ b/one_fm/custom/property_setter/purchase_order.py
@@ -10,7 +10,7 @@ def get_purchase_order_properties():
         {
             "property": "default_print_format",
             "property_type": "Data",
-            "value": "Purchase Order Format",
+            "value": "Purchase Order",
             "doc_type": "Purchase Order",
             "doctype_or_field": "DocType"
         },

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -76,13 +76,11 @@ class MOM(Document):
 
 				
 			
-	def on_submit(self):
-		if self.project_type=="External":
-			self.create_poc_check()
-		
+	def on_submit(self):	
 		if self.project_type != "External":
 			self.create_task_and_assign()
 		else:
+			self.create_poc_check()
 			if self.issues == "Yes":
 				self.create_task_and_assign()
 	

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -33,6 +33,7 @@ class MOM(Document):
 		"""
 			Create a POC Check if all the rows in the attendees table in a MOM record are not checked as attended
 		"""	
+		
 		table_checks  = [int(i.attended_meeting) for i in self.attendees]
 		if not any(table_checks):
 		#Create POC Check if no row in the POC table is marked
@@ -76,7 +77,8 @@ class MOM(Document):
 				
 			
 	def on_submit(self):
-		self.create_poc_check()
+		if self.project_type=="External":
+			self.create_poc_check()
 		project_type = frappe.db.get_value("Project", self.project, "project_type")
 		if project_type != "External":
 			self.create_task_and_assign()

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -79,8 +79,8 @@ class MOM(Document):
 	def on_submit(self):
 		if self.project_type=="External":
 			self.create_poc_check()
-		project_type = frappe.db.get_value("Project", self.project, "project_type")
-		if project_type != "External":
+		
+		if self.project_type != "External":
 			self.create_task_and_assign()
 		else:
 			if self.issues == "Yes":

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -179,7 +179,7 @@ one_fm.patches.v15_0.update_timesheet_records
 one_fm.patches.v15_0.update_item_workflow_state
 one_fm.patches.v15_0.update_project_details
 one_fm.patches.v15_0.update_rfp_records
-one_fm.patches.v15_0.update_purchase_order_property_setter #20
+one_fm.patches.v15_0.update_purchase_order_property_setter
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_assign_rfp_to_purchase_officer

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -179,6 +179,7 @@ one_fm.patches.v15_0.update_timesheet_records
 one_fm.patches.v15_0.update_item_workflow_state
 one_fm.patches.v15_0.update_project_details
 one_fm.patches.v15_0.update_rfp_records
+one_fm.patches.v15_0.update_purchase_order_property_setter #20
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_assign_rfp_to_purchase_officer

--- a/one_fm/patches/v15_0/update_purchase_order_property_setter.py
+++ b/one_fm/patches/v15_0/update_purchase_order_property_setter.py
@@ -1,0 +1,5 @@
+from one_fm.custom.property_setter.purchase_order import get_purchase_order_properties
+from one_fm.setup.setup import add_property_setter
+
+def execute():
+    add_property_setter(get_purchase_order_properties())

--- a/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
+++ b/one_fm/purchase/doctype/request_for_material_item/request_for_material_item.json
@@ -20,6 +20,8 @@
   "reserve_qty",
   "from_date",
   "to_date",
+  "is_fixed_asset",
+  "maintain_stock",
   "section_break_4",
   "requested_description",
   "description",
@@ -440,6 +442,22 @@
    "fieldname": "to_date",
    "fieldtype": "Date",
    "label": "To Date",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fetch_from": "item_code.is_fixed_asset",
+   "fieldname": "is_fixed_asset",
+   "fieldtype": "Check",
+   "label": "Is Fixed Asset",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fetch_from": "item_code.is_stock_item",
+   "fieldname": "maintain_stock",
+   "fieldtype": "Check",
+   "label": "Maintain Stock",
    "read_only": 1
   },
   {


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to purchase order property settings, project MOM task assignment logic, and enhancements to the Request for Material Item doctype. The most notable changes include updating the default print format for purchase orders, refining the logic for creating tasks and checks on MOM submission, and adding new fields to better track item properties in material requests.

**Purchase Order Property Updates:**

* Changed the default print format for `Purchase Order` by updating the `default_print_format` property value from `"Purchase Order Format"` to `"Purchase Order"`.
* Added a new patch script `update_purchase_order_property_setter.py` and registered it in `patches.txt` to ensure the property setter update is applied during migrations. [[1]](diffhunk://#diff-c2d559187715a0f03e9bea5fa8eb8e9347548cd3716a71c75d63b7dbaae4d639R1-R5) [[2]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R181)

**Project MOM Logic Improvements:**

* Refined the `on_submit` method in the `MOM` doctype so that `create_poc_check()` is only called for non-external projects or when issues are present, improving task and check creation logic.
* Minor code formatting/cleanup in the `create_poc_check` method.

**Request for Material Item Enhancements:**

* Added two new read-only checkbox fields, `is_fixed_asset` and `maintain_stock`, to the `Request for Material Item` doctype, automatically fetching values from the linked item code. [[1]](diffhunk://#diff-d858d9043077627c08eb3bcdee3462c552431b4238ac45ace981074f71e21491R23-R24) [[2]](diffhunk://#diff-d858d9043077627c08eb3bcdee3462c552431b4238ac45ace981074f71e21491R447-R462)