### PR TITLE
fix: delete linked todo

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -227,6 +227,11 @@ standard_queries = {
 }
 
 doc_events = {
+	"*":{
+		"on_trash":[
+			"one_fm.overrides.todo.delete_linked_todos"
+		]
+	},
 	"Stock Entry": {
 		"validate": [
 			"one_fm.overrides.stock_entry.alert_item_multiple_entry",

--- a/one_fm/one_fm/doctype/client_event/client_event.py
+++ b/one_fm/one_fm/doctype/client_event/client_event.py
@@ -12,7 +12,9 @@ class ClientEvent(Document):
 		self.validate_workflow_transition()
 
 	def validate_date_time(self):
-		if not self.is_new() and self.workflow_state != "Pending Approval":
+		if not self.is_new() and self.workflow_state not in ("Pending Approval", None):
+			return
+		if self.workflow_state == "Approved":
 			return
 		now = now_datetime()
 

--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -18,6 +18,15 @@ class ToDo(FrappeToDo):
         except Exception as e:
             frappe.log_error(message=f"Failed to delete Google Task on ToDo trash: {e}", title="ToDo on_trash Error")
 
+def delete_linked_todos(doc, method):
+    todos = frappe.get_all("ToDo", filters={
+        "reference_type": doc.doctype,
+        "reference_name": doc.name
+    }, pluck="name")
+
+    for todo in todos:
+        frappe.delete_doc("ToDo", todo, force=1)
+
 def validate_todo(doc, method):
     notify_todo_status_change(doc)
     set_todo_type_from_refernce_doc(doc)


### PR DESCRIPTION
This pull request introduces a new mechanism to automatically delete all `ToDo` items linked to any document when that document is deleted, and refines the validation logic for client event workflows. The main changes are grouped below:

### Automatic Deletion of Linked ToDos

* Added a new `delete_linked_todos` function in `one_fm/overrides/todo.py` that finds and deletes all `ToDo` records referencing a document being deleted.
* Registered the `delete_linked_todos` function to the `on_trash` event for all doctypes in `one_fm/hooks.py`, ensuring that linked `ToDo` items are cleaned up whenever any document is deleted.

### Client Event Workflow Validation

* Updated the `validate_date_time` method in `one_fm/one_fm/doctype/client_event/client_event.py` to only perform date/time validation when the workflow state is `"Pending Approval"` or `None`, improving the accuracy of workflow transitions.