### PR TITLE
fix: Leave handover

### DIFF
--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -40,6 +40,7 @@ class LeaveHandover(Document):
 		if self.leave_start_date == today():
 			self.action_handover(revert=False)
 
+	@frappe.whitelist()
 	def action_handover(self, revert=False):
 		if revert and self.employee_user_id != frappe.session.user:
 			frappe.throw(_("You are not authorized to revert this Leave Handover."))

--- a/one_fm/public/js/doctype_js/leave_application.js
+++ b/one_fm/public/js/doctype_js/leave_application.js
@@ -108,39 +108,39 @@ frappe.ui.form.on("Leave Application", {
         }
         updateCustomIsPaidVisibility(frm)
         manage_leave_extension(frm)
-        // Leave Handover Creation - Pused to after leave handover management process complition
-		// if (frm.doc.status == 'Approved') {
-		// 	frm.add_custom_button(__('Leave Handover'), function() {
-		// 		frappe.call({
-		// 			method: 'one_fm.one_fm.doctype.leave_handover.leave_handover.get_handover_data',
-		// 			args: {
-		// 				leave_application: frm.doc.name
-		// 			},
-		// 			callback: function(r) {
-		// 				if (r.message) {
-		// 					frappe.model.with_doctype('Leave Handover', function() {
-		// 						var doc = frappe.model.get_new_doc('Leave Handover');
-		// 						doc.employee = r.message.employee;
-		// 						doc.employee_name = r.message.employee_name;
-		// 						doc.leave_application = r.message.leave_application;
-		// 						doc.leave_start_date = r.message.leave_start_date;
-		// 						doc.resumption_date = r.message.resumption_date;
-		// 						if (r.message.handover_items) {
-		// 							r.message.handover_items.forEach(item => {
-		// 								var child = frappe.model.add_child(doc, 'Handover Item', 'handover_items');
-		// 								child.reference_doctype = item.reference_doctype;
-		// 								child.reference_docname = item.reference_docname;
-		// 							});
-		// 						}
-		// 						frappe.set_route('Form', 'Leave Handover', doc.name);
-		// 					});
-		// 				}
-		// 			},
-		// 			freeze: true,
-		// 			freeze_message: __("Creating Leave Handover...")
-		// 		});
-		// 	}, __('Create'));
-		// }
+        // Leave Handover Creation
+		if (frm.doc.status == 'Approved') {
+			frm.add_custom_button(__('Leave Handover'), function() {
+				frappe.call({
+					method: 'one_fm.one_fm.doctype.leave_handover.leave_handover.get_handover_data',
+					args: {
+						leave_application: frm.doc.name
+					},
+					callback: function(r) {
+						if (r.message) {
+							frappe.model.with_doctype('Leave Handover', function() {
+								var doc = frappe.model.get_new_doc('Leave Handover');
+								doc.employee = r.message.employee;
+								doc.employee_name = r.message.employee_name;
+								doc.leave_application = r.message.leave_application;
+								doc.leave_start_date = r.message.leave_start_date;
+								doc.resumption_date = r.message.resumption_date;
+								if (r.message.handover_items) {
+									r.message.handover_items.forEach(item => {
+										var child = frappe.model.add_child(doc, 'Handover Item', 'handover_items');
+										child.reference_doctype = item.reference_doctype;
+										child.reference_docname = item.reference_docname;
+									});
+								}
+								frappe.set_route('Form', 'Leave Handover', doc.name);
+							});
+						}
+					},
+					freeze: true,
+					freeze_message: __("Creating Leave Handover...")
+				});
+			}, __('Create'));
+		}
     },
     onload: function(frm) {
         $.each(frm.fields_dict, function(fieldname, field) {


### PR DESCRIPTION
This pull request re-enables and improves the Leave Handover creation process for approved leave applications, making it easier for users to initiate handovers directly from the Leave Application form. Additionally, it enhances the backend by allowing the `action_handover` method to be called from the client side, supporting more flexible workflows.

**Leave Handover Process Improvements:**

* Restored and updated the custom button logic in `leave_application.js` to allow users to create a Leave Handover when a leave application is approved, streamlining the workflow and improving usability.

**Backend Enhancements:**

* Added the `@frappe.whitelist()` decorator to the `action_handover` method in `leave_handover.py`, enabling it to be called from the client side and supporting integration with frontend actions.