### PR TITLE
feat: site transport stop location doctype changes

### DIFF
--- a/one_fm/operations/doctype/site_transport_stop_location/site_transport_stop_location.js
+++ b/one_fm/operations/doctype/site_transport_stop_location/site_transport_stop_location.js
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, ONE FM and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Site Transport Stop Location', {
+    refresh: function (frm) {
+        apply_location_filters(frm);
+    },
+    site_arrangement: function (frm) {
+        apply_location_filters(frm);
+    }
+});
+
+function apply_location_filters(frm) {
+    // Filter the Link field for "One Location Many Sites" arrangement
+    frm.set_query("transport_stop_location", function () {
+        return {
+            filters: [
+                ["Location", "location_type", "=", "Stop Location"]
+            ]
+        };
+    });
+
+    // Filter the child table location field for "One Site Many Locations" arrangement
+    frm.set_query("location", "transport_stop_locations", function () {
+        return {
+            filters: [
+                ["Location", "location_type", "=", "Stop Location"]
+            ]
+        };
+    });
+
+    // Filter the 'site' Link field (in "One Site Many Locations")
+    frm.set_query("site", function () {
+        return {
+            filters: [
+                ["Operations Site", "status", "=", "Active"]
+            ]
+        };
+    });
+
+    // Filter 'sites' field in 'sites' child table (in "One Location Many Sites")
+    frm.set_query("sites", "sites", function () {
+        return {
+            filters: [
+                ["Operations Site", "status", "=", "Active"]
+            ]
+        };
+    });
+}

--- a/one_fm/operations/doctype/site_transport_stop_location/site_transport_stop_location.json
+++ b/one_fm/operations/doctype/site_transport_stop_location/site_transport_stop_location.json
@@ -1,100 +1,98 @@
 {
- "actions": [],
- "creation": "2026-02-23 9:00:00",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "naming_series",
-  "site_arrangement",
-  "one_location_many_sites_section",
-  "transport_stop_location",
-  "sites",
-  "one_site_many_locations_section",
-  "site",
-  "transport_stop_locations"
- ],
- "fields": [
-  {
-   "default": "STP-LOC-",
-   "fieldname": "naming_series",
-   "fieldtype": "Select",
-   "in_filter": 1,
-   "in_global_search": 1,
-   "label": "Series",
-   "options": "STP-LOC-",
-   "read_only": 1
-  },
-  {
-   "fieldname": "site_arrangement",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Site Arrangement",
-   "options": "One Location Many Sites\nOne Site Many Locations"
-  },
-  {
-   "fieldname": "one_location_many_sites_section",
-   "fieldtype": "Section Break",
-   "label": "One Location Many Sites",
-   "depends_on": "eval:doc.site_arrangement=='One Location Many Sites'"
-  },
-  {
-   "fieldname": "transport_stop_location",
-   "fieldtype": "Link",
-   "in_standard_filter": 1,
-   "label": "Transport Stop Location",
-   "options": "Location"
-  },
-  {
-   "fieldname": "sites",
-   "fieldtype": "Table",
-   "label": "Sites",
-   "options": "Location To Site Mapping"
-  },
-  {
-   "fieldname": "one_site_many_locations_section",
-   "fieldtype": "Section Break",
-   "label": "One Site Many Locations",
-   "depends_on": "eval:doc.site_arrangement=='One Site Many Locations'"
-  },
-  {
-   "fieldname": "site",
-   "fieldtype": "Link",
-   "in_standard_filter": 1,
-   "label": "Site",
-   "options": "Operations Site"
-  },
-  {
-   "fieldname": "transport_stop_locations",
-   "fieldtype": "Table",
-   "label": "Transport Stop Locations",
-   "options": "Site To Location Mapping"
-  }
- ],
- "modified": "2026-02-23 9:00:00",
- "modified_by": "Administrator",
- "module": "Operations",
- "name": "Site Transport Stop Location",
- "autoname": "naming_series:",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "quick_entry": 1,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "track_changes": 1
+    "actions": [],
+    "creation": "2026-02-23 9:00:00",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "site_transport_stop_location_name",
+        "site_arrangement",
+        "one_location_many_sites_section",
+        "transport_stop_location",
+        "sites",
+        "one_site_many_locations_section",
+        "site",
+        "transport_stop_locations"
+    ],
+    "fields": [
+        {
+            "fieldname": "site_transport_stop_location_name",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Site Transport Stop Location Name",
+            "reqd": 1,
+            "unique": 1
+        },
+        {
+            "fieldname": "site_arrangement",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Site Arrangement",
+            "options": "One Location Many Sites\nOne Site Many Locations"
+        },
+        {
+            "fieldname": "one_location_many_sites_section",
+            "fieldtype": "Section Break",
+            "label": "One Location Many Sites",
+            "depends_on": "eval:doc.site_arrangement=='One Location Many Sites'"
+        },
+        {
+            "fieldname": "transport_stop_location",
+            "fieldtype": "Link",
+            "in_standard_filter": 1,
+            "label": "Transport Stop Location",
+            "options": "Location"
+        },
+        {
+            "fieldname": "sites",
+            "fieldtype": "Table",
+            "label": "Sites",
+            "options": "Location To Site Mapping"
+        },
+        {
+            "fieldname": "one_site_many_locations_section",
+            "fieldtype": "Section Break",
+            "label": "One Site Many Locations",
+            "depends_on": "eval:doc.site_arrangement=='One Site Many Locations'"
+        },
+        {
+            "fieldname": "site",
+            "fieldtype": "Link",
+            "in_standard_filter": 1,
+            "label": "Site",
+            "options": "Operations Site"
+        },
+        {
+            "fieldname": "transport_stop_locations",
+            "fieldtype": "Table",
+            "label": "Transport Stop Locations",
+            "options": "Site To Location Mapping"
+        }
+    ],
+    "modified": "2026-02-23 9:00:00",
+    "modified_by": "Administrator",
+    "module": "Operations",
+    "name": "Site Transport Stop Location",
+    "autoname": "field:site_transport_stop_location_name",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "System Manager",
+            "share": 1,
+            "write": 1
+        }
+    ],
+    "quick_entry": 1,
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": [],
+    "track_changes": 1
 }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -267,7 +267,6 @@ one_fm.patches.v15_0.add_assignment_rule_contracts_legal_manager #2
 one_fm.patches.v15_0.add_assignment_rule_contracts_operation_admin #2
 one_fm.patches.v15_0.add_assignment_rule_contracts_sales_manager #2
 one_fm.patches.v15_0.add_transport_stop_vehicle_field
-one_fm.patches.v15_0.populate_site_transport_stop_location_name
 one_fm.patches.v15_0.add_location_type_field
 
 [post_model_sync]
@@ -321,3 +320,4 @@ one_fm.patches.v15_0.populate_abbreviation_data #1-2
 one_fm.patches.v15_0.rename_accommodation_hierarchy #1-2
 one_fm.patches.v15_0.add_roster_client_day_off_checker_assignment_rules
 one_fm.patches.v15_0.add_hd_ticket_doctype_related_fields #2
+one_fm.patches.v15_0.populate_site_transport_stop_location_name

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -267,6 +267,7 @@ one_fm.patches.v15_0.add_assignment_rule_contracts_legal_manager #2
 one_fm.patches.v15_0.add_assignment_rule_contracts_operation_admin #2
 one_fm.patches.v15_0.add_assignment_rule_contracts_sales_manager #2
 one_fm.patches.v15_0.add_transport_stop_vehicle_field
+one_fm.patches.v15_0.populate_site_transport_stop_location_name
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/populate_site_transport_stop_location_name.py
+++ b/one_fm/patches/v15_0/populate_site_transport_stop_location_name.py
@@ -1,0 +1,13 @@
+import frappe
+
+def execute():
+	# Populate the new mandatory field 'site_transport_stop_location_name' 
+	# with the existing record ID (name) for all records.
+	
+	frappe.db.sql("""
+		UPDATE `tabSite Transport Stop Location`
+		SET site_transport_stop_location_name = name
+		WHERE site_transport_stop_location_name IS NULL OR site_transport_stop_location_name = ''
+	""")
+	
+	frappe.db.commit()

--- a/one_fm/patches/v15_0/populate_site_transport_stop_location_name.py
+++ b/one_fm/patches/v15_0/populate_site_transport_stop_location_name.py
@@ -3,11 +3,15 @@ import frappe
 def execute():
 	# Populate the new mandatory field 'site_transport_stop_location_name' 
 	# with the existing record ID (name) for all records.
-	
+
+	# Reload the DocType to ensure the column exists before running the UPDATE
+	frappe.reload_doc("operations", "doctype", "site_transport_stop_location")
+
+	if not frappe.db.has_column("Site Transport Stop Location", "site_transport_stop_location_name"):
+		return
+
 	frappe.db.sql("""
 		UPDATE `tabSite Transport Stop Location`
 		SET site_transport_stop_location_name = name
 		WHERE site_transport_stop_location_name IS NULL OR site_transport_stop_location_name = ''
 	""")
-	
-	frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
1. Filter the Transport Stop Locations in the The Site Transport Stop Location DocType to only the Locations selected as "Stop Location".
2. Filter any fields linking to Operations Site to only show sites with status = Active.
3. Add a field before the Site Arrangement field called Site Transport Stop Location Name, which will act as the ID of the records.


## Output screenshots (optional)
https://github.com/user-attachments/assets/c879e79c-a58b-41f2-9be7-1751f0ba0074



## Was child table created?
Yes
    - [] is attachment required?
        did you test attachment


## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox