### PR TITLE
fix: Medical Appointment - Attendance update

### DIFF
--- a/one_fm/custom/custom_field/attendance.py
+++ b/one_fm/custom/custom_field/attendance.py
@@ -47,7 +47,9 @@ def get_attendance_custom_fields():
                 "fieldname": "comment",
                 "fieldtype": "Small Text",
                 "insert_after": "attendance_comment",
-                "label": "Comment"
+                "label": "Comment",
+                "allow_on_submit": 1,
+                "read_only_depends_on": "eval:doc.docstatus==1"
             },
             {
                 "fieldname": "attendance_comment",

--- a/one_fm/custom/property_setter/attendance.py
+++ b/one_fm/custom/property_setter/attendance.py
@@ -22,8 +22,36 @@ def get_attendance_properties():
             "doc_type": "Attendance",
             "doctype_or_field": "DocField",
             "field_name": "working_hours",
-            "property": "depends_on",
-            "property_type": "Data"
+            "property": "read_only",
+            "property_type": "Data",
+            "value": "1"
+        },
+        {
+            "doctype": "Property Setter",
+            "doc_type": "Attendance",
+            "doctype_or_field": "DocField",
+            "field_name": "working_hours",
+            "property": "allow_on_submit",
+            "property_type": "Data",
+            "value": "1"
+        },
+        {
+            "doctype": "Property Setter",
+            "doc_type": "Attendance",
+            "doctype_or_field": "DocField",
+            "field_name": "status",
+            "property": "allow_on_submit",
+            "property_type": "Data",
+            "value": "1"
+        },
+        {
+            "doctype": "Property Setter",
+            "doc_type": "Attendance",
+            "doctype_or_field": "DocField",
+            "field_name": "status",
+            "property": "read_only_depends_on",
+            "property_type": "Data",
+            "value": "eval:doc.docstatus==1"
         },
         {
             "doctype": "Property Setter",
@@ -68,6 +96,6 @@ def get_attendance_properties():
             "field_name": "status",
             "property": "options",
             "property_type": "Select",
-            "value": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nHoliday\nOn Hold"
+            "value": "Present\nAbsent\nOn Leave\nHalf Day\nWork From Home\nDay Off\nClient Day Off\nFingerprint Appointment\nMedical Appointment\nHoliday\nOn Hold"
         }
     ]

--- a/one_fm/grd/doctype/medical_appointment/medical_appointment.py
+++ b/one_fm/grd/doctype/medical_appointment/medical_appointment.py
@@ -131,6 +131,7 @@ class MedicalAppointment(Document):
 			"comment": _("Created via Medical Appointment: {0}").format(self.name)
 		})
 		attendance_doc.insert(ignore_permissions=True)
+		attendance_doc.submit()
 
 	def on_submit(self):
 		self.validate_appointment_date()
@@ -155,7 +156,7 @@ class MedicalAppointment(Document):
 			{
 				"attendance_date": getdate(self.date_and_time_confirmation),
 				"employee": self.employee,
-				"status": "On Hold"
+				"status": ["in", ["On Hold", "Absent"]]
 			}
 		)
 

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -211,6 +211,7 @@ one_fm.patches.v15_0.mark_present_attendance_check
 one_fm.patches.v15_0.update_shift_request_doctype
 one_fm.patches.v15_0.update_historical_paci_documents
 one_fm.patches.v15_0.update_po_item_descriptions
+one_fm.patches.v15_0.update_attendance_properties #1
 
 
 [post_model_sync]

--- a/one_fm/patches/v15_0/update_attendance_properties.py
+++ b/one_fm/patches/v15_0/update_attendance_properties.py
@@ -1,0 +1,8 @@
+from one_fm.setup.setup import add_property_setter
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.property_setter.attendance import get_attendance_properties
+from one_fm.custom.custom_field.attendance import get_attendance_custom_fields
+
+def execute():
+    add_property_setter(get_attendance_properties())
+    create_custom_fields(get_attendance_custom_fields())


### PR DESCRIPTION
This pull request introduces several improvements to the attendance functionality, focusing on enhancing field properties, expanding attendance status options, and ensuring proper handling of attendance records related to medical appointments. The changes add new patch logic to update attendance properties and custom fields, and adjust the workflow for creating and updating attendance documents.

**Attendance field property enhancements:**

* Made the `working_hours` and `status` fields read-only and allowed them to be edited on submit, with conditional read-only logic based on document status in `one_fm/custom/property_setter/attendance.py`.
* Updated the `comment` field in attendance custom fields to allow editing on submit and made it read-only when the document is submitted in `one_fm/custom/custom_field/attendance.py`.

**Attendance status options expansion:**

* Added new status options (`Fingerprint Appointment`, `Medical Appointment`) to the attendance status field, increasing flexibility for tracking different types of attendance in `one_fm/custom/property_setter/attendance.py`.

**Medical appointment attendance workflow improvements:**

* Automatically submits the attendance document after creation from a medical appointment in `one_fm/grd/doctype/medical_appointment/medical_appointment.py`.
* Updated the attendance status filter to include both `On Hold` and `Absent` when updating attendance status from medical appointments in `one_fm/grd/doctype/medical_appointment/medical_appointment.py`.

**Patch and migration logic:**

* Added a new patch entry and implementation to update attendance properties and custom fields during migration in `one_fm/patches.txt` and `one_fm/patches/v15_0/update_attendance_properties.py`. [[1]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R214) [[2]](diffhunk://#diff-4467c3e6c9c15bfbe14ac5d3df9357f5d769d2de0e9c9c9829ac9889d144ec28R1-R8)