### PR TITLE
fix: project override - remove super().onload

### DIFF
--- a/one_fm/overrides/project.py
+++ b/one_fm/overrides/project.py
@@ -126,6 +126,5 @@ class ProjectOverride(Project):
         get_depreciation_expense_amount(self)
 
     def on_update(self):
-        super().on_update()
         update_project_manager_name(self, None)
         on_project_update_switch_shift_site_post_to_inactive(self, None)


### PR DESCRIPTION
This pull request makes a small change to the `on_update` method in `project.py`, removing the call to the superclass's `on_update` method. Since there is no on_update on super class