### PR TITLE
chore: revert previous careers page guest access fix & apply new fix 

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -490,6 +490,10 @@ website_route_rules = [
 		"from_route": "/careers/opening/<path:lang>/<path:job_id>",
 		"to_route": "careers/opening"
 	},
+    {
+		"from_route": "/careers",
+		"to_route": "careers"
+	},
 	{
 		"from_route": "/services/view_more/<path:title>",
 		"to_route": "services/view_more"

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -490,7 +490,7 @@ website_route_rules = [
 		"from_route": "/careers/opening/<path:lang>/<path:job_id>",
 		"to_route": "careers/opening"
 	},
-    {
+	{
 		"from_route": "/careers",
 		"to_route": "careers"
 	},

--- a/one_fm/www/careers/index.py
+++ b/one_fm/www/careers/index.py
@@ -3,7 +3,6 @@ from frappe.utils import getdate
 from .utils import remove_html_tags, get_department_list
 
 def get_context(context):
-    context.allow_guest = True
     context.no_cache = 1
     # Get recent openings
     context.recent_openings = get_recent_openings()


### PR DESCRIPTION
Story link: https://onefm.atlassian.net/browse/OFP-949

## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Make one-fm.com/careers page accessible to guest users.

## Output screenshots (optional)
https://github.com/user-attachments/assets/621607bf-cbda-41a2-b75f-ec9e312b249f
