### PR TITLE
feat: assign shift - client event

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -791,8 +791,20 @@ def create_client_event_shift_assignment(date):
 	roster = get_client_event_schedule(date, employment_type)
 	if not roster:
 		return
-	try:
-		for employee_scedule in roster:
+	for employee_schedule in roster:
+		existing_assignments = frappe.db.get_list(
+			"Shift Assignment",
+			filters={
+				'employee': employee_schedule.employee,
+				'start_date': employee_schedule.start_datetime.date(),
+				'docstatus': 1,
+				'is_event_based_shift': 1
+			},
+			fields=['name']
+		)
+		if existing_assignments:
+			continue
+		try:
 			shift_assignment = frappe.get_doc(
 				{
 					"doctype": "Shift Assignment",
@@ -813,8 +825,8 @@ def create_client_event_shift_assignment(date):
 			)
 			shift_assignment.insert(ignore_permissions=True)
 			shift_assignment.submit()
-	except Exception as e:
-		frappe.log_error(message=frappe.get_traceback(), title='Error Creating Client Event Shift Assignment')
+		except Exception as e:
+			frappe.log_error(message=frappe.get_traceback(), title='Error Creating Client Event Shift Assignment')
 
 def get_client_event_schedule(date, employment_type):
 	from frappe.query_builder import DocType

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -755,7 +755,7 @@ def assign_am_shift():
 		roster.extend(non_shift)
 
 	create_shift_assignment(roster, date, 'AM')
-
+	create_client_event_shift_assignment(date)
 
 def assign_pm_shift():
 	date = cstr(getdate())
@@ -783,7 +783,62 @@ def assign_pm_shift():
 		roster.extend(non_shift)
 
 	create_shift_assignment(roster, date, 'PM')
+	create_client_event_shift_assignment(date)
 
+def create_client_event_shift_assignment(date):
+	date = cstr(getdate())
+	employment_type = ["Full-time", "Part-time", "Intern", "Subcontractor"]
+	roster = get_client_event_schedule(date, employment_type)
+	if not roster:
+		return
+	try:
+		for employee_scedule in roster:
+			shift_assignment = frappe.get_doc(
+				{
+					"doctype": "Shift Assignment",
+					"employee": employee_schedule.employee,
+					"employee_name": employee_schedule.employee_name,
+					"start_date": employee_schedule.start_datetime.date(),
+					"end_date": employee_schedule.end_datetime.date(),
+					"shift": employee_schedule.shift,
+					"employee_schedule": employee_schedule.name,
+					"site": employee_schedule.site,
+					"project": employee_schedule.project,
+					"is_event_based_shift": 1,
+					"event_staff": employee_schedule.event_staff,
+					"start_datetime": employee_schedule.start_datetime,
+					"end_datetime": employee_schedule.end_datetime,
+					"site_location": employee_schedule.site_location,
+				}
+			)
+			shift_assignment.insert(ignore_permissions=True)
+			shift_assignment.submit()
+	except Exception as e:
+		frappe.log_error(message=frappe.get_traceback(), title='Error Creating Client Event Shift Assignment')
+
+def get_client_event_schedule(date, employment_type):
+	from frappe.query_builder import DocType
+
+	EmployeeSchedule = DocType('tabEmployee Schedule')
+	Employee = DocType('tabEmployee')
+
+	return (
+		frappe.qb.from_(EmployeeSchedule)
+		.select(EmployeeSchedule.star)
+		.where(
+			(EmployeeSchedule.date == date) &
+			(EmployeeSchedule.roster_type == "Basic") &
+			(EmployeeSchedule.is_event_schedule == 1) &
+			(EmployeeSchedule.employee.isin(
+				frappe.qb.from_(Employee)
+				.select(Employee.name)
+				.where(
+					(Employee.status == "Active") &
+					(Employee.employment_type.isin(employment_type))
+				)
+			))
+		)
+	).run(as_dict=True)
 
 def end_previous_shifts(time):
 	shift_type = get_shift_type(time)


### PR DESCRIPTION
This pull request adds functionality to automatically create shift assignments for employees scheduled for client events, both in the AM and PM shift assignment processes. It introduces a new helper function to generate these assignments and a supporting query function to retrieve the relevant event schedules.

**New client event shift assignment workflow:**

* Added calls to the new `create_client_event_shift_assignment` function in both `assign_am_shift` and `assign_pm_shift` to ensure event-based shift assignments are created during both shifts. [[1]](diffhunk://#diff-ab70bcb1e246615611fd826ed688b338c649aeec25036e3e60e48f44d3313b5fL758-R758) [[2]](diffhunk://#diff-ab70bcb1e246615611fd826ed688b338c649aeec25036e3e60e48f44d3313b5fR786-R841)

**New helper functions:**

* Introduced `create_client_event_shift_assignment(date)` to generate and submit shift assignments for employees scheduled for client events on a given date. This function handles errors gracefully and logs them if they occur.
* Added `get_client_event_schedule(date, employment_type)` which queries for event-based employee schedules for active employees of specified employment types on the given date.