### PR TITLE
chore: add seats field to vehicle doctype

### DIFF
--- a/one_fm/custom/custom_field/vehicle.py
+++ b/one_fm/custom/custom_field/vehicle.py
@@ -117,6 +117,14 @@ def get_vehicle_custom_fields():
                 "fieldname": "image",
                 "fieldtype": "Attach Image",
                 "label": "Image"
-            }
+            },
+            {
+                "fieldname": "seats",
+                "fieldtype": "Int",
+                "label": "Seats",
+                "insert_after": "doors",
+                "translatable": 1,
+                "reqd": 1
+            },
         ]
     }

--- a/one_fm/custom/custom_field/vehicle.py
+++ b/one_fm/custom/custom_field/vehicle.py
@@ -123,7 +123,6 @@ def get_vehicle_custom_fields():
                 "fieldtype": "Int",
                 "label": "Seats",
                 "insert_after": "doors",
-                "translatable": 1,
                 "reqd": 1
             },
         ]

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -252,6 +252,7 @@ one_fm.patches.v15_0.update_leave_application_properties
 one_fm.patches.v15_0.add_supplier_name_in_arabic_field
 one_fm.patches.v15_0.update_leave_extension_attendance
 one_fm.patches.v15_0.adjust_vehicle_fields
+one_fm.patches.v15_0.add_seats_field_to_vehicle
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/add_seats_field_to_vehicle.py
+++ b/one_fm/patches/v15_0/add_seats_field_to_vehicle.py
@@ -1,0 +1,5 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.custom_field.vehicle import get_vehicle_custom_fields
+
+def execute():
+    create_custom_fields(get_vehicle_custom_fields())


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Add 'seats' field to Vehicle DocType to store number of seats per vehicle.


## Output screenshots (optional)
<img width="1193" height="415" alt="Screenshot 2026-03-02 at 11 09 14 AM" src="https://github.com/user-attachments/assets/eea32d85-28bd-4c13-b33e-c8fcf2058aec" />


## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
