### PR TITLE
chore: delete .js file causing redirect from jobs page to careers page

### DIFF
--- a/one_fm/public/js/web/one_fm.js
+++ b/one_fm/public/js/web/one_fm.js
@@ -1,3 +1,0 @@
-if (['/jobs/', '/jobs'].includes(window.location.pathname)){
-    window.location.href = '/careers';
-}


### PR DESCRIPTION
Story link: https://onefm.atlassian.net/browse/OFP-949

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
When accessing one-fm.com/jobs, it loads briefly then redirects the user to the one-fm.com/careers page instead.

Deleted the .js file with redirect logic to remedy this.
