### PR TITLE
chore: add accommodations childtable to the operations shift doctype

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -1,204 +1,217 @@
 {
- "actions": [],
- "creation": "2020-04-28 18:51:50.039815",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "site",
-  "project",
-  "site_location",
-  "column_break_2",
-  "status",
-  "governorate_area",
-  "service_type",
-  "shift_details_section",
-  "shift_number",
-  "shift_type",
-  "automate_roster",
-  "supervisor",
-  "supervisor_name",
-  "column_break_8",
-  "shift_supervisor",
-  "section_break_12",
-  "start_time",
-  "end_time",
-  "column_break_15",
-  "duration",
-  "shift_classification"
- ],
- "fields": [
-  {
-   "fieldname": "site",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Site",
-   "options": "Operations Site"
-  },
-  {
-   "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fetch_from": "site.project",
-   "fieldname": "project",
-   "fieldtype": "Link",
-   "label": "Project",
-   "options": "Project",
-   "read_only": 1
-  },
-  {
-   "fieldname": "shift_details_section",
-   "fieldtype": "Section Break",
-   "label": "Shift Details"
-  },
-  {
-   "fieldname": "shift_type",
-   "fieldtype": "Link",
-   "label": "Shift Type",
-   "options": "Shift Type"
-  },
-  {
-   "default": "0",
-   "description": "If checked, the system automatically creates Employee Schedules for all Employees having this as their default shift.",
-   "fieldname": "automate_roster",
-   "fieldtype": "Check",
-   "label": "Automate Roster"
-  },
-  {
-   "fieldname": "section_break_12",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "supervisor",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "ignore_user_permissions": 1,
-   "label": "Shift Supervisor",
-   "options": "Employee"
-  },
-  {
-   "fetch_from": "supervisor.employee_name",
-   "fieldname": "supervisor_name",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Supervisor Name",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_8",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fetch_from": "shift_type.start_time",
-   "fieldname": "start_time",
-   "fieldtype": "Time",
-   "label": "Start time",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "shift_type.end_time",
-   "fieldname": "end_time",
-   "fieldtype": "Time",
-   "label": "End time",
-   "read_only": 1
-  },
-  {
-   "description": "In hours",
-   "fetch_from": "shift_type.duration",
-   "fieldname": "duration",
-   "fieldtype": "Float",
-   "label": "Duration",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "shift_type.shift_type",
-   "fieldname": "shift_classification",
-   "fieldtype": "Data",
-   "label": "Shift Classification",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_15",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "service_type",
-   "fieldtype": "Link",
-   "label": "Service Type",
-   "options": "Service Type",
-   "reqd": 1
-  },
-  {
-   "fieldname": "shift_number",
-   "fieldtype": "Int",
-   "label": "Shift Number",
-   "reqd": 1
-  },
-  {
-   "fieldname": "site_location",
-   "fieldtype": "Link",
-   "label": "Site Location",
-   "options": "Location"
-  },
-  {
-   "fetch_from": "site_location.governorate_area",
-   "fetch_if_empty": 1,
-   "fieldname": "governorate_area",
-   "fieldtype": "Link",
-   "label": "Governorate Area",
-   "options": "Governorate Area"
-  },
-  {
-   "default": "Active",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Status",
-   "options": "Active\nInactive"
-  },
-  {
-   "description": "Index of the table is the priority of the supervisor",
-   "fieldname": "shift_supervisor",
-   "fieldtype": "Table",
-   "label": "Shift Supervisor",
-   "options": "Operations Shift Supervisor"
-  }
- ],
- "links": [
-  {
-   "group": "Operations",
-   "link_doctype": "Operations Role",
-   "link_fieldname": "shift"
-  }
- ],
- "modified": "2024-12-17 16:34:20.846883",
- "modified_by": "Administrator",
- "module": "Operations",
- "name": "Operations Shift",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "quick_entry": 1,
- "search_fields": "site, project",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "track_changes": 1
+    "actions": [],
+    "creation": "2020-04-28 18:51:50.039815",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "site",
+        "project",
+        "site_location",
+        "column_break_2",
+        "status",
+        "governorate_area",
+        "service_type",
+        "shift_details_section",
+        "shift_number",
+        "shift_type",
+        "automate_roster",
+        "supervisor",
+        "supervisor_name",
+        "column_break_8",
+        "shift_supervisor",
+        "section_break_12",
+        "start_time",
+        "end_time",
+        "column_break_15",
+        "duration",
+        "shift_classification",
+        "accommodation_details_section",
+        "accommodations"
+    ],
+    "fields": [
+        {
+            "fieldname": "site",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Site",
+            "options": "Operations Site"
+        },
+        {
+            "fieldname": "column_break_2",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fetch_from": "site.project",
+            "fieldname": "project",
+            "fieldtype": "Link",
+            "label": "Project",
+            "options": "Project",
+            "read_only": 1
+        },
+        {
+            "fieldname": "shift_details_section",
+            "fieldtype": "Section Break",
+            "label": "Shift Details"
+        },
+        {
+            "fieldname": "shift_type",
+            "fieldtype": "Link",
+            "label": "Shift Type",
+            "options": "Shift Type"
+        },
+        {
+            "default": "0",
+            "description": "If checked, the system automatically creates Employee Schedules for all Employees having this as their default shift.",
+            "fieldname": "automate_roster",
+            "fieldtype": "Check",
+            "label": "Automate Roster"
+        },
+        {
+            "fieldname": "section_break_12",
+            "fieldtype": "Section Break"
+        },
+        {
+            "fieldname": "supervisor",
+            "fieldtype": "Link",
+            "hidden": 1,
+            "ignore_user_permissions": 1,
+            "label": "Shift Supervisor",
+            "options": "Employee"
+        },
+        {
+            "fetch_from": "supervisor.employee_name",
+            "fieldname": "supervisor_name",
+            "fieldtype": "Data",
+            "hidden": 1,
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Supervisor Name",
+            "read_only": 1
+        },
+        {
+            "fieldname": "column_break_8",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fetch_from": "shift_type.start_time",
+            "fieldname": "start_time",
+            "fieldtype": "Time",
+            "label": "Start time",
+            "read_only": 1
+        },
+        {
+            "fetch_from": "shift_type.end_time",
+            "fieldname": "end_time",
+            "fieldtype": "Time",
+            "label": "End time",
+            "read_only": 1
+        },
+        {
+            "description": "In hours",
+            "fetch_from": "shift_type.duration",
+            "fieldname": "duration",
+            "fieldtype": "Float",
+            "label": "Duration",
+            "read_only": 1
+        },
+        {
+            "fetch_from": "shift_type.shift_type",
+            "fieldname": "shift_classification",
+            "fieldtype": "Data",
+            "label": "Shift Classification",
+            "read_only": 1
+        },
+        {
+            "fieldname": "column_break_15",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "service_type",
+            "fieldtype": "Link",
+            "label": "Service Type",
+            "options": "Service Type",
+            "reqd": 1
+        },
+        {
+            "fieldname": "shift_number",
+            "fieldtype": "Int",
+            "label": "Shift Number",
+            "reqd": 1
+        },
+        {
+            "fieldname": "site_location",
+            "fieldtype": "Link",
+            "label": "Site Location",
+            "options": "Location"
+        },
+        {
+            "fetch_from": "site_location.governorate_area",
+            "fetch_if_empty": 1,
+            "fieldname": "governorate_area",
+            "fieldtype": "Link",
+            "label": "Governorate Area",
+            "options": "Governorate Area"
+        },
+        {
+            "default": "Active",
+            "fieldname": "status",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Status",
+            "options": "Active\nInactive"
+        },
+        {
+            "description": "Index of the table is the priority of the supervisor",
+            "fieldname": "shift_supervisor",
+            "fieldtype": "Table",
+            "label": "Shift Supervisor",
+            "options": "Operations Shift Supervisor"
+        },
+        {
+            "fieldname": "accommodation_details_section",
+            "fieldtype": "Section Break",
+            "label": "Accommodation Details"
+        },
+        {
+            "fieldname": "accommodations",
+            "fieldtype": "Table",
+            "label": "Accommodations",
+            "options": "Operations Shift Accommodation"
+        }
+    ],
+    "links": [
+        {
+            "group": "Operations",
+            "link_doctype": "Operations Role",
+            "link_fieldname": "shift"
+        }
+    ],
+    "modified": "2024-12-17 16:34:20.846883",
+    "modified_by": "Administrator",
+    "module": "Operations",
+    "name": "Operations Shift",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "System Manager",
+            "share": 1,
+            "write": 1
+        }
+    ],
+    "quick_entry": 1,
+    "search_fields": "site, project",
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": [],
+    "track_changes": 1
 }

--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -189,7 +189,7 @@
             "link_fieldname": "shift"
         }
     ],
-    "modified": "2024-12-17 16:34:20.846883",
+    "modified": "2024-12-18 00:00:00.000000",
     "modified_by": "Administrator",
     "module": "Operations",
     "name": "Operations Shift",

--- a/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.js
+++ b/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, ONE FM and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Operations Shift Accommodation', {
+    // refresh: function(frm) {
+
+    // }
+});

--- a/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.json
+++ b/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.json
@@ -1,47 +1,47 @@
 {
-    "actions": [],
-    "allow_rename": 1,
-    "creation": "2026-03-04 14:20:00.000000",
-    "doctype": "DocType",
-    "editable_grid": 1,
-    "engine": "InnoDB",
-    "field_order": [
-        "accommodation",
-        "column_break_1",
-        "accommodation_name"
-    ],
-    "fields": [
-        {
-            "fieldname": "accommodation",
-            "fieldtype": "Link",
-            "in_list_view": 1,
-            "label": "Accommodation",
-            "options": "Accommodation",
-            "reqd": 1
-        },
-        {
-            "fieldname": "column_break_1",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fetch_from": "accommodation.accommodation",
-            "fieldname": "accommodation_name",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Accommodation Name",
-            "read_only": 1
-        }
-    ],
-    "index_web_pages_for_search": 1,
-    "istable": 1,
-    "links": [],
-    "modified": "2026-03-04 14:20:00.000000",
-    "modified_by": "Administrator",
-    "module": "Operations",
-    "name": "Operations Shift Accommodation",
-    "owner": "Administrator",
-    "permissions": [],
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": []
+  "actions": [],
+  "allow_rename": 1,
+  "creation": "2026-03-04 14:20:00.000000",
+  "doctype": "DocType",
+  "editable_grid": 1,
+  "engine": "InnoDB",
+  "field_order": [
+    "accommodation",
+    "column_break_1",
+    "accommodation_name"
+  ],
+  "fields": [
+    {
+      "fieldname": "accommodation",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Accommodation",
+      "options": "Accommodation",
+      "reqd": 1
+    },
+    {
+      "fieldname": "column_break_1",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fetch_from": "accommodation.accommodation",
+      "fieldname": "accommodation_name",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "label": "Accommodation Name",
+      "read_only": 1
+    }
+  ],
+  "index_web_pages_for_search": 1,
+  "istable": 1,
+  "links": [],
+  "modified": "2026-03-04 14:20:00.000000",
+  "modified_by": "Administrator",
+  "module": "Operations",
+  "name": "Operations Shift Accommodation",
+  "owner": "Administrator",
+  "permissions": [],
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": []
 }

--- a/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.json
+++ b/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.json
@@ -1,0 +1,47 @@
+{
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2026-03-04 14:20:00.000000",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "accommodation",
+        "column_break_1",
+        "accommodation_name"
+    ],
+    "fields": [
+        {
+            "fieldname": "accommodation",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Accommodation",
+            "options": "Accommodation",
+            "reqd": 1
+        },
+        {
+            "fieldname": "column_break_1",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fetch_from": "accommodation.accommodation",
+            "fieldname": "accommodation_name",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Accommodation Name",
+            "read_only": 1
+        }
+    ],
+    "index_web_pages_for_search": 1,
+    "istable": 1,
+    "links": [],
+    "modified": "2026-03-04 14:20:00.000000",
+    "modified_by": "Administrator",
+    "module": "Operations",
+    "name": "Operations Shift Accommodation",
+    "owner": "Administrator",
+    "permissions": [],
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
+}

--- a/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.py
+++ b/one_fm/operations/doctype/operations_shift_accommodation/operations_shift_accommodation.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class OperationsShiftAccommodation(Document):
+	pass


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Add "Accommodations" childtable to the Operations Shift DocType


## Solution description
Describe your code changes in detail for reviewers.


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1440" height="675" alt="Screenshot 2026-03-04 at 2 39 03 PM" src="https://github.com/user-attachments/assets/b8777e76-672b-4209-bace-74123544fb3d" />


## Was child table created?
Yes
    - [] is attachment required?
        did you test attachment


## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
