### PR TITLE
fix: allow preparation for active employees only

### DIFF
--- a/one_fm/grd/doctype/preparation/preparation.py
+++ b/one_fm/grd/doctype/preparation/preparation.py
@@ -101,7 +101,7 @@ class Preparation(Document):
 
     def on_submit(self):
         self.validate_mandatory_fields_on_submit()
-
+        validate_preparation_table(self)
         self.db_set('submitted_by', frappe.session.user)
         self.db_set('submitted_on', now_datetime())
         self.recall_create_work_permit_renewal() ## create work permit record for renewals
@@ -373,8 +373,8 @@ def cancel_delete_doc(doctype,source,row):
 
 def validate_preparation_table(doc):
     """Ensure that all the employees in the preparation table are in Active Status"""
-    
-    all_active_staff = frappe.get_all("Employee",{'status': ["IN",["Active","Vacation"]]})
+
+    all_active_staff = frappe.get_all("Employee",{'status': ["IN",["Active"]]})
     if all_active_staff:
         all_active_staff_list = [o.name for o in all_active_staff]
         for each in doc.preparation_record:

--- a/one_fm/grd/doctype/work_permit/work_permit.json
+++ b/one_fm/grd/doctype/work_permit/work_permit.json
@@ -396,11 +396,11 @@
    "options": "Preparation"
   },
   {
-   "depends_on": "eval:doc.workflow_state=='Pending By PAM' || doc.workflow_state=='Pending By Operator'",
+   "depends_on": "eval:doc.workflow_state=='Pending By Supervisor' || doc.workflow_state=='Pending By PAM' || doc.workflow_state=='Pending By Operator'",
    "fieldname": "new_work_permit_expiry_date",
    "fieldtype": "Date",
    "label": "Updated Work Permit Expiry Date",
-   "mandatory_depends_on": "eval:doc.workflow_state=='Pending By PAM' || doc.workflow_state=='Pending By Operator'"
+   "mandatory_depends_on": "eval:doc.workflow_state=='Pending By Supervisor' || doc.workflow_state=='Pending By PAM' || doc.workflow_state=='Pending By Operator'"
   },
   {
    "allow_on_submit": 1,
@@ -808,13 +808,13 @@
    "options": "User"
   },
   {
-   "depends_on": "eval:doc.workflow_state == \"Pending by Supervisor\" || doc.workflow_state == \"Pending by Operator\" || doc.workflow_state == \"Completed\"|| doc.workflow_state == \"Pending By PAM\"",
+   "depends_on": "eval:doc.workflow_state == \"Pending By Supervisor\" || doc.workflow_state == \"Pending by Operator\" || doc.workflow_state == \"Completed\"|| doc.workflow_state == \"Pending By PAM\"",
    "fieldname": "payment_details_section_section",
    "fieldtype": "Section Break",
    "label": "Payment Details Section"
   },
   {
-   "depends_on": "eval:doc.workflow_state=='Pending By PAM' || doc.workflow_state=='Pending By Operator'",
+   "depends_on": "eval:doc.workflow_state=='Pending By Supervisor' || doc.workflow_state=='Pending By PAM' || doc.workflow_state=='Pending By Operator'",
    "fieldname": "work_permit_information_section",
    "fieldtype": "Section Break",
    "label": "Work Permit Information"
@@ -921,7 +921,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-11-27 12:10:29.849038",
+ "modified": "2025-12-24 20:01:52.632169",
  "modified_by": "Administrator",
  "module": "GRD",
  "name": "Work Permit",

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -62,17 +62,18 @@ class WorkPermit(Document):
                 frappe.throw(_("{0}'s Relieving Date has been set to {1}. Work Permit processing is not allowed.").format(employee_details.employee_name, employee_details.relieving_date))
 
     def validate_workflow_state_fields(self):
-        states = ['Pending By PAM Operator', 'Pending By Operator']
+        states = ['Pending By Supervisor', 'Pending By PAM']
         db_state = frappe.db.get_value("Work Permit", self.name, 'workflow_state')
         # check for required fields based on workflow
-        if db_state in states and not self.new_work_permit_expiry_date:
-            frappe.throw("Missing Data fill Updated Work Permit Expiry Date field.")
-
-        # check if receipt uploaded and status is supervisor
-        if self.attach_invoice and self.workflow_state=="Pending By PAM Operator":
-            # send email to perm operation
-            send_workflow_action_email(self, [self.pam_operator])
-        # frappe.throw(f"""{pam_operator_email}, {self.attach_invoice}, {self.workflow_state}""")
+        if db_state in states:
+            msg = False
+            if  not self.attach_invoice:
+                msg = "Upload the required document(Invoice)"
+            if not self.new_work_permit_expiry_date:
+                msg = ((msg+" and ") if msg else "") + "Set <i>Updated Work Permit Expiry Date</i>"
+            if msg:
+                msg += " to submit"
+                frappe.throw(_(msg))
 
 
     def send_work_permit_receipt_to_perm_operator(self):

--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -67,7 +67,7 @@ class WorkPermit(Document):
         # check for required fields based on workflow
         if db_state in states:
             msg = False
-            if  not self.attach_invoice:
+            if not self.attach_invoice:
                 msg = "Upload the required document(Invoice)"
             if not self.new_work_permit_expiry_date:
                 msg = ((msg+" and ") if msg else "") + "Set <i>Updated Work Permit Expiry Date</i>"
@@ -239,7 +239,7 @@ class WorkPermit(Document):
                 self.set_work_permit_attachment_in_employee_doctype(self.new_work_permit_expiry_date)
             else:
                 msg = False
-                if  not self.attach_invoice:
+                if not self.attach_invoice:
                     msg = "Upload the required document(Invoice)"
                 if not self.new_work_permit_expiry_date:
                     msg = ((msg+" and ") if msg else "") + "Set <i>Updated Work Permit Expiry Date</i>"


### PR DESCRIPTION
This pull request introduces several updates to the work permit and preparation processes, primarily tightening validation logic and expanding workflow conditions to ensure data integrity and proper field requirements. The most significant changes are grouped below by theme.

**Validation and Business Logic Improvements:**

* The `validate_preparation_table` function now only considers employees with `"Active"` status (removing `"Vacation"` as a valid status), strengthening the requirement that only active staff can be processed in preparations.
* The `on_submit` method in `preparation.py` now calls `validate_preparation_table` to enforce employee status checks at submission, ensuring invalid records are caught early.

**Workflow and Field Requirement Updates:**

* Several field dependencies in `work_permit.json` have been updated to include `"Pending By Supervisor"` as a trigger for mandatory fields and section visibility, broadening the scope of required user actions and improving workflow accuracy. [[1]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L399-R403) [[2]](diffhunk://#diff-941a51bfcf79006f6f34485c60009d121c14613a93fc9fcb8e0c388a4413ea95L811-R817)
* The validation logic in `work_permit.py` for workflow states now requires both the invoice attachment and the updated work permit expiry date to be set before submission for the `"Pending By Supervisor"` and `"Pending By PAM"` states, ensuring critical documents and dates are provided before proceeding.

**Metadata Update:**

* The `modified` timestamp in `work_permit.json` has been updated to reflect the latest changes.