### PR TITLE
Fix  late notification on checkin creation from shift permission

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -316,6 +316,8 @@ def notify_supervisor_about_late_entry(checkin):
 	This method notify the supervisor about the late entry of an employee
 	"""
 	try:
+		if checkin.get('shift_permission'):
+			return # return if employee checkin is created from shift permission
 		auto_attendance_employee = frappe.get_value("Employee", {'name':checkin.employee}, ['auto_attendance'])
 		if auto_attendance_employee == 0:
 			shift_permission = frappe.db.sql(f""" select name from `tabShift Permission` where employee = '{checkin.employee}' and date = '{now_datetime().date()}' and log_type = 'IN' and workflow_state IN ('Pending','Approved') ;  """)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [*] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/18123

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
updated the codebase to only send late notifications to checkins with no Shift permission linked
## Is there a business logic within a doctype?
    - [] Yes
    - [*] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [*] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [*] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [*] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [*] Chrome
  - [] Safari
  - [] Firefox
