### PR TITLE
feat: cancel shift permission

### DIFF
--- a/one_fm/operations/doctype/shift_permission/shift_permission.py
+++ b/one_fm/operations/doctype/shift_permission/shift_permission.py
@@ -115,7 +115,36 @@ class ShiftPermission(Document):
 				create_notification_log(subject, message, [employee_user], self)
 
 	def on_cancel(self):
-		pass
+		if getdate(self.date) < getdate():
+			frappe.throw(_("Cannot cancel shift permission for a past date."))
+
+		# Revert checkin
+		checkins = frappe.get_all("Employee Checkin", filters={"shift_permission": self.name}, fields=["name"])
+		for checkin in checkins:
+			frappe.delete_doc("Employee Checkin", checkin.name, ignore_permissions=True)
+
+		# Revert shift assignment datetimes
+		if self.assigned_shift:
+			shift_assignment = frappe.get_doc("Shift Assignment", self.assigned_shift)
+			if shift_assignment.shift_type:
+				shift_type = frappe.get_value("Shift Type", shift_assignment.shift_type, ["start_time", "end_time"], as_dict=True)
+
+				start_time = shift_type.start_time
+				end_time = shift_type.end_time
+
+				# Recalculate start_datetime
+				start_datetime = datetime.combine(shift_assignment.start_date, datetime.min.time()) + start_time
+
+				# Recalculate end_datetime, handling midnight crossing
+				end_date = shift_assignment.start_date
+				if start_time > end_time:
+					end_date = frappe.utils.add_days(end_date, 1)
+				end_datetime = datetime.combine(end_date, datetime.min.time()) + end_time
+
+				frappe.db.set_value("Shift Assignment", self.assigned_shift, {
+					"start_datetime": start_datetime,
+					"end_datetime": end_datetime
+				})
 
 
 	def update_shift_assignment_checkin(self) -> None:


### PR DESCRIPTION
This pull request adds important logic to the `on_cancel` method of the `Shift Permission` doctype in `shift_permission.py`. The changes prevent cancellation of shift permissions for past dates and ensure that related records are properly reverted when a shift permission is cancelled.

Key changes:

**Shift Permission cancellation logic:**

* Prevents cancelling a shift permission if the date is in the past by throwing a validation error.

**Data consistency and cleanup:**

* Deletes any associated `Employee Checkin` records when a shift permission is cancelled.
* If the shift permission is linked to a `Shift Assignment`, recalculates and restores the original `start_datetime` and `end_datetime` fields on the `Shift Assignment` document, handling midnight crossing if necessary.