### PR TITLE
chore: revert previous careers page guest access fix & apply new fix

### DIFF
--- a/one_fm/www/careers/index.py
+++ b/one_fm/www/careers/index.py
@@ -2,8 +2,8 @@ import frappe
 from frappe.utils import getdate
 from .utils import remove_html_tags, get_department_list
 
-@frappe.whitelist(allow_guest=True)
 def get_context(context):
+    context.allow_guest = True
     context.no_cache = 1
     # Get recent openings
     context.recent_openings = get_recent_openings()


### PR DESCRIPTION
Story link: https://onefm.atlassian.net/browse/OFP-949

## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Make one-fm.com/careers page accessible to guest users.

## Output screenshots (optional)
https://github.com/user-attachments/assets/621607bf-cbda-41a2-b75f-ec9e312b249f
