### PR TITLE
feat: validate pr required

### DIFF
--- a/one_fm/public/js/doctype_js/purchase_invoice.js
+++ b/one_fm/public/js/doctype_js/purchase_invoice.js
@@ -1,11 +1,29 @@
 frappe.ui.form.on('Purchase Invoice', {
     validate: function(frm){
-        validate_purchase_receipt_required(frm);
+        frm.events.validate_pr_required(frm);
         if(frm.doc.__islocal || frm.doc.docstatus==0){
             if(frm.doc.supplier){
                 set_expense_head(frm);
             }
         }     
+    },
+    validate_pr_required: function(frm) {
+        frappe.db.get_value('Buying Settings', 'Buying Settings', 'pr_required')
+        .then(r => {
+            if (r.message && r.message.pr_required == "Yes") {
+                // Get supplier setting
+                return frappe.db.get_value('Supplier', frm.doc.supplier, 'allow_purchase_invoice_creation_without_purchase_receipt');
+            }
+            return null;
+        })
+        .then(supplier_r => {
+            if (supplier_r && !supplier_r.message.allow_purchase_invoice_creation_without_purchase_receipt) {
+                validate_purchase_receipt_required(frm);
+            }
+        })
+        .catch(err => {
+            console.error('Error fetching settings:', err);
+        });
     },
     refresh: function(frm){
         add_create_sales_invoice_button(frm);


### PR DESCRIPTION
This pull request refactors the validation logic for requiring a purchase receipt in the `Purchase Invoice` form. The main improvement is moving the logic into a new method that checks both global and supplier-specific settings before deciding if validation is needed.

**Validation logic improvements:**

* Added a new method `validate_pr_required` to `purchase_invoice.js` that first checks the `Buying Settings` for the `pr_required` flag, and then checks the supplier's `allow_purchase_invoice_creation_without_purchase_receipt` setting before calling `validate_purchase_receipt_required`. This makes the validation more robust and configurable.
* Updated the `validate` event to use the new `validate_pr_required` method instead of directly calling `validate_purchase_receipt_required`.