### PR TITLE
feat: employee residency expiry date

### DIFF
--- a/one_fm/one_fm/custom/employee.json
+++ b/one_fm/one_fm/custom/employee.json
@@ -4699,7 +4699,7 @@
    "columns": 0,
    "creation": "2021-04-18 13:24:39.253044",
    "default": null,
-   "depends_on": "eval:doc.under_company_residency==1",
+   "depends_on": "eval:doc.under_company_residency==1 && doc.pam_type != 'Kuwaiti'",
    "description": null,
    "docstatus": 0,
    "dt": "Employee",

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -26,6 +26,9 @@ class EmployeeOverride(EmployeeMaster):
         from erpnext.controllers.status_updater import validate_status
         validate_status(self.status, ["Active", "Court Case", "Absconding", "Left","Vacation"])
 
+        if self.pam_type == "Kuwaiti":
+		self.residency_expiry_date = None
+
         self.employee = self.name
         self.set_employee_name()
         set_employee_name(self, method=None)

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -27,7 +27,7 @@ class EmployeeOverride(EmployeeMaster):
         validate_status(self.status, ["Active", "Court Case", "Absconding", "Left","Vacation"])
 
         if self.pam_type == "Kuwaiti":
-		self.residency_expiry_date = None
+            self.residency_expiry_date = None
 
         self.employee = self.name
         self.set_employee_name()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -194,3 +194,5 @@ one_fm.patches.v15_0.update_job_applicant_field
 one_fm.patches.v15_0.create_compliance_checker_process_task
 one_fm.patches.v15_0.update_preparation_records
 one_fm.patches.v15_0.update_hr_settings_with_grd_settings #2025-10-07
+one_fm.patches.v15_0.clear_residency_expiry_date
+one_fm.patches.v15_0.update_residency_expiry_date_depends_on

--- a/one_fm/patches/v15_0/clear_residency_expiry_date.py
+++ b/one_fm/patches/v15_0/clear_residency_expiry_date.py
@@ -1,0 +1,8 @@
+import frappe
+
+def execute():
+    frappe.db.sql("""
+        UPDATE `tabEmployee`
+        SET `residency_expiry_date` = NULL
+        WHERE `pam_type` = 'Kuwaiti'
+    """)

--- a/one_fm/patches/v15_0/update_residency_expiry_date_depends_on.py
+++ b/one_fm/patches/v15_0/update_residency_expiry_date_depends_on.py
@@ -1,0 +1,6 @@
+import frappe
+
+def execute():
+    custom_field = frappe.get_doc('Custom Field', 'Employee-residency_expiry_date')
+    custom_field.depends_on = 'eval:doc.under_company_residency==1 and doc.pam_type != "Kuwaiti"'
+    custom_field.save()

--- a/one_fm/patches/v15_0/update_residency_expiry_date_depends_on.py
+++ b/one_fm/patches/v15_0/update_residency_expiry_date_depends_on.py
@@ -2,5 +2,5 @@ import frappe
 
 def execute():
     custom_field = frappe.get_doc('Custom Field', 'Employee-residency_expiry_date')
-    custom_field.depends_on = 'eval:doc.under_company_residency==1 and doc.pam_type != "Kuwaiti"'
+    custom_field.depends_on = 'eval:doc.under_company_residency==1 && doc.pam_type != "Kuwaiti"'
     custom_field.save()

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -33,7 +33,6 @@ frappe.ui.form.on('Employee', {
                 }
             };
         });
-		frm.trigger("pam_type");
 	},
 	pam_type: function(frm) {
 		if (frm.doc.pam_type === 'Kuwaiti') {

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -33,6 +33,12 @@ frappe.ui.form.on('Employee', {
                 }
             };
         });
+		frm.trigger("pam_type");
+	},
+	pam_type: function(frm) {
+		if (frm.doc.pam_type === 'Kuwaiti') {
+			frm.set_value('residency_expiry_date', null);
+		}
 	},
 	one_fm_provide_accommodation_by_company: function(frm){
 		set_current_address(frm);


### PR DESCRIPTION
This pull request updates the handling of the `residency_expiry_date` field for employees with the `pam_type` set to "Kuwaiti". The main goal is to ensure that this field is cleared and hidden for Kuwaiti employees, both in the backend and frontend, and to update existing records accordingly. The changes include backend validation, UI logic, database patches, and updates to custom field dependencies.

**Backend logic and data integrity:**

* In `one_fm/overrides/employee.py`, the `validate` method now clears the `residency_expiry_date` field whenever an employee's `pam_type` is "Kuwaiti", ensuring data integrity at the model level.
* Added a patch script `clear_residency_expiry_date.py` to set `residency_expiry_date` to NULL for all existing Kuwaiti employees in the database.

**Frontend and field visibility:**

* In `one_fm/public/js/doctype_js/employee.js`, added logic to automatically clear the `residency_expiry_date` field in the UI when the `pam_type` is set to "Kuwaiti".
* Updated the `depends_on` property of the `residency_expiry_date` custom field (in both the JSON and via a patch script) so the field is only shown when `under_company_residency` is true and `pam_type` is not "Kuwaiti". [[1]](diffhunk://#diff-bf6ce1e3e680d51a589f25b5830bb23d507791e77f25e84465de1cf2e58849bbL4702-R4702) [[2]](diffhunk://#diff-a22f255cb0c79df2c52c7d9ed0d10b892073b41f5378ec0df995ca2ddf0c258fR1-R6)

**Database migration and patch registration:**

* Registered two new patch scripts in `one_fm/patches.txt` to ensure the above changes are applied to existing data and field configurations during deployment.