### PR TITLE
fix: change_log  v15_4_11

### DIFF
--- a/one_fm/change_log/v15/v15_4_11.md
+++ b/one_fm/change_log/v15/v15_4_11.md
@@ -1,9 +1,9 @@
 # Version v15.4.11 Release Notes
 
 ## Features & Enhancements
-- Attednance Check approver is fixed to a single user
-- Configuration update in Buying Settigns to Controls whether Purchase Orders can be created directly from Request for Material without requiring a Request for Purchase.
-- Update Quality Feedback - Item code, quanity and item name details
+- Attendance Check approver is fixed to a single user
+- Configuration update in Buying Settings to Controls whether Purchase Orders can be created directly from Request for Material without requiring a Request for Purchase.
+- Update Quality Feedback - Item code, quantity and item name details
 - Employee status values extended with "Not Returned from Leave"
 - Sends daily reminders to Transportation Supervisors for medical appointments scheduled for the next day
 - Inform Agency license expiry to recruitment team
@@ -12,7 +12,7 @@
 - Update Demand Letter quantity from Employee creation
 - Inform the recruitment team Demand Letter quota completion
 - Client Event - Event Staff - dates marked required
-- Google Sheet Data Export is accessible to the shared user and preform export data
+- Google Sheet Data Export is accessible to the shared user and perform export data
 - Contracts UI fix and Contract Item updated by operational requirements
 - Mark absent for Absconding and Not Returned from Leave employees
 - Enhanced Quality Feedback from Employee Uniform and Quality Feedback Form language update


### PR DESCRIPTION
This pull request makes minor corrections to the `v15_4_11.md` changelog file, improving the clarity and accuracy of the release notes. The changes primarily address typos and wording issues.

- Changelog improvements:
  * Fixed typos in feature descriptions, such as correcting "Attednance" to "Attendance", "quanity" to "quantity", and "preform" to "perform". [[1]](diffhunk://#diff-b6ea0059915cefc2f8569d561b51c96b35c6c2e52b204ed49ad6e3639bb04529L4-R6) [[2]](diffhunk://#diff-b6ea0059915cefc2f8569d561b51c96b35c6c2e52b204ed49ad6e3639bb04529L15-R15)
  * Clarified terminology, e.g., changing "Buying Settigns" to "Buying Settings".