### PR TITLE
Add OJT to Working availability validation in Employee Schedule

### DIFF
--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.py
@@ -36,6 +36,7 @@ class EmployeeSchedule(Document):
 				frappe.db.set_value("Employee Schedule", employee_schedule.name, "day_off_ot", 0)
 
 	def validate(self):
+		self.validate_ojt_change()
 		self.validate_leave_application()
 		self.validate_relieving_date()
 		if self.employee_availability=='Working' and self.shift_type and self.date:
@@ -77,6 +78,12 @@ class EmployeeSchedule(Document):
 			relieving_date = frappe.db.get_value("Employee", self.employee, "relieving_date")
 			if relieving_date and getdate(self.date) > getdate(relieving_date):
 				frappe.throw(_("Employee {0} is expected to leave on {1}, so cannot be scheduled for {2}").format(self.employee, relieving_date, self.date))
+
+	def validate_ojt_change(self):
+		if not self.is_new() and self.on_the_job_training and self.employee_availability == "Working":
+			old_doc = self.get_doc_before_save()
+			if old_doc and old_doc.employee_availability == "On-the-job Training":
+				frappe.throw(_("Cannot change availability to 'Working' while an OJT record is linked. To change to 'Working', please delete this schedule and create a new one through Roster."))
 
 	def validate_offs(self):
 		"""

--- a/one_fm/operations/doctype/employee_schedule/test_employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/test_employee_schedule.py
@@ -4,8 +4,86 @@
 # See license.txt
 from __future__ import unicode_literals
 
-# import frappe
-import unittest
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate, add_days
 
-class TestEmployeeSchedule(unittest.TestCase):
-	pass
+class TestEmployeeSchedule(FrappeTestCase):
+	def setUp(self):
+		# Create test employee if not exists
+		if not frappe.db.exists("Employee", "TEST-EMP-001"):
+			doc = frappe.get_doc({
+				"doctype": "Employee",
+				"employee": "TEST-EMP-001",
+				"employee_name": "Test Employee",
+				"status": "Active",
+				"gender": "Male",
+				"date_of_birth": "1990-01-01",
+				"date_of_joining": nowdate()
+			})
+			doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
+		self.employee = "TEST-EMP-001"
+
+	def test_block_change_from_ojt_to_working_with_linked_ojt(self):
+		# Create Employee Schedule with OJT
+		# We use a dummy name for OJT to avoid needing to create the record,
+		# we'll use frappe.db.set_value to put it there if link validation fails on insert.
+
+		schedule = frappe.get_doc({
+			"doctype": "Employee Schedule",
+			"employee": self.employee,
+			"date": add_days(nowdate(), 20),
+			"employee_availability": "On-the-job Training",
+			"roster_type": "Basic"
+		})
+		schedule.insert(ignore_permissions=True)
+
+		# Set the OJT field manually to bypass link validation if it exists
+		frappe.db.set_value("Employee Schedule", schedule.name, "on_the_job_training", "OJT-MOCK-001")
+		schedule.reload()
+
+		# Try to change to Working
+		schedule.employee_availability = "Working"
+
+		expected_msg = "Cannot change availability to 'Working' while an OJT record is linked. To change to 'Working', please delete this schedule and create a new one through Roster."
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			schedule.save()
+
+		self.assertIn(expected_msg, str(cm.exception))
+
+	def test_allow_change_to_working_if_no_ojt_linked(self):
+		# Create Employee Schedule without OJT
+		schedule = frappe.get_doc({
+			"doctype": "Employee Schedule",
+			"employee": self.employee,
+			"date": add_days(nowdate(), 21),
+			"employee_availability": "On-the-job Training",
+			"roster_type": "Basic"
+		})
+		schedule.insert(ignore_permissions=True)
+
+		# Try to change to Working
+		schedule.employee_availability = "Working"
+		schedule.save() # Should not throw
+		self.assertEqual(schedule.employee_availability, "Working")
+
+	def test_allow_change_from_other_to_working_even_with_ojt_linked(self):
+		# Create Employee Schedule with OJT but from Day Off
+		schedule = frappe.get_doc({
+			"doctype": "Employee Schedule",
+			"employee": self.employee,
+			"date": add_days(nowdate(), 22),
+			"employee_availability": "Day Off",
+			"roster_type": "Basic"
+		})
+		schedule.insert(ignore_permissions=True)
+
+		# Set the OJT field manually
+		frappe.db.set_value("Employee Schedule", schedule.name, "on_the_job_training", "OJT-MOCK-001")
+		schedule.reload()
+
+		# Try to change to Working
+		schedule.employee_availability = "Working"
+		schedule.save() # Should not throw as per requirement 1
+		self.assertEqual(schedule.employee_availability, "Working")


### PR DESCRIPTION
This change implements a validation in the `Employee Schedule` DocType to prevent users from manually changing the availability from "On-the-job Training" to "Working" when the schedule is linked to an OJT record. This ensures data consistency and directs users to use the Roster for such changes.

Key changes:
- Modified `one_fm/operations/doctype/employee_schedule/employee_schedule.py` to include `validate_ojt_change`.
- Added comprehensive tests in `one_fm/operations/doctype/employee_schedule/test_employee_schedule.py`.

---
*PR created automatically by Jules for task [505463007372979811](https://jules.google.com/task/505463007372979811) started by @pjamsheer*