### PR TITLE
fix: set date_time moved to after validation of shift assignment override

### DIFF
--- a/one_fm/overrides/shift_assignment.py
+++ b/one_fm/overrides/shift_assignment.py
@@ -8,8 +8,8 @@ from one_fm.api.v1.utils import response
 class ShiftAssignmentOverride(ShiftAssignment):
 
     def validate(self):
-        self.set_datetime()
         super(ShiftAssignmentOverride, self).validate()
+        self.set_datetime()
 
     def validate_overlapping_shifts(self):
         overlapping_dates = self.get_overlapping_dates()


### PR DESCRIPTION
To fix issue with wrong start & end datetime values for specific shift (Management-Head Office @ Burj Humoud-Afternoon-3)