### PR TITLE
Create Script Report: Employee Leave Balance Summary

### DIFF
--- a/report/employee_leave_balance_summary/employee_leave_balance_summary.json
+++ b/report/employee_leave_balance_summary/employee_leave_balance_summary.json
@@ -1,0 +1,31 @@
+{
+ "creation": "2024-11-16 09:27:10.472327",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  }
+ ],
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2024-11-16 09:27:10.472327",
+ "modified_by": "Administrator",
+ "module": "Human Resources",
+ "name": "Employee Leave Balance Summary",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Employee",
+ "report_name": "Employee Leave Balance Summary",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "HR User"
+  }
+ ]
+}

--- a/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -1,0 +1,41 @@
+import frappe
+
+def execute(filters=None):
+	company = filters.get("company")
+
+	head = [
+		{"fieldname": "employee_id", "label": "Employee ID", "fieldtype": "Data", "width": 120},
+		{"fieldname": "employee_name", "label": "Employee Name", "fieldtype": "Data", "width": 200},
+		{"fieldname": "available_sick_leave", "label": "Available Sick Leave Days", "fieldtype": "Float", "width": 150}
+	]
+
+	data = []
+
+	employees = frappe.db.sql("""
+		SELECT
+			name,
+			employee_name
+		FROM
+			`tabEmployee`
+		WHERE
+			company = %(company)s
+	""", {"company": company}, as_dict=True)
+
+	for employee in employees:
+		sick_leave_balance = frappe.db.sql("""
+			SELECT
+				SUM(leave_days)
+			FROM
+				`tabLeave Ledger`
+			WHERE
+				employee = %(employee)s
+				AND leave_type = 'Sick Leave'
+		""", {"employee": employee.name}, as_dict=True)[0]["SUM(leave_days)"] or 0
+
+		data.append({
+			"employee_id": employee.name,
+			"employee_name": employee.employee_name,
+			"available_sick_leave": sick_leave_balance
+		})
+
+	return head, data


### PR DESCRIPTION
This pull request creates a new Script Report named 'Employee Leave Balance Summary' within the 'Human Resources' module of the `one_fm` app. The report displays Employee ID, Employee Name, and Available Sick Leave Days, and it has a mandatory filter for Company.