### PR TITLE
fix: notify ToDo status change on condition

### DIFF
--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -27,6 +27,8 @@ def notify_todo_status_change(doc):
     """Notify user if ToDo status changes. Modular, clear, and logs notification."""
     if doc.is_new():
         return
+    if not doc.notify_allocated_to_via_email:
+        return
     status_in_db = frappe.db.get_value(doc.doctype, doc.name, "status")
     if status_in_db != doc.status and doc.assigned_by != doc.allocated_to:
         user = frappe.session.user


### PR DESCRIPTION
This pull request makes a targeted improvement to the notification logic for ToDo status changes. The main change is a new check that prevents notification emails from being sent unless the `notify_allocated_to_via_email` flag is set.

* Notification logic update: Added a conditional check to ensure that notifications are only sent if `doc.notify_allocated_to_via_email` is `True`, preventing unnecessary emails when the flag is not set.