### PR TITLE
fix: notification - transport user

### DIFF
--- a/one_fm/grd/doctype/medical_appointment/medical_appointment.py
+++ b/one_fm/grd/doctype/medical_appointment/medical_appointment.py
@@ -246,9 +246,9 @@ def send_medical_appointment_reminders():
 		{pickup_locations_html}
 		"""
 
-		frappe.new_doc(
-			"Notification Log",
+		frappe.get_doc(
 			{
+				"doctype": "Notification Log",
 				"for_user": supervisor,
 				"document_type": "Medical Appointment",
 				"subject": f"Reminder: {len(supervisor_appointments)} medical appointments for tomorrow.",


### PR DESCRIPTION
This pull request makes a small adjustment to the way notification logs are created when sending medical appointment reminders. Instead of using `frappe.new_doc`, the code now uses `frappe.get_doc` to instantiate the `Notification Log` document.

- Changed the instantiation of `Notification Log` documents in `send_medical_appointment_reminders` from `frappe.new_doc` to `frappe.get_doc` in `medical_appointment.py`