### PR TITLE
feat: agency tracking

### DIFF
--- a/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
+++ b/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
@@ -30,7 +30,14 @@
   "easy_apply_to",
   "subcontract_hiring_settings_section",
   "subcontract_employment_type",
-  "subcontract_residency_status"
+  "subcontract_residency_status",
+  "agency_tab",
+  "hiring_agency_section",
+  "inform_agency_license_expiry_to_recruitment_team",
+  "agency_license_expiry_inform_period_days",
+  "agency_expiry_notification_email",
+  "column_break_cpky",
+  "inactive_agency_on_license_expiry"
  ],
  "fields": [
   {
@@ -195,11 +202,51 @@
    "label": "Job Offer Print Format",
    "mandatory_depends_on": "auto_email_job_offer",
    "options": "Print Format"
+  },
+  {
+   "fieldname": "hiring_agency_section",
+   "fieldtype": "Section Break",
+   "label": "Hiring Agency Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "inform_agency_license_expiry_to_recruitment_team",
+   "fieldtype": "Check",
+   "label": "Inform Agency License Expiry to Recruitment Team"
+  },
+  {
+   "fieldname": "agency_tab",
+   "fieldtype": "Tab Break",
+   "label": "Agency"
+  },
+  {
+   "fieldname": "column_break_cpky",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "inform_agency_license_expiry_to_recruitment_team",
+   "fieldname": "agency_expiry_notification_email",
+   "fieldtype": "Data",
+   "label": "Agency Expiry Notification Email",
+   "options": "Email"
+  },
+  {
+   "default": "0",
+   "fieldname": "inactive_agency_on_license_expiry",
+   "fieldtype": "Check",
+   "label": "Inactive Agency on License Expiry"
+  },
+  {
+   "depends_on": "inform_agency_license_expiry_to_recruitment_team",
+   "description": "Leave zero then, system will inform recruitment team on the day of license expiry. For example if the value is 30 then the system will inform the recruitment team 30 days prior to the license expiry date",
+   "fieldname": "agency_license_expiry_inform_period_days",
+   "fieldtype": "Int",
+   "label": "Agency License Expiry Inform Period Days"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-12-30 17:44:45.951842",
+ "modified": "2026-01-06 07:50:49.204202",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Hiring Settings",
@@ -216,6 +263,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
+++ b/one_fm/hiring/doctype/hiring_settings/hiring_settings.json
@@ -37,7 +37,14 @@
   "agency_license_expiry_inform_period_days",
   "agency_expiry_notification_email",
   "column_break_cpky",
-  "inactive_agency_on_license_expiry"
+  "inactive_agency_on_license_expiry",
+  "demand_letter_settings_section",
+  "inform_demand_letter_validity_expiry_to_recruitment_team",
+  "demand_letter_validity_expiry_inform_period_days",
+  "demand_letter_validity_expiry_notification_email",
+  "column_break_iofg",
+  "inform_demand_letter_quota_completion",
+  "demand_letter_quota_completion_notification_email"
  ],
  "fields": [
   {
@@ -206,7 +213,7 @@
   {
    "fieldname": "hiring_agency_section",
    "fieldtype": "Section Break",
-   "label": "Hiring Agency Settings"
+   "label": "Agency Settings"
   },
   {
    "default": "0",
@@ -242,11 +249,54 @@
    "fieldname": "agency_license_expiry_inform_period_days",
    "fieldtype": "Int",
    "label": "Agency License Expiry Inform Period Days"
+  },
+  {
+   "fieldname": "demand_letter_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Demand Letter Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "inform_demand_letter_validity_expiry_to_recruitment_team",
+   "fieldtype": "Check",
+   "label": "Inform Demand Letter Validity Expiry to Recruitment Team"
+  },
+  {
+   "depends_on": "inform_demand_letter_validity_expiry_to_recruitment_team",
+   "description": "Leave zero then, system will inform recruitment team on the day of demand letter validity till date. For example if the value is 30 then the system will inform the recruitment team 30 days prior to the demand letter validity till date",
+   "fieldname": "demand_letter_validity_expiry_inform_period_days",
+   "fieldtype": "Int",
+   "label": "Demand Letter Validity Expiry Inform Period Days"
+  },
+  {
+   "depends_on": "inform_demand_letter_validity_expiry_to_recruitment_team",
+   "fieldname": "demand_letter_validity_expiry_notification_email",
+   "fieldtype": "Data",
+   "label": "Demand Letter Validity Expiry Notification Email",
+   "options": "Email"
+  },
+  {
+   "fieldname": "column_break_iofg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Inform the recruitment team and show message on screen if demand letter quota completed on employee creation for the agency, designation and gender",
+   "fieldname": "inform_demand_letter_quota_completion",
+   "fieldtype": "Check",
+   "label": "Inform Demand Letter Quota Completion"
+  },
+  {
+   "depends_on": "inform_demand_letter_quota_completion",
+   "fieldname": "demand_letter_quota_completion_notification_email",
+   "fieldtype": "Data",
+   "label": "Demand Letter Quota Completion Notification Email",
+   "options": "Email"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2026-01-06 07:50:49.204202",
+ "modified": "2026-01-06 09:07:14.570098",
  "modified_by": "Administrator",
  "module": "Hiring",
  "name": "Hiring Settings",

--- a/one_fm/one_fm/doctype/agency/agency.js
+++ b/one_fm/one_fm/doctype/agency/agency.js
@@ -3,8 +3,8 @@
 
 frappe.ui.form.on('Agency', {
 	refresh: function(frm) {
-    set_address_and_contact_html(frm);
-    frm.set_df_property('attachments_required_section', 'hidden', frm.doc.__islocal);
+		set_address_and_contact_html(frm);
+		frm.set_df_property('attachments_required_section', 'hidden', frm.doc.__islocal);
 	},
 	agency_website: function(frm) {
 		validate_website_adress(frm);

--- a/one_fm/one_fm/doctype/agency/agency.py
+++ b/one_fm/one_fm/doctype/agency/agency.py
@@ -7,15 +7,15 @@ import frappe, re
 from frappe.model.document import Document
 from frappe.contacts.address_and_contact import load_address_and_contact, delete_contact_and_address
 from frappe import _
-from frappe.utils import getdate, today
-from one_fm.one_fm.doctype.demand_letter.demand_letter import get_valid_demand_letter
-from one_fm.one_fm.doctype.agency_contract.agency_contract import get_valid_agency_contract
+from frappe.utils import getdate, today, add_days
+from one_fm.processor import sendemail
 
 class Agency(Document):
 	def validate(self):
-		self.validate_active_agency()
 		if self.agency_website:
 			validate_website_adress(self.agency_website)
+
+	def after_insert(self):
 		create_supplier_for_agency(self)
 		self.create_user_for_agency()
 
@@ -37,12 +37,6 @@ class Agency(Document):
 
 	def on_trash(self):
 		delete_contact_and_address('Customer', self.name)
-
-	def validate_active_agency(self):
-		if self.active:
-			active_details = is_agency_active(self)
-			if not active_details['active']:
-				frappe.throw(_(active_details['message']))
 
 @frappe.whitelist()
 def validate_website_adress(website):
@@ -67,31 +61,73 @@ def create_supplier_for_agency(agency):
 		supplier.save(ignore_permissions=True)
 		agency.supplier_code = supplier.name
 
-def is_agency_active(agency):
-	active = True
-	msg = "Active"
-	if not agency.attach_copy_of_agency_license:
-		active = False
-		msg = "Attach Copy of Agency Lisence to Make Agency Active"
-	elif not agency.verify_copy_of_agency_license:
-		active = False
-		msg = "Please Verify if the Agency has an Country Authorized Licences"
-	elif getdate(today()) > getdate(agency.license_validity_date):
-		active = False
-		msg = "Agency Lisence Validity is Expired"
-	elif not get_valid_agency_contract(agency.name):
-		active = False
-		msg = "Agency has no Active or Valid Contract"
-	elif not get_valid_demand_letter(agency.name):
-		active = False
-		msg = "Agency has no Valid Demand Letter"
-
-	return {'active': active, 'message': msg}
-
-def make_agency_active(agency):
-	if is_agency_active(agency)['active']:
-		agency.active = True
-		agency.save(ignore_permissions=True)
-
 def agency_has_website_permission(doc, ptype, user, verbose=False):
-    return True
+	return True
+
+def inactive_agency_on_license_expiry():
+	if not frappe.db.get_single_value("Hiring Settings", "inactive_agency_on_license_expiry"):
+		return
+
+	agencies = frappe.get_all("Agency", filters={"active": 1, "license_validity_date": ["<", today()]}, fields=["name"])
+	for agency in agencies:
+		frappe.db.set_value("Agency", agency.name, "active", 0)
+
+def inform_license_expiry():
+	if not frappe.db.get_single_value("Hiring Settings", "inform_agency_license_expiry_to_recruitment_team"):
+		return
+
+	inform_period_days = frappe.db.get_single_value("Hiring Settings", "agency_license_expiry_inform_period_days") or 0
+
+	notify_date = add_days(today(), inform_period_days)
+	agencies = frappe.get_all("Agency", filters={"active": 1, "license_validity_date": notify_date}, fields=["name", "license_validity_date", "company_email"])
+
+	if not agencies:
+		return
+
+	# Get the notification email from settings
+	notification_email = frappe.db.get_single_value("Hiring Settings", "agency_expiry_notification_email")
+
+	if not notification_email:
+		return
+
+	# Build the message with all agency details
+	agency_details = ""
+	for agency in agencies:
+		if agency.name:
+			agency_details += f"""
+				<tr>
+					<td style="padding: 8px; border: 1px solid #ddd;">{agency.name}</td>
+					<td style="padding: 8px; border: 1px solid #ddd;">{agency.license_validity_date}</td>
+					<td style="padding: 8px; border: 1px solid #ddd;">{agency.company_email or 'N/A'}</td>
+				</tr>
+			"""
+
+	if not agency_details:
+		return
+
+	message = f"""
+		<p>Dear Team,</p>
+		<p>The following agencies have licenses expiring on {notify_date}:</p>
+		<table style="border-collapse: collapse; width: 100%; margin: 20px 0;">
+			<thead>
+				<tr style="background-color: #f2f2f2;">
+					<th style="padding: 8px; border: 1px solid #ddd; text-align: left;">Agency Name</th>
+					<th style="padding: 8px; border: 1px solid #ddd; text-align: left;">Expiry Date</th>
+					<th style="padding: 8px; border: 1px solid #ddd; text-align: left;">Company Email</th>
+				</tr>
+			</thead>
+			<tbody>
+				{agency_details}
+			</tbody>
+		</table>
+		<p>Please take the necessary actions to follow up on license renewals.</p>
+		<p>Best regards,<br>ONE FM Team</p>
+	"""
+
+
+	sendemail(
+		recipients=[notification_email],
+		subject=f"Agency License Expiry Notification - {len(agencies)} Agency(ies) Expiring on {notify_date}",
+		message=message,
+		is_external_mail=True
+	)

--- a/one_fm/one_fm/doctype/agency/agency.py
+++ b/one_fm/one_fm/doctype/agency/agency.py
@@ -68,9 +68,14 @@ def inactive_agency_on_license_expiry():
 	if not frappe.db.get_single_value("Hiring Settings", "inactive_agency_on_license_expiry"):
 		return
 
-	agencies = frappe.get_all("Agency", filters={"active": 1, "license_validity_date": ["<", today()]}, fields=["name"])
-	for agency in agencies:
-		frappe.db.set_value("Agency", agency.name, "active", 0)
+	frappe.db.sql("""
+		UPDATE 
+			`tabAgency`
+		SET 
+			active = 0
+		WHERE 
+			active = 1 AND license_validity_date < %s
+	""", today())
 
 def inform_license_expiry():
 	if not frappe.db.get_single_value("Hiring Settings", "inform_agency_license_expiry_to_recruitment_team"):

--- a/one_fm/one_fm/doctype/demand_letter/demand_letter.json
+++ b/one_fm/one_fm/doctype/demand_letter/demand_letter.json
@@ -1,12 +1,12 @@
 {
  "actions": [],
- "autoname": "field:demand_letter",
+ "autoname": "naming_series:",
  "creation": "2020-05-05 11:19:43.703964",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "demand_letter",
+  "naming_series",
   "agency",
   "agency_name",
   "column_break_4",
@@ -30,14 +30,6 @@
  ],
  "fields": [
   {
-   "fieldname": "demand_letter",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Demand Letter",
-   "reqd": 1,
-   "unique": 1
-  },
-  {
    "fieldname": "agency",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -46,6 +38,7 @@
    "reqd": 1
   },
   {
+   "fetch_from": "agency.country",
    "fieldname": "country",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -163,14 +156,23 @@
    "fieldname": "authorized_signatory",
    "fieldtype": "Select",
    "label": "Authorized Signatory"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Series",
+   "options": "DL-.YYYY.-",
+   "reqd": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-07 14:11:33.369849",
+ "modified": "2026-01-06 08:10:58.442635",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Demand Letter",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -186,7 +188,9 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/one_fm/one_fm/doctype/demand_letter/demand_letter.py
+++ b/one_fm/one_fm/doctype/demand_letter/demand_letter.py
@@ -5,19 +5,87 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
-from frappe.utils import today, getdate
+from frappe.utils import today, getdate, add_days
+from one_fm.processor import sendemail
 
 class DemandLetter(Document):
 	pass
 
-def get_valid_demand_letter(agency, date=today()):
-	query = """
-		select
-			*
-		from
-			`tabDemand Letter`
-		where
-			docstatus=1 and (%(date_given)s between date_of_issue and valid_till_date) and agency=%(agency)s
+def get_demand_letter_quota(agency, designation, gender):
+	demands = get_demand_letter(agency, designation, gender)
+	if not demands:
+		return {}
+
+	for demand in demands:
+		available_quota = demand.quantity - demand.used_quantity
+		if available_quota > 0:
+			return demand
+
+	return {}
+
+def get_demand_letter(agency, designation, gender):
+	demand_letters = frappe.db.get_all("Demand Letter", {
+		"agency": agency,
+		"docstatus": 0,
+		"valid_till_date": [">=", today()]
+	}, ["name"])
+	if not demand_letters:
+		return []
+	return frappe.db.get_all(
+		"Demand Letter Demand",
+		{
+			"parent": ["in", [d.name for d in demand_letters]],
+			"designation": designation,
+			"gender": gender
+		},
+		["quantity", "used_quantity", "name"]
+	)
+
+def inform_demand_letter_validity_expiry():
+	if not frappe.db.get_single_value("Hiring Settings", "inform_demand_letter_validity_expiry_to_recruitment_team"):
+		return
+
+	inform_period_days = frappe.db.get_single_value("Hiring Settings", "demand_letter_validity_expiry_inform_period_days") or 0
+
+	notify_date = add_days(today(), inform_period_days)
+
+	demand_letters = frappe.get_all("Demand Letter", filters={"valid_till_date": notify_date}, fields=["name", "valid_till_date", "agency", "agency_name"])
+
+	if not demand_letters:
+		return
+
+	notification_email = frappe.db.get_single_value("Hiring Settings", "demand_letter_validity_expiry_notification_email")
+	if not notification_email:
+		return
+
+	agency_details = ""
+	for dl in demand_letters:
+		agency_details += f"""
+			<tr>
+				<td style="padding: 8px; border: 1px solid #ddd;">{dl.name}</td>
+				<td style="padding: 8px; border: 1px solid #ddd;">{dl.valid_till_date}</td>
+				<td style="padding: 8px; border: 1px solid #ddd;">{dl.agency_name}</td>
+			</tr>
+		"""
+
+	message = f"""
+		<p>Dear Recruitment Team,</p>
+		<p>The following Demand Letter(s) are expiring on ({notify_date}):</p>
+		<table style="border-collapse: collapse; width: 100%;">
+			<tr>
+				<th style="padding: 8px; border: 1px solid #ddd;">Demand Letter</th>
+				<th style="padding: 8px; border: 1px solid #ddd;">Validity End Date</th>
+				<th style="padding: 8px; border: 1px solid #ddd;">Requesting Agency</th>
+			</tr>
+			{agency_details}
+		</table>
+		<p>Please take the necessary actions.</p>
+		<p>Best Regards,<br/>ONE FM System</p>
 	"""
-	demand_letter = frappe.db.sql(query.format(),{"date_given": getdate(date), "agency": agency}, as_dict = 1)
-	return demand_letter if demand_letter else False
+
+	sendemail(
+		recipients=[notification_email],
+		subject=f"Demand Letter Validity Expiry Notification - {len(demand_letters)} Demand Letter(s) Expiring Today",
+		message=message,
+		is_external_mail=True
+	)

--- a/one_fm/one_fm/doctype/demand_letter/demand_letter.py
+++ b/one_fm/one_fm/doctype/demand_letter/demand_letter.py
@@ -26,7 +26,7 @@ def get_demand_letter_quota(agency, designation, gender):
 def get_demand_letter(agency, designation, gender):
 	demand_letters = frappe.db.get_all("Demand Letter", {
 		"agency": agency,
-		"docstatus": 0,
+		"docstatus": 1,
 		"valid_till_date": [">=", today()]
 	}, ["name"])
 	if not demand_letters:
@@ -85,7 +85,7 @@ def inform_demand_letter_validity_expiry():
 
 	sendemail(
 		recipients=[notification_email],
-		subject=f"Demand Letter Validity Expiry Notification - {len(demand_letters)} Demand Letter(s) Expiring Today",
+		subject=f"Demand Letter Validity Expiry Notification - {len(demand_letters)} Demand Letter(s) Expiring on {notify_date}",
 		message=message,
 		is_external_mail=True
 	)

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -20,6 +20,7 @@ from one_fm.utils import call_to_get_assurance_level, get_domain, get_standard_n
 from six import string_types
 from frappe import _
 from one_fm.operations.doctype.operations_shift.operations_shift import get_supervisor_operations_shifts
+from one_fm.one_fm.doctype.demand_letter.demand_letter import get_demand_letter, get_demand_letter_quota
 
 class EmployeeOverride(EmployeeMaster):
     def validate(self):
@@ -55,6 +56,7 @@ class EmployeeOverride(EmployeeMaster):
         employee_validate_attendance_by_timesheet(self, method=None)
         validate_leaves(self)
         self.validate_relieving_date()
+        self.update_agency_employee_count()
 
     def toggle_auto_attendance(self):
         try:
@@ -116,6 +118,7 @@ class EmployeeOverride(EmployeeMaster):
     def after_insert(self):
         employee_after_insert(self, method=None)
         self.assign_role_profile_based_on_designation()
+        self.update_agency_employee_count()
 
     @frappe.whitelist()
     def run_employee_id_generation(self):
@@ -137,6 +140,41 @@ class EmployeeOverride(EmployeeMaster):
                 user.save()
             else:
                 frappe.msgprint("Role profile not set in Designation, please set default.")
+
+    def update_agency_employee_count(self):
+        if not self.job_applicant:
+            return
+        agency = frappe.db.get_value("Job Applicant", self.job_applicant, "one_fm_agency")
+        if not agency:
+            return
+        if agency:
+            if not  get_demand_letter(agency, self.designation, self.gender):
+                return
+            demand_letter = get_demand_letter_quota(agency, self.designation, self.gender)
+            available_quota = 0
+            if demand_letter:
+                available_quota = demand_letter.quantity - demand_letter.used_quantity
+            if available_quota <= 0:
+                inform_demand_letter_quota_completion = frappe.db.get_single_value("Hiring Settings", "inform_demand_letter_quota_completion")
+                if not inform_demand_letter_quota_completion:
+                    return
+
+                if inform_demand_letter_quota_completion:
+                    frappe.msgprint(f"Demand letter quota for agency {self.agency} has been exhausted.")
+                    completion_notification_email = frappe.db.get_single_value("Hiring Settings", "demand_letter_quota_completion_notification_email")
+
+                    if not completion_notification_email:
+                        return
+
+                    sendemail(
+                        recipients=[completion_notification_email],
+                        subject="Demand Letter Quota Exhausted",
+                        message=f"The demand letter quota for agency {self.agency} has been exhausted."
+                    )
+            elif demand_letter:
+                # Update used quantity
+                new_used_quantity = demand_letter.used_quantity + 1
+                frappe.db.set_value("Demand Letter Demand", demand_letter.name, "used_quantity", new_used_quantity)
 
     def on_update(self):
         super(EmployeeOverride, self).on_update()

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -146,34 +146,34 @@ class EmployeeOverride(EmployeeMaster):
         agency = frappe.db.get_value("Job Applicant", self.job_applicant, "one_fm_agency")
         if not agency:
             return
-        if agency:
-            if not  get_demand_letter(agency, self.designation, self.gender):
+
+        if not get_demand_letter(agency, self.designation, self.gender):
+            return
+        demand_letter = get_demand_letter_quota(agency, self.designation, self.gender)
+        available_quota = 0
+        if demand_letter:
+            available_quota = demand_letter.quantity - demand_letter.used_quantity
+        if available_quota <= 0:
+            inform_demand_letter_quota_completion = frappe.db.get_single_value("Hiring Settings", "inform_demand_letter_quota_completion")
+            if not inform_demand_letter_quota_completion:
                 return
-            demand_letter = get_demand_letter_quota(agency, self.designation, self.gender)
-            available_quota = 0
-            if demand_letter:
-                available_quota = demand_letter.quantity - demand_letter.used_quantity
-            if available_quota <= 0:
-                inform_demand_letter_quota_completion = frappe.db.get_single_value("Hiring Settings", "inform_demand_letter_quota_completion")
-                if not inform_demand_letter_quota_completion:
+
+            if inform_demand_letter_quota_completion:
+                frappe.msgprint(f"Demand letter quota for agency {agency} has been exhausted.")
+                completion_notification_email = frappe.db.get_single_value("Hiring Settings", "demand_letter_quota_completion_notification_email")
+
+                if not completion_notification_email:
                     return
 
-                if inform_demand_letter_quota_completion:
-                    frappe.msgprint(f"Demand letter quota for agency {agency} has been exhausted.")
-                    completion_notification_email = frappe.db.get_single_value("Hiring Settings", "demand_letter_quota_completion_notification_email")
-
-                    if not completion_notification_email:
-                        return
-
-                    sendemail(
-                        recipients=[completion_notification_email],
-                        subject="Demand Letter Quota Exhausted",
-                        message=f"The demand letter quota for agency {agency} has been exhausted."
-                    )
-            elif demand_letter:
-                # Update used quantity
-                new_used_quantity = demand_letter.used_quantity + 1
-                frappe.db.set_value("Demand Letter Demand", demand_letter.name, "used_quantity", new_used_quantity)
+                sendemail(
+                    recipients=[completion_notification_email],
+                    subject="Demand Letter Quota Exhausted",
+                    message=f"The demand letter quota for agency {agency} has been exhausted."
+                )
+        elif demand_letter:
+            # Update used quantity
+            new_used_quantity = demand_letter.used_quantity + 1
+            frappe.db.set_value("Demand Letter Demand", demand_letter.name, "used_quantity", new_used_quantity)
 
     def on_update(self):
         super(EmployeeOverride, self).on_update()

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -56,7 +56,6 @@ class EmployeeOverride(EmployeeMaster):
         employee_validate_attendance_by_timesheet(self, method=None)
         validate_leaves(self)
         self.validate_relieving_date()
-        self.update_agency_employee_count()
 
     def toggle_auto_attendance(self):
         try:
@@ -160,7 +159,7 @@ class EmployeeOverride(EmployeeMaster):
                     return
 
                 if inform_demand_letter_quota_completion:
-                    frappe.msgprint(f"Demand letter quota for agency {self.agency} has been exhausted.")
+                    frappe.msgprint(f"Demand letter quota for agency {agency} has been exhausted.")
                     completion_notification_email = frappe.db.get_single_value("Hiring Settings", "demand_letter_quota_completion_notification_email")
 
                     if not completion_notification_email:
@@ -169,7 +168,7 @@ class EmployeeOverride(EmployeeMaster):
                     sendemail(
                         recipients=[completion_notification_email],
                         subject="Demand Letter Quota Exhausted",
-                        message=f"The demand letter quota for agency {self.agency} has been exhausted."
+                        message=f"The demand letter quota for agency {agency} has been exhausted."
                     )
             elif demand_letter:
                 # Update used quantity

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -237,6 +237,7 @@ one_fm.patches.v15_0.create_process_task_for_medical_reminders
 one_fm.patches.v15_0.add_assignment_rule_action_attendance_check_approver
 one_fm.patches.v15_0.update_existing_attendance_checks
 one_fm.patches.v15_0.add_process_task_agency_expiry_actions
+one_fm.patches.v15_0.add_process_task_demand_letter_expiry
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_client_event

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -236,6 +236,7 @@ one_fm.patches.v15_0.add_buying_settings_custom_field
 one_fm.patches.v15_0.create_process_task_for_medical_reminders
 one_fm.patches.v15_0.add_assignment_rule_action_attendance_check_approver
 one_fm.patches.v15_0.update_existing_attendance_checks
+one_fm.patches.v15_0.add_process_task_agency_expiry_actions
 
 [post_model_sync]
 one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_client_event

--- a/one_fm/patches/v15_0/add_process_task_agency_expiry_actions.py
+++ b/one_fm/patches/v15_0/add_process_task_agency_expiry_actions.py
@@ -1,0 +1,24 @@
+from one_fm.utils import create_process_task
+
+def execute():
+    create_process_task(
+        process_name= "Others",
+        erp_document= "Agency",
+        task_description= "Agency License Expiry Notification",
+        task_type= "Routine",
+        is_routine_task= 1,
+        frequency= "Daily",
+        is_automated= 1,
+        method= "one_fm.one_fm.doctype.agency.agency.inform_license_expiry"
+    )
+
+    create_process_task(
+        process_name= "Others",
+        erp_document= "Agency",
+        task_description= "Agency Inactive on License Expiry",
+        task_type= "Routine",
+        is_routine_task= 1,
+        frequency= "Daily",
+        is_automated= 1,
+        method= "one_fm.one_fm.doctype.agency.agency.inactive_agency_on_license_expiry"
+    )

--- a/one_fm/patches/v15_0/add_process_task_demand_letter_expiry.py
+++ b/one_fm/patches/v15_0/add_process_task_demand_letter_expiry.py
@@ -1,0 +1,13 @@
+from one_fm.utils import create_process_task
+
+def execute():
+    create_process_task(
+        process_name= "Others",
+        erp_document= "Demand Letter",
+        task_description= "Demand Letter Expiry Notification",
+        task_type= "Routine",
+        is_routine_task= 1,
+        frequency= "Daily",
+        is_automated= 1,
+        method= "one_fm.one_fm.doctype.demand_letter.demand_letter.inform_demand_letter_validity_expiry"
+    )


### PR DESCRIPTION
This pull request introduces significant enhancements to the agency and demand letter management workflows, focusing on automating notifications and quota tracking, improving data structure, and supporting process automation. The changes include new notification and automation settings in `Hiring Settings`, enhancements to the agency and demand letter doctypes, new background tasks for expiry notifications, and improved handling of demand letter quotas during employee creation.

**Key changes include:**

### 1. Automated Notifications & Process Tasks

* Added new scheduled process tasks to automate daily agency license expiry notifications, automatic agency deactivation on license expiry, and demand letter validity expiry notifications. This is achieved by introducing new patch scripts and utility calls to create these process tasks. [[1]](diffhunk://#diff-3dad5b579ff7683cb054f3d7c63c0fa421dfa45eefa1817b3a4d4bf9ed519cccR1-R24) [[2]](diffhunk://#diff-e4936a1755ba9e734eab7cd73857e58ca494c62786a2f7d36c799e44866f32cbR1-R13) [[3]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R236-R237)
* Implemented functions to send notification emails to recruitment teams when agency licenses or demand letters are about to expire, based on configurable periods in `Hiring Settings`. [[1]](diffhunk://#diff-25ca2d3c5c58ee3a59ec152ac0e5aa871382216ae7b8ad2059f693bceb301be7L70-R133) [[2]](diffhunk://#diff-7952ae9b075c0fa9cb767dbab04c359360c07d9f5b2f7d5828c3a73920f15e64L8-R91)

### 2. Hiring Settings Enhancements

* Extended `Hiring Settings` with new fields to control agency and demand letter expiry notifications, including notification periods, email recipients, and options to auto-inactivate agencies upon license expiry or inform on demand letter quota completion. [[1]](diffhunk://#diff-8bd05bf39084fa309fa9b7a7a46cc43043749c77df2c2ad7c8650cdd5c059d53L33-R47) [[2]](diffhunk://#diff-8bd05bf39084fa309fa9b7a7a46cc43043749c77df2c2ad7c8650cdd5c059d53R212-R299) [[3]](diffhunk://#diff-8bd05bf39084fa309fa9b7a7a46cc43043749c77df2c2ad7c8650cdd5c059d53R316)

### 3. Agency Doctype & Logic Updates

* Added logic to automatically deactivate agencies when their license expires and to notify relevant teams via email. The previous manual validation for agency activation was removed in favor of the automated process. [[1]](diffhunk://#diff-25ca2d3c5c58ee3a59ec152ac0e5aa871382216ae7b8ad2059f693bceb301be7L10-R18) [[2]](diffhunk://#diff-25ca2d3c5c58ee3a59ec152ac0e5aa871382216ae7b8ad2059f693bceb301be7L41-L46) [[3]](diffhunk://#diff-25ca2d3c5c58ee3a59ec152ac0e5aa871382216ae7b8ad2059f693bceb301be7L70-R133)
* Refactored code to remove the `is_agency_active` and related manual activation logic, relying now on the automated scheduled task.

### 4. Demand Letter Doctype & Quota Management

* Changed the demand letter naming to use a series (`naming_series`) instead of a direct data field, and added a new field for this purpose. Improved the structure by fetching the country from the agency and supporting dynamic row formats. [[1]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20L3-R9) [[2]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20L32-L39) [[3]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20R41) [[4]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20R159-R175) [[5]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20R191-R194)
* Added logic to track and update demand letter quotas when creating employees, and to notify when quotas are exhausted, including sending notification emails if configured. [[1]](diffhunk://#diff-7952ae9b075c0fa9cb767dbab04c359360c07d9f5b2f7d5828c3a73920f15e64L8-R91) [[2]](diffhunk://#diff-99f9e9d41e461282a68bef5a288697693e0cad970ccd25918bdd96e904069762R23) [[3]](diffhunk://#diff-99f9e9d41e461282a68bef5a288697693e0cad970ccd25918bdd96e904069762R120) [[4]](diffhunk://#diff-99f9e9d41e461282a68bef5a288697693e0cad970ccd25918bdd96e904069762R143-R177)

---

**References:**  
[[1]](diffhunk://#diff-8bd05bf39084fa309fa9b7a7a46cc43043749c77df2c2ad7c8650cdd5c059d53L33-R47) [[2]](diffhunk://#diff-8bd05bf39084fa309fa9b7a7a46cc43043749c77df2c2ad7c8650cdd5c059d53R212-R299) [[3]](diffhunk://#diff-8bd05bf39084fa309fa9b7a7a46cc43043749c77df2c2ad7c8650cdd5c059d53R316) [[4]](diffhunk://#diff-25ca2d3c5c58ee3a59ec152ac0e5aa871382216ae7b8ad2059f693bceb301be7L10-R18) [[5]](diffhunk://#diff-25ca2d3c5c58ee3a59ec152ac0e5aa871382216ae7b8ad2059f693bceb301be7L41-L46) [[6]](diffhunk://#diff-25ca2d3c5c58ee3a59ec152ac0e5aa871382216ae7b8ad2059f693bceb301be7L70-R133) [[7]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20L3-R9) [[8]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20L32-L39) [[9]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20R41) [[10]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20R159-R175) [[11]](diffhunk://#diff-b98d137bb3846ed0884f4b278134d594f2e2021220c89b3b4451c3e73db2fc20R191-R194) [[12]](diffhunk://#diff-7952ae9b075c0fa9cb767dbab04c359360c07d9f5b2f7d5828c3a73920f15e64L8-R91) [[13]](diffhunk://#diff-99f9e9d41e461282a68bef5a288697693e0cad970ccd25918bdd96e904069762R23) [[14]](diffhunk://#diff-99f9e9d41e461282a68bef5a288697693e0cad970ccd25918bdd96e904069762R120) [[15]](diffhunk://#diff-99f9e9d41e461282a68bef5a288697693e0cad970ccd25918bdd96e904069762R143-R177) [[16]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R236-R237) [[17]](diffhunk://#diff-3dad5b579ff7683cb054f3d7c63c0fa421dfa45eefa1817b3a4d4bf9ed519cccR1-R24) [[18]](diffhunk://#diff-e4936a1755ba9e734eab7cd73857e58ca494c62786a2f7d36c799e44866f32cbR1-R13)