### PR TITLE
fix: validate - client event

### DIFF
--- a/one_fm/custom/workflow/client_event.json
+++ b/one_fm/custom/workflow/client_event.json
@@ -59,7 +59,7 @@
     },
     {
       "state": "Cancelled",
-      "doc_status": "2",
+      "doc_status": "1",
       "style": "Danger",
       "is_optional_state": 0,
       "avoid_status_override": 0,

--- a/one_fm/one_fm/doctype/client_event/client_event.json
+++ b/one_fm/one_fm/doctype/client_event/client_event.json
@@ -42,12 +42,14 @@
    "fieldname": "start_date",
    "fieldtype": "Date",
    "label": "Start Date",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Draft\"",
    "reqd": 1
   },
   {
    "fieldname": "end_date",
    "fieldtype": "Date",
    "label": "End Date",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Draft\"",
    "reqd": 1
   },
   {
@@ -55,6 +57,7 @@
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Event Start Datetime",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Draft\"",
    "reqd": 1
   },
   {
@@ -62,6 +65,7 @@
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Event End Datetime",
+   "read_only_depends_on": "eval: doc.workflow_state != \"Draft\"",
    "reqd": 1
   },
   {
@@ -158,7 +162,7 @@
    "link_fieldname": "client_event"
   }
  ],
- "modified": "2026-01-05 15:41:48.248806",
+ "modified": "2026-01-27 18:35:34.388248",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Client Event",

--- a/one_fm/one_fm/doctype/client_event/client_event.py
+++ b/one_fm/one_fm/doctype/client_event/client_event.py
@@ -12,7 +12,7 @@ class ClientEvent(Document):
 		self.validate_workflow_transition()
 
 	def validate_date_time(self):
-		if self.workflow_state != "Draft":
+		if not self.is_new() and self.workflow_state != "Pending Approval":
 			return
 		now = now_datetime()
 
@@ -39,6 +39,8 @@ class ClientEvent(Document):
 			return
 		if not self.has_value_changed("workflow_state"):
 			return
+		if self.workflow_state == "Approved":
+			return
 
 		event_staff_exists = self.has_submitted_event_staff()
 		if not event_staff_exists:
@@ -52,34 +54,24 @@ class ClientEvent(Document):
 		event_finished = today_date > end_date
 
 		if not event_started:
-			if event_staff_exists:
-				self.handle_ongoing_event_cancellation(event_started=False)
+			self.handle_ongoing_event_cancellation(event_started=False)
 			return
 
-		if self.workflow_state == "Draft":
-			if event_finished:
+		if event_finished:
+			if self.workflow_state in ("Draft", "Rejected"):
 				frappe.throw(
-					"You are unable to return this client event to draft as the event has already taken place. Please approve."
+					f"You are unable to {self.workflow_state.lower()} this client event as the event has already taken place. Please approve."
 				)
-			elif event_started:
-				frappe.throw(
-					"You are unable to return this client event to draft as the event has already started. Please approve."
-				)
-
-		if self.workflow_state == "Rejected":
-			if event_finished:
-				frappe.throw(
-					"You are unable to reject this client event as the event has already taken place. Please approve."
-				)
-			elif event_started:
-				self.handle_ongoing_event_cancellation()
-
-		if self.workflow_state == "Cancelled":
-			if event_finished:
+			elif self.workflow_state == "Cancelled":
 				frappe.throw(
 					"You are unable to cancel this client event as the event has already taken place."
 				)
-			elif event_started:
+		elif event_started:
+			if self.workflow_state == "Draft":
+				frappe.throw(
+					"You are unable to return this client event to draft as the event has already started. Please approve."
+				)
+			elif self.workflow_state in ("Rejected", "Cancelled"):
 				self.handle_ongoing_event_cancellation()
 
 	def has_submitted_event_staff(self):
@@ -105,6 +97,13 @@ class ClientEvent(Document):
 			else:
 				event_staff_doc.end_date = getdate(today())
 				event_staff_doc.save(ignore_permissions=True)
+		frappe.msgprint("All related Event Staff records have been updated due to event cancellation.", alert=True)
+
+	def on_cancel(self):
+		self.validate_workflow_transition()
+
+	def on_update_after_submit(self):
+		self.validate_workflow_transition()
 
 	@frappe.whitelist()
 	def add_event_staff(self, staff):

--- a/one_fm/one_fm/doctype/client_event/client_event.py
+++ b/one_fm/one_fm/doctype/client_event/client_event.py
@@ -8,6 +8,12 @@ import json
 
 class ClientEvent(Document):
 	def validate(self):
+		self.validate_date_time()
+		self.validate_workflow_transition()
+
+	def validate_date_time(self):
+		if self.workflow_state != "Draft":
+			return
 		now = now_datetime()
 
 		# Rule 1: Start Date or Start Datetime must be in the future
@@ -27,7 +33,6 @@ class ClientEvent(Document):
 			frappe.throw("The scheduled end date/time must be later than Start Date or Start Datetime. Please adjust the event details.")
 		if self.event_start_datetime and self.event_end_datetime and get_datetime(self.event_end_datetime) < get_datetime(self.event_start_datetime):
 			frappe.throw("The scheduled end date/time must be later than Start Date or Start Datetime. Please adjust the event details.")
-		self.validate_workflow_transition()
 
 	def validate_workflow_transition(self):
 		if self.is_new():

--- a/one_fm/one_fm/doctype/client_event/client_event.py
+++ b/one_fm/one_fm/doctype/client_event/client_event.py
@@ -90,6 +90,8 @@ class ClientEvent(Document):
 			filters={"client_event": self.name, "docstatus": 1},
 			fields=["name"]
 		)
+		if not event_staffs:
+			return
 		for event_staff in event_staffs:
 			event_staff_doc = frappe.get_doc("Event Staff", event_staff.name)
 			if not event_started:
@@ -97,7 +99,7 @@ class ClientEvent(Document):
 			else:
 				event_staff_doc.end_date = getdate(today())
 				event_staff_doc.save(ignore_permissions=True)
-		frappe.msgprint("All related Event Staff records have been updated due to event cancellation.", alert=True)
+		frappe.msgprint("All related Event Staff records have been updated due to changes in the status of this client event.", alert=True)
 
 	def on_cancel(self):
 		self.validate_workflow_transition()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -276,7 +276,7 @@ one_fm.patches.v15_0.clear_residency_expiry_date
 one_fm.patches.v15_0.update_residency_expiry_date_depends_on
 one_fm.patches.v15_0.add_assignment_rule_and_wf_fingerprint_appointment
 one_fm.patches.v15_0.update_finger_print_appointment_workflow_state
-one_fm.patches.v15_0.add_workflow_client_event #1
+one_fm.patches.v15_0.add_workflow_client_event #2
 one_fm.patches.v15_0.add_shift_assignment_event_based_fields
 one_fm.patches.v15_0.add_shift_assignment_shift_type_mandatory_depends_on # re-run
 one_fm.patches.v15_0.add_quality_feedback_template_custom_field #2025-12-11


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the `Client Event` workflow and validation logic, focusing on stricter workflow state transitions, improved date/time validation, and enhanced user feedback. The changes also update field properties and workflow status handling to ensure data consistency and a better user experience.

**Workflow and Validation Enhancements:**

* Refactored the `validate` method in `client_event.py` to call new helper methods for date/time and workflow transition validation, ensuring that events cannot be moved to certain workflow states if the event has already started or finished, and preventing invalid transitions such as cancelling or rejecting completed events. Improved error messages for clarity. [[1]](diffhunk://#diff-6351d482ea5b5e598c33731adac33ccde4168a4f93aefe3123349141bfda6699R11-R16) [[2]](diffhunk://#diff-6351d482ea5b5e598c33731adac33ccde4168a4f93aefe3123349141bfda6699L30-R43) [[3]](diffhunk://#diff-6351d482ea5b5e598c33731adac33ccde4168a4f93aefe3123349141bfda6699L50-R74)
* Added hooks for `on_cancel` and `on_update_after_submit` events to enforce workflow transition validation during these actions, and provided user feedback when related staff records are updated due to event cancellation.

**Field and Workflow Configuration Updates:**

* Made the `start_date`, `end_date`, `event_start_datetime`, and `event_end_datetime` fields read-only unless the workflow state is "Draft", preventing edits after the draft stage.
* Changed the workflow configuration so that the "Cancelled" state now uses `doc_status` 1 instead of 2, aligning its behavior with other states.

**Other Maintenance:**

* Updated the workflow patch reference in `patches.txt` to reflect the new version.
* Updated the `modified` timestamp in the `client_event.json` DocType definition.