### PR TITLE
Accommodation headcount

### DIFF
--- a/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
+++ b/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
@@ -95,47 +95,47 @@ def get_total_row(data):
 
 
 def get_submitted_occupied_count(filters, is_temp=False):
-    """
-    Count occupied beds based on SUBMITTED (docstatus=1) Accommodation Checkin Checkout documents.
-    This avoids counting beds reserved by Draft check-ins.
-    """
-    conditions = []
-    values = {}
+	"""
+	Count occupied beds based on SUBMITTED (docstatus=1) Accommodation Checkin Checkout documents.
+	This avoids counting beds reserved by Draft check-ins.
+	"""
+	conditions = []
+	values = {}
 
-    # Basic Bed filters
-    if filters.get('accommodation'):
-        conditions.append("b.accommodation = %(accommodation)s")
-        values['accommodation'] = filters.get('accommodation')
-    
-    if filters.get('bed_space_type'):
-        conditions.append("b.bed_space_type = %(bed_space_type)s")
-        values['bed_space_type'] = filters.get('bed_space_type')
+	# Basic Bed filters
+	if filters.get('accommodation'):
+		conditions.append("b.accommodation = %(accommodation)s")
+		values['accommodation'] = filters.get('accommodation')
+	
+	if filters.get('bed_space_type'):
+		conditions.append("b.bed_space_type = %(bed_space_type)s")
+		values['bed_space_type'] = filters.get('bed_space_type')
 
-    if filters.get('gender'):
-        conditions.append("b.gender = %(gender)s")
-        values['gender'] = filters.get('gender')
-        
-    conditions.append("b.disabled = 0")
+	if filters.get('gender'):
+		conditions.append("b.gender = %(gender)s")
+		values['gender'] = filters.get('gender')
+		
+	conditions.append("b.disabled = 0")
 
-    # Policy condition for Temporary vs Permanent
-    if is_temp:
-        # Temporary: Policy is MISSING or EMPTY
-        policy_condition = "(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')"
-    else:
-        # Permanent: Policy is PRESENT
-        policy_condition = "(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')"
+	# Policy condition for Temporary vs Permanent
+	if is_temp:
+		# Temporary: Policy is MISSING or EMPTY
+		policy_condition = "(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')"
+	else:
+		# Permanent: Policy is PRESENT
+		policy_condition = "(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')"
 
-    query = f"""
-        SELECT count(distinct b.name)
-        FROM `tabBed` b
-        INNER JOIN `tabAccommodation Checkin Checkout` c ON b.name = c.bed
-        WHERE
-            c.docstatus = 1  -- Only Submitted Checkins
-            AND c.type = 'IN' 
-            AND c.checked_out = 0 
-            AND {policy_condition}
-            AND {" AND ".join(conditions)}
-    """
-    
-    result = frappe.db.sql(query, values)
-    return result[0][0] if result else 0
+	query = f"""
+		SELECT count(distinct b.name)
+		FROM `tabBed` b
+		INNER JOIN `tabAccommodation Checkin Checkout` c ON b.name = c.bed
+		WHERE
+			c.docstatus = 1  -- Only Submitted Checkins
+			AND c.type = 'IN' 
+			AND c.checked_out = 0 
+			AND {policy_condition}
+			AND {" AND ".join(conditions)}
+	"""
+	
+	result = frappe.db.sql(query, values)
+	return result[0][0] if result else 0

--- a/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
+++ b/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
@@ -117,24 +117,35 @@ def get_submitted_occupied_count(filters, is_temp=False):
         
     conditions.append("b.disabled = 0")
 
+    conditions.append("c.docstatus = 1") # Only Submitted Checkins
+    conditions.append("c.type = 'IN'")
+    conditions.append("c.checked_out = 0")
+    
     # Policy condition for Temporary vs Permanent
     if is_temp:
         # Temporary: Policy is MISSING or EMPTY
-        policy_condition = "(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')"
+        conditions.append("(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')")
     else:
         # Permanent: Policy is PRESENT
-        policy_condition = "(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')"
+        conditions.append("(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')")
 
+    # We use count(distinct b.name) to handle rare cases of data inconsistency where 
+    # a bed might be linked to multiple active, submitted check-ins.
+    
+    # Performance Note:
+    # For optimal performance, especially with large datasets, ensure the following indexes exist
+    # on the 'tabAccommodation Checkin Checkout' table:
+    # 1. bed (Link field, used in JOIN)
+    # 2. docstatus, type, checked_out (Used in WHERE clause)
+    # Consider adding a composite index on (docstatus, type, checked_out, bed) covers the query perfectly.
+    
+    where_clause = " AND ".join(conditions)
+    
     query = f"""
         SELECT count(distinct b.name)
         FROM `tabBed` b
         INNER JOIN `tabAccommodation Checkin Checkout` c ON b.name = c.bed
-        WHERE
-            c.docstatus = 1  -- Only Submitted Checkins
-            AND c.type = 'IN' 
-            AND c.checked_out = 0 
-            AND {policy_condition}
-            AND {" AND ".join(conditions)}
+        WHERE {where_clause}
     """
     
     result = frappe.db.sql(query, values)

--- a/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
+++ b/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
@@ -117,61 +117,36 @@ def get_submitted_occupied_count(filters, is_temp=False):
 		
 	conditions.append("b.disabled = 0")
 
-<<<<<<< HEAD
-    conditions.append("c.docstatus = 1") # Only Submitted Checkins
-    conditions.append("c.type = 'IN'")
-    conditions.append("c.checked_out = 0")
-    
-    # Policy condition for Temporary vs Permanent
-    if is_temp:
-        # Temporary: Policy is MISSING or EMPTY
-        conditions.append("(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')")
-    else:
-        # Permanent: Policy is PRESENT
-        conditions.append("(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')")
+	conditions.append("c.docstatus = 1") # Only Submitted Checkins
+	conditions.append("c.type = 'IN'")
+	conditions.append("c.checked_out = 0")
 
-    # We use count(distinct b.name) to handle rare cases of data inconsistency where 
-    # a bed might be linked to multiple active, submitted check-ins.
-    
-    # Performance Note:
-    # For optimal performance, especially with large datasets, ensure the following indexes exist
-    # on the 'tabAccommodation Checkin Checkout' table:
-    # 1. bed (Link field, used in JOIN)
-    # 2. docstatus, type, checked_out (Used in WHERE clause)
-    # Consider adding a composite index on (docstatus, type, checked_out, bed) covers the query perfectly.
-    
-    where_clause = " AND ".join(conditions)
-    
-    query = f"""
-        SELECT count(distinct b.name)
-        FROM `tabBed` b
-        INNER JOIN `tabAccommodation Checkin Checkout` c ON b.name = c.bed
-        WHERE {where_clause}
-    """
-    
-    result = frappe.db.sql(query, values)
-    return result[0][0] if result else 0
-=======
 	# Policy condition for Temporary vs Permanent
 	if is_temp:
 		# Temporary: Policy is MISSING or EMPTY
-		policy_condition = "(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')"
+		conditions.append("(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')")
 	else:
 		# Permanent: Policy is PRESENT
-		policy_condition = "(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')"
+		conditions.append("(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')")
 
+	# We use count(distinct b.name) to handle rare cases of data inconsistency where 
+	# a bed might be linked to multiple active, submitted check-ins.
+	
+	# Performance Note:
+	# For optimal performance, especially with large datasets, ensure the following indexes exist
+	# on the 'tabAccommodation Checkin Checkout' table:
+	# 1. bed (Link field, used in JOIN)
+	# 2. docstatus, type, checked_out (Used in WHERE clause)
+	# Consider adding a composite index on (docstatus, type, checked_out, bed) covers the query perfectly.
+	
+	where_clause = " AND ".join(conditions)
+	
 	query = f"""
 		SELECT count(distinct b.name)
 		FROM `tabBed` b
 		INNER JOIN `tabAccommodation Checkin Checkout` c ON b.name = c.bed
-		WHERE
-			c.docstatus = 1  -- Only Submitted Checkins
-			AND c.type = 'IN' 
-			AND c.checked_out = 0 
-			AND {policy_condition}
-			AND {" AND ".join(conditions)}
+		WHERE {where_clause}
 	"""
 	
 	result = frappe.db.sql(query, values)
 	return result[0][0] if result else 0
->>>>>>> 5c1bad8c58dd00679155618728244c79c94de594

--- a/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
+++ b/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
@@ -33,10 +33,13 @@ def get_data(filters):
 		filters['accommodation'] = acc.name
 		filters['disabled'] = 0
 		total_no_of_bed_space = frappe.db.count('Bed', filters)
-		filters['status'] = 'Occupied'
-		occupied_bed = frappe.db.count('Bed', filters)
-		filters['status'] = 'Occupied Temporarily'
-		occupied_temporarily = frappe.db.count('Bed', filters)
+		# filters['status'] = 'Occupied'
+		# occupied_bed = frappe.db.count('Bed', filters)
+		occupied_bed = get_submitted_occupied_count(filters, is_temp=False)
+
+		# filters['status'] = 'Occupied Temporarily'
+		# occupied_temporarily = frappe.db.count('Bed', filters)
+		occupied_temporarily = get_submitted_occupied_count(filters, is_temp=True)
 		filters['status'] = 'Booked'
 		booked_bed = frappe.db.count('Bed', filters)
 		filters['status'] = 'Vacant'
@@ -89,3 +92,50 @@ def get_total_row(data):
 		total_occupied_percent,
 		total_vacant_percent,
 	]
+
+
+def get_submitted_occupied_count(filters, is_temp=False):
+    """
+    Count occupied beds based on SUBMITTED (docstatus=1) Accommodation Checkin Checkout documents.
+    This avoids counting beds reserved by Draft check-ins.
+    """
+    conditions = []
+    values = {}
+
+    # Basic Bed filters
+    if filters.get('accommodation'):
+        conditions.append("b.accommodation = %(accommodation)s")
+        values['accommodation'] = filters.get('accommodation')
+    
+    if filters.get('bed_space_type'):
+        conditions.append("b.bed_space_type = %(bed_space_type)s")
+        values['bed_space_type'] = filters.get('bed_space_type')
+
+    if filters.get('gender'):
+        conditions.append("b.gender = %(gender)s")
+        values['gender'] = filters.get('gender')
+        
+    conditions.append("b.disabled = 0")
+
+    # Policy condition for Temporary vs Permanent
+    if is_temp:
+        # Temporary: Policy is MISSING or EMPTY
+        policy_condition = "(c.attach_print_accommodation_policy IS NULL OR c.attach_print_accommodation_policy = '')"
+    else:
+        # Permanent: Policy is PRESENT
+        policy_condition = "(c.attach_print_accommodation_policy IS NOT NULL AND c.attach_print_accommodation_policy != '')"
+
+    query = f"""
+        SELECT count(distinct b.name)
+        FROM `tabBed` b
+        INNER JOIN `tabAccommodation Checkin Checkout` c ON b.name = c.bed
+        WHERE
+            c.docstatus = 1  -- Only Submitted Checkins
+            AND c.type = 'IN' 
+            AND c.checked_out = 0 
+            AND {policy_condition}
+            AND {" AND ".join(conditions)}
+    """
+    
+    result = frappe.db.sql(query, values)
+    return result[0][0] if result else 0


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
Accommodation headcount[https://onefm.atlassian.net/browse/OFP-914]

## Analysis and design (optional)
Update the Bed Space Summary Report to display "Occupied" and "Occupied Temporarily" counts based on Submitted Check-in documents only. Currently, it counts beds reserved by Draft check-ins as well, causing a discrepancy with the Check-in/Checkout report.

## Solution description
**Goal**
Update the Bed Space Summary Report to display "Occupied" and "Occupied Temporarily" counts based on Submitted Check-in documents only. Currently, it counts beds reserved by Draft check-ins as well, causing a discrepancy with the Check-in/Checkout report.

**Proposed Changes**
apps/one_fm/one_fm/accommodation/report/bed_space_summary_report/bed_space_summary_report.py
**Modify** get_data function to use a custom SQL query instead of frappe.db.count for the "Occupied" columns.

**Logic Change:**
**Instead of:**
filters['status'] = 'Occupied'
occupied_bed = frappe.db.count('Bed', filters)
**Use**:
occupied_bed = get_submitted_occupied_count(filters, is_temp=False)
The helper function get_submitted_occupied_count will perform a SQL query:

Join tabBed (b) and tabAccommodation Checkin Checkout (c) on b.name = c.bed.
Filter c.docstatus = 1 (Submitted).Filter c.type = 'IN' and c.checked_out = 0.Filter b.disabled = 0.
Apply policy
 logic: c.attach_print_accommodation_policy is NOT NULL/Empty for 'Occupied', and IS NULL/Empty for 'Occupied Temporarily'.
Apply standard filters from the report (gender, bed_space_type, accommodation).
**Verification Plan**

1. Manual Verification
2. Run the report for "Farwaniya 171".
3. Check the "Occupied Temporarily" count. It should decrease by 16 (from 403 to 387), matching the user's Checkin report.
4. Ensure "Total Bed" and "Vacant" counts remain unchanged.

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Areas affected and ensured
bed space summary report file

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox