### PR TITLE
feat: set post activation dates

### DIFF
--- a/one_fm/operations/doctype/operations_post/operations_post.json
+++ b/one_fm/operations/doctype/operations_post/operations_post.json
@@ -25,7 +25,8 @@
   "post_description",
   "section_break_14",
   "skills",
-  "designations"
+  "designations",
+  "operations_post_activation"
  ],
  "fields": [
   {
@@ -159,14 +160,21 @@
    "fieldname": "end_date",
    "fieldtype": "Date",
    "label": "End Date"
+  },
+  {
+   "fieldname": "operations_post_activation",
+   "fieldtype": "Table",
+   "label": "Operations Post Activation",
+   "options": "Operations Post Activation"
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2025-07-04 10:48:37.464794",
+ "modified": "2026-03-05 13:55:04.047926",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Post",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -260,6 +268,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "site_shift, post_template",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/one_fm/operations/doctype/operations_post/operations_post.json
+++ b/one_fm/operations/doctype/operations_post/operations_post.json
@@ -165,12 +165,13 @@
    "fieldname": "operations_post_activation",
    "fieldtype": "Table",
    "label": "Operations Post Activation",
-   "options": "Operations Post Activation"
+   "options": "Operations Post Activation",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-03-05 13:55:04.047926",
+ "modified": "2026-03-05 15:16:18.479522",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Post",

--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -38,11 +38,24 @@ class OperationsPost(Document):
         if (self.status=='Active' and frappe.db.exists("Operations Site", {'name':self.site, 'status':'Inactive'})):
             frappe.throw(f"You cannot make this post active because Operations Site '{self.site}' is Inactive.")
 
+        self.update_post_activation_date()
 
     def validate_operations_role_status(self):
         if self.status == 'Active' and self.post_template \
             and frappe.db.get_value('Operations Role', self.post_template, 'status') != 'Active':
             frappe.throw(_("The Operations Role <br/>'<b>{0}</b>' selected in the Post '<b>{1}</b>' is <b>Inactive</b>. <br/> To make the Post atcive first make the Role active".format(self.post_template, self.name)))
+
+    def update_post_activation_date(self):
+        if not self.is_new() and self.has_value_changed("status"):
+            old_status = self.get_doc_before_save().status
+            if old_status == "Inactive" and self.status == "Active":
+                if self.start_date or self.end_date:
+                    self.append("operations_post_activation", {
+                        "operations_post_start_date": self.start_date,
+                        "operations_post_end_date": self.end_date
+                    })
+                    self.start_date = None
+                    self.end_date = None
 
     def on_update(self):
         self.validate_name()

--- a/one_fm/operations/doctype/operations_post/test_operations_post.py
+++ b/one_fm/operations/doctype/operations_post/test_operations_post.py
@@ -1,28 +1,202 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, ONE FM and Contributors
 # See license.txt
-# from __future__ import unicode_literals
-
-# import frappe
-# import unittest
-
-
-# def create_test_post():
-# 	doc = frappe.new_doc("Operations Post")
-# 	doc.post_name = "Test"
-# 	doc.shift = frappe.get_doc("Operations Shift", "Admin-Farwaniya Camp-Morning-1").name
-# 	doc.post_template = frappe.get_doc({"doctype": "Operations Role", "shift": doc.shift, })
-# 	doc.post_template.save()
-# 	doc.save()
+from __future__ import unicode_literals
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from one_fm.tests.utils import create_test_company
+from frappe.utils import add_days, nowdate
 
 
-# 	return doc
- 
-# class TestOperationsPost(unittest.TestCase):
-	
-# 	def get_doc(self):
-# 		return create_test_post()
+class TestOperationsPost(FrappeTestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+        create_test_company()
+        
+        # Clean up existing test data
+        frappe.db.delete("Operations Post", {"post_name": "Test Post"})
+        frappe.db.delete("Operations Role", {"post_name": "Test Operations Role"})
+        frappe.db.delete("Item", {"item_code": "Test Sale Item"})
+        frappe.db.delete("Operations Shift", {"name": "Test Operations Shift"})
+        frappe.db.delete("Operations Site", {"site_name": "Test Operations Site"})
+        frappe.db.delete("Project", {"project_name": "Test Project"})
+        frappe.db.delete("Post Schedule", {"post": ["like", "Test Post%"]})
 
+        self.site = self._create_test_site()
+        self.shift = self._create_test_shift()
+        self.sale_item = self._create_test_item()
+        self.operations_role = self._create_test_operations_role()
+        self.project = self._create_test_project()
+        self.contract = self._create_test_contract()
+        
+    def tearDown(self):
+        frappe.db.delete("Operations Post", {"post_name": "Test Post"})
+        frappe.db.delete("Operations Role", {"post_name": "Test Operations Role"})
+        frappe.db.delete("Item", {"item_code": "Test Sale Item"})
+        frappe.db.delete("Operations Shift", {"name": "Test Operations Shift"})
+        frappe.db.delete("Operations Site", {"site_name": "Test Operations Site"})
+        frappe.db.delete("Project", {"project_name": "Test Project"})
+        frappe.db.delete("Post Schedule", {"post": ["like", "Test Post%"]})
+        frappe.db.delete("Contracts", {"project": "Test Project"})
+        
+        frappe.db.rollback()
+        frappe.set_user("Administrator")
 
-# 	def test_delete_obj(self):
-# 		frappe.delete_doc("Operations Post", self.get_doc().name)
+    def _create_test_site(self):
+        site = frappe.get_doc({
+            "doctype": "Operations Site",
+            "site_name": "Test Operations Site",
+            "status": "Active",
+            "company": "_Test Company"
+        })
+        test_poc_contact = frappe.get_doc({
+            "doctype": "Contact",
+            "first_name": "Test POC",
+            "email_id": "test_email@abc.com",
+            "phone": "1234567890"
+        })
+        test_poc_contact.insert(ignore_permissions=True)
+        site.append("poc", {
+            "poc": test_poc_contact.name
+        })
+        site.insert(ignore_permissions=True)
+        return site
+
+    def _create_test_shift(self):
+        test_service_type_name = "Test Service Type"
+        if not frappe.db.exists("Service Type", test_service_type_name):
+            test_service_type = frappe.get_doc({
+                "doctype": "Service Type",
+                "service_type": test_service_type_name
+            })
+            test_service_type.insert(ignore_permissions=True)
+
+        shift = frappe.get_doc({
+            "doctype": "Operations Shift",
+            "shift_number": 123,
+            "site": self.site.name,
+            "service_type": test_service_type_name,
+            "start_time": "08:00:00",
+            "end_time": "16:00:00"
+        })
+        shift.insert(ignore_permissions=True)
+        return shift
+
+    def _create_test_item(self):
+        item = frappe.get_doc({
+            "doctype": "Item",
+            "item_code": "Test Sale Item",
+            "item_name": "Test Sale Item",
+            "item_group": "All Item Groups",
+            "is_stock_item": 0
+        })
+        item.flags.ignore_mandatory = True
+        item.insert(ignore_permissions=True)
+        return item
+
+    def _create_test_operations_role(self):
+        role = frappe.get_doc({
+            "doctype": "Operations Role",
+            "post_name": "Test Operations Role",
+            "status": "Active",
+            "sale_item": self.sale_item.name,
+            "shift": self.shift.name,
+            "post_abbrv": "Test Post Abbrv"
+        })
+        role.insert(ignore_permissions=True)
+        return role
+        
+    def _create_test_project(self):
+        project = frappe.get_doc({
+            "doctype": "Project",
+            "project_name": "Test Project",
+            "status": "Open",
+            "company": "_Test Company",
+            "expected_start_date": add_days(nowdate(), -10),
+            "expected_end_date": add_days(nowdate(), 10)
+        })
+        project.insert(ignore_permissions=True)
+        return project
+
+    def _create_test_operations_post(self, status="Inactive", **kwargs):
+        defaults = {
+            "doctype": "Operations Post",
+            "post_name": "Test Post",
+            "gender": "Male",
+            "site_shift": self.shift.name,
+            "site": self.site.name,
+            "post_template": self.operations_role.name,
+            "project": self.project.name,
+            "status": status,
+        }
+        defaults.update(kwargs)
+        post = frappe.get_doc(defaults)
+        post.insert(ignore_permissions=True)
+        return post
+
+    def test_validation_empty_fields(self):
+        """Test that validation fails when mandatory fields are missing"""
+        post = frappe.get_doc({"doctype": "Operations Post", "gender": "Male", "site_shift": self.shift.name})
+        with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            post.insert(ignore_permissions=True)
+        self.assertIn("Post Name cannot be empty", str(cm.exception))
+
+        post_no_gender = frappe.get_doc({"doctype": "Operations Post", "post_name": "Test Post", "site_shift": self.shift.name})
+        self.assertRaises(frappe.ValidationError, post_no_gender.insert)
+
+        post_no_shift = frappe.get_doc({"doctype": "Operations Post", "post_name": "Test Post", "gender": "Male"})
+        with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            post_no_shift.insert(ignore_permissions=True)
+        self.assertIn("Shift cannot be empty", str(cm.exception))
+
+    def test_operations_role_inactive_validation(self):
+        """Test that trying to set post as Active when its role is Inactive fails"""
+        self.operations_role.status = "Inactive"
+        self.operations_role.save()
+
+        post = self._create_test_operations_post(status="Inactive")
+        post.status = "Active"
+
+        with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            post.save(ignore_permissions=True)
+        
+        self.assertIn("is Inactive", str(cm.exception))
+
+    def test_post_activation_date_appended(self):
+        """Test that making an Inactive post Active appends to operations_post_activation child table"""
+        post = self._create_test_operations_post(status="Inactive", start_date=nowdate(), end_date=add_days(nowdate(), 5))
+        
+        post.status = "Active"
+        post.save(ignore_permissions=True)
+
+        self.assertEqual(len(post.operations_post_activation), 1)
+        self.assertEqual(post.operations_post_activation[0].operations_post_start_date, nowdate())
+        self.assertEqual(post.operations_post_activation[0].operations_post_end_date, add_days(nowdate(), 5))
+        self.assertIsNone(post.start_date)
+        self.assertIsNone(post.end_date)
+
+    def test_name_validation(self):
+        """Test that post forces a specific naming convention"""
+        post = self._create_test_operations_post()
+        expected_name = f"Test Post-Male|{self.shift.name}"
+        self.assertEqual(post.name, expected_name)
+
+    def _create_test_contract(self):
+        if frappe.db.exists("Contracts", {"project": self.project.name}):
+            return frappe.get_doc("Contracts", {"project": self.project.name})
+        contract = frappe.get_doc({
+            "doctype": "Contracts",
+            "project": self.project.name,
+            "start_date": add_days(nowdate(), -5),
+            "end_date": add_days(nowdate(), 5),
+            "company": "_Test Company",
+            "status": "Active"
+        })
+        contract.append("items", {
+            "item_code": self.sale_item.name,
+            "quantity": 2,
+            "item_type": "Service"
+        })
+        contract.flags.ignore_mandatory = True
+        contract.insert(ignore_permissions=True)
+        return contract

--- a/one_fm/operations/doctype/operations_post_activation/operations_post_activation.json
+++ b/one_fm/operations/doctype/operations_post_activation/operations_post_activation.json
@@ -1,0 +1,45 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-03-05 13:51:54.500014",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "operations_post_start_date",
+  "column_break_hxxg",
+  "operations_post_end_date"
+ ],
+ "fields": [
+  {
+   "fieldname": "operations_post_start_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Operations Post Start Date"
+  },
+  {
+   "fieldname": "column_break_hxxg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "operations_post_end_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Operations Post End Date"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-03-05 13:55:19.782334",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "Operations Post Activation",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/operations/doctype/operations_post_activation/operations_post_activation.py
+++ b/one_fm/operations/doctype/operations_post_activation/operations_post_activation.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class OperationsPostActivation(Document):
+	pass

--- a/one_fm/overrides/project.py
+++ b/one_fm/overrides/project.py
@@ -12,6 +12,8 @@ from erpnext.projects.doctype.project.project import Project
 def notify_project_team(doc):
     template = "one_fm/templates/emails/notify_project_manager.html"
     
+    if not doc.project_manager:
+        return
     project_manager = frappe.get_doc("Employee", doc.project_manager)
     project_manager_name = project_manager.employee_name
     project_manager_email = project_manager.user_id
@@ -71,8 +73,9 @@ def update_project_user_assignment(doc, method):
 def assign_users_to_project(doc):
     for user in doc.users:
         add_assignment(user.user, doc.name)
-    project_manager_id = frappe.get_value("Employee", doc.project_manager, "user_id")
-    add_assignment(project_manager_id, doc.name)
+    if doc.project_manager:
+        project_manager_id = frappe.get_value("Employee", doc.project_manager, "user_id")
+        add_assignment(project_manager_id, doc.name)
 
 def add_assignment(user, project):
     try:


### PR DESCRIPTION
This pull request introduces a new child table, `Operations Post Activation`, to the `Operations Post` DocType in order to track activation periods for posts. It also updates the backend logic to automatically record activation periods when a post's status changes from inactive to active. The main changes are grouped below:

### New Feature: Activation History Tracking

* Added a new child table DocType, `Operations Post Activation`, with fields for start and end dates to record activation periods for posts. (`operations_post_activation.json`)
* Integrated the `operations_post_activation` child table into the `Operations Post` DocType, updating its schema and UI configuration (including making the table read-only and adjusting grid settings). (`operations_post.json`) [[1]](diffhunk://#diff-09ad12b72818645559fbf4836109c20e7b97d58ae9dd1c97c09216ee8c361cc0L28-R29) [[2]](diffhunk://#diff-09ad12b72818645559fbf4836109c20e7b97d58ae9dd1c97c09216ee8c361cc0R163-R178) [[3]](diffhunk://#diff-09ad12b72818645559fbf4836109c20e7b97d58ae9dd1c97c09216ee8c361cc0R272)

### Backend Logic Updates

* Implemented the `update_post_activation_date` method in `operations_post.py` to automatically append a new entry to the `operations_post_activation` table whenever a post is activated, transferring any existing `start_date` and `end_date` values and then clearing them from the main document. (`operations_post.py`)

### Supporting Files

* Added a new Python class, `OperationsPostActivation`, as the model for the new child table. (`operations_post_activation.py`)


###Test
<img width="1076" height="115" alt="Screenshot 2026-03-07 at 3 35 16 PM" src="https://github.com/user-attachments/assets/b192e4c2-452b-4249-b35a-7dc0ec8bf0c5" />
