### PR TITLE
Add GST Number Field to Client DocType

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -43,6 +43,11 @@
    "unique": 1
   },
   {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Number"
+  },
+  {
    "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",


### PR DESCRIPTION
This PR adds a GST Number field to the Client DocType in the one_fm app. Note: I was unable to run tests due to issues with determining the correct site name.