### PR TITLE
feat: process in leave handover

### DIFF
--- a/one_fm/one_fm/doctype/handover_item/handover_item.json
+++ b/one_fm/one_fm/doctype/handover_item/handover_item.json
@@ -8,6 +8,7 @@
  "field_order": [
   "reference_doctype",
   "reference_docname",
+  "role",
   "roles_assigned",
   "column_break_vjik",
   "reliever",
@@ -95,13 +96,19 @@
    "hidden": 1,
    "label": "Reliever Role Profile",
    "options": "Role Profile"
+  },
+  {
+   "fieldname": "role",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Role"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-20 21:00:49.235975",
+ "modified": "2026-01-09 07:04:15.374510",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Handover Item",

--- a/one_fm/one_fm/doctype/leave_handover/leave_handover.py
+++ b/one_fm/one_fm/doctype/leave_handover/leave_handover.py
@@ -175,52 +175,22 @@ def get_handover_data(leave_application):
 	employee = leave_application_doc.employee
 
 	# Fetch projects
-	projects = frappe.get_all(
-		"Project",
-		filters={"status": "Open", "account_manager": employee},
-		fields=["name"],
-	)
-	for project in projects:
-		handover_items.append({
-			"reference_doctype": "Project",
-			"reference_docname": project.name,
-		})
+	add_to_handover_items(handover_items, "Project", {"status": "Open", "account_manager": employee}, "Project Manager")
 
 	# Fetch operations sites
-	sites = frappe.get_all(
-		"Operations Site",
-		filters={"status": "Active", "site_supervisor": employee},
-		fields=["name"],
-	)
-	for site in sites:
-		handover_items.append({
-			"reference_doctype": "Operations Site",
-			"reference_docname": site.name,
-		})
+	add_to_handover_items(handover_items, "Operations Site", {"status": "Active", "site_supervisor": employee}, "Site Supervisor")
 
 	# Fetch process tasks
-	tasks = frappe.get_all(
-		"Process Task",
-		filters={"is_active": 1, "employee": employee},
-		fields=["name"],
-	)
-	for task in tasks:
-		handover_items.append({
-			"reference_doctype": "Process Task",
-			"reference_docname": task.name,
-		})
+	add_to_handover_items(handover_items, "Process Task", {"is_active": 1, "employee": employee}, "Process Task Actor")
 
 	# Fetch employees reporting to the leave applicant
-	employees = frappe.get_all(
-		"Employee",
-		filters={"status": ("in", ["Active", "Vacation"]), "reports_to": employee},
-		fields=["name"],
-	)
-	for emp in employees:
-		handover_items.append({
-			"reference_doctype": "Employee",
-			"reference_docname": emp.name,
-		})
+	add_to_handover_items(handover_items, "Employee", {"status": ("in", ["Active", "Vacation"]), "reports_to": employee}, "Reporting To")
+
+	# Fetch processes to handover
+	employee_user_id = frappe.db.get_value("Employee", employee, "user_id")
+	if employee_user_id:
+		add_to_handover_items(handover_items, "Process", {"process_owner": employee_user_id}, "Process Owner")
+		add_to_handover_items(handover_items, "Process", {"business_analyst": employee_user_id}, "Business Analyst")
 
 	return {
 		"employee": leave_application_doc.employee,
@@ -230,6 +200,16 @@ def get_handover_data(leave_application):
 		"resumption_date": leave_application_doc.resumption_date,
 		"handover_items": handover_items,
 	}
+
+def add_to_handover_items(handover_items, doctype, filters, role=None):
+	items = frappe.get_all(doctype, filters=filters, pluck="name")
+
+	for item in items:
+		handover_items.append({
+			"reference_doctype": doctype,
+			"reference_docname": item,
+			"role": role
+		})
 
 @frappe.whitelist()
 def reliever_assignment_on_leave_start(date=None):

--- a/one_fm/public/js/doctype_js/leave_application.js
+++ b/one_fm/public/js/doctype_js/leave_application.js
@@ -130,6 +130,7 @@ frappe.ui.form.on("Leave Application", {
 										var child = frappe.model.add_child(doc, 'Handover Item', 'handover_items');
 										child.reference_doctype = item.reference_doctype;
 										child.reference_docname = item.reference_docname;
+										child.role = item.role;
 									});
 								}
 								frappe.set_route('Form', 'Leave Handover', doc.name);


### PR DESCRIPTION
This pull request enhances the handover process for leave applications by introducing a new `role` field to the `Handover Item` doctype and updating the logic for generating handover items. The changes improve clarity around each handover item's responsibility and streamline the code for fetching and assigning these items.

**Schema and Data Model Updates:**

* Added a new `role` field (type: Data) to the `Handover Item` doctype and included it in the field order and list view, allowing each handover item to specify its associated role. [[1]](diffhunk://#diff-5be3636bc7b0877c928b5e7d2330d0ad1f735ffe521237b4a0b00ae2893b78f5R11) [[2]](diffhunk://#diff-5be3636bc7b0877c928b5e7d2330d0ad1f735ffe521237b4a0b00ae2893b78f5R99-R111)

**Backend Logic Improvements:**

* Refactored the `get_handover_data` function in `leave_handover.py` to use a new helper function `add_to_handover_items`, which standardizes the process of fetching related records and attaching the appropriate `role` to each handover item. This also adds new handover items for processes where the employee is a `Process Owner` or `Business Analyst`. [[1]](diffhunk://#diff-1f312b7072e586be533f567aa7b55958e358cbc53772dca96dc2486cc35f2849L178-R193) [[2]](diffhunk://#diff-1f312b7072e586be533f567aa7b55958e358cbc53772dca96dc2486cc35f2849R204-R213)

**Frontend Integration:**

* Updated the client-side code in `leave_application.js` to set the new `role` field when adding handover items to the form, ensuring the role information is correctly displayed and stored.