### PR TITLE
fix: birthday reminder

### DIFF
--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -105,25 +105,33 @@ def is_email_notifications_allowed(user):
     # If all conditions pass, return True (email notifications are allowed)
     return True
 
-
 @frappe.whitelist()
 def is_user_id_company_prefred_email_in_employee(user_id):
 	'''
-		This method is used for finding the receiver is company prefered_email
-		in the employee record linked with the user_id
-		args:
-			user_id: email id (Text)(Email)
-		return True if user id is company prefered email id
-		return False if employee not exists for the user id / user id is company prefered email id
+	Check if user_id is an active employee's company email set as preferred contact.
+	Args:
+		user_id: email id (Text/Email)
+	Returns:
+		True if user_id matches an active employee's company email with Company Email preference
+		False otherwise
 	'''
-	user_id_company_prefred_in_employee = False
-	employee = frappe.db.exists('Employee', {'user_id': user_id}) or frappe.db.exists('Employee', {'personal_email': user_id})
-	if employee:
-		employee_details = frappe.db.get_value("Employee", employee, ["prefered_email", "company_email", "prefered_contact_email", "status", "personal_email"], as_dict=1)
-		if employee_details:
-			if all((employee_details.get("prefered_contact_email", "") == 'Company Email', employee_details.get("prefered_email", "") == employee_details.get("company_email", ""), ((employee_details.get("prefered_email", "") == user_id) or (employee_details.get("personal_email", "") == user_id)), employee_details.get("status", "") == "Active")):
-				user_id_company_prefred_in_employee = True
-	return user_id_company_prefred_in_employee
+	employee = frappe.db.get_value(
+		"Employee",
+		{
+			"user_id": user_id,
+			"status": "Active",
+			"prefered_contact_email": "Company Email",
+			"company_email": user_id,
+			"prefered_email": user_id
+		},
+		["name"],
+		as_dict=1
+	)
+
+	if not employee:
+		return False
+
+	return True
 
 @frappe.whitelist()
 def send_whatsapp(sender_id, template_name, content_variables):

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -39,7 +39,7 @@ from frappe.workflow.doctype.workflow_action.workflow_action import (
 
 import erpnext
 from erpnext.setup.doctype.employee.employee import (
-    get_holiday_list_for_employee, get_all_employee_emails, get_employee_email
+    get_holiday_list_for_employee, get_employee_email
 )
 
 
@@ -51,7 +51,7 @@ from hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry import (
 
 from one_fm.api.notification import create_notification_log, get_employee_user_id
 
-from one_fm.processor import sendemail
+from one_fm.processor import sendemail, is_user_id_company_prefred_email_in_employee
 from one_fm.one_fm.payroll_utils import get_user_list_by_role
 from one_fm.operations.doctype.operations_shift.operations_shift import get_shift_supervisor
 from one_fm.api import api
@@ -3660,65 +3660,63 @@ def get_sender_email() -> str | None:
 @frappe.whitelist()
 def send_birthday_reminders():
     """Send Employee birthday reminders if no 'Stop Birthday Reminders' is not set."""
-    from hrms.controllers.employee_reminders import send_birthday_reminder, get_employees_who_are_born_today,get_birthday_reminder_text_and_message
+    from hrms.controllers.employee_reminders import send_birthday_reminder, get_employees_who_are_born_today, get_birthday_reminder_text_and_message
 
     to_send = int(frappe.db.get_single_value("HR Settings", "send_birthday_reminders")) or is_scheduler_emails_enabled()
     if not to_send:
         return
 
     sender = get_sender_email()
+    if not sender:
+        return
+
     employees_born_today = get_employees_who_are_born_today()
 
     for company, birthday_persons in employees_born_today.items():
-        employee_emails = get_all_employee_emails(company,is_birthday = True)
+        employee_emails = get_users_for_reminders(birthday=True)
 
-        birthday_person_emails = [get_employee_email(doc) for doc in birthday_persons]
+        birthday_person_emails = [birthday_person.get("user_id") for birthday_person in birthday_persons]
         recipients = list(set(employee_emails) - set(birthday_person_emails))
 
         reminder_text, message = get_birthday_reminder_text_and_message(birthday_persons)
-        send_birthday_reminder(recipients, reminder_text, birthday_persons, message, sender)
+        if recipients and len(recipients) > 0:
+            send_birthday_reminder(recipients, reminder_text, birthday_persons, message, sender)
 
-        if len(birthday_persons) > 1:
+        if birthday_persons and len(birthday_persons) > 1:
             # special email for people sharing birthdays
             for person in birthday_persons:
-                person_email = person["user_id"] or person["personal_email"] or person["company_email"]
-                if frappe.get_value("Notification Settings",person['user_id'],'custom_enable_employee_birthday_notification'):
+                if not person.get('user_id'):
+                    continue
+                allowed_to_remind = get_users_for_reminders(birthday=True, user_id=person.get('user_id'))
+                if allowed_to_remind:
                     others = [d for d in birthday_persons if d != person]
                     reminder_text, message = get_birthday_reminder_text_and_message(others)
-                    send_birthday_reminder(person_email, reminder_text, others, message, sender)
+                    send_birthday_reminder(person.get('user_id'), reminder_text, others, message, sender)
 
+def get_users_for_reminders(birthday=False, anniversary=False, user_id=False):
+    """Returns a list of user IDs for employees who have opted in for birthday or anniversary reminders."""
+    allowed_users = []
+    if not birthday and not anniversary:
+        return allowed_users
 
+    filters = {}
+    if birthday:
+        filters["custom_enable_employee_birthday_notification"] = 1
+    if anniversary:
+        filters["custom_enable_work_anniversary_notification"] = 1
+    if user_id:
+        filters["name"] = user_id
 
-def get_all_employee_emails(company,is_birthday=False,is_anniversary = False):
-    """Returns list of employee emails either based on user_id or company_email"""
-
-    if not is_birthday and not is_anniversary:
-        return []
-    all_users=[]
-    if is_anniversary:
-        all_users = frappe.get_all("Notification Settings",{'custom_enable_work_anniversary_notification':1},['name'])
-    if is_birthday:
-        all_users = frappe.get_all("Notification Settings",{'custom_enable_employee_birthday_notification':1},['name'])
-    if all_users and None not in all_users:
-        all_users = [i.name for i in all_users]
-    else:
-        return []
-    employee_list = frappe.get_all(
-        "Employee", fields=["name", "employee_name"], filters={'user_id':['IN',all_users],"status": "Active", "company": company}
+    users = frappe.get_all(
+        "Notification Settings",
+        filters=filters,
+        fields=['name']
     )
-
-    employee_emails = []
-    for employee in employee_list:
-        if not employee:
-            continue
-        user, company_email, personal_email = frappe.db.get_value(
-            "Employee", employee, ["user_id", "company_email", "personal_email"]
-        )
-        email = user or company_email or personal_email
-        if email:
-            employee_emails.append(email)
-    return employee_emails
-
+    if users:
+        for user in users:
+            if is_user_id_company_prefred_email_in_employee(user.name):
+                allowed_users.append(user.name)
+    return allowed_users
 
 @frappe.whitelist()
 def send_work_anniversary_reminders():
@@ -3736,7 +3734,7 @@ def send_work_anniversary_reminders():
     message += _("Everyone, let’s congratulate them on their work anniversary!")
 
     for company, anniversary_persons in employees_joined_today.items():
-        employee_emails = get_all_employee_emails(company,is_anniversary=True)
+        employee_emails = get_users_for_reminders(anniversary=True)
 
         anniversary_person_emails = [get_employee_email(doc) for doc in anniversary_persons]
         recipients = list(set(employee_emails) - set(anniversary_person_emails))


### PR DESCRIPTION
This pull request refactors the logic for sending birthday and work anniversary reminders to employees. The main improvements include streamlining how eligible recipients are determined, centralizing notification preference checks, and improving code readability and maintainability.

**Refactoring notification recipient logic:**

* Replaced the old `get_all_employee_emails` function with a new `get_users_for_reminders` function, which filters users based on their notification settings and ensures only active employees with company-preferred emails are included.
* Updated calls in `send_birthday_reminders` and `send_work_anniversary_reminders` to use `get_users_for_reminders` for determining eligible recipients, improving consistency and reliability. [[1]](diffhunk://#diff-f233b284a4608da1fb5bbfc175686061301f7086f4d60ec454a4b8c160260ae0R3670-R3719) [[2]](diffhunk://#diff-f233b284a4608da1fb5bbfc175686061301f7086f4d60ec454a4b8c160260ae0L3739-R3737)

**Centralizing and simplifying eligibility checks:**

* Refactored `is_user_id_company_prefred_email_in_employee` to use a single database query for determining if a user is an active employee with company email preference, reducing code complexity and improving performance.
* Integrated `is_user_id_company_prefred_email_in_employee` into the new recipient selection logic, ensuring only valid users receive notifications.

**Code cleanup and import adjustments:**

* Removed unused imports and updated import statements to reflect the new function usage, helping maintain code clarity. [[1]](diffhunk://#diff-f233b284a4608da1fb5bbfc175686061301f7086f4d60ec454a4b8c160260ae0L42-R42) [[2]](diffhunk://#diff-f233b284a4608da1fb5bbfc175686061301f7086f4d60ec454a4b8c160260ae0L54-R54)