### PR TITLE
fix: todo update on timesheet approval

### DIFF
--- a/one_fm/overrides/timesheet.py
+++ b/one_fm/overrides/timesheet.py
@@ -140,15 +140,18 @@ class TimesheetOveride(Timesheet):
 
 
     def delete_todo(self):
-        todos_linked_to_timesheet = frappe.db.get_all('ToDo',
+        todos_linked_to_timesheet = frappe.db.get_list('ToDo',
             filters={'reference_type': self.doctype, 'reference_name': self.name},
             pluck='name'
         )
         if not todos_linked_to_timesheet:
             return
         for todo in todos_linked_to_timesheet:
-            frappe.delete_doc('ToDo', todo, ignore_permissions=True)
-
+            try:
+                frappe.delete_doc('ToDo', todo, ignore_permissions=True)
+            except Exception as e:
+                frappe.log_error(message=f"Failed to delete ToDo {todo} on Timesheet update: {e}", title="Timesheet ToDo Deletion Error")
+                continue
 
     def fetch_description(self):
         return f"""


### PR DESCRIPTION
This pull request updates the `delete_todo` method in the `one_fm/overrides/timesheet.py` file to make ToDo deletion more robust and to improve error handling. The main change is the addition of exception handling to ensure that any issues deleting ToDo items are logged, rather than causing the whole process to fail.

Error handling improvements:

* Wrapped the deletion of each `ToDo` item in a try-except block to catch and log any exceptions, preventing the process from stopping if a single deletion fails. (`one_fm/overrides/timesheet.py`)

Other changes:

* Switched from `frappe.db.get_all` to `frappe.db.get_list` for fetching ToDo items, which is a minor update but does not affect functionality.