### PR TITLE
fix: pathfinder log - assignment

### DIFF
--- a/one_fm/custom/assignment_rule/pathfinder_log_process_owner.json
+++ b/one_fm/custom/assignment_rule/pathfinder_log_process_owner.json
@@ -6,7 +6,7 @@
   "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.<br>The details of the request are as follows:<br></p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\"><thead><tr><th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th><th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th></tr></thead><tbody><tr><td style=\"padding: 10px;\">Process Name</td><td style=\"padding: 10px;\">{{process_name}}</td></tr><tr><td style=\"padding: 10px;\">Goal Description</td><td style=\"padding: 10px;\">{{goal_description}}</td></tr><tr><td style=\"padding: 10px;\">Type</td><td style=\"padding: 10px;\">{{type}}</td></tr><tr><td style=\"padding: 10px;\">Process Owner User</td><td style=\"padding: 10px;\">{{process_owner_user}}</td></tr></tbody></table><p></p>",
   "is_assignment_rule_with_workflow": 0,
   "assign_condition": "workflow_state in (\"Pending Process Mapping\", \"Pending Templates Definition\")",
-  "unassign_condition": "workflow_state in (\"Pending Process Mapping Review\", \"Pending Templates Review\")",
+  "unassign_condition": "workflow_state in (\"Pending Process Map Review\", \"Pending Templates Review\")",
   "rule": "Based on Field",
   "field": "process_owner_user",
   "doctype": "Assignment Rule",


### PR DESCRIPTION
This pull request updates the unassignment condition in the `one_fm/custom/assignment_rule/pathfinder_log_process_owner.json` configuration to correct a workflow state value. This ensures that unassignment now triggers at the appropriate workflow state.

- **Configuration correction:**
  * Updated the `unassign_condition` to use `"Pending Process Map Review"` instead of the incorrect `"Pending Process Mapping Review"` for the workflow state, improving the accuracy of assignment rule triggers.