### PR TITLE
Add GST Number Field to Client DocType

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -24,6 +24,11 @@
    "unique": 1
   },
   {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Number"
+  },
+  {
    "fieldname": "route",
    "fieldtype": "Data",
    "in_list_view": 1,


### PR DESCRIPTION
This PR adds the GST Number field to the Client DocType in the one_fm app. Please run bench migrate and the tests manually after merging due to a potential environment configuration issue.