### PR TITLE
feat: reason in shift request

### DIFF
--- a/one_fm/custom/custom_field/shift_request.py
+++ b/one_fm/custom/custom_field/shift_request.py
@@ -284,6 +284,14 @@ def get_shift_request_custom_fields():
                 "read_only": 1,
                 "options": "User",
                 "ignore_user_permissions": 1
-             }
+             },
+            {
+                "fieldname": "reason",
+                "fieldtype": "Small Text",
+                "insert_after": "status",
+                "label": "Reason",
+                "reqd": 1,
+                "translatable": 1
+            }
         ]
     }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -220,6 +220,7 @@ one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_o
 one_fm.patches.v15_0.update_attendance_properties #1
 one_fm.patches.v15_0.create_quality_feedback_reminder_process_task
 one_fm.patches.v15_0.add_style_field_to_workflow_document_state
+one_fm.patches.v15_0.add_reason_field_to_shift_request
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_client_event

--- a/one_fm/patches/v15_0/add_reason_field_to_shift_request.py
+++ b/one_fm/patches/v15_0/add_reason_field_to_shift_request.py
@@ -1,0 +1,6 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.custom_field.shift_request import get_shift_request_custom_fields
+
+def execute():
+    create_custom_fields(get_shift_request_custom_fields())


### PR DESCRIPTION
This pull request introduces a new required "Reason" field to the Shift Request form and ensures its creation via a migration patch. The changes are grouped into two main themes: feature addition and migration support.

**Feature Addition:**

* Added a new required custom field `reason` (type: Small Text) to the Shift Request form, making it translatable and positioned after the `status` field.

**Migration Support:**

* Created a migration script `add_reason_field_to_shift_request.py` that uses the custom field definition to add the new field during deployment.
* Registered the migration patch in `patches.txt` to ensure it runs as part of the update process.