### PR TITLE
feat: update workflow in client event

### DIFF
--- a/one_fm/custom/workflow/client_event.json
+++ b/one_fm/custom/workflow/client_event.json
@@ -10,6 +10,7 @@
     {
       "state": "Draft",
       "doc_status": "0",
+      "style": "Danger",
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Operations Supervisor",
@@ -19,6 +20,7 @@
     {
       "state": "Pending Approval",
       "doc_status": "0",
+      "style": "Warning",
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Operations Supervisor",
@@ -28,9 +30,40 @@
     {
       "state": "Approved",
       "doc_status": "1",
+      "style": "Success",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Operations Manager",
+      "send_email": 1,
+      "doctype": "Workflow Document State"
+    },
+    {
+      "state": "Approved",
+      "doc_status": "1",
+      "style": "Success",
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Operations Supervisor",
+      "send_email": 1,
+      "doctype": "Workflow Document State"
+    },
+    {
+      "state": "Rejected",
+      "doc_status": "0",
+      "style": "Inverse",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Operations Manager",
+      "send_email": 1,
+      "doctype": "Workflow Document State"
+    },
+    {
+      "state": "Cancelled",
+      "doc_status": "2",
+      "style": "Danger",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Operations Manager",
       "send_email": 1,
       "doctype": "Workflow Document State"
     }
@@ -41,6 +74,19 @@
       "action": "Submit for Review",
       "next_state": "Pending Approval",
       "allowed": "Operations Supervisor",
+      "allow_self_approval": 1,
+      "send_email_to_creator": 0,
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "doctype": "Workflow Transition"
+    },
+    {
+      "state": "Pending Approval",
+      "action": "Approve",
+      "next_state": "Approved",
+      "allowed": "Operations Manager",
       "allow_self_approval": 1,
       "send_email_to_creator": 0,
       "skip_multiple_action": 0,
@@ -64,8 +110,34 @@
     },
     {
       "state": "Pending Approval",
-      "action": "Approve",
-      "next_state": "Approved",
+      "action": "Return To Draft",
+      "next_state": "Draft",
+      "allowed": "Operations Supervisor",
+      "allow_self_approval": 1,
+      "send_email_to_creator": 0,
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "doctype": "Workflow Transition"
+    },
+    {
+      "state": "Pending Approval",
+      "action": "Reject",
+      "next_state": "Rejected",
+      "allowed": "Operations Manager",
+      "allow_self_approval": 1,
+      "send_email_to_creator": 0,
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "doctype": "Workflow Transition"
+    },
+    {
+      "state": "Approved",
+      "action": "Cancel",
+      "next_state": "Cancelled",
       "allowed": "Operations Manager",
       "allow_self_approval": 1,
       "send_email_to_creator": 0,

--- a/one_fm/one_fm/doctype/client_event/client_event.js
+++ b/one_fm/one_fm/doctype/client_event/client_event.js
@@ -6,7 +6,7 @@ frappe.ui.form.on("Client Event", {
         frm.events.add_event_staff(frm);
     },
     add_event_staff(frm) {
-        if (frm.doc.workflow_state == "Approved") {
+        if (["Approved", "Pending Approval"].includes(frm.doc.workflow_state)) {
             frm.add_custom_button(__("Add Staff to Event"), function() {
                 let d = new frappe.ui.Dialog({
                     title: __("Add Staff to Event"),

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -272,7 +272,7 @@ one_fm.patches.v15_0.clear_residency_expiry_date
 one_fm.patches.v15_0.update_residency_expiry_date_depends_on
 one_fm.patches.v15_0.add_assignment_rule_and_wf_fingerprint_appointment
 one_fm.patches.v15_0.update_finger_print_appointment_workflow_state
-one_fm.patches.v15_0.add_workflow_client_event
+one_fm.patches.v15_0.add_workflow_client_event #1
 one_fm.patches.v15_0.add_shift_assignment_event_based_fields
 one_fm.patches.v15_0.add_shift_assignment_shift_type_mandatory_depends_on # re-run
 one_fm.patches.v15_0.add_update_custom_field #2025-11-10


### PR DESCRIPTION
This pull request makes several improvements and adjustments to the `Client Event` workflow, primarily to enhance workflow state handling, permissions, and user interface cues. The main changes include adding new workflow states and transitions, updating permissions for different roles, and improving the frontend logic for when staff can be added to events.

**Workflow enhancements and permissions:**

* Added new workflow states (`Rejected`, `Cancelled`) and duplicated the `Approved` state for different roles, each with distinct styles, permissions, and email notifications. This allows for more granular control and clearer status representation in the workflow.
* Introduced new workflow transitions, including explicit actions for `Approve`, `Reject`, `Cancel`, and `Return To Draft`, specifying which roles are allowed to perform each action and ensuring proper state progression. [[1]](diffhunk://#diff-d89f8871464b7eb8ecfe31d5befb6c8832fe1e3aea3444f3cf7409bf553a86d4R85-R97) [[2]](diffhunk://#diff-d89f8871464b7eb8ecfe31d5befb6c8832fe1e3aea3444f3cf7409bf553a86d4L67-R140)

**User interface improvements:**

* Assigned visual styles (`Danger`, `Warning`, `Success`, `Inverse`) to each workflow state for better clarity in the UI. [[1]](diffhunk://#diff-d89f8871464b7eb8ecfe31d5befb6c8832fe1e3aea3444f3cf7409bf553a86d4R13) [[2]](diffhunk://#diff-d89f8871464b7eb8ecfe31d5befb6c8832fe1e3aea3444f3cf7409bf553a86d4R23) [[3]](diffhunk://#diff-d89f8871464b7eb8ecfe31d5befb6c8832fe1e3aea3444f3cf7409bf553a86d4R33-R68)
* Updated the client-side logic in `client_event.js` so that the "Add Staff to Event" button is available in both the `Approved` and `Pending Approval` states, making it more flexible for users to manage event staffing.

**Maintenance and housekeeping:**

* Updated the patch entry in `patches.txt` to clarify and possibly re-run the workflow patch for `client_event`.