### PR TITLE
feat: Leave handover

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.js
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.js
@@ -9,7 +9,10 @@ frappe.ui.form.on("Leave Handover", {
 					__("You are about to replace the reliever with the Leave Applicant in each of the documents referenced in the table. Do you want to proceed?"),
 					() => {
 						frappe.call({
-							method: "revert_handover",
+							method: "action_handover",
+							args: {
+								revert: true
+							},
 							doc: frm.doc,
 							callback: function(r) {
 								if (!r.exc) {

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.json
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.json
@@ -48,22 +48,25 @@
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "leave_application.from_date",
    "fieldname": "leave_start_date",
    "fieldtype": "Date",
    "label": "Leave Start Date",
    "read_only": 1
   },
   {
+   "fetch_from": "leave_application.resumption_date",
    "fieldname": "resumption_date",
    "fieldtype": "Date",
    "label": "Resumption Date",
    "read_only": 1
   },
   {
+   "default": "Draft",
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Pending\nTransferred\nReverted",
+   "options": "Draft\nSubmitted\nTransferred\nReverted",
    "read_only": 1
   },
   {
@@ -99,7 +102,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-28 12:42:27.876029",
+ "modified": "2025-11-03 13:40:35.348488",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Leave Handover",

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -5,14 +5,12 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 from collections import Counter
+from frappe.utils import today
 
 class LeaveHandover(Document):
 	def validate(self):
 		if not self.handover_items:
 			frappe.throw(_("No responsibilities found for {0}").format(self.employee_name))
-
-	def before_save(self):
-		self.status = "Pending"
 
 	def on_submit(self):
 		no_reliever_rows = []
@@ -37,13 +35,23 @@ class LeaveHandover(Document):
 				title=_("Not Accepted")
 			)
 
-		self.handover()
-		self.assign_role_on_handover()
+		self.db_set("status", "Submitted")
 
-	def handover(self):
-		if self.employee_user_id != frappe.session.user:
-			frappe.throw(_("You are not authorized to submit this Leave Handover."))
+		if self.leave_start_date == today():
+			self.action_handover(revert=False)
 
+	def action_handover(self, revert=False):
+		if revert and self.employee_user_id != frappe.session.user:
+			frappe.throw(_("You are not authorized to revert this Leave Handover."))
+		self.update_doc_assignment(revert=revert)
+		if not revert:
+			self.assign_role_on_handover()
+		else:
+			self.revert_roles_assignment()
+		status = "Reverted" if revert else "Transferred"
+		self.db_set("status", status)
+
+	def update_doc_assignment(self, revert=False):
 		for item in self.handover_items:
 			field_to_update = {
 				"Project": "account_manager",
@@ -53,7 +61,8 @@ class LeaveHandover(Document):
 			}.get(item.reference_doctype)
 
 			if field_to_update:
-				values_to_update = {field_to_update: item.reliever}
+				employee = item.reliever if not revert else self.employee
+				values_to_update = {field_to_update: employee}
 				name_field_to_update = {
 					"Project": "manager_name",
 					"Operations Site": "account_supervisor_name",
@@ -61,10 +70,10 @@ class LeaveHandover(Document):
 				}.get(item.reference_doctype)
 
 				if name_field_to_update:
-					values_to_update[name_field_to_update] = item.reliever_name
+					values_to_update[name_field_to_update] = item.reliever_name if not revert else self.employee_name
 				frappe.db.set_value(item.reference_doctype, item.reference_docname, values_to_update)
-
-		self.db_set("status", "Transferred")
+				if revert:
+					frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
 
 	def assign_role_on_handover(self):
 		for item in self.handover_items:
@@ -77,7 +86,7 @@ class LeaveHandover(Document):
 
 			# Define the roles based on the reference doctype
 			doctype_to_check = item.reference_doctype
-			if doctype_to_check not in ["Project","Operations Site","Process Task","Employee"]:
+			if doctype_to_check not in ["Project", "Operations Site", "Process Task", "Employee"]:
 				continue
 
 			roles_to_assign = get_user_roles_for_doctype(reliever_user_id, doctype_to_check)
@@ -105,37 +114,7 @@ class LeaveHandover(Document):
 					", ".join(newly_assigned_roles)
 				)
 
-	@frappe.whitelist()
-	def revert_handover(self):
-		if self.employee_user_id != frappe.session.user:
-			frappe.throw(_("You are not authorized to revert this Leave Handover."))
-
-		for item in self.handover_items:
-			field_to_update = {
-				"Project": "account_manager",
-				"Operations Site": "account_supervisor",
-				"Process Task": "employee",
-				"Employee": "reports_to",
-			}.get(item.reference_doctype)
-
-			if field_to_update:
-				values_to_update = {field_to_update: self.employee}
-				name_field_to_update = {
-					"Project": "manager_name",
-					"Operations Site": "account_supervisor_name",
-					"Process Task": "employee_name",
-				}.get(item.reference_doctype)
-
-				if name_field_to_update:
-					values_to_update[name_field_to_update] = self.employee_name
-
-				frappe.db.set_value(item.reference_doctype, item.reference_docname, values_to_update)
-				frappe.db.set_value("Handover Item", item.name, "status", "Reverted")
-
-		self.revert_roles()
-		self.db_set("status", "Reverted")
-
-	def revert_roles(self):
+	def revert_roles_assignment(self):
 		for item in self.handover_items:
 			if not item.reliever:
 				continue
@@ -250,3 +229,20 @@ def get_handover_data(leave_application):
 		"resumption_date": leave_application_doc.resumption_date,
 		"handover_items": handover_items,
 	}
+
+@frappe.whitelist()
+def reliever_assignment_on_leave_start(date=None):
+	if not date:
+		date = today()
+	leave_handovers = frappe.get_all(
+		"Leave Handover",
+		filters={
+			"leave_start_date": ["<=", date],
+			"resumption_date": [">", date],
+			"status": "Submitted"
+		},
+		fields=["name", "employee"]
+	)
+	for leave_handover in leave_handovers:
+		handover = frappe.get_doc("Leave Handover", leave_handover.name)
+		handover.action_handover()

--- a/one_fm/one_fm/doctype/reliever_assignment/reliever_assignment.py
+++ b/one_fm/one_fm/doctype/reliever_assignment/reliever_assignment.py
@@ -23,11 +23,7 @@ class RelieverAssignment(Document):
 		
 	def after_insert(self):
 		self.assign_roles()
-		self.assign_reportees()
 		self.assign_todos()
-		self.assign_projects()
-		self.assign_operations_site()
-		self.assign_process_tasks()
 		self.get_single_doctypes()
 		self.get_approval_doctypes()
 		
@@ -79,44 +75,6 @@ class RelieverAssignment(Document):
 			reliever_user.db_set("role_profile_name", None)
 
 		reliever_user.add_roles(roles_to_be_assigned)
-
-	def assign_process_tasks(self):
-		ProcessTask = DocType("Process Task")
-		process_tasks = (
-			frappe.qb.from_(ProcessTask)
-			.select(ProcessTask.name)
-			.where((ProcessTask.direct_report_reviewer == self.on_leave_employee))
-		).run(as_dict=True)
-
-
-		if len(process_tasks) > 0:
-			# Log data for reversal
-			self.add_assigned_documents("Process Task", "Docfield", process_tasks, fieldname="direct_report_reviewer")
-
-			frappe.qb.update(ProcessTask ).set(
-				ProcessTask.direct_report_reviewer, self.reliever).set(
-				ProcessTask.direct_report_reviewer_name, self.reliever_name).set(
-				ProcessTask.modified, now()).where(
-				ProcessTask.direct_report_reviewer == self.on_leave_employee
-			).run()
-
-	def assign_reportees(self):
-		Employee = DocType("Employee")
-		reportees = (
-			frappe.qb.from_(Employee)
-			.select(Employee.name)
-			.where(
-				(Employee.reports_to == self.on_leave_employee)
-				& (Employee.status == "Active"))
-		).run(as_dict=True)
-
-		if len(reportees) > 0:
-			# Log data for reversal
-			self.add_assigned_documents("Employee", "Docfield", reportees, fieldname="reports_to")
-
-			frappe.qb.update(Employee).set(Employee.reports_to, self.reliever).set(Employee.modified, now()).where(
-				Employee.reports_to == self.on_leave_employee).where(Employee.status == "Active").run()
-
 
 	def assign_todos(self):
 		ToDo = DocType("ToDo")
@@ -185,51 +143,6 @@ class RelieverAssignment(Document):
 						.where(ReferenceType[fieldname] == value_to_replace) \
 						.where(ReferenceType[status_field].isin(status_to_check)) \
 					.run()
-
-
-	def assign_projects(self):
-		Project = DocType("Project")
-		assigned_projects = (
-			frappe.qb.from_(Project)
-			.select(Project.name)
-			.where(
-				(Project.account_manager == self.on_leave_employee)
-				& (Project.status == "Open")
-			)
-		).run(as_dict=True)
-
-		if len(assigned_projects) > 0:
-			# Log data for reversal
-			self.add_assigned_documents("Project", "Docfield", assigned_projects, fieldname="account_manager")
-
-			frappe.qb.update(Project).set(
-				Project.account_manager, self.reliever).set(
-				Project.manager_name, self.reliever_name).set(
-				Project.modified, now()).where(
-				Project.account_manager == self.on_leave_employee).where(Project.status == "Open").run()
-
-
-	def assign_operations_site(self):
-		OperationsSite = DocType("Operations Site")
-		assigned_sites = (
-			frappe.qb.from_(OperationsSite)
-			.select(OperationsSite.name)
-			.where(
-				(OperationsSite.account_supervisor == self.on_leave_employee)
-				& (OperationsSite.status == "Active")
-			)
-		).run(as_dict=True)
-
-		if len(assigned_sites) > 0:
-			# Log data for reversal
-			self.add_assigned_documents("Operations Site", "Docfield", assigned_sites, fieldname="account_supervisor")
-
-			frappe.qb.update(OperationsSite).set(
-				OperationsSite.account_supervisor, self.reliever).set(
-				OperationsSite.account_supervisor_name, self.reliever_name).set(
-				OperationsSite.modified, now()).where(
-				OperationsSite.account_supervisor == self.on_leave_employee).where(OperationsSite.status == "Active").run()
-
 
 	def add_assigned_documents(self, reference_doctype, based_on, doclist, fieldname=None, reference_docname=None):
 		self.append("assigned_documents", {

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -188,6 +188,7 @@ one_fm.patches.v15_0.update_workflow_state_style
 one_fm.patches.v15_0.update_fingerprint_appointment_workflow
 one_fm.patches.v15_0.add_update_custom_field #2025-10-29
 one_fm.patches.v15_0.update_attendance_status_options
+one_fm.patches.v15_0.add_leave_handover_process_task
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_assign_rfp_to_purchase_officer #re-run

--- a/one_fm/patches/v15_0/add_leave_handover_process_task.py
+++ b/one_fm/patches/v15_0/add_leave_handover_process_task.py
@@ -1,0 +1,55 @@
+import frappe
+from frappe.utils import today
+from one_fm.setup.assignment_rule import create_assignment_rule, get_assignment_rule_json_file
+from one_fm.custom.workflow.workflow import get_workflow_json_file, create_workflow
+
+def execute():
+    create_process_task()
+
+def create_process_task():
+    process_name = "Attendance Process"
+    if not frappe.db.exists("Process", process_name):
+        frappe.get_doc({
+            "process_name": process_name,
+            "description": process_name,
+            "doctype": "Process",
+            "process_owner_name": "Administrator",
+            "process_owner": "Administrator"
+        }).insert(ignore_permissions=True)
+
+    task_type = "Routine"
+    if not frappe.db.exists("Task Type", task_type):
+        frappe.get_doc({
+            "name": task_type,
+            "is_routine_task": 1,
+            "doctype": "Task Type"
+        }).insert(ignore_permissions=True)
+
+    method = "one_fm.one_fm.doctype.leave_handover.leave_handover.reliever_assignment_on_leave_start"
+    document_type = "Leave Handover"
+    if not frappe.db.exists("Method", method):
+        frappe.get_doc({
+            "method": method,
+            "document_type": document_type,
+            "description": "To assign reliever on leave start date from leave handover.",
+            "doctype": "Method"
+        }).insert(ignore_permissions=True)
+
+    process_task = frappe.get_doc({
+        "naming_series": "P-TASK-.YYYY.-",
+        "process_name": process_name,
+        "is_erp_task": 1,
+        "is_automated": 1,
+        "is_active": 1,
+        "erp_document": document_type,
+        "task": "Assign reliever on leave start date from leave handover.",
+        "task_type": task_type,
+        "method": method,
+        "frequency": "Cron",
+        "cron_format": "45 23 * * *",
+        "hours_per_frequency": 0.5,
+        "coordination_needed": "No",
+        "start_date": today(),
+        "doctype": "Process Task",
+    }).insert(ignore_permissions=True)
+    return process_task.name


### PR DESCRIPTION
This pull request refactors the leave handover process to improve maintainability and automate reliever assignment on leave start. The main changes include consolidating assignment and revert logic, updating the status workflow, automating reliever assignment via a scheduled process task, and cleaning up redundant code in related modules.

**Leave Handover Process Refactor:**

* Consolidated assignment and revert logic into a single `action_handover` method in `leave_handover.py`, replacing the previous `handover` and `revert_handover` methods, and updated the status handling to include "Draft" and "Submitted" states. [[1]](diffhunk://#diff-1f312b7072e586be533f567aa7b55958e358cbc53772dca96dc2486cc35f2849R8-L16) [[2]](diffhunk://#diff-1f312b7072e586be533f567aa7b55958e358cbc53772dca96dc2486cc35f2849L40-R54) [[3]](diffhunk://#diff-7582324c1559e4b9ea584f13f96d0e463c53d52b25b030aa3debdec342576bbaR51-R69)
* Automated reliever assignment on leave start by adding the `reliever_assignment_on_leave_start` function and wiring it to a new scheduled process task via a migration patch. [[1]](diffhunk://#diff-1f312b7072e586be533f567aa7b55958e358cbc53772dca96dc2486cc35f2849R232-R248) [[2]](diffhunk://#diff-9f5d0915974dd4d32fd45f8a9b25d92b6458bf49b4e410592d64b9c63d85c513R1-R55) [[3]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R191)

**Frontend and API Changes:**

* Updated the frontend call in `leave_handover.js` to use the new `action_handover` method with a `revert` flag, aligning with backend refactor.

**Cleanup in Related Modules:**

* Removed redundant assignment methods (`assign_projects`, `assign_operations_site`, `assign_process_tasks`, `assign_reportees`) from `reliever_assignment.py`, centralizing assignment logic in the leave handover process. [[1]](diffhunk://#diff-6b3b5db37582c0e6756ecf01fd98d25ef368657d98a0e546b97886b6cbfcec12L26-L30) [[2]](diffhunk://#diff-6b3b5db37582c0e6756ecf01fd98d25ef368657d98a0e546b97886b6cbfcec12L83-L120) [[3]](diffhunk://#diff-6b3b5db37582c0e6756ecf01fd98d25ef368657d98a0e546b97886b6cbfcec12L189-L233)

**Workflow and Status Updates:**

* Updated status options and default values in the `leave_handover.json` schema to reflect new workflow states and make fields read-only where appropriate. [[1]](diffhunk://#diff-7582324c1559e4b9ea584f13f96d0e463c53d52b25b030aa3debdec342576bbaR51-R69) [[2]](diffhunk://#diff-7582324c1559e4b9ea584f13f96d0e463c53d52b25b030aa3debdec342576bbaL102-R105)