### PR TITLE
feat: workflow banner message

### DIFF
--- a/one_fm/api/utils.py
+++ b/one_fm/api/utils.py
@@ -36,3 +36,21 @@ def set_up_face_recognition_server_credentials():
     except Exception as e:
         frappe.log_error("Face Recognition Setup", frappe.get_traceback())
         return {'error':True, 'message':e}
+
+@frappe.whitelist()
+def get_workflow_state_banner_message(doctype, workflow_state):
+    """
+    Retrieves a banner message from the Workflow Document State.
+    """
+    if not doctype or not workflow_state:
+        return None
+
+    workflow_name = frappe.db.get_value("Workflow", {"document_type": doctype, "is_active": 1}, "name")
+
+    if not workflow_name:
+        return None
+
+    message = frappe.db.get_value("Workflow Document State", {"parent": workflow_name, "state": workflow_state}, "banner_message")
+    style = frappe.db.get_value("Workflow State", workflow_state, "style")
+
+    return {"message": message, "style": style}

--- a/one_fm/custom/custom_field/workflow_document_state.py
+++ b/one_fm/custom/custom_field/workflow_document_state.py
@@ -7,6 +7,13 @@ def get_workflow_document_state_custom_fields():
                 "label": "Style",
                 "insert_after": "update_value",
                 "fetch_from": "state.style"
+            },
+            {
+                "label": "Banner Message",
+                "fieldname": "banner_message",
+                "fieldtype": "Small Text",
+                "insert_after": "message",
+                "description": "The message here will be displayed when a document in this workflow state is opened.",
             }
         ]
     }

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -33,7 +33,8 @@ app_include_js = [
 		"/assets/one_fm/js/desk.js",
         "/assets/one_fm/js/showdown.min.js",
 		"/assets/one_fm/js/form_overrides/workflow_override.js",
-        "text_editor.bundle.js"
+        "text_editor.bundle.js",
+        "/assets/one_fm/js/workflow_banner.js"
 ]
 # include js, css files in header of web template
 # web_include_css = "/assets/one_fm/css/one_fm.css"

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -223,6 +223,7 @@ one_fm.patches.v15_0.add_style_field_to_workflow_document_state
 one_fm.patches.v15_0.add_reason_field_to_shift_request
 one_fm.patches.v15_0.add_workflow_on_the_job_training #2
 one_fm.patches.v15_0.reprocess_preparation_submit
+one_fm.patches.v15_0.add_banner_message_field_to_workflow_document_state
 one_fm.patches.v15_0.add_stock_settings_custom_fields
 
 [post_model_sync]

--- a/one_fm/patches/v15_0/add_banner_message_field_to_workflow_document_state.py
+++ b/one_fm/patches/v15_0/add_banner_message_field_to_workflow_document_state.py
@@ -1,0 +1,6 @@
+import frappe
+from one_fm.custom.custom_field.workflow_document_state import get_workflow_document_state_custom_fields
+
+def execute():
+    from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+    create_custom_fields(get_workflow_document_state_custom_fields())

--- a/one_fm/public/js/workflow_banner.js
+++ b/one_fm/public/js/workflow_banner.js
@@ -1,0 +1,101 @@
+(function() {
+    'use strict';
+    
+    // Store original set_intro method
+    const original_set_intro = frappe.ui.form.Form.prototype.set_intro;
+    
+    // Cache for workflow state banner data to reduce API calls
+    const workflow_banner_cache = {};
+    
+    // Color mapping for workflow states
+    const COLOR_MAP = {
+        'Success': 'green',
+        'Warning': 'orange',
+        'Danger': 'red',
+        'Primary': 'blue',
+        'Info': 'blue',
+        'Inverse': 'darkgrey'
+    };
+    
+    // Override set_intro method
+    frappe.ui.form.Form.prototype.set_intro = function(txt, color) {
+        const frm = this;
+        
+        // Check if workflow is enabled for this doctype
+        if (frm.doc && frm.doc.workflow_state) {
+            // Fetch and prepend workflow banner
+            fetch_workflow_banner(frm, function(banner_html) {
+                if (banner_html) {
+                    // Call original set_intro with workflow banner first
+                    original_set_intro.call(frm, banner_html.message, banner_html.color);
+                }
+                
+                // Then append the original intro message if provided
+                if (txt) {
+                    original_set_intro.call(frm, txt, color);
+                }
+            });
+        } else {
+            // No workflow, call original method normally
+            original_set_intro.call(frm, txt, color);
+        }
+    };
+    
+    // Function to fetch workflow banner message
+    function fetch_workflow_banner(frm, callback) {
+        const current_state = frm.doc.workflow_state;
+        
+        if (!current_state) {
+            callback(null);
+            return;
+        }
+        
+        // Check cache first
+        if (workflow_banner_cache[current_state]) {
+            callback(workflow_banner_cache[current_state]);
+            return;
+        }
+        
+        // Fetch from server
+        frappe.call({
+            method: 'one_fm.api.utils.get_workflow_state_banner_message',
+            args: {
+                doctype: frm.doc.doctype,
+                workflow_state: frm.doc.workflow_state
+            },
+            callback: function(r) {
+                if (r.message) {
+                    const banner_data = {
+                        message: r.message.message || '',
+                        color: COLOR_MAP[r.message.style] || 'blue'
+                    };
+                    
+                    // Cache the result
+                    workflow_banner_cache[current_state] = banner_data;
+                    callback(banner_data);
+                } else {
+                    callback(null);
+                }
+            },
+            error: function(r) {
+                console.error('Error fetching workflow banner:', r);
+                callback(null);
+            }
+        });
+    }
+    
+    // Clear cache when workflow state changes
+    frappe.ui.form.on('*', {
+        after_workflow_action: function(frm) {
+            // Clear cache for current state
+            if (frm.doc.workflow_state && workflow_banner_cache[frm.doc.workflow_state]) {
+                delete workflow_banner_cache[frm.doc.workflow_state];
+            }
+            
+            // Refresh to show new banner
+            frm.refresh();
+        }
+    });
+    
+    console.log('Workflow Banner Wrapper (set_intro) initialized');
+})();


### PR DESCRIPTION
This pull request introduces a new feature that displays a customizable banner message on forms based on the current workflow state of a document. It does so by adding a new "Banner Message" field to workflow document states, providing backend and frontend logic to retrieve and display the message, and ensuring the feature is initialized and maintained correctly in the UI. The changes are grouped below by theme.

**Workflow Banner Feature Implementation**

* Added a new "Banner Message" custom field to the `Workflow Document State` to allow administrators to specify a message shown for each workflow state. [[1]](diffhunk://#diff-0be621b4f871fc46402f6569f64ad86bdb93f8748f1a9f83f216695d2cf4883aR10-R16) [[2]](diffhunk://#diff-773b752d81c8c128eb913f77e74dd65f74b861b37204dc072c9a352d1ebd769dR1-R6) [[3]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R226)
* Added a backend API method `get_workflow_state_banner_message` to fetch the banner message and style for a given document type and workflow state.

**Frontend Integration**

* Implemented `workflow_banner.js` to override the form's `set_intro` method, fetching and displaying the workflow banner message and style dynamically on form load and after workflow actions.
* Registered the new JavaScript file `workflow_banner.js` to be included in the app's assets, ensuring the banner functionality is loaded on relevant forms.