### PR TITLE
chore: revert previous careers page guest permissions fix and apply fix when fetching data from db

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -490,10 +490,6 @@ website_route_rules = [
 		"from_route": "/careers/opening/<path:lang>/<path:job_id>",
 		"to_route": "careers/opening"
 	},
-    {
-		"from_route": "/careers",
-		"to_route": "careers"
-	},
 	{
 		"from_route": "/services/view_more/<path:title>",
 		"to_route": "services/view_more"

--- a/one_fm/www/careers/index.py
+++ b/one_fm/www/careers/index.py
@@ -26,7 +26,7 @@ def get_recent_openings():
                                     'status': 'Open'
                                 },
                                 ["name","job_title_in_arabic","designation", "description", "description_in_arabic","one_fm_job_opening_created", "department", "job_title"],
-                                order_by="one_fm_job_opening_created desc",
+                                order_by="one_fm_job_opening_created desc", ignore_permissions=True
                                 )
     for opening in recent_openings_raw_format:
         data = {


### PR DESCRIPTION
Story link: https://onefm.atlassian.net/browse/OFP-949

## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Make one-fm.com/careers page accessible to guest users.

## Output screenshots (optional)
https://github.com/user-attachments/assets/621607bf-cbda-41a2-b75f-ec9e312b249f
