### PR TITLE
feat: notify employee on status change

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -196,6 +196,8 @@ class EmployeeOverride(EmployeeMaster):
         self.notify_employee_id_update()
         self.remove_user_on_employee_left()
         self.notify_supervisor_of_status_change()
+        if self.has_value_changed("status") and self.status == "Not Returned from Leave":
+            self.inform_employee_status_update()
 
     def inform_employee_id_update(self):
         """
@@ -350,18 +352,18 @@ class EmployeeOverride(EmployeeMaster):
                 message = status_validate.message()
                 if message:
                     frappe.throw(message)
-        if last_doc and last_doc.get('status') != "Active":
-            if self.status == "Not Returned from Leave":
-                inform_employee_status_update(self)
 
     def inform_employee_status_update(self):
-        subject = f"Your Employee Status changed to {self.status}"
-        message = f"Dear {self.employee_name}, your status has been changed to {self.status}, please contact your supervisor"
-        send_push_notification(
-            employee_id=self.employee_id,
-            title=subject,
-            body=message
-        )
+        try:
+            subject = f"Your Employee Status changed to {self.status}"
+            message = f"Dear {self.employee_name}, your status has been changed to {self.status}, please contact your supervisor"
+            send_push_notification(
+                employee_id=self.employee_id,
+                title=subject,
+                body=message
+            )
+        except Exception as e:
+            frappe.log_error(message=f"Failed to send status update notification: {str(e)}", title="Employee Status Update Notification")
 
     def clear_schedules(self):
         # clear future employee schedules

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -350,7 +350,18 @@ class EmployeeOverride(EmployeeMaster):
                 message = status_validate.message()
                 if message:
                     frappe.throw(message)
+        if last_doc and last_doc.get('status') != "Active":
+            if self.status == "Not Returned from Leave":
+                inform_employee_status_update(self)
 
+    def inform_employee_status_update(self):
+        subject = f"Your Employee Status changed to {self.status}"
+        message = f"Dear {self.employee_name}, your status has been changed to {self.status}, please contact your supervisor"
+        send_push_notification(
+            employee_id=self.employee_id,
+            title=subject,
+            body=message
+        )
 
     def clear_schedules(self):
         # clear future employee schedules


### PR DESCRIPTION
This pull request introduces a notification feature for employees whose status changes to "Not Returned from Leave". The main change is the addition of a method to send a push notification to the affected employee.

**Employee status change notifications:**

* Added logic in `validate_status_change` to call a new notification method when an employee's status is updated to "Not Returned from Leave".
* Introduced a new method `inform_employee_status_update` in `employee.py` to send a push notification to the employee with a relevant subject and message.