### PR TITLE
feat: update contract items fields

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -221,7 +221,7 @@ function load_js(page) {
 							label: "Post Status",
 							fieldname: "post_status",
 							fieldtype: "Select",
-							options: "\nPlan Post\nPost Off\nSuspend Post\nCancel Post",
+							options: "\nPlan Post\nPost Off\nClient Post Off\nSuspend Post\nCancel Post",
 							reqd: 1
 						},
 						{
@@ -286,7 +286,7 @@ function load_js(page) {
 						{
 							fieldname: "sb3",
 							fieldtype: "Section Break",
-							depends_on: "eval:doc.post_status == 'Post Off'",
+							depends_on: "eval:doc.post_status == 'Post Off' || doc.post_status == 'Client Post Off'",
 						},
 						{
 							label: "Paid",
@@ -306,7 +306,7 @@ function load_js(page) {
 						{
 							fieldname: "sb5",
 							fieldtype: "Section Break",
-							depends_on: "eval:doc.post_status == 'Post Off'",
+							depends_on: "eval:doc.post_status == 'Post Off' || doc.post_status == 'Client Post Off'",
 						},
 						{
 							label: "Post Off From Date",
@@ -315,7 +315,7 @@ function load_js(page) {
 							default: date
 						},
 						{ label: "Repeat", fieldname: "repeat", fieldtype: "Select", options: "Does not repeat\nSelected Days Only\nDaily\nWeekly\nMonthly\nYearly" },
-						{ "fieldtype": "Section Break", "fieldname": "sb1", "depends_on": "eval:doc.post_status=='Post Off' && doc.repeat=='Weekly'" },
+						{ "fieldtype": "Section Break", "fieldname": "sb1", "depends_on": "eval:(doc.post_status=='Post Off' || doc.post_status=='Client Post Off') && doc.repeat=='Weekly'" },
 						{ "label": "Sunday", "fieldname": "sunday", "fieldtype": "Check" },
 						{ "label": "Wednesday", "fieldname": "wednesday", "fieldtype": "Check" },
 						{ "label": "Saturday", "fieldname": "saturday", "fieldtype": "Check" },
@@ -325,7 +325,7 @@ function load_js(page) {
 						{ "fieldtype": "Column Break", "fieldname": "cb2" },
 						{ "label": "Tuesday", "fieldname": "tuesday", "fieldtype": "Check" },
 						{ "label": "Friday", "fieldname": "friday", "fieldtype": "Check" },
-						{ "fieldtype": "Section Break", "fieldname": "sb2", "depends_on": "eval:doc.post_status=='Post Off' && doc.repeat!= 'Does not repeat' && doc.repeat!= 'Selected Days Only'" },
+						{ "fieldtype": "Section Break", "fieldname": "sb2", "depends_on": "eval:(doc.post_status=='Post Off' || doc.post_status=='Client Post Off') && doc.repeat!= 'Does not repeat' && doc.repeat!= 'Selected Days Only'" },
 						{ "label": "Repeat Till", "fieldtype": "Date", "fieldname": "repeat_till", "depends_on": "eval:doc.project_end_date==0" },
 						{
 							fieldname: "sb2",

--- a/one_fm/operations/doctype/contract_item/contract_item.json
+++ b/one_fm/operations/doctype/contract_item/contract_item.json
@@ -218,11 +218,11 @@
   },
   {
    "default": "Full Month",
-   "depends_on": "eval:doc.rate_type == 'Monthly' & doc.item_type != 'Items'",
+   "depends_on": "eval:doc.rate_type == 'Monthly' && doc.item_type != 'Items'",
    "fieldname": "off_type",
    "fieldtype": "Select",
    "label": "Off Type",
-   "mandatory_depends_on": "eval:doc.rate_type == 'Monthly' & doc.item_type != 'Items'",
+   "mandatory_depends_on": "eval:doc.rate_type == 'Monthly' && doc.item_type != 'Items'",
    "options": "Full Month\nDays Off"
   },
   {
@@ -256,7 +256,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.off_type == 'Full Month' & doc.item_type!='Items'",
+   "depends_on": "eval:doc.off_type == 'Full Month' && doc.item_type!='Items'",
    "description": "If Yearly Month is checked then the invoice will calculate based on the factor 30.4166.",
    "fieldname": "is_yearly_month",
    "fieldtype": "Check",
@@ -352,7 +352,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-01-19 06:50:59.449028",
+ "modified": "2026-01-19 08:55:02.600728",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contract Item",

--- a/one_fm/operations/doctype/contract_item/contract_item.json
+++ b/one_fm/operations/doctype/contract_item/contract_item.json
@@ -26,6 +26,7 @@
   "shift_hours",
   "gender",
   "service_type",
+  "is_daily_operation_handled_by_us",
   "rate_type",
   "off_type",
   "is_yearly_month",
@@ -35,7 +36,6 @@
   "overtime_rate",
   "site",
   "operational_requirements_section",
-  "operational_frequency",
   "select_specific_days",
   "sunday",
   "monday",
@@ -44,8 +44,7 @@
   "thursday",
   "friday",
   "saturday",
-  "column_break_ilmm",
-  "monthly_count"
+  "column_break_ilmm"
  ],
  "fields": [
   {
@@ -179,6 +178,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.item_type != 'Items'",
    "fieldname": "overtime_rate",
    "fieldtype": "Currency",
    "label": "Overtime Rate"
@@ -208,28 +208,30 @@
    "mandatory_depends_on": "eval:doc.item_type != \"Items\""
   },
   {
+   "depends_on": "eval:doc.item_type != \"Items\"",
    "fieldname": "rate_type",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Rate Type",
-   "options": "Monthly\nHourly\nDaily",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.item_type != \"Items\"",
+   "options": "Monthly\nHourly\nDaily"
   },
   {
    "default": "Full Month",
-   "depends_on": "eval:doc.rate_type=='Monthly'",
+   "depends_on": "eval:doc.rate_type == 'Monthly' & doc.item_type != 'Items'",
    "fieldname": "off_type",
    "fieldtype": "Select",
    "label": "Off Type",
-   "options": "Full Month\nDays Off",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.rate_type == 'Monthly' & doc.item_type != 'Items'",
+   "options": "Full Month\nDays Off"
   },
   {
+   "depends_on": "eval:doc.item_type != \"Items\"",
    "fieldname": "service_type",
    "fieldtype": "Select",
    "label": "Service Type",
-   "options": "\nManpower\nPost Schedule",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.item_type != \"Items\"",
+   "options": "\nManpower\nPost Schedule"
   },
   {
    "depends_on": "eval:doc.off_type=='Days Off' && doc.rate_type=='Monthly'",
@@ -254,7 +256,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.off_type == 'Full Month'",
+   "depends_on": "eval:doc.off_type == 'Full Month' & doc.item_type!='Items'",
    "description": "If Yearly Month is checked then the invoice will calculate based on the factor 30.4166.",
    "fieldname": "is_yearly_month",
    "fieldtype": "Check",
@@ -264,7 +266,7 @@
    "fieldname": "item_type",
    "fieldtype": "Select",
    "label": "Item Type",
-   "options": "Manpower\nItems"
+   "options": "Service\nItems"
   },
   {
    "depends_on": "eval:doc.item_type == \"Items\"",
@@ -280,14 +282,7 @@
    "label": "Operational Requirements"
   },
   {
-   "fieldname": "operational_frequency",
-   "fieldtype": "Select",
-   "label": "Operational Frequency",
-   "options": "Weekly\nMonthly"
-  },
-  {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly'",
    "description": "Check to specify days manually. Leave unchecked to use system defaults.",
    "fieldname": "select_specific_days",
    "fieldtype": "Check",
@@ -295,7 +290,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly' && doc.select_specific_days == 1",
+   "depends_on": "eval:doc.select_specific_days == 1",
    "fieldname": "sunday",
    "fieldtype": "Check",
    "label": "Sunday"
@@ -306,56 +301,58 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly' && doc.select_specific_days == 1",
+   "depends_on": "eval:doc.select_specific_days == 1",
    "fieldname": "monday",
    "fieldtype": "Check",
    "label": "Monday"
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly' && doc.select_specific_days == 1",
+   "depends_on": "eval:doc.select_specific_days == 1",
    "fieldname": "tuesday",
    "fieldtype": "Check",
    "label": "Tuesday"
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly' && doc.select_specific_days == 1",
+   "depends_on": "eval:doc.select_specific_days == 1",
    "fieldname": "wednesday",
    "fieldtype": "Check",
    "label": "Wednesday"
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly' && doc.select_specific_days == 1",
+   "depends_on": "eval:doc.select_specific_days == 1",
    "fieldname": "thursday",
    "fieldtype": "Check",
    "label": "Thursday"
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly' && doc.select_specific_days == 1",
+   "depends_on": "eval:doc.select_specific_days == 1",
    "fieldname": "friday",
    "fieldtype": "Check",
    "label": "Friday"
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.operational_frequency == 'Weekly' && doc.select_specific_days == 1",
+   "depends_on": "eval:doc.select_specific_days == 1",
    "fieldname": "saturday",
    "fieldtype": "Check",
    "label": "Saturday"
   },
   {
-   "depends_on": "eval:doc.operational_frequency == 'Monthly'",
-   "fieldname": "monthly_count",
-   "fieldtype": "Int",
-   "label": "Monthly Count"
+   "depends_on": "eval:doc.service_type == 'Manpower'",
+   "fieldname": "is_daily_operation_handled_by_us",
+   "fieldtype": "Select",
+   "label": "Is Daily Operation Handled by Us?",
+   "mandatory_depends_on": "eval:doc.service_type == 'Manpower'",
+   "options": "\nYes\nNo"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-12-24 21:52:53.980361",
+ "modified": "2026-01-19 06:50:59.449028",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Contract Item",

--- a/one_fm/operations/doctype/post_schedule/post_schedule.json
+++ b/one_fm/operations/doctype/post_schedule/post_schedule.json
@@ -65,7 +65,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Post Status",
-   "options": "\nPlanned\nPost Off\nSuspended\nCancelled"
+   "options": "\nPlanned\nPost Off\nClient Post Off\nSuspended\nCancelled"
   },
   {
    "depends_on": "eval:doc.post_status==\"Post Off\" || doc.post_status==\"Suspended\" || doc.post_status==\"Cancelled\"",
@@ -124,7 +124,7 @@
   }
  ],
  "links": [],
- "modified": "2025-04-08 08:29:11.882051",
+ "modified": "2026-01-19 06:59:41.102373",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Post Schedule",
@@ -144,6 +144,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
This pull request updates the `contract_item.json` DocType configuration, focusing on simplifying operational requirements, improving field dependencies, and enhancing clarity for contract item types and service handling. The main changes include removing the `operational_frequency` and `monthly_count` fields, refining dependencies for several fields, and introducing a new field to specify if daily operations are handled by the company.

**Operational requirements simplification:**
- Removed the `operational_frequency` and `monthly_count` fields, and updated the logic so that day selection checkboxes (`sunday` through `saturday`) now depend only on `select_specific_days`, not on the removed `operational_frequency` field. This simplifies how operational days are specified. [[1]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8L38) [[2]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8L47-R47) [[3]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8L282-R293) [[4]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8L309-R355)

**Field dependency improvements:**
- Added or updated `depends_on` and `mandatory_depends_on` conditions for several fields (`overtime_rate`, `rate_type`, `off_type`, `service_type`, `is_yearly_month`) to ensure they are only shown or required when `item_type` is not 'Items', making the form more context-aware. [[1]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8R181) [[2]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8R211-R234) [[3]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8L257-R259)

**New field for daily operation handling:**
- Added a new field `is_daily_operation_handled_by_us` (select: Yes/No), which is required when `service_type` is 'Manpower', to explicitly capture responsibility for daily operations. [[1]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8R29) [[2]](diffhunk://#diff-5c36087525ce31413e1af49e1c8ee0a9f571d415b7b912c47557c3c7f91f92f8L309-R355)

**Contract item type clarification:**
- Changed the `item_type` select options from `Manpower\nItems` to `Service\nItems`, clarifying the distinction between service-based and item-based contract items.

**Minor field adjustments:**
- Updated the `off_type` field dependency to require both `rate_type == 'Monthly'` and `item_type != 'Items'` for display and requirement.

These changes collectively make the contract item form more intuitive, reduce unnecessary complexity, and ensure fields are shown only when relevant to the user's context.