### PR TITLE
BUG: NEXT DOCUMENT BUTTON RETURNS "NO FURTHER RECORDS" WHEN THERE ARE RECORDS

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -4619,67 +4619,65 @@ def get_task_type(task_type="Repetitive", is_routine_task=0):
     return task_type
 
 
+COMPARABLE_FIELDTYPES = {"Date", "Datetime", "Int", "Float", "Currency", "Percent", "Duration"}
+ALWAYS_COMPARABLE = {"name", "modified", "creation"}
+
+def is_comparable_field(doctype, sort_field):
+    if sort_field in ALWAYS_COMPARABLE:
+        return True
+    field_meta = frappe.get_meta(doctype).get_field(sort_field)
+    return field_meta and field_meta.fieldtype in COMPARABLE_FIELDTYPES
+
+
 @frappe.whitelist()
 def get_next(doctype, value, prev, filters=None, sort_order="desc", sort_field="modified"):
-	prev = int(prev)
-	if not filters:
-		filters = []
-	if isinstance(filters, str):
-		filters = json.loads(filters)
-	condition = ">" if sort_order.lower() == "asc" else "<"
+    prev = int(prev)
+    if not filters:
+        filters = []
+    if isinstance(filters, str):
+        filters = json.loads(filters)
 
-	if prev:
-		sort_order = "asc" if sort_order.lower() == "desc" else "desc"
-		condition = "<" if condition == ">" else ">"
+    condition = ">" if sort_order.lower() == "asc" else "<"
+    if prev:
+        sort_order = "asc" if sort_order.lower() == "desc" else "desc"
+        condition = "<" if condition == ">" else ">"
 
+    if not is_comparable_field(doctype, sort_field):
+        current_value = frappe.db.get_value(doctype, value, sort_field)
+        current_modified = frappe.db.get_value(doctype, value, "modified")
 
-	if sort_field == "status":
-		current_status = frappe.db.get_value(doctype, value, "status")
-		current_modified = frappe.db.get_value(doctype, value, "modified")
-		
-		same_status_filters = filters + [
-			[doctype, "status", "=", current_status],
-			[doctype, "modified", condition, current_modified]
-		]
-		
-		res = frappe.get_list(
-			doctype,
-			fields=["name"],
-			filters=same_status_filters,
-			order_by=f"`tab{doctype}`.modified {sort_order}",
-			limit_page_length=1,
-			as_list=True,
-		)
-		
-		if not res:
-			different_status_filters = filters + [
-				[doctype, "status", condition, current_status]
-			]
-			
-			res = frappe.get_list(
-				doctype,
-				fields=["name"],
-				filters=different_status_filters,
-				order_by=f"`tab{doctype}`.status {sort_order}, `tab{doctype}`.modified {sort_order}",
-				limit_page_length=1,
-				as_list=True,
-			)
-	
-	else:
-		filters.append([doctype, sort_field, condition, frappe.get_value(doctype, value, sort_field)])
-		
-		res = frappe.get_list(
-			doctype,
-			fields=["name"],
-			filters=filters,
-			order_by=f"`tab{doctype}`.{sort_field} {sort_order}",
-			limit_start=0,
-			limit_page_length=1,
-			as_list=True,
-		)
+        res = frappe.get_list(
+            doctype,
+            fields=["name"],
+            filters=filters + [
+                [doctype, sort_field, "=", current_value],
+                [doctype, "modified", condition, current_modified]
+            ],
+            order_by=f"`tab{doctype}`.modified {sort_order}",
+            limit_page_length=1,
+            as_list=True,
+        )
 
-	if not res:
-		frappe.msgprint(_("No further records"))
-		return None
-	else:
-		return res[0][0]
+        if not res:
+            res = frappe.get_list(
+                doctype,
+                fields=["name"],
+                filters=filters + [[doctype, sort_field, condition, current_value]],
+                order_by=f"`tab{doctype}`.{sort_field} {sort_order}, `tab{doctype}`.modified {sort_order}",
+                limit_page_length=1,
+                as_list=True,
+            )
+    else:
+        res = frappe.get_list(
+            doctype,
+            fields=["name"],
+            filters=filters + [[doctype, sort_field, condition, frappe.db.get_value(doctype, value, sort_field)]],
+            order_by=f"`tab{doctype}`.{sort_field} {sort_order}",
+            limit_page_length=1,
+            as_list=True,
+        )
+
+    if not res:
+        frappe.msgprint(_("No further records"))
+        return None
+    return res[0][0]


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [X] Bug


## Clearly and concisely describe the feature, chore or bug.
Next button kept returning no further records even when there are records

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Updated get_next method to use a different logic, when sorted by certain fields

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
