### PR TITLE
feat: transactions not allowed to use group warehouses

### DIFF
--- a/one_fm/overrides/queries.py
+++ b/one_fm/overrides/queries.py
@@ -36,7 +36,7 @@ def warehouse_query(doctype, txt, searchfield, start, page_len, filters, as_dict
         from
             `tabWarehouse`
         where
-            docstatus < 2
+            docstatus < 2 and is_group=0
             {store_keeper_condition}
             and ({scond}) and disabled=0
             {fcond} {mcond}


### PR DESCRIPTION
This pull request makes a targeted improvement to the warehouse query logic. The change ensures that only non-group warehouses are included in query results, which helps prevent group-type warehouses from appearing where only individual warehouses are relevant.

- Updated the SQL query in `warehouse_query` (in `one_fm/overrides/queries.py`) to filter out group warehouses by adding `is_group=0` to the WHERE clause.