### PR TITLE
feat: Change medical insurance validation message

### DIFF
--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.py
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.py
@@ -50,7 +50,7 @@ class MedicalInsurance(Document):
 
 
     def set_depend_on_fields(self):
-        if self.upload_medical_insurance == None:
+        if self.upload_medical_insurance is None:
             frappe.throw(_('You need to upload the Medical Insurance document before you can mark this record as “Done”.'))
 
 

--- a/one_fm/grd/doctype/medical_insurance/medical_insurance.py
+++ b/one_fm/grd/doctype/medical_insurance/medical_insurance.py
@@ -51,7 +51,7 @@ class MedicalInsurance(Document):
 
     def set_depend_on_fields(self):
         if self.upload_medical_insurance == None:
-            frappe.throw(_('Upload Medical Insurance Is Required To Submit'))
+            frappe.throw(_('You need to upload the Medical Insurance document before you can mark this record as “Done”.'))
 
 
 def valid_work_permit_exists(preparation_name):


### PR DESCRIPTION
Changed the validation message in the Medical Insurance doctype from "Upload Medical Insurance Is Required To Submit" to "You need to upload the Medical Insurance document before you can mark this record as “Done”."