### PR TITLE
fix: missing shift assignment support email

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1077,10 +1077,15 @@ def validate_shift_assignment(is_scheduled_event=True):
 				roster_emp.append(r)
 
 	if len(roster)>0:
-		sender = frappe.get_value("Email Account", filters = {"default_outgoing": 1}, fieldname = "email_id") or None
-		recipient = frappe.get_value("Email Account", {"name":"Develop"}, ["email_id"])
-		msg = frappe.render_template('one_fm/templates/emails/missing_shift_assignment.html', context={"rosters": roster})
-		sendemail(sender=sender, recipients= recipient, content=msg, subject="Missed Shift Assignments List", delayed=False, is_scheduler_email=is_scheduled_event)
+		missing_shift_assignment_support_email(roster, is_scheduled_event)
+
+def missing_shift_assignment_support_email(roster, is_scheduler_email=True):
+	sender = frappe.get_value("Email Account", filters = {"default_outgoing": 1}, fieldname = "email_id") or None
+	recipient = frappe.get_value("Email Account", {"name":"Support"}, ["email_id"])
+	if not recipient:
+		return
+	msg = frappe.render_template('one_fm/templates/emails/missing_shift_assignment.html', context={"rosters": roster})
+	sendemail(sender=sender, recipients= recipient, content=msg, subject="Missed Shift Assignments List", delayed=False, is_scheduler_email=is_scheduler_email)
 
 def validate_am_shift_assignment(is_scheduled_event=True):
 	"""
@@ -1126,10 +1131,7 @@ def validate_am_shift_assignment(is_scheduled_event=True):
 	roster = [i for i in roster if not i.employee in todays_leaves]
 
 	if len(roster)>0:
-		sender = frappe.get_value("Email Account", filters = {"default_outgoing": 1}, fieldname = "email_id") or None
-		recipient = frappe.get_value("Email Account", {"name":"Support"}, ["email_id"])
-		msg = frappe.render_template('one_fm/templates/emails/missing_shift_assignment.html', context={"rosters": roster})
-		sendemail(sender=sender, recipients= recipient, content=msg, subject="Missed Shift Assignments List", delayed=False, is_scheduler_email=True)
+		missing_shift_assignment_support_email(roster)
 		frappe.enqueue(create_shift_assignment, roster = roster, date = date, time='AM', is_async=True, queue='long')
 
 def validate_pm_shift_assignment():
@@ -1170,12 +1172,8 @@ def validate_pm_shift_assignment():
 	roster = [i for i in roster if not i.employee in todays_leaves]
 
 	if len(roster)>0:
-		sender = frappe.get_value("Email Account", filters = {"default_outgoing": 1}, fieldname = "email_id") or None
-		recipient = frappe.get_value("Email Account", {"name":"Support"}, ["email_id"])
-		msg = frappe.render_template('one_fm/templates/emails/missing_shift_assignment.html', context={"rosters": roster})
-		sendemail(sender=sender, recipients= recipient, content=msg, subject="Missed Shift Assignments List", delayed=False)
+		missing_shift_assignment_support_email(roster)
 		frappe.enqueue(create_shift_assignment, roster = roster, date = date, time='PM', is_async=True, queue='long')
-
 
 def overtime_shift_assignment():
 	"""

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1079,7 +1079,7 @@ def validate_shift_assignment(is_scheduled_event=True):
 	if len(roster)>0:
 		missing_shift_assignment_support_email(roster, is_scheduled_event)
 
-def missing_shift_assignment_support_email(roster, is_scheduler_email=True):
+def missing_shift_assignment_support_email(roster, is_scheduler_email=False):
 	sender = frappe.get_value("Email Account", filters = {"default_outgoing": 1}, fieldname = "email_id") or None
 	recipient = frappe.get_value("Email Account", {"name":"Support"}, ["email_id"])
 	if not recipient:
@@ -1131,7 +1131,7 @@ def validate_am_shift_assignment(is_scheduled_event=True):
 	roster = [i for i in roster if not i.employee in todays_leaves]
 
 	if len(roster)>0:
-		missing_shift_assignment_support_email(roster)
+		missing_shift_assignment_support_email(roster, True)
 		frappe.enqueue(create_shift_assignment, roster = roster, date = date, time='AM', is_async=True, queue='long')
 
 def validate_pm_shift_assignment():


### PR DESCRIPTION
This pull request refactors the logic for sending support emails about missing shift assignments in `one_fm/api/tasks.py`. The main improvement is extracting the email-sending code into a reusable function, which reduces code duplication and improves maintainability.

Code refactoring and reuse:

* Extracted the repeated email-sending logic for missing shift assignments into a new helper function, `missing_shift_assignment_support_email`, and updated `validate_shift_assignment`, `validate_am_shift_assignment`, and `validate_pm_shift_assignment` to use this function. [[1]](diffhunk://#diff-ab70bcb1e246615611fd826ed688b338c649aeec25036e3e60e48f44d3313b5fR1080-R1088) [[2]](diffhunk://#diff-ab70bcb1e246615611fd826ed688b338c649aeec25036e3e60e48f44d3313b5fL1129-R1134) [[3]](diffhunk://#diff-ab70bcb1e246615611fd826ed688b338c649aeec25036e3e60e48f44d3313b5fL1173-L1179)

Bug fix / consistency:

* Ensured that the support email is only sent if the recipient exists, preventing potential errors if the "Support" email account is missing.