### PR TITLE
feat: add checkbox to buying settings and adjust code logic accordingly

### DIFF
--- a/one_fm/custom/custom_field/buying_settings.py
+++ b/one_fm/custom/custom_field/buying_settings.py
@@ -4,6 +4,7 @@ def get_buying_settings_custom_fields():
             {
                 "default": "Yes",
                 "label": "Can 'Purchase Order' be created from 'Request for Material' directly?",
+                "description": "Controls whether Purchase Orders can be created directly from Request for Material without requiring a Request for Purchase.",
                 "fieldname": "po_from_rfm",
                 "fieldtype": "Select",
                 "insert_after": "po_required",

--- a/one_fm/custom/custom_field/buying_settings.py
+++ b/one_fm/custom/custom_field/buying_settings.py
@@ -1,0 +1,13 @@
+def get_buying_settings_custom_fields():
+    return {
+        "Buying Settings": [
+            {
+                "default": "Yes",
+                "label": "Can 'Purchase Order' be created from 'Request for Material' directly?",
+                "fieldname": "po_from_rfm",
+                "fieldtype": "Select",
+                "insert_after": "po_required",
+                "options": "Yes\nNo"
+            }
+        ]
+    }

--- a/one_fm/overrides/purchase_order.py
+++ b/one_fm/overrides/purchase_order.py
@@ -197,7 +197,7 @@ class PurchaseOrderOverride(PurchaseOrder):
     def validate(self):
         super(PurchaseOrderOverride, self).validate()
         buying_settings = frappe.get_single("Buying Settings")
-        if buying_settings.po_from_rfm == "No":
+        if buying_settings.get("po_from_rfm", "Yes") == "No":
             if self.request_for_material and not self.one_fm_request_for_purchase:
                 frappe.throw(_("Request for Purchase is required for this Purchase Order to be processed further"))
 

--- a/one_fm/overrides/purchase_order.py
+++ b/one_fm/overrides/purchase_order.py
@@ -196,8 +196,8 @@ class PurchaseOrderOverride(PurchaseOrder):
 
     def validate(self):
         super(PurchaseOrderOverride, self).validate()
-        buying_settings = frappe.get_single("Buying Settings")
-        if buying_settings.get("po_from_rfm", "Yes") == "No":
+        po_from_rfm = frappe.db.get_single_value("Buying Settings", "po_from_rfm")
+        if po_from_rfm in ("No", None):
             if self.request_for_material and not self.one_fm_request_for_purchase:
                 frappe.throw(_("Request for Purchase is required for this Purchase Order to be processed further"))
 

--- a/one_fm/overrides/purchase_order.py
+++ b/one_fm/overrides/purchase_order.py
@@ -196,8 +196,10 @@ class PurchaseOrderOverride(PurchaseOrder):
 
     def validate(self):
         super(PurchaseOrderOverride, self).validate()
-        if self.request_for_material and not self.one_fm_request_for_purchase:
-            frappe.throw(_("Request for Purchase is required for this Purchase Order to be processed further"))
+        buying_settings = frappe.get_single("Buying Settings")
+        if buying_settings.po_from_rfm == "No":
+            if self.request_for_material and not self.one_fm_request_for_purchase:
+                frappe.throw(_("Request for Purchase is required for this Purchase Order to be processed further"))
 
     def on_submit(self):
         self.update_purchased_quantities()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -230,6 +230,7 @@ one_fm.patches.v15_0.add_workflow_shift_permission
 one_fm.patches.v15_0.update_attendance_is_unscheduled
 one_fm.patches.v15_0.update_employee_status_options
 one_fm.patches.v15_0.set_conversion_factor_precision
+one_fm.patches.v15_0.add_buying_settings_custom_field
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_client_event

--- a/one_fm/patches/v15_0/add_buying_settings_custom_field.py
+++ b/one_fm/patches/v15_0/add_buying_settings_custom_field.py
@@ -1,0 +1,6 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.custom_field.buying_settings import get_buying_settings_custom_fields
+
+def execute():
+    create_custom_fields(get_buying_settings_custom_fields())
+

--- a/one_fm/setup/custom_field.py
+++ b/one_fm/setup/custom_field.py
@@ -96,6 +96,7 @@ from one_fm.custom.custom_field.asset_movement_item import get_asset_movement_it
 from one_fm.custom.custom_field.quality_feedback_template import get_quality_feedback_template_custom_fields
 from one_fm.custom.custom_field.currency_exchange_settings import get_currency_exchange_settings_custom_fields
 from one_fm.custom.custom_field.workflow_document_state import get_workflow_document_state_custom_fields
+from one_fm.custom.custom_field.buying_settings import get_buying_settings_custom_fields
 
 def get_custom_fields():
 	"""ONEFM specific custom fields that need to be added to the masters in ERPNext"""
@@ -197,5 +198,6 @@ def get_custom_fields():
 	custom_fields.update(get_quality_feedback_template_custom_fields())
 	custom_fields.update(get_currency_exchange_settings_custom_fields())
 	custom_fields.update(get_workflow_document_state_custom_fields())
+	custom_fields.update(get_buying_settings_custom_fields())
 
 	return custom_fields


### PR DESCRIPTION
Story link: https://onefm.atlassian.net/browse/OFP-922

## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Add a "select" field to the "Buying Settings" DocType called "Can 'Purchase Order' be created from 'Request for Material' directly?" to control the instances where a PO can be created from an RFM without a linked RFP.


## Solution description
1. Added a custom 'select' field to the Buying Settings DocType.
2. Adjusted validation code on save to check for the value of the field before proceeding with the rest of the evaluation.


## Is there a business logic within a doctype?
    - [x] Yes
    - [] No


## Output screenshots (optional)
https://github.com/user-attachments/assets/d7a4f471-df23-450e-bc19-ec00d69d3dd4


## Areas affected and ensured
1. `one_fm/custom/custom_field/buying_settings.py`
2. `one_fm/overrides/purchase_order.py`
3. `one_fm/patches.txt`
4. `one_fm/patches/v15_0/add_buying_settings_custom_field.py`
5. `one_fm/setup/custom_field.py`


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
    Yes


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
