### PR TITLE
feat: added validation for rfp to be mandatory when rfm is linked to po

### DIFF
--- a/one_fm/overrides/purchase_order.py
+++ b/one_fm/overrides/purchase_order.py
@@ -194,6 +194,11 @@ def filter_purchase_uoms(doctype, txt, searchfield, start, page_len, filters):
 
 class PurchaseOrderOverride(PurchaseOrder):  
 
+    def validate(self):
+        super(PurchaseOrderOverride, self).validate()
+        if self.request_for_material and not self.one_fm_request_for_purchase:
+            frappe.throw(_("Request for Purchase is required for this Purchase Order to be processed further"))
+
     def on_submit(self):
         self.update_purchased_quantities()
         self.update_ordered_and_pending_quantities()

--- a/one_fm/tests/test_purchase_order.py
+++ b/one_fm/tests/test_purchase_order.py
@@ -9,4 +9,19 @@ class TestPurchaseOrder_(FrappeTestCase):
         field_order = json.loads(doctype_meta.field_order)
         self.assertIn('custom_place_of_delivery', field_order)
         self.assertIn('custom_terms_of_shipment', field_order)
+
+    def test_request_for_purchase_validation(self):
+        po = frappe.get_doc({
+            "doctype": "Purchase Order",
+            "supplier": "_Test Supplier",
+            "company": "_Test Company",
+            "request_for_material": "_Test Request for Material",
+            "items": [
+                {
+                    "item_code": "_Test Item",
+                    "qty": 1
+                }
+            ]
+        })
+        self.assertRaises(frappe.ValidationError, po.insert)
         


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://onefm.atlassian.net/browse/OFP-710

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
- Added validation for RFP to be mandatory if RFM is linked while creating PO

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Purchase Order

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.
No

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
