### PR TITLE
feat: temporary deployment - links

### DIFF
--- a/one_fm/one_fm/doctype/temporary_deployment/temporary_deployment.js
+++ b/one_fm/one_fm/doctype/temporary_deployment/temporary_deployment.js
@@ -3,20 +3,16 @@
 
 frappe.ui.form.on("Temporary Deployment", {
     refresh(frm) {
-        // Prevent creation of Temporary Post from the Connections badge (+) button
-        frm.sidebar.linked_with && frm.sidebar.linked_with.wrapper
-            && frm.sidebar.linked_with.wrapper
-                .find('[data-doctype="Temporary Post"] .btn-new')
+        // Hide the (+) button for Temporary Post in the form's Connections dashboard section.
+        // The connections section (rendered from the DocType's `links` array) lives in
+        // frm.dashboard.wrapper — run immediately and after a delay for async rendering.
+        function hide_new_btn() {
+            frm.dashboard.wrapper
+                .find('[data-doctype="Temporary Post"]')
+                .find('.btn-new-doc, .btn-new, .link-new-doc')
                 .hide();
-    },
-
-    onload_post_render(frm) {
-        // Also hide after the connections panel fully renders
-        setTimeout(() => {
-            frm.sidebar.linked_with && frm.sidebar.linked_with.wrapper
-                && frm.sidebar.linked_with.wrapper
-                    .find('[data-doctype="Temporary Post"] .btn-new')
-                    .hide();
-        }, 500);
+        }
+        hide_new_btn();
+        setTimeout(hide_new_btn, 500);
     }
 });

--- a/one_fm/one_fm/doctype/temporary_deployment/temporary_deployment.js
+++ b/one_fm/one_fm/doctype/temporary_deployment/temporary_deployment.js
@@ -1,8 +1,22 @@
 // Copyright (c) 2026, ONE FM and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Temporary Deployment", {
-// 	refresh(frm) {
+frappe.ui.form.on("Temporary Deployment", {
+    refresh(frm) {
+        // Prevent creation of Temporary Post from the Connections badge (+) button
+        frm.sidebar.linked_with && frm.sidebar.linked_with.wrapper
+            && frm.sidebar.linked_with.wrapper
+                .find('[data-doctype="Temporary Post"] .btn-new')
+                .hide();
+    },
 
-// 	},
-// });
+    onload_post_render(frm) {
+        // Also hide after the connections panel fully renders
+        setTimeout(() => {
+            frm.sidebar.linked_with && frm.sidebar.linked_with.wrapper
+                && frm.sidebar.linked_with.wrapper
+                    .find('[data-doctype="Temporary Post"] .btn-new')
+                    .hide();
+        }, 500);
+    }
+});

--- a/one_fm/one_fm/doctype/temporary_deployment/temporary_deployment.json
+++ b/one_fm/one_fm/doctype/temporary_deployment/temporary_deployment.json
@@ -121,8 +121,14 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2026-03-03 05:36:37.071782",
+ "links": [
+  {
+   "group": "Connections",
+   "link_doctype": "Temporary Post",
+   "link_fieldname": "temporary_deployment"
+  }
+ ],
+ "modified": "2026-03-15 09:46:45.276417",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Temporary Deployment",


### PR DESCRIPTION
This pull request introduces changes to the `Temporary Deployment` doctype to restrict the creation of related `Temporary Post` records from the Connections badge in the sidebar. It also updates the doctype configuration to explicitly link `Temporary Post` to `Temporary Deployment` in the Connections panel.

UI behavior adjustments:

* Modified `temporary_deployment.js` to hide the "New Temporary Post" button in the Connections badge both on form refresh and after the connections panel fully renders, preventing users from creating `Temporary Post` records from this location.

Doctype configuration update:

* Updated `temporary_deployment.json` to add a `Temporary Post` link under the Connections group, establishing an explicit relationship between the two doctypes in the sidebar.