### PR TITLE
chore: update employee name in handover

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.json
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:LH-{employee}-{###}",
  "creation": "2025-10-20 18:38:27.555256",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -98,10 +99,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-20 20:04:58.934733",
+ "modified": "2025-10-28 12:42:27.876029",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Leave Handover",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -53,8 +53,17 @@ class LeaveHandover(Document):
 			}.get(item.reference_doctype)
 
 			if field_to_update:
-				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, item.reliever)
-	
+				values_to_update = {field_to_update: item.reliever}
+				name_field_to_update = {
+					"Project": "manager_name",
+					"Operations Site": "account_supervisor_name",
+					"Process Task": "employee_name",
+				}.get(item.reference_doctype)
+
+				if name_field_to_update:
+					values_to_update[name_field_to_update] = item.reliever_name
+				frappe.db.set_value(item.reference_doctype, item.reference_docname, values_to_update)
+
 		self.db_set("status", "Transferred")
 
 	def assign_role_on_handover(self):
@@ -110,7 +119,17 @@ class LeaveHandover(Document):
 			}.get(item.reference_doctype)
 
 			if field_to_update:
-				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, self.employee)
+				values_to_update = {field_to_update: self.employee}
+				name_field_to_update = {
+					"Project": "manager_name",
+					"Operations Site": "account_supervisor_name",
+					"Process Task": "employee_name",
+				}.get(item.reference_doctype)
+
+				if name_field_to_update:
+					values_to_update[name_field_to_update] = self.employee_name
+
+				frappe.db.set_value(item.reference_doctype, item.reference_docname, values_to_update)
 				frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
 
 		self.revert_roles()


### PR DESCRIPTION
This pull request introduces improvements to the leave handover process in the One FM module, focusing on better data consistency and naming conventions. The most important changes are the enhancement of the handover and revert logic to update additional name fields in related documents, and the introduction of a more descriptive autonaming pattern for leave handover records.

**Leave Handover Logic Improvements:**

* The `handover` method in `leave_handover.py` now updates not only the reliever field but also related name fields (`manager_name`, `account_supervisor_name`, or `employee_name`) in the referenced documents, ensuring more complete data transfer during handover.
* The `revert_handover` method similarly updates both the main field and the corresponding name field when reverting a handover, maintaining data integrity when roles are restored.

**Naming and Configuration Updates:**

* The `leave_handover.json` configuration now includes an autonaming rule (`LH-{employee}-{###}`) for clearer and more consistent document identification.
* The naming rule for the `Leave Handover` DocType is set to "Expression" to support the new autonaming format.