### PR TITLE
FEAT OFP-354 feat: Update Purchase Tracker with Company Currency Column

### DIFF
--- a/one_fm/purchase/report/purchase_tracker/purchase_tracker.js
+++ b/one_fm/purchase/report/purchase_tracker/purchase_tracker.js
@@ -2,77 +2,77 @@
 // For license information, please see license.txt
 
 frappe.query_reports["Purchase Tracker"] = {
-		"filters": [
-	{
-	"fieldname": "from_date",
-	"fieldtype": "Date",
-	"label": "From Date",
-	"mandatory": 0,
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "to_date",
-	"fieldtype": "Date",
-	"label": "To Date",
-	"mandatory": 0,
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "rfp_no",
-	"fieldtype": "Link",
-	"label": "RFP No",
-	"mandatory": 0,
-	"options": "Request for Purchase",
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "rfp_type",
-	"fieldtype": "Select",
-	"label": "Type",
-	"mandatory": 0,
-	"options": "\nIndividual\nStock\nProject\nDepartment\nOnboarding",
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "project",
-	"fieldtype": "Link",
-	"label": "Project",
-	"mandatory": 0,
-	"options": "Project",
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "site",
-	"fieldtype": "Link",
-	"label": "Site",
-	"mandatory": 0,
-	"options": "Operations Site",
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "employee_id",
-	"fieldtype": "Link",
-	"label": "Employee ID",
-	"mandatory": 0,
-	"options": "Employee",
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "department",
-	"fieldtype": "Link",
-	"label": "Department",
-	"mandatory": 0,
-	"options": "Department",
-	"wildcard_filter": 0
-	},
-	{
-	"fieldname": "erf_no",
-	"fieldtype": "Link",
-	"label": "ERF No",
-	"mandatory": 0,
-	"options": "ERF",
-	"wildcard_filter": 0
-	}
+"filters": [
+ {
+"fieldname": "from_date",
+"fieldtype": "Date",
+"label": "From Date",
+"mandatory": 0,
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "to_date",
+"fieldtype": "Date",
+"label": "To Date",
+"mandatory": 0,
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "rfp_no",
+"fieldtype": "Link",
+"label": "RFP No",
+"mandatory": 0,
+"options": "Request for Purchase",
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "rfp_type",
+"fieldtype": "Select",
+"label": "Type",
+"mandatory": 0,
+"options": "\nIndividual\nStock\nProject\nDepartment\nOnboarding",
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "project",
+"fieldtype": "Link",
+"label": "Project",
+"mandatory": 0,
+"options": "Project",
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "site",
+"fieldtype": "Link",
+"label": "Site",
+"mandatory": 0,
+"options": "Operations Site",
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "employee_id",
+"fieldtype": "Link",
+"label": "Employee ID",
+"mandatory": 0,
+"options": "Employee",
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "department",
+"fieldtype": "Link",
+"label": "Department",
+"mandatory": 0,
+"options": "Department",
+"wildcard_filter": 0
+ },
+ {
+"fieldname": "erf_no",
+"fieldtype": "Link",
+"label": "ERF No",
+"mandatory": 0,
+"options": "ERF",
+"wildcard_filter": 0
+ }
 ],
 "formatter": function(value, row, column, data, default_formatter) {
 if (column.fieldname === "purchase_order" && value) {
@@ -89,4 +89,4 @@ return html;
 }
 return default_formatter(value, row, column, data);
 }
-	};
+ };

--- a/one_fm/purchase/report/purchase_tracker/purchase_tracker.py
+++ b/one_fm/purchase/report/purchase_tracker/purchase_tracker.py
@@ -148,6 +148,7 @@ def get_columns(filters=None):
         {"label": "RFP Amount", "fieldname": "rfp_amount", "fieldtype": "Currency", "options": "currency", "width": 110},
         {"label": "RFP Amount (Company Currency)", "fieldname": "rfp_amount_company_currency", "fieldtype": "Currency", "width": 110},
         {"label": "Purchase Order", "fieldname": "purchase_order", "fieldtype": "Data", "width": 160},
+        # NOTE: This hidden 'currency' column is required because the 'options' attribute of the 'RFP Amount' column depends on the presence of the 'currency' field.
         {"label": "Currency", "fieldname": "currency", "fieldtype": "Data", "hidden": 1},
     ]
 

--- a/one_fm/purchase/report/purchase_tracker/purchase_tracker.py
+++ b/one_fm/purchase/report/purchase_tracker/purchase_tracker.py
@@ -3,10 +3,9 @@
 
 import frappe
 
-
 def get_data(filters):
     filters = filters or {}
-    conditions = ["rfp.docstatus = 1"]  # only submitted RFP
+    conditions = ["rfp.docstatus = 1"] # only submitted RFP
     params = {}
 
     # Date range on creation
@@ -47,6 +46,7 @@ def get_data(filters):
             rfp.name AS rfp_no,
             DATE(rfp.creation) AS rfp_date,
             rfp.type AS type,
+            rfp.currency,
             rfp.employee AS employee_id,
             rfp.employee_name AS employee_name,
             rfp.department AS department,
@@ -57,7 +57,8 @@ def get_data(filters):
             item.qty AS qty,
             item.uom AS uom,
             item.supplier AS supplier,
-            (item.rate * item.qty) AS rfp_amount
+            (item.rate * item.qty) AS rfp_amount,
+            item.base_amount AS rfp_amount_company_currency
         FROM `tabRequest for Purchase` rfp
         INNER JOIN `tabRequest for Purchase Quotation Item` item ON item.parent = rfp.name
         LEFT JOIN `tabRequest for Material` rfm ON rfm.name = rfp.request_for_material
@@ -99,7 +100,6 @@ def get_data(filters):
         r["purchase_order"] = ", ".join(sorted(po_map.get(key, []))) if po_map.get(key) else ""
 
     return rows
-
 
 def get_columns(filters=None):
     filters = filters or {}
@@ -145,13 +145,14 @@ def get_columns(filters=None):
         {"label": "Quantity", "fieldname": "qty", "fieldtype": "Float", "width": 90},
         {"label": "UoM", "fieldname": "uom", "fieldtype": "Link", "options": "UOM", "width": 70},
         {"label": "Supplier", "fieldname": "supplier", "fieldtype": "Link", "options": "Supplier", "width": 140},
-        {"label": "RFP Amount", "fieldname": "rfp_amount", "fieldtype": "Currency", "width": 110},
+        {"label": "RFP Amount", "fieldname": "rfp_amount", "fieldtype": "Currency", "options": "currency", "width": 110},
+        {"label": "RFP Amount (Company Currency)", "fieldname": "rfp_amount_company_currency", "fieldtype": "Currency", "width": 110},
         {"label": "Purchase Order", "fieldname": "purchase_order", "fieldtype": "Data", "width": 160},
+        {"label": "Currency", "fieldname": "currency", "fieldtype": "Data", "hidden": 1},
     ]
 
     columns.extend(tail_columns)
     return columns
-
 
 def execute(filters=None):
     columns = get_columns(filters or {})


### PR DESCRIPTION
This change updates the Purchase Tracker report to include a new column, "RFP Amount (Company Currency)," which displays the `base_amount` from the RFP item. It also ensures that the existing "RFP Amount" column dynamically shows the correct currency symbol based on the RFP document's currency.

## Is this a Feature, Chore or Bug?
- [*] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1365" height="357" alt="image" src="https://github.com/user-attachments/assets/e175c6b9-8b85-4cd8-8b57-bf3af90662ed" />


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
