### PR TITLE
feat: validate event staff-schedule from client event

### DIFF
--- a/one_fm/one_fm/doctype/client_event/client_event.js
+++ b/one_fm/one_fm/doctype/client_event/client_event.js
@@ -10,88 +10,141 @@ frappe.ui.form.on("Client Event", {
             frm.add_custom_button(__("Add Staff to Event"), function() {
                 let d = new frappe.ui.Dialog({
                     title: __("Add Staff to Event"),
-                    fields: [
-                        {
-                            label: __("Staff"),
-                            fieldname: "staff",
-                            fieldtype: "Table",
-                            fields: [
-                                {
-                                    label: __("Employee"),
-                                    fieldname: "employee",
-                                    fieldtype: "Link",
-                                    options: "Employee",
-                                    in_list_view: 1,
-                                    reqd: 1,
-                                    get_query: () => {
-                                        let designations = (frm.doc.staffing_requirements || []).map(d => d.designation);
-                                        return {
-                                            filters: {
-                                                designation: ["in", designations]
-                                            }
-                                        };
-                                    },
-                                    onchange: function() {
-                                        let employee = this.get_value();
-                                        let row = this.grid_row;
-                                        if (employee) {
-                                            row.doc.roster_type = 'Basic';
-                                            frappe.db.get_value('Employee', employee, 'designation', (r) => {
-                                                row.doc.designation = r.designation;
-                                                row.refresh();
-                                            });
-                                        }
-                                    }
-                                },
-                                {
-                                    label: __("Designation"),
-                                    fieldname: "designation",
-                                    fieldtype: "Link",
-                                    options: "Designation",
-                                    in_list_view: 1,
-                                    reqd: 1,
-                                },
-                                {
-                                    label: __("Roster Type"),
-                                    fieldname: "roster_type",
-                                    fieldtype: "Select",
-                                    options: "Basic\nOver-Time",
-                                    in_list_view: 1,
-                                    reqd: 1,
-                                },
-                                {
-                                    label: __("Day Off OT"),
-                                    fieldname: "day_off_ot",
-                                    fieldtype: "Check",
-                                    depends_on: "eval:doc.roster_type=='Basic'",
-                                },
-                                {
-                                    label: __("Operations Shift"),
-                                    fieldname: "operations_shift",
-                                    fieldtype: "Link",
-                                    options: "Operations Shift",
-                                },
-                            ],
-                        },
-                    ],
+                    fields: get_add_staff_event_dialog_fields(frm),
                     primary_action_label: __("Submit"),
                     primary_action: (values) => {
-                        frm.call({
-                            method: "add_event_staff",
-                            doc: frm.doc,
-                            args: {
-                                staff: JSON.stringify(values.staff)
-                            },
-                            callback: function(r) {
-                                frappe.msgprint(__("Event Staff created successfully."));
-                                frm.reload_doc();
+                        let employees = values.staff.map(s => s.employee);
+                        return new Promise((resolve, reject) => {
+                            confirm_conflict_schedules(frm, employees, resolve, reject);
+                        }).then((result) => {
+                            if (result) {
+                                frm.events.submit_event_staff(frm, values);
                             }
+                            d.hide();
                         });
-                        d.hide();
                     },
                 });
                 d.show();
             });
         }
+    },
+    submit_event_staff(frm, values) {
+        frm.call({
+            method: "add_event_staff",
+            doc: frm.doc,
+            args: {
+                staff: JSON.stringify(values.staff)
+            },
+            callback: function(r) {
+                if (r.message) {
+                    frappe.show_alert(__("Event Staff added successfully."));
+                }
+            }
+        });
     }
 });
+
+function get_add_staff_event_dialog_fields(frm) {
+    return [
+    {
+            label: __("Staff"),
+            fieldname: "staff",
+            fieldtype: "Table",
+            fields: [
+                {
+                    label: __("Employee"),
+                    fieldname: "employee",
+                    fieldtype: "Link",
+                    options: "Employee",
+                    in_list_view: 1,
+                    reqd: 1,
+                    get_query: () => {
+                        let designations = (frm.doc.staffing_requirements || []).map(d => d.designation);
+                        return {
+                            filters: {
+                                designation: ["in", designations]
+                            }
+                        };
+                    },
+                    onchange: function() {
+                        let employee = this.get_value();
+                        let row = this.grid_row;
+                        if (employee) {
+                            row.doc.roster_type = 'Basic';
+                            frappe.db.get_value('Employee', employee, 'designation', (r) => {
+                                row.doc.designation = r.designation;
+                                row.refresh();
+                            });
+                        }
+                    }
+                },
+                {
+                    label: __("Designation"),
+                    fieldname: "designation",
+                    fieldtype: "Link",
+                    options: "Designation",
+                    in_list_view: 1,
+                    reqd: 1,
+                },
+                {
+                    label: __("Roster Type"),
+                    fieldname: "roster_type",
+                    fieldtype: "Select",
+                    options: "Basic\nOver-Time",
+                    in_list_view: 1,
+                    reqd: 1,
+                },
+                {
+                    label: __("Day Off OT"),
+                    fieldname: "day_off_ot",
+                    fieldtype: "Check",
+                    depends_on: "eval:doc.roster_type=='Basic'",
+                },
+                {
+                    label: __("Operations Shift"),
+                    fieldname: "operations_shift",
+                    fieldtype: "Link",
+                    options: "Operations Shift",
+                },
+            ],
+        },
+    ]
+}
+
+function confirm_conflict_schedules(frm, employees, resolve, reject) {
+    frappe.call({
+        method: "one_fm.one_fm.doctype.event_staff.event_staff.get_conflicting_dates",
+        args: {
+            employee: employees,
+            start_date: frm.doc.start_date,
+            end_date: frm.doc.end_date,
+        },
+        callback: function (r) {
+            if (r.message && r.message.length > 0) {
+                let conflicting_dates = r.message;
+                let total_days = frappe.datetime.get_day_diff(frm.doc.end_date, frm.doc.start_date) + 1;
+                let message = "";
+
+                if (conflicting_dates.length === total_days) {
+                    message = __("Do you want to Replace the Existing Employee Schedule?");
+                } else {
+                    message = __("Employee Schedule exists for {0} out of {1} days. <br>Details: {2}. <br>Do you want to Replace the Existing Employee Schedules for conflicting days?", [conflicting_dates.length, total_days, conflicting_dates.join(", ")]);
+                }
+
+                frappe.confirm(
+                    message,
+                    () => {
+                        resolve(true);
+                    },
+                    () => {
+                        resolve(false);
+                    }
+                );
+            } else {
+                resolve(true);
+            }
+        },
+        freeze: true,
+        freeze_message: __("Checking for schedule conflicts...")
+    });
+}

--- a/one_fm/one_fm/doctype/client_event/client_event.py
+++ b/one_fm/one_fm/doctype/client_event/client_event.py
@@ -41,3 +41,4 @@ class ClientEvent(Document):
 			doc.operations_shift = record.get("operations_shift")
 			doc.save(ignore_permissions=True)
 			doc.submit()
+		return True

--- a/one_fm/one_fm/doctype/event_staff/event_staff.py
+++ b/one_fm/one_fm/doctype/event_staff/event_staff.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import getdate, add_days, date_diff, today
 import datetime
+import json
 
 class EventStaff(Document):
 	def validate(self):
@@ -211,11 +212,23 @@ def get_existing_schedules(employee=None, start_date=None, end_date=None, event_
 
 	filters = {"docstatus": 0}
 
+	# Handle employee parameter - could be a list, JSON string, or simple string
+	if isinstance(employee, str):
+		# Try to parse as JSON first (for list of employees)
+		try:
+			employee = json.loads(employee)
+		except (json.JSONDecodeError, ValueError):
+			# If JSON parsing fails, it's a simple employee ID string
+			pass
+
 	if event_staff:
 		filters["event_staff"] = event_staff
 		filters["is_event_schedule"] = 1
 	else:
-		filters["employee"] = employee
+		if isinstance(employee, list):
+			filters["employee"] = ["in", employee]
+		else:
+			filters["employee"] = employee
 		filters["date"] = ["between", [start_date, end_date]]
 
 	return frappe.get_all(


### PR DESCRIPTION
This pull request enhances the workflow for adding staff to a client event by introducing a schedule conflict check before submission and improving the handling of employee lists in backend methods. The changes ensure that users are warned about conflicting schedules and can choose to proceed or not, and that employee data is consistently handled whether passed as a single value or a list.

**Improvements to adding staff to events:**
- The "Add Staff to Event" dialog now checks for scheduling conflicts before submitting. If conflicts exist, users are prompted to confirm whether to replace existing schedules for the affected dates. The dialog only proceeds if the user confirms. [[1]](diffhunk://#diff-28da6f25dd0549ae89d5593a0b525757b8bf9557e5d56d075659f962e424b4caL13-R48) [[2]](diffhunk://#diff-28da6f25dd0549ae89d5593a0b525757b8bf9557e5d56d075659f962e424b4caL76-R150)
- The dialog fields and primary action logic have been refactored for better modularity and readability, moving field definitions to a helper function and extracting the submission logic.

**Backend enhancements for employee handling:**
- The backend method for adding event staff now returns a success indicator, improving API consistency.
- The `get_existing_schedules` function now robustly parses the `employee` parameter, supporting both single employee strings and lists (including JSON-encoded lists), ensuring compatibility with frontend changes.
- Added a missing import for `json` in `event_staff.py` to support the new employee parameter handling.