### PR TITLE
fix: project manager field in project

### DIFF
--- a/one_fm/custom/custom_field/project.py
+++ b/one_fm/custom/custom_field/project.py
@@ -30,12 +30,6 @@ def get_project_custom_fields():
                 "fieldtype": "Small Text",
             },
             {
-                "label": "",
-                "fieldname": "custom_column_break_hzhov",
-                "insert_after":"users_section",
-                "fieldtype": "Column Break",
-            },
-            {
                 "label": "Success and Completion Criteria",
                 "fieldname": "custom_success_and_completion_criteria",
                 "insert_after": "custom_column_break_acgz2",
@@ -259,13 +253,13 @@ def get_project_custom_fields():
             {
                 "fieldname": "column_break_64",
                 "fieldtype": "Column Break",
-                "insert_after": "manager_name"
+                "insert_after": "no_of_posts_as_per_contract"
             },
             {
                 "fieldname": "project_manager",
                 "label": "Project Manager",
                 "fieldtype": "Link",
-                "insert_after": "no_of_posts_as_per_contract",
+                "insert_after": "users_section",
                 "options": "Employee",
                 "ignore_user_permissions": 1,
                 "mandatory_depends_on": "eval:doc.project_type==\"External\""

--- a/one_fm/operations/doctype/mom_followup/mom_followup.json
+++ b/one_fm/operations/doctype/mom_followup/mom_followup.json
@@ -66,7 +66,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "project.manager_name",
+   "fetch_from": "project.project_manager_name",
    "fieldname": "project_manager_name",
    "fieldtype": "Data",
    "label": "Project Manager Name",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -243,7 +243,7 @@ one_fm.patches.v15_0.update_leave_application_custom_field
 one_fm.patches.v15_0.process_task_for_remind_annual_leave_employees_to_helpdesk_user
 one_fm.patches.v15_0.process_task_for_send_open_hd_ticket_count
 one_fm.patches.v15_0.add_employee_uniform_field_to_quality_feedback
-one_fm.patches.v15_0.rename_account_manager_to_project_manager
+one_fm.patches.v15_0.rename_account_manager_to_project_manager #1-5
 one_fm.patches.v15_0.add_shift_request_custom_fields
 one_fm.patches.v15_0.add_employee_project_manager_name_custom_field
 

--- a/one_fm/patches/v15_0/rename_account_manager_to_project_manager.py
+++ b/one_fm/patches/v15_0/rename_account_manager_to_project_manager.py
@@ -1,12 +1,18 @@
 import frappe
 from frappe.model.utils.rename_field import rename_field
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.custom_field.project import get_project_custom_fields
 
 def execute():
-    # Rename fields in Project doctype
-    if frappe.db.has_column("Project", "account_manager"):
-        rename_field("Project", "account_manager", "project_manager")
-    if frappe.db.has_column("Project", "manager_name"):
-        rename_field("Project", "manager_name", "project_manager_name")
-
+    create_custom_fields(get_project_custom_fields())
+    query = """
+        UPDATE `tabProject`
+        SET project_manager = account_manager,
+            project_manager_name = manager_name
+        WHERE account_manager IS NOT NULL OR manager_name IS NOT NULL
+    """
+    frappe.db.sql(query)
+    frappe.db.delete("Custom Field", {"dt": "Project", "fieldname": "account_manager"})
+    frappe.db.delete("Custom Field", {"dt": "Project", "fieldname": "manager_name"})
     # Migrate data in custom fields if needed (for custom_field table)
     frappe.db.commit()


### PR DESCRIPTION
This pull request updates the handling of project manager fields in the Project doctype, focusing on renaming, migrating data, and updating related custom fields. The changes ensure consistency in field naming and improve data integrity across the codebase.

**Project Manager Field Renaming and Migration:**

* The patch script `rename_account_manager_to_project_manager.py` now creates the latest custom fields, migrates data from `account_manager` and `manager_name` to `project_manager` and `project_manager_name`, and deletes the old fields to maintain a clean schema.

**Custom Field Updates and Reordering:**

* In `get_project_custom_fields`, the insertion order for several fields was updated: `column_break_64` now follows `no_of_posts_as_per_contract`, and `project_manager` is inserted after `users_section` instead of `no_of_posts_as_per_contract`. Additionally, a redundant column break field was removed for clarity. [[1]](diffhunk://#diff-564bd29ae2b707b1c59cf4d593467d3a474f2a568e7f6782d5723b937c16f06dL262-R262) [[2]](diffhunk://#diff-564bd29ae2b707b1c59cf4d593467d3a474f2a568e7f6782d5723b937c16f06dL32-L37)

**Related Field Reference Updates:**

* The `project_manager_name` field in `mom_followup.json` now fetches its value from `project.project_manager_name` instead of the old `project.manager_name`, reflecting the new naming convention.

**Patch File Annotation:**

* The entry for the renaming patch in `patches.txt` was annotated with `#1-5` for tracking purposes.