### PR TITLE
fix: status Not Returned from Leave

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -24,7 +24,7 @@ from one_fm.operations.doctype.operations_shift.operations_shift import get_supe
 class EmployeeOverride(EmployeeMaster):
     def validate(self):
         from erpnext.controllers.status_updater import validate_status
-        validate_status(self.status, ["Active", "Court Case", "Absconding", "Left","Vacation"])
+        validate_status(self.status, ["Active", "Court Case", "Absconding", "Left", "Vacation", "Not Returned from Leave"])
 
         if self.pam_type == "Kuwaiti":
             self.residency_expiry_date = None
@@ -371,7 +371,7 @@ def get_employee_id_based_on_residency(employee_id, residency, employee=False, e
 def update_user_doc(doc):
     if not doc.is_new():
         old_self = doc.get_doc_before_save().status
-        if doc.status in ['Left','Absconding','Court Case'] and doc.status not in [old_self] and doc.user_id:
+        if doc.status in ['Left','Absconding','Court Case', 'Not Returned from Leave'] and doc.status not in [old_self] and doc.user_id:
             user_doc = frappe.get_doc('User',doc.user_id)
             if user_doc.enabled == 1:
                 user_doc.enabled = 0

--- a/one_fm/public/js/doctype_js/employee.js
+++ b/one_fm/public/js/doctype_js/employee.js
@@ -148,7 +148,7 @@ const set_current_address = (frm) => {
 
 // SET MANDATORY FIELDS
 let set_mandatory = frm => {
-	if (['Left', 'Court Case', 'Absconding', 'Vacation'].includes(frm.doc.status)){
+	if (['Left', 'Court Case', 'Absconding', 'Vacation', 'Not Returned from Leave'].includes(frm.doc.status)){
 		toggle_required(frm, 0);
 	} else {
 		toggle_required(frm, 1);

--- a/one_fm/public/js/doctype_list_js/employee_list.js
+++ b/one_fm/public/js/doctype_list_js/employee_list.js
@@ -3,7 +3,7 @@ frappe.listview_settings['Employee'] = {
 	filters: [["status","=", "Active"]],
 	get_indicator: function(doc) {
 		var indicator = [__(doc.status), frappe.utils.guess_colour(doc.status), "status,=," + doc.status];
-		indicator[1] = {"Active": "green", "Court Case": "warning", "Absconding": "danger", "Left": "darkgrey"}[doc.status];
+		indicator[1] = {"Active": "green", "Court Case": "warning", "Absconding": "danger", "Not Returned from Leave": "danger", "Left": "darkgrey"}[doc.status];
 		return indicator;
 	},
 	onload: function(listview) {


### PR DESCRIPTION
This pull request adds support for a new employee status, "Not Returned from Leave", across both backend and frontend code. The changes ensure that this status is handled consistently in validation, user management, UI indicators, and form logic.

**Backend logic updates:**
* Added "Not Returned from Leave" as a valid status in the `validate` method of `EmployeeOverride`, allowing employees to have this status.
* Updated user deactivation logic to include "Not Returned from Leave" as a status that disables a user's account when set.

**Frontend/UI updates:**
* Included "Not Returned from Leave" in the list of statuses that make certain employee form fields non-mandatory in `employee.js`.
* Updated the employee list view indicator color mapping to treat "Not Returned from Leave" as a "danger" status for visual consistency.