### PR TITLE
feat: contract expiry reminder email enhancement

### DIFF
--- a/one_fm/one_fm/doctype/action_user/action_user.json
+++ b/one_fm/one_fm/doctype/action_user/action_user.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "creation": "2026-03-16 15:00:00",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-03-16 12:52:31.861466",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Action User",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/one_fm/doctype/action_user/action_user.py
+++ b/one_fm/one_fm/doctype/action_user/action_user.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+class ActionUser(Document):
+	pass

--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
@@ -18,6 +18,8 @@
   "column_break_tusm",
   "day_off_reliever_default_shift_checker_threshold",
   "weekend_reliever_default_shift_checker_threshold",
+  "contracts_notification_section",
+  "notify_contract_expiry_users",
   "section_break_2",
   "zenquote_keyword_category",
   "zenquotes_api_key",
@@ -235,12 +237,24 @@
    "fieldtype": "Int",
    "label": "Day Off Reliever Default Shift Checker Threshold ",
    "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "contracts_notification_section",
+   "fieldtype": "Section Break",
+   "label": "Contracts Notification"
+  },
+  {
+   "fieldname": "notify_contract_expiry_users",
+   "fieldtype": "Table MultiSelect",
+   "label": "Notify Contract Expiry Users",
+   "options": "Action User"
   }
  ],
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-19 16:57:43.493790",
+ "modified": "2026-03-16 12:54:32.000729",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "ONEFM General Setting",

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -1002,12 +1002,8 @@ def send_contract_reminders(is_scheduled_event=True):
         contracts_due_internal_notification = frappe.get_all("Contracts",{'contract_end_internal_notification_date':getdate(), 'workflow_state': 'Active'},['contract_end_internal_notification',\
             'contract_end_internal_notification_date', 'contract_termination_decision_period','contract_termination_decision_period_date','name','start_date','end_date','duration','client', 'contract'])
 
-        relevant_roles = ["Finance Manager",'Legal Manager','Projects Manager','Operations Manager']
-        active_users = frappe.get_all("User",{'enabled':1})
-        active_users_ = [i.name for i in active_users] if active_users else []
-        active_users_.remove("Administrator")
-        relevant_users = frappe.get_all("Has Role",{'role':['IN',relevant_roles],'parent':['IN',active_users_]},['distinct parent'])
-        users = [i.parent for i in relevant_users]
+        action_users = frappe.get_all("Action User", {"parent": "ONEFM General Setting", "parenttype": "ONEFM General Setting"}, pluck="user")
+        users = list(set(action_users))
         if contracts_due_internal_notification:
             contracts_due_internal_notification_list = [[i.contract_termination_decision_period,i.contract_end_internal_notification,\
                 get_date_str(i.contract_termination_decision_period_date) if i.contract_termination_decision_period_date else None,i.name,get_date_str(i.start_date),get_date_str(i.contract_end_internal_notification_date) if i.contract_end_internal_notification_date else None,\

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -1012,8 +1012,11 @@ def send_contract_reminders(is_scheduled_event=True):
             contracts_due_internal_notification_list = [[i.contract_termination_decision_period,i.contract_end_internal_notification,\
                 get_date_str(i.contract_termination_decision_period_date) if i.contract_termination_decision_period_date else None,i.name,get_date_str(i.start_date),get_date_str(i.contract_end_internal_notification_date) if i.contract_end_internal_notification_date else None,\
                 get_date_str(i.end_date),i.duration,i.client,i.contract] for i in contracts_due_internal_notification]
+
+            # Build a list of all contract contexts to render in a single grouped email
+            contracts_list = []
             for each in contracts_due_internal_notification_list:
-                context = {
+                contracts_list.append({
                     "project": each[8],
                     "contract_end_internal_notif_period": get_field_with_label("Contracts", "contract_end_internal_notification", each[1]),
                     "start_date": each[4],
@@ -1025,9 +1028,12 @@ def send_contract_reminders(is_scheduled_event=True):
                     "document_id": each[3],
                     "link": frappe.utils.get_url_to_form("Contracts", each[3]),
                     "attachment": frappe.utils.get_url(each[9]) if each[9] else None
-                }
-                msg = frappe.render_template('one_fm/templates/emails/contracts_reminder.html', context=context)
-                sendemail(recipients=users, subject="Expiring Contracts", content=msg, is_scheduler_email=is_scheduled_event)
+                })
+
+            # Render all expiring contracts into a single email and send once to all recipients
+            context = {"contracts_list": contracts_list}
+            msg = frappe.render_template('one_fm/templates/emails/contracts_reminder.html', context=context)
+            sendemail(recipients=users, subject="Contract Internal Notification Period for Expiring Contracts", content=msg, is_scheduler_email=is_scheduled_event)
     except Exception as e:
         frappe.log_error(message=str(e), title="Contract Reminder Error")
 

--- a/one_fm/operations/doctype/contracts/test_contracts.py
+++ b/one_fm/operations/doctype/contracts/test_contracts.py
@@ -1,10 +1,152 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2020, ONE FM and Contributors
+# Copyright (c) 2026, ONE FM and Contributors
 # See license.txt
 from __future__ import unicode_literals
 
-# import frappe
-import unittest
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import getdate, add_days, nowdate, add_months
+from unittest.mock import patch
+from one_fm.operations.doctype.contracts.contracts import send_contract_reminders
 
-class TestContracts(unittest.TestCase):
-	pass
+class TestContracts(FrappeTestCase):
+	"""Test Suite for Contracts DocType, focusing on contract reminders grouping logic."""
+
+	def setUp(self):
+		"""
+		Preparation Phase:
+		1. Set user to Administrator.
+		2. Clean up data from previous test runs.
+		3. Setup common master data (e.g. ONEFM General Setting).
+		"""
+		frappe.set_user("Administrator")
+
+		# Clean up older test data
+		frappe.db.delete("Contracts", {"name": ("like", "TEST-CONTRACT-%")})
+		frappe.db.delete("Customer", {"name": ("like", "TEST-CLIENT-%")})
+		frappe.db.delete("Project", {"name": ("like", "Test Project%")})
+
+		# Create Test Customers and Projects
+		for i in [1, 2]:
+			if not frappe.db.exists("Customer", f"TEST-CLIENT-{i}"):
+				frappe.get_doc({
+					"doctype": "Customer",
+					"customer_name": f"TEST-CLIENT-{i}",
+					"customer_group": "Commercial",
+					"territory": "All Territories"
+				}).insert(ignore_permissions=True)
+
+			project_name = "Test Project Alpha" if i == 1 else "Test Project Beta"
+			if not frappe.db.exists("Project", project_name):
+				frappe.get_doc({
+					"doctype": "Project",
+					"project_name": project_name
+				}).insert(ignore_permissions=True)
+
+		# Clear existing notify users if any to avoid test interference
+		settings = frappe.get_doc("ONEFM General Setting")
+		settings.set("notify_contract_expiry_users", [])
+
+		# Create test users if they don't exist
+		for email in ["test_notify1@example.com", "test_notify2@example.com"]:
+			if not frappe.db.exists("User", email):
+				user = frappe.get_doc({
+					"doctype": "User",
+					"email": email,
+					"first_name": "Test Notify",
+					"send_welcome_email": 0
+				}).insert(ignore_permissions=True)
+
+			settings.append("notify_contract_expiry_users", {"user": email})
+
+		settings.save(ignore_permissions=True)
+
+	def tearDown(self):
+		"""
+		Reset Phase:
+		1. Clean up transactional records.
+		2. Restore common master data to default.
+		"""
+		frappe.db.delete("Contracts", {"name": ("like", "TEST-CONTRACT-%")})
+		frappe.db.delete("Customer", {"name": ("like", "TEST-CLIENT-%")})
+		frappe.db.delete("Project", {"name": ("like", "Test Project%")})
+
+		frappe.db.sql("""
+			DELETE FROM `tabAction User`
+			WHERE parent = 'ONEFM General Setting' AND user IN ('test_notify1@example.com', 'test_notify2@example.com')
+		""")
+
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+
+	@patch('one_fm.operations.doctype.contracts.contracts.sendemail')
+	def test_send_contract_reminders_grouped_email_delivery(self, mock_sendemail):
+		"""
+		Verifies that multiple contracts expiring today generate a single grouped email
+		sent to the configurable 'notify_contract_expiry_users' Action Users in ONEFM General Setting.
+		"""
+
+		# Setup two test contracts that match the internal notification logic
+		# The update_contract_dates() method calculates:
+		# 1. contract_termination_decision_period_date = add_months(end_date, -contract_termination_decision_period)
+		# 2. contract_end_internal_notification_date = add_months(contract_termination_decision_period_date, -contract_end_internal_notification)
+
+		# So to get contract_end_internal_notification_date = today:
+		# end_date = add_months(today, contract_termination_decision_period + contract_end_internal_notification)
+
+		contract1 = frappe.get_doc({
+			"doctype": "Contracts",
+			"contract": "TEST-CONTRACT-001",
+			"client": "TEST-CLIENT-1",
+			"project": "Test Project Alpha",
+			"start_date": add_days(nowdate(), -60),
+			"end_date": add_months(getdate(), 4),  # 3 (decision period) + 1 (notification) = 4 months
+			"contract_end_internal_notification": 1,
+			"contract_termination_decision_period": 3,
+			"workflow_state": "Draft"
+		}).insert(ignore_permissions=True)
+		contract1.db_set("workflow_state", "Active")
+
+		contract2 = frappe.get_doc({
+			"doctype": "Contracts",
+			"contract": "TEST-CONTRACT-002",
+			"client": "TEST-CLIENT-2",
+			"project": "Test Project Beta",
+			"start_date": add_days(nowdate(), -120),
+			"end_date": add_months(getdate(), 3),  # 1 (decision period) + 2 (notification) = 3 months
+			"contract_end_internal_notification": 2,
+			"contract_termination_decision_period": 1,
+			"workflow_state": "Draft"
+		}).insert(ignore_permissions=True)
+		contract2.db_set("workflow_state", "Active")
+
+		# Commit to ensure contracts are saved to database before the send_contract_reminders query
+		frappe.db.commit()
+
+		# Action: Trigger the scheduled event
+		send_contract_reminders(is_scheduled_event=False)
+
+		# Verify: Determine if sendemail patch was called exactly ONCE
+		self.assertEqual(
+			mock_sendemail.call_count, 1,
+			"sendemail should only be called once, grouping all contracts into a single email."
+		)
+
+		call_kwargs = mock_sendemail.call_args[1]
+
+		# Verify Recipients mapping
+		self.assertIn(
+			"test_notify1@example.com", call_kwargs.get("recipients", []),
+			"Recipients from ONEFM General Setting action users must be included."
+		)
+		self.assertIn(
+			"test_notify2@example.com", call_kwargs.get("recipients", []),
+			"Recipients from ONEFM General Setting action users must be included."
+		)
+
+		# Verify Content Grouping (Should include both clients from the contracts)
+		email_content = call_kwargs.get("content", "")
+		self.assertIn("TEST-CLIENT-1", email_content, "First contract data missing from grouped email")
+		self.assertIn("TEST-CLIENT-2", email_content, "Second contract data missing from grouped email")
+		self.assertEqual(call_kwargs.get("subject"), "Contract Internal Notification Period for Expiring Contracts")

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -332,3 +332,4 @@ one_fm.patches.v15_0.add_assignment_rule_employee_resignation_pending_operations
 one_fm.patches.v15_0.add_workflow_resignation_withdrawal
 one_fm.patches.v15_0.update_client_event_workflow_state
 one_fm.patches.v15_0.delete_attendance_checks_mar18_2026 #2
+one_fm.patches.v15_0.add_contract_notification_recipients #1

--- a/one_fm/patches/v15_0/add_contract_notification_recipients.py
+++ b/one_fm/patches/v15_0/add_contract_notification_recipients.py
@@ -1,0 +1,30 @@
+import frappe
+
+def execute():
+	frappe.reload_doc("one_fm", "doctype", "action_user")
+	frappe.reload_doc("one_fm", "doctype", "onefm_general_setting")
+
+	settings = frappe.get_single("ONEFM General Setting")
+	
+	emails = [
+		"a.magar@one-fm.com",
+		"abdullah@one-fm.com",
+		"t.anwar@one-fm.com",
+		"m.wahid@one-fm.com",
+		"saoud@one-fm.com",
+		"m.alsubaie@one-fm.com"
+	]
+
+	# Find users by their email
+	users = frappe.get_all("User", filters={"email": ["in", emails]}, pluck="name")
+
+	existing_users = [row.user for row in settings.get("notify_contract_expiry_users", [])]
+	
+	added_any = False
+	for user in set(users):
+		if user not in existing_users:
+			settings.append("notify_contract_expiry_users", {"user": user})
+			added_any = True
+			
+	if added_any:
+		settings.save(ignore_permissions=True)

--- a/one_fm/templates/emails/contracts_reminder.html
+++ b/one_fm/templates/emails/contracts_reminder.html
@@ -128,7 +128,7 @@
       {% if contract.attachment is not none %}
       <tr>
         <th>Attachment</th>
-        <td><a href={{ contract.attachment }}>Contract Attachment</a></td>
+        <td><a href="{{ contract.attachment }}">Contract Attachment</a></td>
       </tr>
       {% endif %}
     </tbody>

--- a/one_fm/templates/emails/contracts_reminder.html
+++ b/one_fm/templates/emails/contracts_reminder.html
@@ -62,61 +62,76 @@
     .container p {
       margin-bottom: 10px;
     }
-    
+
+    .contract-block {
+      margin-bottom: 32px;
+    }
+
+    .contract-divider {
+      border: none;
+      border-top: 2px solid #cccccc;
+      margin: 24px 0;
+    }
     </style>
     
     <div class="container">
       <p>Please note that, today is the Contract internal notification Period for the following expiring contracts.</p>
     </div>
-    
+
+  {% for contract in contracts_list %}
+  {% if not loop.first %}
+  <hr class="contract-divider">
+  {% endif %}
+  <div class="contract-block">
   <table>
     <tbody class="contract_reminder">
       <tr>
         <th>Project</th>
-        <td>{{ project }}</td>
+        <td>{{ contract.project }}</td>
       </tr>
       <tr>
-        <th>{{ contract_end_internal_notif_period.name }}</th>
-        <td>{{ contract_end_internal_notif_period.value }}</td>
+        <th>{{ contract.contract_end_internal_notif_period.name }}</th>
+        <td>{{ contract.contract_end_internal_notif_period.value }}</td>
       </tr>
       <tr>
         <th>Start Date</th>
-        <td>{{ start_date }}</td>
+        <td>{{ contract.start_date }}</td>
       </tr>
       <tr>
-        <th>{{ contract_end_internal_notif_date.name }}</th>
-        <td>{{ contract_end_internal_notif_date.value }}</td>
+        <th>{{ contract.contract_end_internal_notif_date.name }}</th>
+        <td>{{ contract.contract_end_internal_notif_date.value }}</td>
       </tr>
       <tr>
-        <th>{{ contract_termination_decision_period.name }}</th>
-        <td>{{ contract_termination_decision_period.value }}</td>
+        <th>{{ contract.contract_termination_decision_period.name }}</th>
+        <td>{{ contract.contract_termination_decision_period.value }}</td>
       </tr>
       <tr>
-        <th>{{ contract_termination_decision_date.name }}</th>
-        <td>{{ contract_termination_decision_date.value }}</td>
+        <th>{{ contract.contract_termination_decision_date.name }}</th>
+        <td>{{ contract.contract_termination_decision_date.value }}</td>
       </tr>
       <tr>
         <th>End Date</th>
-        <td>{{ end_date }}</td>
+        <td>{{ contract.end_date }}</td>
       </tr>
       <tr>
         <th>Duration</th>
-        <td>{{ duration }}</td>
+        <td>{{ contract.duration }}</td>
       </tr>
       <tr>
         <th>Document ID</th>
-        <td>{{ document_id }}</td>
+        <td>{{ contract.document_id }}</td>
       </tr>
       <tr>
         <th>Link</th>
-        <td><a href="{{ link }}">Contract Form</a></td>
+        <td><a href="{{ contract.link }}">Contract Form</a></td>
       </tr>
-      {% if attachment is not none %}
+      {% if contract.attachment is not none %}
       <tr>
         <th>Attachment</th>
-        <td><a href={{ attachment }}>Contract Attachment</a></td>
+        <td><a href={{ contract.attachment }}>Contract Attachment</a></td>
       </tr>
       {% endif %}
     </tbody>
   </table>
-    
+  </div>
+  {% endfor %}


### PR DESCRIPTION
This pull request refactors the contract reminder notification system to send a single grouped email for all expiring contracts, instead of sending individual emails for each contract. The changes also update the email template to properly display multiple contracts in a clear, separated format.

Grouped contract reminder notifications:

* Refactored `send_contract_reminders` in `contracts.py` to collect all expiring contracts into a single `contracts_list` and render them together in one email, sent once to all recipients. [[1]](diffhunk://#diff-71416cff5bfcd080f483bda1d2784925039e4bf45f46262a591773443fdc13b7R1015-R1019) [[2]](diffhunk://#diff-71416cff5bfcd080f483bda1d2784925039e4bf45f46262a591773443fdc13b7L1028-R1036)

Email template improvements:

* Updated `contracts_reminder.html` to iterate over `contracts_list`, displaying each contract in its own block. Added a divider between contracts for clarity and switched all template variables to reference the contract object.