### PR TITLE
fix: datetime has no attribute today

### DIFF
--- a/one_fm/tasks/one_fm/daily.py
+++ b/one_fm/tasks/one_fm/daily.py
@@ -16,7 +16,7 @@ def generate_contracts_invoice():
         dt = datetime
         contracts = frappe.get_list('Contracts', filters={
             'workflow_state': 'Active',
-            # 'due_date':str(dt.today().date().day)
+            # 'due_date':str(getdate().day)
         })
         # generate
         for contract in contracts:
@@ -26,7 +26,7 @@ def generate_contracts_invoice():
             if str(contract_due_date).lower() == "end of month" and getdate() == get_last_day(getdate()):
                 contract_doc.generate_sales_invoice()
 
-            elif contract_due_date == str(dt.today().date().day):
+            elif contract_due_date == str(getdate().day):
                 contract_doc.generate_sales_invoice()
 
     except Exception as e:
@@ -42,7 +42,7 @@ def roster_projection_view_task():
     report = frappe.get_doc("Report", 'Roster Projection View')
     background_enqueue_run(report.name,
                            filters=json.dumps(
-                               {'month': dt.today().month, 'year': dt.today().year}), user='Administrator'
+                               {'month': getdate().month, 'year': getdate().year}), user='Administrator'
                            )
 
 

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3908,7 +3908,7 @@ def set_out_of_office(employee_email, start_date, end_date, custom_reliever_name
         service.users().settings().updateVacation(userId='me', body=vacation_settings).execute()
         frappe.msgprint(f"Out-of-office set for {employee_email} from {start_date} to {end_date}.")
     except Exception as e:
-        frappe.log_error(title="Failed to set out-of-office", message=str(e))
+        frappe.log_error(title="Failed to set out-of-office - {0} - {1}".format(employee_email, start_date), message=str(e))
 
 
 def disable_out_of_office(employee_email):
@@ -4253,7 +4253,7 @@ def add_calendar_event(employee_email, start_date, end_date, employee_name, leav
 
         frappe.msgprint(f"Calendar event created for {employee_email} leave.")
     except Exception as e:
-        frappe.log_error(title="Failed to create calendar event", message=str(e))
+        frappe.log_error(title="Failed to create calendar event - {0} - {1}".format(employee_email, leave_application_name), message=str(e))
 
 
 def cancel_calendar_event(employee_email, leave_application_name):


### PR DESCRIPTION
This pull request updates date handling and logging for contract invoice generation, roster projection, and Google integration utilities. The main focus is to standardize date usage and improve error logging for better traceability.

**Date handling improvements:**

* Replaced usage of `datetime.today()` with `getdate()` for consistency and to align with Frappe's date utilities in `generate_contracts_invoice` and `roster_projection_view_task` in `one_fm/daily.py`. [[1]](diffhunk://#diff-7226f715c94486f8ca8b283a4e437868e48538d0ef72df00f32ea9e041abb260L19-R19) [[2]](diffhunk://#diff-7226f715c94486f8ca8b283a4e437868e48538d0ef72df00f32ea9e041abb260L29-R29) [[3]](diffhunk://#diff-7226f715c94486f8ca8b283a4e437868e48538d0ef72df00f32ea9e041abb260L45-R45)

**Error logging enhancements:**

* Improved error log messages in `set_out_of_office` and `add_calendar_event` functions in `one_fm/utils.py` to include contextual information such as `employee_email`, `start_date`, and `leave_application_name`. [[1]](diffhunk://#diff-f233b284a4608da1fb5bbfc175686061301f7086f4d60ec454a4b8c160260ae0L3911-R3911) [[2]](diffhunk://#diff-f233b284a4608da1fb5bbfc175686061301f7086f4d60ec454a4b8c160260ae0L4256-R4256)