### PR TITLE
fix: leave handover

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.json
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:LH-{employee}-{###}",
  "creation": "2025-10-20 18:38:27.555256",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -98,10 +99,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-20 20:04:58.934733",
+ "modified": "2025-10-28 12:42:27.876029",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Leave Handover",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -53,8 +53,17 @@ class LeaveHandover(Document):
 			}.get(item.reference_doctype)
 
 			if field_to_update:
-				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, item.reliever)
-	
+				values_to_update = {field_to_update: item.reliever}
+				name_field_to_update = {
+					"Project": "manager_name",
+					"Operations Site": "account_supervisor_name",
+					"Process Task": "employee_name",
+				}.get(item.reference_doctype)
+
+				if name_field_to_update:
+					values_to_update[name_field_to_update] = item.reliever_name
+				frappe.db.set_value(item.reference_doctype, item.reference_docname, values_to_update)
+
 		self.db_set("status", "Transferred")
 
 	def assign_role_on_handover(self):
@@ -110,7 +119,17 @@ class LeaveHandover(Document):
 			}.get(item.reference_doctype)
 
 			if field_to_update:
-				frappe.db.set_value(item.reference_doctype, item.reference_docname, field_to_update, self.employee)
+				values_to_update = {field_to_update: self.employee}
+				name_field_to_update = {
+					"Project": "manager_name",
+					"Operations Site": "account_supervisor_name",
+					"Process Task": "employee_name",
+				}.get(item.reference_doctype)
+
+				if name_field_to_update:
+					values_to_update[name_field_to_update] = self.employee_name
+
+				frappe.db.set_value(item.reference_doctype, item.reference_docname, values_to_update)
 				frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
 
 		self.revert_roles()


### PR DESCRIPTION
This pull request introduces improvements to the `Leave Handover` DocType and its related handover logic. The main changes focus on enhancing the naming convention for records and updating the handover and revert processes to handle multiple field updates more robustly.

**DocType configuration updates:**

* Added an `autoname` pattern (`LH-{employee}-{###}`) and set the `naming_rule` to `Expression` for the `Leave Handover` DocType, ensuring more descriptive and consistent record names. [[1]](diffhunk://#diff-7582324c1559e4b9ea584f13f96d0e463c53d52b25b030aa3debdec342576bbaR4) [[2]](diffhunk://#diff-7582324c1559e4b9ea584f13f96d0e463c53d52b25b030aa3debdec342576bbaL101-R106)

**Logic improvements in handover and revert processes:**

* Updated the `handover` and `revert_handover` methods in `leave_handover.py` to support updating both the reliever field and an additional name field (`manager_name`, `account_supervisor_name`, or `employee_name`) for specific doctypes in a single database call, improving data integrity and reducing code duplication. [[1]](diffhunk://#diff-1f312b7072e586be533f567aa7b55958e358cbc53772dca96dc2486cc35f2849L56-R65) [[2]](diffhunk://#diff-1f312b7072e586be533f567aa7b55958e358cbc53772dca96dc2486cc35f2849L113-R132)