### PR TITLE
feat: active operations post-start date mandatory

### DIFF
--- a/one_fm/operations/doctype/operations_post/operations_post.json
+++ b/one_fm/operations/doctype/operations_post/operations_post.json
@@ -102,7 +102,8 @@
    "fieldtype": "Link",
    "label": "Operations Role",
    "options": "Operations Role",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "depends_on": "site_shift",
@@ -152,7 +153,8 @@
    "default": "Today",
    "fieldname": "start_date",
    "fieldtype": "Date",
-   "label": "Start Date"
+   "label": "Start Date",
+   "mandatory_depends_on": "eval:doc.status==\"Active\""
   },
   {
    "fetch_from": "project.expected_end_date",
@@ -171,7 +173,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-03-05 15:16:18.479522",
+ "modified": "2026-03-10 15:50:39.869781",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Post",

--- a/one_fm/operations/doctype/operations_post/operations_post.py
+++ b/one_fm/operations/doctype/operations_post/operations_post.py
@@ -48,7 +48,7 @@ class OperationsPost(Document):
     def update_post_activation_date(self):
         if not self.is_new() and self.has_value_changed("status"):
             old_status = self.get_doc_before_save().status
-            if old_status == "Inactive" and self.status == "Active":
+            if old_status == "Active" and self.status == "Inactive":
                 if self.start_date or self.end_date:
                     self.append("operations_post_activation", {
                         "operations_post_start_date": self.start_date,

--- a/one_fm/operations/doctype/operations_post/test_operations_post.py
+++ b/one_fm/operations/doctype/operations_post/test_operations_post.py
@@ -136,15 +136,15 @@ class TestOperationsPost(FrappeTestCase):
 
     def test_validation_empty_fields(self):
         """Test that validation fails when mandatory fields are missing"""
-        post = frappe.get_doc({"doctype": "Operations Post", "gender": "Male", "site_shift": self.shift.name})
+        post = frappe.get_doc({"doctype": "Operations Post", "gender": "Male", "site_shift": self.shift.name, "status": "Inactive"})
         with self.assertRaises(frappe.exceptions.ValidationError) as cm:
             post.insert(ignore_permissions=True)
         self.assertIn("Post Name cannot be empty", str(cm.exception))
 
-        post_no_gender = frappe.get_doc({"doctype": "Operations Post", "post_name": "Test Post", "site_shift": self.shift.name})
+        post_no_gender = frappe.get_doc({"doctype": "Operations Post", "post_name": "Test Post", "site_shift": self.shift.name, "status": "Inactive"})
         self.assertRaises(frappe.ValidationError, post_no_gender.insert)
 
-        post_no_shift = frappe.get_doc({"doctype": "Operations Post", "post_name": "Test Post", "gender": "Male"})
+        post_no_shift = frappe.get_doc({"doctype": "Operations Post", "post_name": "Test Post", "gender": "Male", "status": "Inactive"})
         with self.assertRaises(frappe.exceptions.ValidationError) as cm:
             post_no_shift.insert(ignore_permissions=True)
         self.assertIn("Shift cannot be empty", str(cm.exception))
@@ -156,6 +156,7 @@ class TestOperationsPost(FrappeTestCase):
 
         post = self._create_test_operations_post(status="Inactive")
         post.status = "Active"
+        post.start_date = nowdate()
 
         with self.assertRaises(frappe.exceptions.ValidationError) as cm:
             post.save(ignore_permissions=True)
@@ -163,10 +164,10 @@ class TestOperationsPost(FrappeTestCase):
         self.assertIn("is Inactive", str(cm.exception))
 
     def test_post_activation_date_appended(self):
-        """Test that making an Inactive post Active appends to operations_post_activation child table"""
-        post = self._create_test_operations_post(status="Inactive", start_date=nowdate(), end_date=add_days(nowdate(), 5))
+        """Test that making an Active post Inactive appends to operations_post_activation child table"""
+        post = self._create_test_operations_post(status="Active", start_date=nowdate(), end_date=add_days(nowdate(), 5))
         
-        post.status = "Active"
+        post.status = "Inactive"
         post.save(ignore_permissions=True)
 
         self.assertEqual(len(post.operations_post_activation), 1)


### PR DESCRIPTION
This pull request introduces several improvements and corrections to the `Operations Post` doctype, focusing on field validation logic, field configuration, and related tests. The most significant changes include fixing the logic for tracking status transitions, updating field dependencies, and ensuring that tests align with the new logic.

**Validation and logic corrections:**

* Corrected the logic in `update_post_activation_date` so that an entry is appended to `operations_post_activation` when a post transitions from "Active" to "Inactive" (previously it was the reverse).
* Updated test `test_post_activation_date_appended` to match the corrected logic: now it verifies that transitioning from "Active" to "Inactive" appends to the child table.

**Field configuration improvements in `operations_post.json`:**

* Added `"search_index": 1` to the `operations_role` field to enable search indexing.
* Added a dependency to the `start_date` field, making it mandatory only when the post status is "Active".

**Test robustness improvements:**

* Updated test cases to explicitly set `status: "Inactive"` when creating test documents, ensuring consistent validation behavior.

**Other:**

* Updated the `modified` timestamp in the doctype JSON to reflect the latest changes.

Ref:
<img width="1298" height="155" alt="Screenshot 2026-03-10 at 6 27 26 PM" src="https://github.com/user-attachments/assets/b41b52c3-11c6-48f8-8c61-6c9e2244a40d" />

https://github.com/user-attachments/assets/0608c555-44bb-4662-90db-aba538c23fb0


