### PR TITLE
Automate Attendance Marking for OJT and Client Event

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -723,7 +723,6 @@ def mark_daily_attendance(start_date, end_date):
             AND e.attendance_by_timesheet = 0
             AND '{start_date}' BETWEEN hl.from_date AND hl.to_date
             AND e.status='Active'
-            AND e.name NOT IN (SELECT employee from `tabEmployee Schedule`es where es.date = '{start_date}' AND es.employee_availability IN ('Day Off', 'Client Day Off', 'Working', 'Client Event', 'On-the-job Training'))
             AND e.date_of_joining < '{today}'
             """,
         as_dict=1)

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -723,6 +723,7 @@ def mark_daily_attendance(start_date, end_date):
             AND e.attendance_by_timesheet = 0
             AND '{start_date}' BETWEEN hl.from_date AND hl.to_date
             AND e.status='Active'
+            AND e.name NOT IN (SELECT employee from `tabEmployee Schedule`es where es.date = '{start_date}' AND es.employee_availability IN ('Day Off', 'Client Day Off'))
             AND e.date_of_joining < '{today}'
             """,
         as_dict=1)

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -243,7 +243,7 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
                 )
                 return
             elif employee_schedule:
-                if employee_schedule.employee_availability in ['Working','Client Event']:
+                if employee_schedule.employee_availability in ['Working','Client Event', 'On-the-job Training']:
                     # continue to mark attendance if checkin exists
                     mark_for_shift_assignment(employee.name, att_date)
                 
@@ -723,7 +723,7 @@ def mark_daily_attendance(start_date, end_date):
             AND e.attendance_by_timesheet = 0
             AND '{start_date}' BETWEEN hl.from_date AND hl.to_date
             AND e.status='Active'
-            AND e.name NOT IN (SELECT employee from `tabEmployee Schedule`es where es.date = '{start_date}' AND es.employee_availability IN ('Day Off', 'Client Day Off'))
+            AND e.name NOT IN (SELECT employee from `tabEmployee Schedule`es where es.date = '{start_date}' AND es.employee_availability IN ('Day Off', 'Client Day Off', 'Working', 'Client Event', 'On-the-job Training'))
             AND e.date_of_joining < '{today}'
             """,
         as_dict=1)
@@ -1320,7 +1320,7 @@ class AttendanceMarking():
 
     def mark_day_off(self):
         days_off = frappe.get_list("Employee Schedule", {
-            'date':self.start.date(), 'employee_availability':'Day Off', "is_replaced": 0
+            'date':self.start.date(), 'employee_availability':['IN', ['Day Off', 'Client Day Off']], "is_replaced": 0
         }, "*")
         for i in days_off:
             try:


### PR DESCRIPTION
Automated attendance marking for 'On-the-job Training' and 'Client Event' by ensuring they are treated as working statuses in the attendance marking logic. This includes updating individual marking, bulk daily marking exclusion, and background day-off marking consistency.

---
*PR created automatically by Jules for task [2687367198607100917](https://jules.google.com/task/2687367198607100917) started by @pjamsheer*