### PR TITLE
fix: medical appointment in roster

### DIFF
--- a/one_fm/one_fm/page/roster/roster.html
+++ b/one_fm/one_fm/page/roster/roster.html
@@ -310,6 +310,13 @@
 
 							<div class="col-sm-12 col-md-3 custompageselecttype mb10">
 								<div class="d-flex">
+									<div class="legendboxview cyanboxcolor"></div>
+									<div class="pl10 font16 cardtitlecolor">Medical Appointment</div>
+								</div>
+							</div>
+
+							<div class="col-sm-12 col-md-3 custompageselecttype mb10">
+								<div class="d-flex">
 									<div class="legendboxview tealboxcolor"></div>
 									<div class="pl10 font16 cardtitlecolor">On-the-job Training</div>
 								</div>

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1177,6 +1177,7 @@ let classmap = {
 	"Holiday": "greyboxcolor",
 	"On Hold": "orangeboxcolor",
 	"Fingerprint Appointment": "cyanboxcolor",
+	"Medical Appointment": "cyanboxcolor",
 	"On-the-job Training": "tealboxcolor",
 };
 
@@ -1196,6 +1197,7 @@ let abbr_map = {
 	"Leave Without Pay": "LWP",
 	"Working": "!",
 	"Fingerprint Appointment": "FA",
+	"Medical Appointment": "MA",
 	"On-the-job Training": "OJT",
 
 };
@@ -1325,6 +1327,7 @@ function render_roster(res, page) {
 		let ot_count = 0;
 		let employeeCellsHTML = ""; // Initialize for batch append
 		let is_fingerprint_appointment = false;
+		let is_medical_appointment = false;
 
 		while (current_day_iter <= end_moment_iter) {
 			let sch = ``;
@@ -1392,10 +1395,13 @@ function render_roster(res, page) {
 						bgclass = "diffdayoffot";
 						data_selectid = `${employee}|${date}|${operations_role}|${shift}|${employee_availability}`;
 					}
-					else if (attendance && in_list(["Day Off", "On Leave", "Absent", "On Hold", "Client Day Off", "Fingerprint Appointment"], attendance)) {
+					else if (attendance && in_list(["Day Off", "On Leave", "Absent", "On Hold", "Client Day Off", "Fingerprint Appointment", "Medical Appointment"], attendance)) {
 						data_selectid = `${employee}|${date}|${employee_availability}`;
 						if (attendance == "Fingerprint Appointment") {
 							is_fingerprint_appointment = true;
+						}
+						if (attendance == "Medical Appointment") {
+							is_medical_appointment = true;
 						}
 
 						if (attendance == "Absent") {
@@ -1422,6 +1428,9 @@ function render_roster(res, page) {
 					if (k == (employees_data[employee_key][date_key].length - 1)) {
 						if (attendance && attendance == "Fingerprint Appointment") {
 							tooltiptext += `Fingerprint Appointment`;
+							abbrv += `${abbr_map[attendance]}<br>`;
+						} else if (attendance && attendance == "Medical Appointment") {
+							tooltiptext += `Medical Appointment`;
 							abbrv += `${abbr_map[attendance]}<br>`;
 						} else if (attendance && attendance == "On Leave" && !employee_availability) {
 							tooltiptext += `${leave_application}<br>${leave_type}`;
@@ -1465,7 +1474,16 @@ function render_roster(res, page) {
 						<div class="${moment().isBefore(current_day_iter) ? "hoverselectclass" : "forbidden"} tablebox borderbox d-flex justify-content-center align-items-center so"
 							data-selectid="${employee}|${date_key}"></div>
 					</td>`;
-			} else {
+			} else if (is_medical_appointment) {
+				let tooltip_html = tooltiptext ? `<span class="customtooltiptext ${bgclass}">${tooltiptext}</span>` : "";
+				let hoverClass = is_medical_appointment ? "forbidden" : (moment().isBefore(current_day_iter) ? "hoverselectclass" : "forbidden");
+				sch = `
+					<td class="${todayClass}">
+						<div class="${hoverClass} tablebox ${bgclass} d-flex justify-content-center align-items-center text-white so customtooltip"
+							data-selectid="${data_selectid}" data-ot="${data_ot}">${abbrv}${tooltip_html}</div>
+					</td>`;
+			}
+			else {
 				let tooltip_html = tooltiptext ? `<span class="customtooltiptext ${bgclass}">${tooltiptext}</span>` : "";
 				let hoverClass = is_fingerprint_appointment ? "forbidden" : (moment().isBefore(current_day_iter) ? "hoverselectclass" : "forbidden");
 				sch = `
@@ -1476,6 +1494,7 @@ function render_roster(res, page) {
 			}
 			employeeCellsHTML += sch;
 			is_fingerprint_appointment = false;
+			is_medical_appointment = false;
 			current_day_iter.add(1, "days");
 		}
 		$employeeRow.append(employeeCellsHTML);


### PR DESCRIPTION
This pull request adds support for displaying "Medical Appointment" as a new attendance type in the roster UI. The changes ensure that "Medical Appointment" is visually represented with the correct color, abbreviation, tooltip, and cell behavior, similar to how "Fingerprint Appointment" is handled.

**UI and Data Representation Improvements:**

* Added a "Medical Appointment" legend item to the roster page to visually indicate this new attendance type (`roster.html`).
* Updated the `classmap` and `abbr_map` objects to include "Medical Appointment" with the appropriate color (`cyanboxcolor`) and abbreviation (`MA`) (`roster.js`). [[1]](diffhunk://#diff-09c6201bdae8582366359d00191389a70c46ee9a8eb0e693c22de818716de33eR1180) [[2]](diffhunk://#diff-09c6201bdae8582366359d00191389a70c46ee9a8eb0e693c22de818716de33eR1200)

**Roster Rendering Logic Updates:**

* Modified the roster rendering logic to recognize "Medical Appointment" as a special attendance type, ensuring it gets the correct cell styling and tooltip, and is marked as non-interactive (`forbidden`) in the UI (`roster.js`). [[1]](diffhunk://#diff-09c6201bdae8582366359d00191389a70c46ee9a8eb0e693c22de818716de33eR1330) [[2]](diffhunk://#diff-09c6201bdae8582366359d00191389a70c46ee9a8eb0e693c22de818716de33eL1395-R1405) [[3]](diffhunk://#diff-09c6201bdae8582366359d00191389a70c46ee9a8eb0e693c22de818716de33eR1432-R1434) [[4]](diffhunk://#diff-09c6201bdae8582366359d00191389a70c46ee9a8eb0e693c22de818716de33eL1468-R1486) [[5]](diffhunk://#diff-09c6201bdae8582366359d00191389a70c46ee9a8eb0e693c22de818716de33eR1497)