### PR TITLE
feat: pathfinder log - log time

### DIFF
--- a/one_fm/custom/assignment_rule/pathfinder_log_business_analyst.json
+++ b/one_fm/custom/assignment_rule/pathfinder_log_business_analyst.json
@@ -7,7 +7,7 @@
   "is_assignment_rule_with_workflow": 0,
   "assign_condition": "workflow_state in (\"Pending Process Map Review\", \"Pending Templates Review\", \"Pending Story Definition\" )",
   "unassign_condition": "workflow_state in (\"Pending Templates Definition\")",
-  "close_condition": "workflow_state == \"In Production\"",
+  "close_condition": "workflow_state == \"Completed\"",
   "rule": "Based on Field",
   "field": "business_analyst_user",
   "doctype": "Assignment Rule",

--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -19,7 +19,8 @@
   "business_analyst_user",
   "business_analyst_name",
   "section_break_qrox",
-  "amended_from"
+  "amended_from",
+  "time_log"
  ],
  "fields": [
   {
@@ -120,18 +121,26 @@
   {
    "fieldname": "amended_from",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Amended From",
    "no_copy": 1,
    "options": "Pathfinder Log",
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "time_log",
+   "fieldtype": "Table",
+   "label": "Time Log",
+   "options": "Pathfinder Log Time",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-06 21:05:01.017942",
+ "modified": "2025-11-17 19:58:41.197164",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Pathfinder Log",

--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.py
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.py
@@ -1,9 +1,45 @@
 # Copyright (c) 2025, ONE FM and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.utils import now_datetime
 
 
 class PathfinderLog(Document):
-	pass
+	def before_save(self):
+		self.set_initial_time_log()
+		self.update_time_log()
+
+	def set_initial_time_log(self):
+		if not self.is_new():
+			return
+		self.time_log = []
+		self.add_time_log()
+
+	def update_time_log(self):
+		if self.is_new():
+			return
+		old_doc = self.get_doc_before_save()
+		if old_doc and old_doc.workflow_state != self.workflow_state:
+			last_log = None
+			if self.time_log:
+				last_log = self.time_log[-1]
+
+			if last_log and last_log.state == old_doc.workflow_state and not last_log.end_time:
+				last_log.end_time = now_datetime()
+				last_log.duration = frappe.utils.time_diff_in_seconds(
+					last_log.end_time, last_log.start_time
+				)
+
+			if self.workflow_state != "Completed":
+				self.add_time_log()
+
+	def add_time_log(self):
+		self.append(
+			"time_log",
+			{
+				"state": self.workflow_state,
+				"start_time": now_datetime()
+			}
+		)

--- a/one_fm/one_fm/doctype/pathfinder_log_time/pathfinder_log_time.json
+++ b/one_fm/one_fm/doctype/pathfinder_log_time/pathfinder_log_time.json
@@ -1,0 +1,63 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-11-17 19:54:01.076711",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "state",
+  "start_time",
+  "column_break_fklj",
+  "end_time",
+  "duration"
+ ],
+ "fields": [
+  {
+   "fieldname": "state",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "State",
+   "read_only": 1
+  },
+  {
+   "fieldname": "start_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Start Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "end_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "End Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "duration",
+   "fieldtype": "Duration",
+   "in_list_view": 1,
+   "label": "Duration",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_fklj",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-11-17 19:57:15.330651",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Pathfinder Log Time",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/one_fm/doctype/pathfinder_log_time/pathfinder_log_time.py
+++ b/one_fm/one_fm/doctype/pathfinder_log_time/pathfinder_log_time.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, ONE FM and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PathfinderLogTime(Document):
+	pass

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -215,7 +215,7 @@ one_fm.patches.v15_0.add_rfm_links_to_asset_movement
 
 [post_model_sync]
 one_fm.patches.v15_0.add_workflow_pathfinder_log #1
-one_fm.patches.v15_0.add_assignment_rule_pathfinder_log_business_analyst #1
+one_fm.patches.v15_0.add_assignment_rule_pathfinder_log_business_analyst #2
 one_fm.patches.v15_0.add_assignment_rule_pathfinder_log_process_owner #1
 one_fm.patches.v15_0.add_assignment_rule_assign_rfp_to_purchase_officer #re-run
 one_fm.patches.v15_0.add_assignment_rule_assign_to_purchase_manager_for_approval #re-run


### PR DESCRIPTION
This pull request introduces a time tracking feature for workflow state transitions in the `Pathfinder Log` doctype. It adds a new child table doctype, `Pathfinder Log Time`, to record the start and end times, as well as the duration, for each workflow state. The system automatically manages these logs as the workflow state changes. Additionally, it updates assignment rule logic and patch versioning.

**Time tracking for workflow states:**

* Added a new child table doctype `Pathfinder Log Time` with fields for `state`, `start_time`, `end_time`, and `duration`, and integrated it as a read-only table field `time_log` in the `Pathfinder Log` doctype. This enables detailed tracking of time spent in each workflow state. [[1]](diffhunk://#diff-0c8754e75ef285b3c1be237120d20312b1f277dd04ea2f92364c0008c68eba3eR1-R63) [[2]](diffhunk://#diff-d2dc8b183d09214d68c0b6be744568e4bd8e99652a5b24a7097378f4c2662ecfL22-R23) [[3]](diffhunk://#diff-d2dc8b183d09214d68c0b6be744568e4bd8e99652a5b24a7097378f4c2662ecfR124-R143)
* Implemented logic in `pathfinder_log.py` to automatically create and update time log entries on workflow state changes, including setting start/end times and calculating durations.
* Added the model class for the new child table doctype in `pathfinder_log_time.py`.

**Assignment rule and patch updates:**

* Changed the assignment rule close condition from "In Production" to "Completed" in `pathfinder_log_business_analyst.json` to match the new workflow.
* Updated the patch version for assignment rule creation in `patches.txt` to ensure the new logic is applied.