### PR TITLE
feat: attendance amendment - shift hours

### DIFF
--- a/one_fm/one_fm/doctype/attendance_amendment/attendance_amendment.js
+++ b/one_fm/one_fm/doctype/attendance_amendment/attendance_amendment.js
@@ -5,6 +5,7 @@ frappe.ui.form.on("Attendance Amendment", {
 	refresh(frm) {
         frm.events.set_year_and_month(frm);
         frm.events.filter_site_by_project(frm);
+        toggle_day_value_fields_in_attendance_details(frm);
     },
     fetch_attendance_record(frm){
         frappe.call({
@@ -25,6 +26,24 @@ frappe.ui.form.on("Attendance Amendment", {
             frm.set_value("month", month_map[frappe.datetime.str_to_obj(frappe.datetime.get_today()).getMonth() + 1]);
         }
     },
+    project(frm) {
+        frm.events.filter_site_by_project(frm);
+        frm.set_value("attendance_details", []);
+        frm.set_value("site", "");
+    },
+    year(frm){
+        frm.set_value("attendance_details", []);
+    },
+    month(frm){
+        frm.set_value("attendance_details", []);
+    },
+    site(frm){
+        frm.set_value("attendance_details", []);
+    },
+    attendance_based_on(frm){
+        frm.set_value("attendance_details", []);
+        toggle_day_value_fields_in_attendance_details(frm);
+    },
     filter_site_by_project(frm){
         // Filter Site field by selected Project
         if(frm.doc.project){
@@ -38,3 +57,13 @@ frappe.ui.form.on("Attendance Amendment", {
         }
     }
 });
+
+function toggle_day_value_fields_in_attendance_details(frm){
+    if (frm.doc.attendance_based_on === "Shift Hours") {
+        frappe.meta.get_docfield("Attendance Amendment Item", "attendance_hours_section", frm.doc.name).hidden = false
+        frappe.meta.get_docfield("Attendance Amendment Item", "attendance_status_section", frm.doc.name).hidden = true
+    } else {
+        frappe.meta.get_docfield("Attendance Amendment Item", "attendance_hours_section", frm.doc.name).hidden = true
+        frappe.meta.get_docfield("Attendance Amendment Item", "attendance_status_section", frm.doc.name).hidden = false
+    }
+}

--- a/one_fm/one_fm/doctype/attendance_amendment/attendance_amendment.py
+++ b/one_fm/one_fm/doctype/attendance_amendment/attendance_amendment.py
@@ -8,21 +8,13 @@ from frappe.utils import cint, cstr
 from calendar import monthrange
 from frappe import _
 
-status_map = {
-	"Present": "P",
-	"Absent": "A",
-	"On Leave": "OL",
-	"Holiday": "H",
-	"Day Off": "DO"
-}
-
 class AttendanceAmendment(Document):
 	@frappe.whitelist()
 	def fetch_attendance_record(self):
 		filters = self.get_attendance_amendment_filters()
 		employee_details = get_employee_details()
-		attendance_map = get_attendance_map(filters)
-		data = get_rows(employee_details, filters, attendance_map)
+		attendance_map = get_attendance_map(filters, self.attendance_based_on)
+		data = get_rows(employee_details, filters, attendance_map, self.attendance_based_on)
 		if data:
 			self.update_attendance_records(data)
 		else:
@@ -45,9 +37,15 @@ class AttendanceAmendment(Document):
 		return frappe._dict(filters)
 	
 	def update_attendance_records(self, data):
-		# data is now a list of dicts, each dict contains attendance info for one employee
+		if not self.attendance_based_on:
+			return
+		self.attendance_details = []
 		for record in data:
-			day_fields = {f"day_{i}": record.get(str(i), '') for i in range(1, 32)}
+			if self.attendance_based_on == "Shift Hours":
+				day_fields = {f"day_{i}_hour": record.get(str(i), '') for i in range(1, 32)}
+			else:
+				day_fields = {f"day_{i}": record.get(str(i), '') for i in range(1, 32)}
+
 			self.append("attendance_details", {
 				"employee": record.get("employee"),
 				"employee_id": record.get("employee_id"),
@@ -79,7 +77,7 @@ def get_employee_details():
 
 	return emp_map
 
-def get_attendance_map(filters):
+def get_attendance_map(filters, attendance_based_on=None):
 	"""Returns a dictionary of employee wise attendance map as per shifts for all the days of the month like
 	{
 		'employee1': {
@@ -109,7 +107,7 @@ def get_attendance_map(filters):
 			d.shift = ""
 
 		attendance_map.setdefault(d.employee, {}).setdefault(d.shift, {})
-		attendance_map[d.employee][d.shift][d.day_of_month] = d.status
+		attendance_map[d.employee][d.shift][d.day_of_month] = d.status if attendance_based_on == "Attendance Status" else d.working_hours
 
 	# leave is applicable for the entire day so all shifts should show the leave entry
 	for employee, leave_days in leave_map.items():
@@ -137,6 +135,7 @@ def get_non_day_off_attendance_records(filters):
 			Extract("day", Attendance.attendance_date).as_("day_of_month"),
 			Attendance.status,
 			OperationsShift.shift_classification.as_("shift"),
+			Attendance.working_hours
 		)
 		.where(
 			(Attendance.docstatus == 1)
@@ -155,7 +154,7 @@ def get_non_day_off_attendance_records(filters):
 
 	return query.run(as_dict=True)
 
-def get_rows(employee_details, filters, attendance_map):
+def get_rows(employee_details, filters, attendance_map, attendance_based_on):
 	records = []
 
 	day_off_attendance_map = get_day_off_attendance_map(filters)
@@ -169,7 +168,7 @@ def get_rows(employee_details, filters, attendance_map):
 			# no attendance records found for employee
 			continue
 
-		attendance_for_employee = get_attendance_status(filters, employee_attendance, employee_day_off_attendance)
+		attendance_for_employee = get_attendance_status(filters, employee_attendance, employee_day_off_attendance, attendance_based_on)
 
 		# set employee details in the first row
 		for record in attendance_for_employee:
@@ -188,6 +187,7 @@ def get_day_off_attendance_map(filters):
 			Attendance.employee,
 			Extract("day", Attendance.attendance_date).as_("day_of_month"),
 			Attendance.status,
+			Attendance.working_hours
 		)
 		.where(
 			(Attendance.docstatus == 1)
@@ -207,7 +207,7 @@ def get_day_off_attendance_map(filters):
 		
 	return day_off_map
 
-def get_attendance_status(filters, employee_non_day_off_attendance, employee_day_off_attendance):
+def get_attendance_status(filters, employee_non_day_off_attendance, employee_day_off_attendance, attendance_based_on):
 	"""Returns list of shift-wise attendance status for employee
 	[
 			{'shift': 'Morning', 1: 'A', 2: 'P', 3: 'A'....},
@@ -216,16 +216,6 @@ def get_attendance_status(filters, employee_non_day_off_attendance, employee_day
 	"""
 	total_days = monthrange(cint(filters.year), cint(filters.month))[1]
 	attendance_values = []
-
-	attendance_status_map = { 
-		**status_map, 
-		"Work From Home": "P", 
-		"Working": "P", 
-		"Client Day Off": "CDO",
-		"Sick Leave": "OL",
-		"Annual Leave": "OL",
-		"Emergency Leave": "OL"
-	}
 
 	employee_non_day_off_attendance = employee_non_day_off_attendance or {}
 
@@ -244,16 +234,21 @@ def get_attendance_status(filters, employee_non_day_off_attendance, employee_day
 			status = attendance_dict.get(day)
 
 			# if status is not found in non day attendance records, check day off attendance
-			if not status:
-				status = employee_day_off_attendance.get(day, "")
+			if attendance_based_on == "Attendance Status":
+				if not status:
+					status = employee_day_off_attendance.get(day, "")
+				if status in ["Present", "Working", "Work From Home", "Absent"]:
+					working_days += 1
 
-			if status in ["Present", "Working", "Work From Home"]:
-				working_days += 1
-			elif status in ["Day Off", "Client Day Off"]:
+			if attendance_based_on == "Shift Hours":
+				if not status:
+					status = employee_day_off_attendance.get(day, 0)
+				if status and status not in ["Day Off", "Client Day Off", "Absent", "On Leave"]:
+					working_days += 1
+
+			if status in ["Day Off", "Client Day Off"]:
 				off_days += 1
 
-			# abbr = attendance_status_map.get(status, "")
-			# row[cstr(day)] = abbr
 			row[cstr(day)] = status
 
 		row["working_days"] = working_days

--- a/one_fm/one_fm/doctype/attendance_amendment/attendance_amendment.py
+++ b/one_fm/one_fm/doctype/attendance_amendment/attendance_amendment.py
@@ -237,7 +237,7 @@ def get_attendance_status(filters, employee_non_day_off_attendance, employee_day
 			if attendance_based_on == "Attendance Status":
 				if not status:
 					status = employee_day_off_attendance.get(day, "")
-				if status in ["Present", "Working", "Work From Home", "Absent"]:
+				if status in ["Present", "Working", "Work From Home"]:
 					working_days += 1
 
 			if attendance_based_on == "Shift Hours":

--- a/one_fm/one_fm/doctype/attendance_amendment_item/attendance_amendment_item.json
+++ b/one_fm/one_fm/doctype/attendance_amendment_item/attendance_amendment_item.json
@@ -47,7 +47,42 @@
   "day_16",
   "day_20",
   "day_24",
-  "day_28"
+  "day_28",
+  "attendance_hours_section",
+  "day_1_hour",
+  "day_5_hour",
+  "day_9_hour",
+  "day_13_hour",
+  "day_17_hour",
+  "day_21_hour",
+  "day_25_hour",
+  "day_29_hour",
+  "column_break_abcd",
+  "day_2_hour",
+  "day_6_hour",
+  "day_10_hour",
+  "day_14_hour",
+  "day_18_hour",
+  "day_22_hour",
+  "day_26_hour",
+  "day_30_hour",
+  "column_break_efgh",
+  "day_3_hour",
+  "day_7_hour",
+  "day_11_hour",
+  "day_15_hour",
+  "day_19_hour",
+  "day_23_hour",
+  "day_27_hour",
+  "day_31_hour",
+  "column_break_ijhk",
+  "day_4_hour",
+  "day_8_hour",
+  "day_12_hour",
+  "day_16_hour",
+  "day_20_hour",
+  "day_24_hour",
+  "day_28_hour"
  ],
  "fields": [
   {
@@ -55,6 +90,12 @@
    "fieldtype": "Link",
    "label": "Employee",
    "options": "Employee"
+  },
+  {
+   "fieldname": "employee_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Employee ID"
   },
   {
    "fetch_from": "employee.employee_name",
@@ -65,220 +106,14 @@
    "read_only": 1
   },
   {
-   "fieldname": "shift",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Shift"
-  },
-  {
    "fieldname": "column_break_umcf",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "attendance_status_section",
-   "fieldtype": "Section Break",
-   "label": "Attendance Status"
-  },
-  {
-   "fieldname": "day_1",
-   "fieldtype": "Select",
-   "label": "Day 1",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_2",
-   "fieldtype": "Select",
-   "label": "Day 2",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_3",
-   "fieldtype": "Select",
-   "label": "Day 3",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_4",
-   "fieldtype": "Select",
-   "label": "Day 4",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "column_break_maby",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_ymzy",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_riqu",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "day_5",
-   "fieldtype": "Select",
-   "label": "Day 5",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_9",
-   "fieldtype": "Select",
-   "label": "Day 9",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_13",
-   "fieldtype": "Select",
-   "label": "Day 13",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_17",
-   "fieldtype": "Select",
-   "label": "Day 17",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_6",
-   "fieldtype": "Select",
-   "label": "Day 6",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_10",
-   "fieldtype": "Select",
-   "label": "Day 10",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_14",
-   "fieldtype": "Select",
-   "label": "Day 14",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_18",
-   "fieldtype": "Select",
-   "label": "Day 18",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_7",
-   "fieldtype": "Select",
-   "label": "Day 7",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_11",
-   "fieldtype": "Select",
-   "label": "Day 11",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_15",
-   "fieldtype": "Select",
-   "label": "Day 15",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_19",
-   "fieldtype": "Select",
-   "label": "Day 19",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_8",
-   "fieldtype": "Select",
-   "label": "Day 8",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_12",
-   "fieldtype": "Select",
-   "label": "Day 12",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_16",
-   "fieldtype": "Select",
-   "label": "Day 16",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_20",
-   "fieldtype": "Select",
-   "label": "Day 20",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_21",
-   "fieldtype": "Select",
-   "label": "Day 21",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_25",
-   "fieldtype": "Select",
-   "label": "Day 25",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "depends_on": "day_29",
-   "fieldname": "day_29",
-   "fieldtype": "Select",
-   "label": "Day 29",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_22",
-   "fieldtype": "Select",
-   "label": "Day 22",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_26",
-   "fieldtype": "Select",
-   "label": "Day 26",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "depends_on": "day_30",
-   "fieldname": "day_30",
-   "fieldtype": "Select",
-   "label": "Day 30",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_23",
-   "fieldtype": "Select",
-   "label": "Day 23",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_27",
-   "fieldtype": "Select",
-   "label": "Day 27",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_24",
-   "fieldtype": "Select",
-   "label": "Day 24",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "fieldname": "day_28",
-   "fieldtype": "Select",
-   "label": "Day 28",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
-  },
-  {
-   "depends_on": "day_31",
-   "fieldname": "day_31",
-   "fieldtype": "Select",
-   "label": "Day 31",
-   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
+   "fieldname": "shift",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Shift"
   },
   {
    "fieldname": "working_days",
@@ -293,17 +128,390 @@
    "label": "Off Days"
   },
   {
-   "fieldname": "employee_id",
+   "fieldname": "attendance_status_section",
+   "fieldtype": "Section Break",
+   "label": "Attendance Status"
+  },
+  {
+   "fieldname": "day_1",
+   "fieldtype": "Select",
+   "label": "Day 1",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_5",
+   "fieldtype": "Select",
+   "label": "Day 5",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_9",
+   "fieldtype": "Select",
+   "label": "Day 9",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_13",
+   "fieldtype": "Select",
+   "label": "Day 13",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_17",
+   "fieldtype": "Select",
+   "label": "Day 17",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_21",
+   "fieldtype": "Select",
+   "label": "Day 21",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_25",
+   "fieldtype": "Select",
+   "label": "Day 25",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "depends_on": "day_29",
+   "fieldname": "day_29",
+   "fieldtype": "Select",
+   "label": "Day 29",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "column_break_maby",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "day_2",
+   "fieldtype": "Select",
+   "label": "Day 2",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_6",
+   "fieldtype": "Select",
+   "label": "Day 6",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_10",
+   "fieldtype": "Select",
+   "label": "Day 10",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_14",
+   "fieldtype": "Select",
+   "label": "Day 14",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_18",
+   "fieldtype": "Select",
+   "label": "Day 18",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_22",
+   "fieldtype": "Select",
+   "label": "Day 22",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_26",
+   "fieldtype": "Select",
+   "label": "Day 26",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "depends_on": "day_30",
+   "fieldname": "day_30",
+   "fieldtype": "Select",
+   "label": "Day 30",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "column_break_ymzy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "day_3",
+   "fieldtype": "Select",
+   "label": "Day 3",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_7",
+   "fieldtype": "Select",
+   "label": "Day 7",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_11",
+   "fieldtype": "Select",
+   "label": "Day 11",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_15",
+   "fieldtype": "Select",
+   "label": "Day 15",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_19",
+   "fieldtype": "Select",
+   "label": "Day 19",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_23",
+   "fieldtype": "Select",
+   "label": "Day 23",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_27",
+   "fieldtype": "Select",
+   "label": "Day 27",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "depends_on": "day_31",
+   "fieldname": "day_31",
+   "fieldtype": "Select",
+   "label": "Day 31",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "column_break_riqu",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "day_4",
+   "fieldtype": "Select",
+   "label": "Day 4",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_8",
+   "fieldtype": "Select",
+   "label": "Day 8",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_12",
+   "fieldtype": "Select",
+   "label": "Day 12",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_16",
+   "fieldtype": "Select",
+   "label": "Day 16",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_20",
+   "fieldtype": "Select",
+   "label": "Day 20",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_24",
+   "fieldtype": "Select",
+   "label": "Day 24",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "day_28",
+   "fieldtype": "Select",
+   "label": "Day 28",
+   "options": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
+  },
+  {
+   "fieldname": "attendance_hours_section",
+   "fieldtype": "Section Break",
+   "label": "Attendance Hours"
+  },
+  {
+   "fieldname": "day_1_hour",
    "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Employee ID"
+   "label": "Day 1"
+  },
+  {
+   "fieldname": "day_5_hour",
+   "fieldtype": "Data",
+   "label": "Day 5"
+  },
+  {
+   "fieldname": "day_9_hour",
+   "fieldtype": "Data",
+   "label": "Day 9"
+  },
+  {
+   "fieldname": "day_13_hour",
+   "fieldtype": "Data",
+   "label": "Day 13"
+  },
+  {
+   "fieldname": "day_17_hour",
+   "fieldtype": "Data",
+   "label": "Day 17"
+  },
+  {
+   "fieldname": "day_21_hour",
+   "fieldtype": "Data",
+   "label": "Day 21"
+  },
+  {
+   "fieldname": "day_25_hour",
+   "fieldtype": "Data",
+   "label": "Day 25"
+  },
+  {
+   "fieldname": "day_29_hour",
+   "fieldtype": "Data",
+   "label": "Day 29"
+  },
+  {
+   "fieldname": "column_break_abcd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "day_2_hour",
+   "fieldtype": "Data",
+   "label": "Day 2"
+  },
+  {
+   "fieldname": "day_6_hour",
+   "fieldtype": "Data",
+   "label": "Day 6"
+  },
+  {
+   "fieldname": "day_10_hour",
+   "fieldtype": "Data",
+   "label": "Day 10"
+  },
+  {
+   "fieldname": "day_14_hour",
+   "fieldtype": "Data",
+   "label": "Day 14"
+  },
+  {
+   "fieldname": "day_18_hour",
+   "fieldtype": "Data",
+   "label": "Day 18"
+  },
+  {
+   "fieldname": "day_22_hour",
+   "fieldtype": "Data",
+   "label": "Day 22"
+  },
+  {
+   "fieldname": "day_26_hour",
+   "fieldtype": "Data",
+   "label": "Day 26"
+  },
+  {
+   "fieldname": "day_30_hour",
+   "fieldtype": "Data",
+   "label": "Day 30"
+  },
+  {
+   "fieldname": "column_break_efgh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "day_3_hour",
+   "fieldtype": "Data",
+   "label": "Day 3"
+  },
+  {
+   "fieldname": "day_7_hour",
+   "fieldtype": "Data",
+   "label": "Day 7"
+  },
+  {
+   "fieldname": "day_11_hour",
+   "fieldtype": "Data",
+   "label": "Day 11"
+  },
+  {
+   "fieldname": "day_15_hour",
+   "fieldtype": "Data",
+   "label": "Day 15"
+  },
+  {
+   "fieldname": "day_19_hour",
+   "fieldtype": "Data",
+   "label": "Day 19"
+  },
+  {
+   "fieldname": "day_23_hour",
+   "fieldtype": "Data",
+   "label": "Day 23"
+  },
+  {
+   "fieldname": "day_27_hour",
+   "fieldtype": "Data",
+   "label": "Day 27"
+  },
+  {
+   "depends_on": "day_31_hour",
+   "fieldname": "day_31_hour",
+   "fieldtype": "Data",
+   "label": "Day 31"
+  },
+  {
+   "fieldname": "column_break_ijhk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "day_4_hour",
+   "fieldtype": "Data",
+   "label": "Day 4"
+  },
+  {
+   "fieldname": "day_8_hour",
+   "fieldtype": "Data",
+   "label": "Day 8"
+  },
+  {
+   "fieldname": "day_12_hour",
+   "fieldtype": "Data",
+   "label": "Day 12"
+  },
+  {
+   "fieldname": "day_16_hour",
+   "fieldtype": "Data",
+   "label": "Day 16"
+  },
+  {
+   "fieldname": "day_20_hour",
+   "fieldtype": "Data",
+   "label": "Day 20"
+  },
+  {
+   "fieldname": "day_24_hour",
+   "fieldtype": "Data",
+   "label": "Day 24"
+  },
+  {
+   "fieldname": "day_28_hour",
+   "fieldtype": "Data",
+   "label": "Day 28"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-04 10:33:59.681133",
+ "modified": "2025-11-18 08:53:14.706731",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Attendance Amendment Item",


### PR DESCRIPTION
This pull request introduces significant changes to the Attendance Amendment feature, allowing users to view and amend attendance either by status or by shift hours. The changes update both the frontend and backend logic to support toggling between these modes, dynamically updating the UI and the data structure accordingly.

**Frontend/UI enhancements:**

* Added the `toggle_day_value_fields_in_attendance_details` function in `attendance_amendment.js` to dynamically show or hide fields in the attendance details table based on whether the amendment is by "Attendance Status" or "Shift Hours". This function is called on form refresh and when the `attendance_based_on` field changes. [[1]](diffhunk://#diff-421a0a9c691e196e44f59a4f23dbe54ac6776681ccdaa215070296539b812f04R8) [[2]](diffhunk://#diff-421a0a9c691e196e44f59a4f23dbe54ac6776681ccdaa215070296539b812f04R29-R46) [[3]](diffhunk://#diff-421a0a9c691e196e44f59a4f23dbe54ac6776681ccdaa215070296539b812f04R60-R69)

**Backend logic updates:**

* Modified the data fetching and processing logic in `attendance_amendment.py` to handle both "Attendance Status" and "Shift Hours" modes. This includes updating the signatures and internal logic of `get_attendance_map`, `get_rows`, and `get_attendance_status` to use the correct fields and calculations based on the selected mode. [[1]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L11-R17) [[2]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L48-R48) [[3]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L82-R80) [[4]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L112-R110) [[5]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L158-R157) [[6]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L172-R171) [[7]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L210-R210) [[8]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L220-L229) [[9]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32R237-L256)

* Updated SQL queries and data mapping to include `working_hours` for attendance records, enabling the new "Shift Hours" mode. [[1]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32R138) [[2]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32R190)

* Removed the now-unnecessary `status_map` and related mapping logic, simplifying the codebase and reducing redundancy. [[1]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L11-R17) [[2]](diffhunk://#diff-b5d96bb4c255594ca936dfe805fa04d0ef8820ca1706d3e5de8e6433482eab32L220-L229)

These changes collectively provide a more flexible and user-friendly way to manage and amend attendance records, supporting both status-based and hours-based workflows.