### PR TITLE
refactor: work permit field changes

### DIFF
--- a/one_fm/custom/workflow/work_permit.json
+++ b/one_fm/custom/workflow/work_permit.json
@@ -223,7 +223,6 @@
     {
       "state": "Rejected",
       "doc_status": "1",
-      "update_field": "work_permit_status",
       "update_value": "Rejected",
       "is_optional_state": 0,
       "avoid_status_override": 0,
@@ -254,7 +253,6 @@
     {
       "state": "Apply Online by PRO",
       "doc_status": "0",
-      "update_field": "work_permit_status",
       "update_value": "Draft",
       "is_optional_state": 0,
       "avoid_status_override": 0,
@@ -265,7 +263,6 @@
     {
       "state": "Pending By Supervisor",
       "doc_status": "0",
-      "update_field": "work_permit_status",
       "update_value": "Pending by Supervisor",
       "is_optional_state": 0,
       "avoid_status_override": 0,
@@ -276,7 +273,6 @@
     {
       "state": "Pending By Previous Company",
       "doc_status": "0",
-      "update_field": "work_permit_status",
       "update_value": "Pending by Previous Company",
       "is_optional_state": 0,
       "avoid_status_override": 0,
@@ -287,7 +283,6 @@
     {
       "state": "Pending  For Payment",
       "doc_status": "0",
-      "update_field": "work_permit_status",
       "update_value": "Pending by Supervisor for Payment",
       "is_optional_state": 0,
       "avoid_status_override": 0,
@@ -298,7 +293,6 @@
     {
       "state": "Pending By Operator",
       "doc_status": "0",
-      "update_field": "work_permit_status",
       "update_value": "Pending by Operator",
       "is_optional_state": 0,
       "avoid_status_override": 0,
@@ -309,7 +303,6 @@
     {
       "state": "Pending By PAM",
       "doc_status": "0",
-      "update_field": "work_permit_status",
       "update_value": "Pending by Operator",
       "is_optional_state": 0,
       "avoid_status_override": 0,
@@ -320,7 +313,6 @@
     {
       "state": "Reason of Rejection",
       "doc_status": "0",
-      "update_field": "work_permit_status",
       "update_value": "Rejected",
       "is_optional_state": 0,
       "avoid_status_override": 0,

--- a/one_fm/grd/doctype/work_permit/work_permit.js
+++ b/one_fm/grd/doctype/work_permit/work_permit.js
@@ -4,11 +4,6 @@
 frappe.ui.form.on('Work Permit', {
     validate: function(frm){
     },
-    work_permit_status: function(frm){
-        if (frm.doc.work_permit_status == "Rejected"){
-            frm.set_value("work_permit_status","read_only",1);
-        }
-    },
     employee: function(frm){
         let {employee} = frm.doc.employee;
         // console.log("hi")
@@ -101,7 +96,7 @@ var set_button_for_medical_insurance_transfer = function(frm){
 }
 };
 var set_restart_application = function(frm){
-    if(frm.doc.docstatus == 1 && frm.doc.work_permit_status == "Rejected"){
+    if(frm.doc.docstatus == 1 && frm.doc.workflow_state == "Rejected"){
         frm.add_custom_button(__('Restart Application'), function(){
             frappe.call({
                 method: "one_fm.hiring.utils.create_new_work_permit", 
@@ -274,7 +269,6 @@ var set_dates_grd_operator = function(frm)
 	if(((frm.doc.grd_operator_apply_work_permit_on_ashal == "Yes") && (!frm.doc.grd_operator_apply_work_permit_on_ashal_date)))
     {
         frm.set_value('grd_operator_apply_work_permit_on_ashal_date',frappe.datetime.now_datetime());
-        frm.set_value('work_permit_status',"Pending by Supervisor");
     }
 };
 var set_upload_work_permit_invoice = function(frm){

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -16,7 +16,6 @@
   "transfer_paper",
   "column_break_8",
   "work_permit_type",
-  "work_permit_status",
   "reason_of_rejection",
   "details_of_rejection",
   "employee_last_checkin",
@@ -318,20 +317,8 @@
   },
   {
    "allow_on_submit": 1,
-   "default": "Draft",
-   "fieldname": "work_permit_status",
-   "fieldtype": "Select",
-   "in_standard_filter": 1,
-   "label": "Work Permit Status",
-   "no_copy": 1,
-   "options": "\nDraft\nPending by Supervisor\nPending by Operator\nPending by Previous Company\nPending by Supervisor for Payment\nCompleted\nClosed\nRejected",
-   "read_only": 1,
-   "translatable": 1
-  },
-  {
-   "allow_on_submit": 1,
    "default": "0",
-   "depends_on": "eval: doc.work_permit_status=='Approved'",
+   "depends_on": "eval: doc.workflow_state=='Approved'",
    "fieldname": "payment_transferred_from_finance_dept",
    "fieldtype": "Check",
    "label": "Payment Transferred From Finance Dept",
@@ -340,7 +327,7 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.work_permit_status=='Approved'",
+   "depends_on": "eval: doc.workflow_state=='Approved'",
    "fieldname": "notify_finance_user",
    "fieldtype": "Link",
    "label": "Notify Finance User",
@@ -365,7 +352,7 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.work_permit_status=='Approved'",
+   "depends_on": "eval: doc.workflow_state=='Approved'",
    "fieldname": "amount_to_pay",
    "fieldtype": "Currency",
    "label": "Amount To Pay",
@@ -373,7 +360,7 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval: doc.work_permit_status=='Rejected'",
+   "depends_on": "eval: doc.workflow_state=='Rejected'",
    "fieldname": "reason_for_rejection",
    "fieldtype": "Data",
    "hidden": 1,
@@ -599,7 +586,7 @@
   {
    "allow_on_submit": 1,
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.work_permit_status=='Approved'",
+   "collapsible_depends_on": "eval: doc.workflow_state=='Approved'",
    "fieldname": "section_break_60",
    "fieldtype": "Section Break",
    "hidden": 1,
@@ -629,14 +616,14 @@
    "options": "ref_doctype"
   },
   {
-   "depends_on": "eval:doc.work_permit_status == \"Rejected\"",
+   "depends_on": "eval:doc.workflow_state == \"Rejected\"",
    "fieldname": "reason_of_rejection",
    "fieldtype": "Select",
    "label": "Reason Of Rejection",
    "options": "\nRejected by PAM\nRejected by previous company"
   },
   {
-   "depends_on": "eval:doc.work_permit_status == \"Rejected\" ",
+   "depends_on": "eval:doc.workflow_state == \"Rejected\" ",
    "fieldname": "details_of_rejection",
    "fieldtype": "Small Text",
    "label": "Details of Rejection"
@@ -858,7 +845,7 @@
    "options": "User"
   },
   {
-   "depends_on": "eval:doc.work_permit_status == \"Pending by Supervisor\" || doc.work_permit_status == \"Pending by Operator\" || doc.work_permit_status == \"Completed\"",
+   "depends_on": "eval:doc.workflow_state == \"Pending by Supervisor\" || doc.workflow_state == \"Pending by Operator\" || doc.workflow_state == \"Completed\"",
    "fieldname": "payment_details_section_section",
    "fieldtype": "Section Break",
    "label": "Payment Details Section"
@@ -971,7 +958,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-25 21:14:09.876478",
+ "modified": "2025-10-28 13:15:55.514530",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -85,12 +85,6 @@
   "work_permit_salary",
   "duration_of_work_permit",
   "visa_reference_number",
-  "section_break_46",
-  "work_contract",
-  "column_break_62",
-  "salary_certificate",
-  "column_break_64",
-  "iqrar",
   "new_passport_details_section",
   "new_passport_type",
   "new_passport_number",
@@ -642,42 +636,11 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.work_permit_type != \"Cancellation\" && doc.work_permit_type != \"New Kuwaiti\"",
-   "fieldname": "section_break_46",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_62",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_64",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "0",
    "fieldname": "notify_to_upload",
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Notify to Upload"
-  },
-  {
-   "allow_on_submit": 1,
-   "fieldname": "work_contract",
-   "fieldtype": "Attach",
-   "label": "Work Contract"
-  },
-  {
-   "allow_on_submit": 1,
-   "fieldname": "salary_certificate",
-   "fieldtype": "Attach",
-   "label": "Salary Certificate"
-  },
-  {
-   "allow_on_submit": 1,
-   "fieldname": "iqrar",
-   "fieldtype": "Attach",
-   "label": "Iqrar"
   },
   {
    "depends_on": "eval:doc.work_permit_type == \"Cancellation\" && doc.workflow_state != \"Draft\"",
@@ -958,7 +921,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-28 13:15:55.514530",
+ "modified": "2025-11-03 15:36:45.697257",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -191,25 +191,20 @@ class WorkPermit(Document):
             if tp:
                 if tp.work_permit_records != []:# If table for tracking wp in the transfer paper records is not empty, update the rows of the work permit records in the transfer paper upon wp referance name
                     for wp_index, wp in enumerate(tp.work_permit_records):
-                        if wp.work_permit_reference == self.name and self.work_permit_status != "Completed":
-                            wp.update({
-                                "status": self.work_permit_status,
-                                "reason_of_rejection": self.reason_of_rejection
-                                })
+                        if wp.work_permit_reference == self.name and self.workflow_state != "Completed":
+                            wp.update({"reason_of_rejection": self.reason_of_rejection})
                             wp.save()
                         if wp.work_permit_reference != self.name and wp_index == len(tp.work_permit_records)-1:
                             tp.append("work_permit_records", {
-                            "work_permit_reference": self.name,
-                            "status": self.work_permit_status,
-                            "reason_of_rejection": self.reason_of_rejection
+                                "work_permit_reference": self.name,
+                                "reason_of_rejection": self.reason_of_rejection
                             })
                         if wp.work_permit_reference  != self.name and wp_index != len(tp.work_permit_records)-1:
                             continue
                 elif tp.work_permit_records == []:# If table for tracking wp in the transfer paper records is empty, append into the table
                     tp.append("work_permit_records", {
-                    "work_permit_reference": self.name,
-                    "status": self.work_permit_status,
-                    "reason_of_rejection": self.reason_of_rejection
+                        "work_permit_reference": self.name,
+                        "reason_of_rejection": self.reason_of_rejection
                     })
             tp.save()
             tp.reload()
@@ -239,7 +234,6 @@ class WorkPermit(Document):
     def on_submit(self):
         if self.work_permit_type not in ['Cancellation', 'New Kuwaiti', 'Local Transfer'] and self.workflow_state != "Rejected":
             if self.workflow_state == "Completed" and self.attach_invoice and self.new_work_permit_expiry_date:
-                self.db_set('work_permit_status', 'Completed')
                 # self.clean_old_wp_record_in_employee_doctype()
                 self.set_work_permit_attachment_in_employee_doctype(self.new_work_permit_expiry_date)
             else:
@@ -252,12 +246,11 @@ class WorkPermit(Document):
                     msg += " to submit"
                     frappe.throw(_(msg))
 
-        if self.work_permit_type == "Cancellation":
-            self.db_set('work_permit_status', 'Completed')
+        # ToDo
+        # If work permit type is Cancellation, set workflow_state to Completed
 
         if self.workflow_state == "Completed":
             if self.work_permit_type == "Local Transfer":
-                self.db_set('work_permit_status', 'Completed')
                 self.update_wp_child_table_in_transfer_paper()
                 self.recall_create_medical_insurance_transfer() # Auto create mi record for transfer wp
                 self.set_work_permit_attachment_in_employee_doctype(self.work_permit_expiry_date, self.attach_work_permit)
@@ -272,11 +265,8 @@ class WorkPermit(Document):
         tp = frappe.get_doc('Transfer Paper',self.transfer_paper)
         if tp:
             for wp in tp.work_permit_records:
-                if wp.work_permit_reference  == self.name and self.work_permit_status == "Completed":
-                    wp.update({
-                        "status": self.work_permit_status,
-                        "reason_of_rejection": self.reason_of_rejection
-                        })
+                if wp.work_permit_reference  == self.name and self.workflow_state == "Completed":
+                    wp.update({"reason_of_rejection": self.reason_of_rejection})
                     wp.save()
             tp.workflow_state = "Completed"
             tp.save()

--- a/one_fm/hiring/doctype/transfer_paper/transfer_paper.js
+++ b/one_fm/hiring/doctype/transfer_paper/transfer_paper.js
@@ -23,11 +23,11 @@ frappe.ui.form.on('Transfer Paper', {
                     filters: {
                     name: frm.doc.work_permit_ref
                     },
-                    fieldname:["work_permit_status"]
+                    fieldname:["workflow_state"]
                 }, 
                 callback: function(r) { 
-                    frm.set_value('work_permit_status', r.message.work_permit_status);
-                    if(r.message.work_permit_status == "Completed"){
+                    frm.set_value('work_permit_status', r.message.workflow_state);
+                    if(r.message.workflow_state == "Completed"){
                         frm.set_value('tp_status', "Completed");
                     }
                 }

--- a/one_fm/hiring/doctype/transfer_paper/transfer_paper.py
+++ b/one_fm/hiring/doctype/transfer_paper/transfer_paper.py
@@ -163,7 +163,7 @@ class TransferPaper(Document):
         work_permit.create_work_permit_transfer(self.name,employee)
 
     def notify_grd_transfer_wp_record(self):
-        wp = frappe.db.get_value("Work Permit",{'transfer_paper':self.name,'work_permit_status':'Draft'})
+        wp = frappe.db.get_value("Work Permit",{'transfer_paper':self.name,'workflow_state':'Draft'})
         if wp:
             wp_record = frappe.get_doc('Work Permit', wp)
             page_link = get_url(wp_record.get_url())

--- a/one_fm/hiring/utils.py
+++ b/one_fm/hiring/utils.py
@@ -278,7 +278,7 @@ def create_wp_for_transferable_employee(doc):
 
 def notify_grd_operator_for_transfer_wp_record(tp):
 	operator = frappe.db.get_single_value("HR Settings", "default_grd_operator_transfer")
-	wp = frappe.db.get_value("Work Permit",{'transfer_paper':tp.name,'work_permit_status':'Draft'})
+	wp = frappe.db.get_value("Work Permit",{'transfer_paper':tp.name,'workflow_state':'Draft'})
 	if wp:
 		wp_record = frappe.get_doc('Work Permit', wp)
 		page_link = get_url(wp_record.get_url())


### PR DESCRIPTION
This pull request removes the usage of the `work_permit_status` field from the Work Permit workflow and related code, consolidating all status logic to use the `workflow_state` field instead. This change simplifies the codebase and improves consistency by ensuring that status-dependent logic and UI elements now reference the workflow state. Several fields and UI dependencies have also been cleaned up or removed as part of this refactor.

**Workflow and Status Refactor:**

* Removed all references to the `work_permit_status` field from workflow state transitions in `work_permit.json`, so status updates now rely solely on `workflow_state`. [[1]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL226) [[2]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL257) [[3]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL268) [[4]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL279) [[5]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL290) [[6]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL301) [[7]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL312) [[8]](diffhunk://#diff-b1659512020b43fbb90698c916bd9ab5b14513f127b7b31bffec48796510d6bcL323)
* Updated all field dependencies, conditions, and UI logic in `work_permit.json` to reference `workflow_state` instead of `work_permit_status`, including field visibility, section collapsibility, and filter logic. [[1]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L319-R315) [[2]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L343-R324) [[3]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L368-R357) [[4]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L602-R583) [[5]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L632-R620) [[6]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L657-L694) [[7]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L861-R811)
* Removed the `work_permit_status` field and its references from the Work Permit DocType definition, cleaning up unused fields and attachments. [[1]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L19) [[2]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L89-L94) [[3]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L657-L694)

**Code and Logic Updates:**

* Refactored backend methods in `work_permit.py` to use `workflow_state` for status checks and updates, removing logic that set or checked `work_permit_status`. [[1]](diffhunk://#diff-accb03519d68ad723074e7dd0e4eb0342899a9c083d56dac35a769b906d0ea9bL194-L211) [[2]](diffhunk://#diff-accb03519d68ad723074e7dd0e4eb0342899a9c083d56dac35a769b906d0ea9bL242) [[3]](diffhunk://#diff-accb03519d68ad723074e7dd0e4eb0342899a9c083d56dac35a769b906d0ea9bL255-L260) [[4]](diffhunk://#diff-accb03519d68ad723074e7dd0e4eb0342899a9c083d56dac35a769b906d0ea9bL275-R269)
* Updated related queries and logic in Transfer Paper and Hiring modules to use `workflow_state` instead of `work_permit_status` for status checks and UI updates. [[1]](diffhunk://#diff-1bfe30088917f2420db40f4855759646d454ba4a2cafcd386228fc135db5ac2dL26-R30) [[2]](diffhunk://#diff-e531c68528b46b50a4e58ffcf940035c044238ec02fcffa50bfab0246bd05441L166-R166) [[3]](diffhunk://#diff-b3b346db7db2b54a203f36bde10031409b908409ea8cd70f744625f3371ad243L281-R281)

**Frontend/UI Cleanup:**

* Removed the `work_permit_status` event handler and related UI logic from `work_permit.js`, ensuring all status-dependent UI behavior is now based on `workflow_state`. [[1]](diffhunk://#diff-d02801f8c4939c18e3e584e055fce84b9fd43d0bf7bdb54b2ac5cca6690a6060L7-L11) [[2]](diffhunk://#diff-d02801f8c4939c18e3e584e055fce84b9fd43d0bf7bdb54b2ac5cca6690a6060L104-R99) [[3]](diffhunk://#diff-d02801f8c4939c18e3e584e055fce84b9fd43d0bf7bdb54b2ac5cca6690a6060L277)

These changes collectively streamline how Work Permit status is managed and referenced throughout the codebase, making future maintenance and feature development easier.