### PR TITLE
feat: New joiner wiki introduction

### DIFF
--- a/one_fm/custom/assignment_rule/assignment_rule.py
+++ b/one_fm/custom/assignment_rule/assignment_rule.py
@@ -3,7 +3,7 @@ import json
 import os
 from one_fm.utils import get_json_file
 
-def get_assignment_rule_json_file(file_name):
+def get_assignment_rule_json_file(file_name, app_name="one_fm"):
     """
     Load JSON data from a file in the 'assignment_rule' folder.
     Args:
@@ -11,7 +11,7 @@ def get_assignment_rule_json_file(file_name):
     Returns:
         dict: The parsed JSON data.
     """
-    folder = frappe.get_app_path("one_fm", "custom", "assignment_rule")
+    folder = frappe.get_app_path(app_name, "custom", "assignment_rule")
     return get_json_file(file_name, folder)
 
 def create_assignment_rule(assignment_rule:dict, process_task_name:str=None):

--- a/one_fm/custom/custom_field/hr_settings.py
+++ b/one_fm/custom/custom_field/hr_settings.py
@@ -131,6 +131,36 @@ def get_hr_settings_custom_fields():
                 "insert_after": "sender",
                 "label": "Helpdesk Email",
                 "description": "Email ID of helpdesk user to send reminders or notifications"
-            }
+            },
+            {
+                "fieldname": "onboarding_settings_tab",
+                "fieldtype": "Tab Break",
+                "insert_after": "costing_print_format",
+                "label": "Onboarding Settings"
+            },
+            {
+                "fieldname": "onboarding_workspace",
+                "fieldtype": "Link",
+                "insert_after": "onboarding_settings_tab",
+                "label": "Onboarding Workspace",
+                "options": "Workspace",
+                "description": "The workspace to set as default for onboarding users. If left blank, the default will be 'Wiki'.",
+            },
+            {
+                "fieldname": "wiki_introduction_doc_link",
+                "fieldtype": "Data",
+                "insert_after": "onboarding_workspace",
+                "label": "Wiki Introduction Doc Link",
+                "options": "URL",
+                "description": "The google doc link for onboarding wiki introduction document.",
+            },
+            {
+                "fieldname": "wiki_assessment_form_link",
+                "fieldtype": "Data",
+                "insert_after": "wiki_introduction_doc_link",
+                "label": "Wiki Assessment Form Link",
+                "options": "URL",
+                "description": "The google form link for onboarding wiki assessment form.",
+            },
         ]
     }

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -198,7 +198,7 @@ class EmployeeOverride(EmployeeMaster):
         self.notify_supervisor_of_status_change()
         if self.has_value_changed("status") and self.status == "Not Returned from Leave":
             self.inform_employee_status_update()
-        self.setup_wiki_intorduction_for_new_employee()
+        self.setup_wiki_introduction_for_new_employee()
 
     def inform_employee_id_update(self):
         """
@@ -445,11 +445,14 @@ class EmployeeOverride(EmployeeMaster):
         except Exception as e:
             frappe.log_error(f"Failed to send notification: {str(e)}", "Employee Status Change Notification")
 
-    def setup_wiki_intorduction_for_new_employee(self):
-        if not (self.status == 'Active' and
-                self.shift_working != 1 and
-                self.attendance_by_timesheet != 1 and
-                self.auto_attendance != 1):
+    def setup_wiki_introduction_for_new_employee(self):
+        if self.status == 'Active':
+            return
+        if self.shift_working == 1:
+            return
+        if self.attendance_by_timesheet == 1:
+            return
+        if self.auto_attendance == 1:
             return
         if not self.user_id:
             return

--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -198,6 +198,7 @@ class EmployeeOverride(EmployeeMaster):
         self.notify_supervisor_of_status_change()
         if self.has_value_changed("status") and self.status == "Not Returned from Leave":
             self.inform_employee_status_update()
+        self.setup_wiki_intorduction_for_new_employee()
 
     def inform_employee_id_update(self):
         """
@@ -444,6 +445,63 @@ class EmployeeOverride(EmployeeMaster):
         except Exception as e:
             frappe.log_error(f"Failed to send notification: {str(e)}", "Employee Status Change Notification")
 
+    def setup_wiki_intorduction_for_new_employee(self):
+        if not (self.status == 'Active' and
+                self.shift_working != 1 and
+                self.attendance_by_timesheet != 1 and
+                self.auto_attendance != 1):
+            return
+        if not self.user_id:
+            return
+        if not self.has_value_changed('user_id'):
+            return
+
+        self.set_default_workspace_for_new_user()
+        self.create_wiki_introduction_todo()
+
+    def set_default_workspace_for_new_user(self):
+        default_workspace = frappe.db.get_value("User", self.user_id, "default_workspace")
+        if not default_workspace:
+            onboarding_workspace = frappe.db.get_single_value("HR Settings", "onboarding_workspace") or "Wiki"
+            frappe.db.set_value("User", self.user_id, "default_workspace", onboarding_workspace, update_modified=False)
+
+    def create_wiki_introduction_todo(self):
+        wiki_introduction_doc_link = frappe.db.get_single_value("HR Settings", "wiki_introduction_doc_link")
+        if not wiki_introduction_doc_link:
+            return
+        description = 'Review the "Wiki Introduction" document. Then, review the 14 linked wikis and complete all associated quizzes and feedback forms within one day.'
+        # Check if a "Todo" with the same description and for the same user already exists
+        if not frappe.db.exists("ToDo", {"allocated_to": self.user_id, "description": ["like", f"%{description}%"]}):
+            frappe.get_doc({
+                "doctype": "ToDo",
+                "allocated_to": self.user_id,
+                "description": f'{description} <br> Please review the following document: <a href="{wiki_introduction_doc_link}">Wiki Introduction</a>',
+                "date": getdate(),
+                "due_date": add_days(getdate(), 30)
+            }).insert(ignore_permissions=True)
+
+def create_wiki_assessment_todo_for_employees():
+    wiki_assessment_form_link = frappe.db.get_single_value("HR Settings", "wiki_assessment_form_link")
+    if not wiki_assessment_form_link:
+        return
+    description = f'Complete the wiki assessments:'
+    employees = frappe.get_all("Employee", filters={
+        "status": "Active",
+        "shift_working": 0,
+        "attendance_by_timesheet": 0,
+        "auto_attendance": 0,
+        "user_id": ["is", "set"],
+        "creation": ["<=", add_days(getdate(), -30)]
+    }, fields=["name", "employee_name", "user_id"])
+    for employee in employees:
+        if not frappe.db.exists("ToDo", {"allocated_to": employee.user_id, "description": ["like", f"%{description}%"]}):
+            frappe.get_doc({
+                "doctype": "ToDo",
+                "allocated_to": employee.user_id,
+                "description": f'{description} <a href="{wiki_assessment_form_link}">Wiki Assessments</a>',
+                "date": getdate(),
+                "due_date": getdate()
+            }).insert(ignore_permissions=True)
 
 def validate_leaves(self):
     if self.status=='Vacation':

--- a/one_fm/overrides/user.py
+++ b/one_fm/overrides/user.py
@@ -1,4 +1,6 @@
 from frappe.core.doctype.user.user import *
+from frappe.query_builder import DocType
+from frappe.utils import add_days, nowdate
 
 class UserOverride(User):
     """
@@ -15,3 +17,17 @@ class UserOverride(User):
         # This ensures no mobile is stored for disabled users
         if not self.enabled:
             self.mobile_no = None
+
+def unlink_wiki_workspace_from_user(after_days_of_user_creation=30):
+    """
+    Unlinks the 'Wiki' workspace from users who were created more than 30 days ago
+    and have 'Wiki' as their default workspace.
+    """
+
+    User = DocType("User")
+    days_ago = add_days(nowdate(), -after_days_of_user_creation)
+    onboarding_workspace = frappe.db.get_single_value("HR Settings", "onboarding_workspace") or "Wiki"
+
+    frappe.qb.update(User).set(User.default_workspace, "").where(
+        (User.default_workspace == onboarding_workspace) & (User.creation <= days_ago)
+    ).run()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -248,6 +248,7 @@ one_fm.patches.v15_0.add_shift_request_custom_fields
 one_fm.patches.v15_0.add_employee_project_manager_name_custom_field
 
 [post_model_sync]
+one_fm.patches.v15_0.process_task_for_wiki_employee_task
 one_fm.patches.v15_0.add_assignment_rule_returning_to_operations_supervisor_of_client_event
 one_fm.patches.v15_0.add_assignment_rule_assigning_operations_manager_for_approval_client_event
 one_fm.patches.v15_0.add_attendance_amendment_assignment_workflow #1
@@ -291,4 +292,4 @@ one_fm.patches.v15_0.add_quality_feedback_workflow #2025-12-04
 one_fm.patches.v15_0.rename_warehouse_fields_in_rfm
 one_fm.patches.v15_0.rename_job_applicant_forth_name #3
 one_fm.patches.v15_0.check_po_kwd_rates
-one_fm.patches.v15_0.add_hr_settings_custom_fields
+one_fm.patches.v15_0.add_hr_settings_custom_fields #1-2

--- a/one_fm/patches/v15_0/process_task_for_wiki_employee_task.py
+++ b/one_fm/patches/v15_0/process_task_for_wiki_employee_task.py
@@ -1,0 +1,31 @@
+import frappe
+from frappe.utils import today
+from one_fm.utils import create_process_task
+
+def execute():
+    create_process_task(
+        "Others",  # process_name
+        "User",  # erp_document
+        "Unlink default workspace from new user after 30 days",  # task_description
+        method="one_fm.overrides.user.unlink_wiki_workspace_from_user",
+        frequency="Daily",
+        cron_format="",  # Not needed for Daily
+        process_owner=None,
+        business_analyst=None,
+        task_type="Routine",
+        is_routine_task=1,
+        is_automated=1
+    )
+    create_process_task(
+        "Others",  # process_name
+        "Employee",  # erp_document
+        "Create wiki assessment todo for new employee after 30 days",  # task_description
+        method="one_fm.overrides.employee.create_wiki_assessment_todo_for_employees",
+        frequency="Daily",
+        cron_format="",  # Not needed for Daily
+        process_owner=None,
+        business_analyst=None,
+        task_type="Routine",
+        is_routine_task=1,
+        is_automated=1
+    )


### PR DESCRIPTION
This pull request introduces improvements to the onboarding workflow for new employees, particularly around the use of the Wiki workspace and onboarding documentation. It automates onboarding tasks, enhances HR settings, and ensures that workspaces and onboarding todos are managed based on employee status and tenure.

**Onboarding automation and workspace management:**

* Added logic in `employee.py` to automatically set the default workspace and create onboarding todos for new employees, including reviewing the Wiki introduction and completing assessments. Also introduced a scheduled task to create assessment todos for employees after 30 days.
* Implemented a function in `user.py` to unlink the Wiki workspace from users who were onboarded more than 30 days ago, and registered a scheduled process to run this daily. [[1]](diffhunk://#diff-8f96cc8d71456aa2cd8fa35adcc9c9fd47a6b5a29868b1ff741f59bb68deae69R20-R33) [[2]](diffhunk://#diff-073261b719000c2d8e659fd6712048ec74145111376a5cf913b0927ec4709f2aR1-R31)

**HR settings enhancements:**

* Added new custom fields to HR Settings for onboarding, including workspace selection and links for onboarding documentation and assessments.

**Supporting changes:**

* Updated the assignment rule utility to allow specifying the app name, improving its flexibility for future use.
* Registered new patch scripts in `patches.txt` to automate onboarding and workspace unlinking processes, and clarified patch references for HR settings. [[1]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R251) [[2]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7L294-R295)