### PR TITLE
feat: mark attendance for non active employees

### DIFF
--- a/one_fm/custom/property_setter/employee.py
+++ b/one_fm/custom/property_setter/employee.py
@@ -1,0 +1,12 @@
+def get_employee_properties():
+    return [
+        {
+            "doctype": "Property Setter",
+            "doc_type": "Employee",
+            "doctype_or_field": "DocField",
+            "field_name": "status",
+            "property": "options",
+            "property_type": "Text",
+            "value": "\nActive\nCourt Case\nAbsconding\nLeft\nVacation\nNot Returned from Leave"
+        }
+    ]

--- a/one_fm/one_fm/custom/employee.json
+++ b/one_fm/one_fm/custom/employee.json
@@ -8296,7 +8296,7 @@
    "field_name": "status",
    "idx": 0,
    "is_system_generated": 1,
-   "modified": "2025-07-02 15:31:37.293270",
+   "modified": "2025-12-24 15:31:37.293270",
    "modified_by": "Administrator",
    "module": null,
    "name": "Employee-status-options",
@@ -8307,7 +8307,7 @@
    "property": "options",
    "property_type": "Text",
    "row_name": null,
-   "value": "\nActive\nCourt Case\nAbsconding\nLeft\nVacation"
+   "value": "\nActive\nCourt Case\nAbsconding\nLeft\nVacation\nNot Returned from Leave"
   },
   {
    "_assign": null,

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -495,48 +495,54 @@ def mark_absent_for_non_active_employees(date, non_active_status):
     mark_absent_for_employees(employees, date, f"{non_active_status} employee")
 
 def mark_absent_for_employees(employees, date, comment, consider_holiday=False):
-    creation = now()
-    owner = frappe.session.user
-    naming_series = 'HR-ATT-.YYYY.-'
+    try:
+        creation = now()
+        owner = frappe.session.user
+        naming_series = 'HR-ATT-.YYYY.-'
 
-    query = """
-        INSERT INTO `tabAttendance` (
-            `name`, `naming_series`, `employee`, `employee_name`,
-            `status`, `attendance_date`, `company`, `department`,
-            `roster_type`, `docstatus`, `modified_by`, `owner`,
-            `creation`, `modified`, `comment`, `is_unscheduled`
-        ) VALUES
-    """
-
-    query_body = ""
-    for employee in employees:
-        status = "Absent"
-        name = f"HR-ATT_{date}_{employee.name}_Basic"
-
-        if consider_holiday:
-            holiday_today = get_holiday_today(date)
-            if holiday_today.get(employee.holiday_list):
-                status = "Holiday"
-                comment = f"Holiday - {holiday_today.get(employee.holiday_list)}"
-
-        query_body += f"""
-            (
-                "{name}", "{naming_series}", "{employee.name}", "{employee.employee_name}",
-                "{status}", "{date}", "{employee.company}", "{employee.department}",
-                "Basic", 1, "{owner}", "{owner}",
-                "{creation}", "{creation}", "{comment}", 0
-            ),"""
-
-    if query_body:
-        query += query_body[:-1]  # Remove trailing comma
-        query += """
-            ON DUPLICATE KEY UPDATE
-            status = VALUES(status),
-            comment = VALUES(comment),
-            modified = VALUES(modified)
+        query = """
+            INSERT INTO `tabAttendance` (
+                `name`, `naming_series`, `employee`, `employee_name`,
+                `status`, `attendance_date`, `company`, `department`,
+                `roster_type`, `docstatus`, `modified_by`, `owner`,
+                `creation`, `modified`, `comment`, `is_unscheduled`
+            ) VALUES
         """
-        frappe.db.sql(query)
-        frappe.db.commit()
+
+        query_body = ""
+        for employee in employees:
+            status = "Absent"
+            name = f"HR-ATT_{date}_{employee.name}_Basic"
+
+            if consider_holiday:
+                holiday_today = get_holiday_today(date)
+                if holiday_today.get(employee.holiday_list):
+                    status = "Holiday"
+                    comment = f"Holiday - {holiday_today.get(employee.holiday_list)}"
+
+            query_body += f"""
+                (
+                    "{name}", "{naming_series}", "{employee.name}", "{employee.employee_name}",
+                    "{status}", "{date}", "{employee.company}", "{employee.department}",
+                    "Basic", 1, "{owner}", "{owner}",
+                    "{creation}", "{creation}", "{comment}", 0
+                ),"""
+
+        if query_body:
+            query += query_body[:-1]  # Remove trailing comma
+            query += """
+                ON DUPLICATE KEY UPDATE
+                status = VALUES(status),
+                comment = VALUES(comment),
+                modified = VALUES(modified)
+            """
+            frappe.db.sql(query)
+            frappe.db.commit()
+    except Exception as e:
+        frappe.log_error(
+            message=frappe.get_traceback(),
+            title="Error in mark_absent_for_employees"
+        )
 
 def remark_for_active_employees(from_date=None):
     if not from_date:from_date=today()

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -429,7 +429,10 @@ def mark_for_active_employees(from_date=None, to_date=None):
     
     # Process employees without schedules/shifts
     mark_attendance_for_unscheduled_employees(active_employees, from_date)
-    
+
+    mark_absent_for_non_active_employees(from_date, "Absconding")
+    mark_absent_for_non_active_employees(from_date, "Not Returned from Leave")
+
     remark_for_active_employees(from_date)
 
 def mark_attendance_for_unscheduled_employees(employees, date):
@@ -474,56 +477,66 @@ def mark_attendance_for_unscheduled_employees(employees, date):
             return
             
         # Create attendance records for unscheduled employees
-        creation = now()
-        owner = frappe.session.user
-        naming_series = 'HR-ATT-.YYYY.-'
-        
-        query = """
-            INSERT INTO `tabAttendance` (
-                `name`, `naming_series`, `employee`, `employee_name`, 
-                `status`, `attendance_date`, `company`, `department`,
-                `roster_type`, `docstatus`, `modified_by`, `owner`,
-                `creation`, `modified`, `comment`, `is_unscheduled`
-            ) VALUES
-        """
-        
-        query_body = ""
-        for emp in unscheduled_employees:
-            # Check if it's a holiday
-            holiday_today = get_holiday_today(date)
-            status = "Absent"
-            comment = "No schedule or shift assignment found"
-            
-            if holiday_today.get(emp.holiday_list):
-                status = "Holiday"
-                comment = f"Holiday - {holiday_today.get(emp.holiday_list)}"
-            
-            name = f"HR-ATT_{date}_{emp.name}_Basic"
-            query_body += f"""
-                (
-                    "{name}", "{naming_series}", "{emp.name}", "{emp.employee_name}",
-                    "{status}", "{date}", "{emp.company}", "{emp.department}",
-                    "Basic", 1, "{owner}", "{owner}",
-                    "{creation}", "{creation}", "{comment}", 1
-                ),"""
-            
-        
-        if query_body:
-            query += query_body[:-1]  # Remove trailing comma
-            query += """
-                ON DUPLICATE KEY UPDATE
-                status = VALUES(status),
-                comment = VALUES(comment),
-                modified = VALUES(modified)
-            """
-            frappe.db.sql(query)
-            frappe.db.commit()
-            
+        comment = "No schedule or shift assignment found"
+        mark_absent_for_employees(unscheduled_employees, date, comment, True)
+
     except Exception as e:
         frappe.log_error(
             message=frappe.get_traceback(),
             title="Error in mark_attendance_for_unscheduled_employees"
         )
+
+def mark_absent_for_non_active_employees(date, non_active_status):
+    employees = frappe.get_all("Employee", {
+        'status': non_active_status,
+        'attendance_by_timesheet':0
+    }, ['name', 'employee_name', 'company', 'department', 'holiday_list'])
+
+    mark_absent_for_employees(employees, date, f"{non_active_status} employee")
+
+def mark_absent_for_employees(employees, date, comment, consider_holiday=False):
+    creation = now()
+    owner = frappe.session.user
+    naming_series = 'HR-ATT-.YYYY.-'
+
+    query = """
+        INSERT INTO `tabAttendance` (
+            `name`, `naming_series`, `employee`, `employee_name`,
+            `status`, `attendance_date`, `company`, `department`,
+            `roster_type`, `docstatus`, `modified_by`, `owner`,
+            `creation`, `modified`, `comment`, `is_unscheduled`
+        ) VALUES
+    """
+
+    query_body = ""
+    for employee in employees:
+        status = "Absent"
+        name = f"HR-ATT_{date}_{employee.name}_Basic"
+
+        if consider_holiday:
+            holiday_today = get_holiday_today(date)
+            if holiday_today.get(employee.holiday_list):
+                status = "Holiday"
+                comment = f"Holiday - {holiday_today.get(employee.holiday_list)}"
+
+        query_body += f"""
+            (
+                "{name}", "{naming_series}", "{employee.name}", "{employee.employee_name}",
+                "{status}", "{date}", "{employee.company}", "{employee.department}",
+                "Basic", 1, "{owner}", "{owner}",
+                "{creation}", "{creation}", "{comment}", 0
+            ),"""
+
+    if query_body:
+        query += query_body[:-1]  # Remove trailing comma
+        query += """
+            ON DUPLICATE KEY UPDATE
+            status = VALUES(status),
+            comment = VALUES(comment),
+            modified = VALUES(modified)
+        """
+        frappe.db.sql(query)
+        frappe.db.commit()
 
 def remark_for_active_employees(from_date=None):
     if not from_date:from_date=today()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -227,6 +227,7 @@ one_fm.patches.v15_0.add_banner_message_field_to_workflow_document_state
 one_fm.patches.v15_0.add_stock_settings_custom_fields
 one_fm.patches.v15_0.update_contracts_workflow #rerun
 one_fm.patches.v15_0.add_workflow_shift_permission
+one_fm.patches.v15_0.update_employee_status_options
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_client_event

--- a/one_fm/patches/v15_0/update_employee_status_options.py
+++ b/one_fm/patches/v15_0/update_employee_status_options.py
@@ -1,0 +1,5 @@
+from one_fm.custom.property_setter.employee import get_employee_properties
+from one_fm.setup.setup import add_property_setter
+
+def execute():
+    add_property_setter(get_employee_properties())

--- a/one_fm/setup/property_setter.py
+++ b/one_fm/setup/property_setter.py
@@ -95,6 +95,7 @@ def get_field_properties():
 	field_properties.extend(get_employee_advance_properties())
 	field_properties.extend(get_employee_incentive_properties())
 	field_properties.extend(get_employee_performance_feedback_properties())
+	field_properties.extend(get_employee_properties())
 	field_properties.extend(get_erf_salary_detail_properties())
 	field_properties.extend(get_expense_claim_properties())
 	field_properties.extend(get_gender_properties())


### PR DESCRIPTION
This pull request updates the employee status options and improves the attendance marking logic for non-active employees. It introduces a new "Not Returned from Leave" status, ensures this status is handled in both property setters and attendance processing, and adds a patch to update existing records. The attendance logic is refactored to better handle non-active statuses and improve error logging.

**Employee Status Options Update:**
- Added "Not Returned from Leave" to the `status` field options for the `Employee` doctype, updating both the property setter definition and the corresponding JSON configuration. [[1]](diffhunk://#diff-a6d23ff1de82e27fd8b621fefb3d43fe9935ab83a03a5fb88135d52a6d9686d0R1-R12) [[2]](diffhunk://#diff-bf6ce1e3e680d51a589f25b5830bb23d507791e77f25e84465de1cf2e58849bbL8310-R8310)
- Introduced a patch script (`update_employee_status_options.py`) and registered it in `patches.txt` to apply the new status option to existing records. [[1]](diffhunk://#diff-22fcb00a7ac9fc59367bddf0aece957c581af3bd2d06fa3e59a54c5fb6ff1228R1-R5) [[2]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R230)

**Attendance Marking Enhancements:**
- Modified the attendance marking logic to automatically mark employees with "Absconding" or "Not Returned from Leave" status as absent, ensuring these cases are handled consistently.
- Refactored and generalized the attendance marking code: added new helper functions (`mark_absent_for_non_active_employees`, `mark_absent_for_employees`), improved error logging, and streamlined the handling of unscheduled employees and holidays. [[1]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eR480-R498) [[2]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL491-L510) [[3]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL521-R544)

**Property Setter Integration:**
- Ensured the new employee properties are included in the global property setter setup by updating the `get_field_properties` function.

**Minor Metadata Update:**
- Updated the `modified` timestamp in the employee property setter JSON to reflect the change.