### PR TITLE
fix: spell check in change log

### DIFF
--- a/one_fm/change_log/v15/v15_4_12.md
+++ b/one_fm/change_log/v15/v15_4_12.md
@@ -1,16 +1,16 @@
 # Version v15.4.12 Release Notes
 
 ## Features & Enhancements
-- Daily send open tickets conut to helpdesk email
+- Daily send open tickets count to helpdesk email
 - Onboarding workspace and todo for wiki introduction for new employees
 - Shift working, accommodation and project in leave application
 - Employee uniform reference in Quality Feedback
 - Update Client Event workflow
 - Client Event - Add staff to event on Pending Approval state
 - Client Event - Validate workflow transition
-- Capture awards and recoginition in Career History
+- Capture awards and recognition in Career History
 - Capture more options in Leave Handover(Process)
-- Configurations for daily oprations handled by us and client requested days in Contract
+- Configurations for daily operations handled by us and client requested days in Contract
 - Roster: reformat employee template data from a dictionary to a list, including full and abbreviated names
 - Client Post of in Post Schedule
 - Post Schedule Checker - Skip items of type "Items" as they don't require post scheduling validation


### PR DESCRIPTION
This pull request corrects several typos in the `v15_4_12.md` changelog file to improve clarity and professionalism. No functional or code changes are included.

- Documentation improvements:
  * Fixed typos in feature descriptions, such as "conut" to "count", "recoginition" to "recognition", and "oprations" to "operations", in the `one_fm/change_log/v15/v15_4_12.md` release notes.