### PR TITLE
feat:employees on the export access table should be able to export sheet

### DIFF
--- a/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.js
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.js
@@ -4,9 +4,16 @@
 frappe.ui.form.on('Google Sheet Data Export', {
 	refresh: (frm) => {
 		if(!frm.is_new()){
-			frm.add_custom_button(__('Export Sheet'), function(){
-				export_data(frm);
-			});
+			const is_system_manager = frappe.user_roles.includes('System Manager');
+			const is_in_export_access = frm.doc.export_access && 
+				frm.doc.export_access.some(row => row.user === frappe.session.user);
+			
+			if (is_system_manager || is_in_export_access) {
+				frm.add_custom_button(__('Export Sheet'), function(){
+					export_data(frm);
+				});
+			}
+
 			const doctype = frm.doc.reference_doctype;
 			if (doctype) {
 				frappe.model.with_doctype(doctype, () => set_filters_and_field(frm));

--- a/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.json
+++ b/one_fm/one_fm/doctype/google_sheet_data_export/google_sheet_data_export.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "enable_auto_update",
+  "export_access",
   "column_break_mqrt",
   "last_execution_date",
   "google_sheet_reference_section",
@@ -138,11 +139,19 @@
    "fieldname": "last_execution_date",
    "fieldtype": "Date",
    "label": "Last execution date"
+  },
+  {
+   "description": "Users who can export this sheet at any time",
+   "fieldname": "export_access",
+   "fieldtype": "Table MultiSelect",
+   "label": "Export Access",
+   "options": "Google Sheet Data Export User"
   }
  ],
+ "grid_page_length": 50,
  "hide_toolbar": 1,
  "links": [],
- "modified": "2024-10-25 13:59:39.287594",
+ "modified": "2025-12-30 09:57:30.445836",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Google Sheet Data Export",
@@ -158,8 +167,13 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Employee"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/one_fm/one_fm/doctype/google_sheet_data_export_user/google_sheet_data_export_user.json
+++ b/one_fm/one_fm/doctype/google_sheet_data_export_user/google_sheet_data_export_user.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-12-30 09:52:49.032714",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-12-30 09:53:08.554763",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Google Sheet Data Export User",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/one_fm/doctype/google_sheet_data_export_user/google_sheet_data_export_user.py
+++ b/one_fm/one_fm/doctype/google_sheet_data_export_user/google_sheet_data_export_user.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, ONE FM and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class GoogleSheetDataExportUser(Document):
+	pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Employees on the export access table should be able to export sheet, via the button

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a check such that system managers, are able to export sheet,and anyone on the export access user list

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.
Google sheet data export

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
