### PR TITLE
Implement customer credit limit check on Sales Order submission

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -364,8 +364,10 @@ doc_events = {
 		"on_submit":"one_fm.one_fm.sales_invoice_custom.submit_sales_invoice",
 		"before_cancel":'one_fm.one_fm.sales_invoice_custom.cancel_sales_invoice',
 		"validate": "one_fm.one_fm.sales_invoice_custom.set_print_settings_from_contracts",
-		"on_update_after_submit": "one_fm.one_fm.sales_invoice_custom.assign_collection_officer_to_sales_invoice_on_workflow_state"
+		"on_update_after_submit": "one_fm.one_fm.sales_invoice_custom.assign_collection_officer_to_sales_invoice_on_workflow_state",
+		"before_submit": "one_fm.one_fm.validation.check_credit_limit"
 	},
+		"before_submit": "one_fm.one_fm.validation.check_credit_limit",
 	"Salary Slip": {
 		"before_submit": "one_fm.overrides.salary_slip.salary_slip_before_submit",
 		"validate": [

--- a/validation.py
+++ b/validation.py
@@ -1,0 +1,17 @@
+
+import frappe
+from frappe import _
+
+def check_credit_limit(doc):
+    '''Check if Sales Order grand_total exceeds customer credit limit'''
+
+    if doc.docstatus != "1":
+        return  # Only check submitted Sales Orders
+
+    customer = frappe.get_doc("Customer", doc.customer)
+    if not customer.credit_limit:
+        return  # No credit limit set
+
+    if doc.grand_total > customer.credit_limit:
+        frappe.throw(_("Sales Order amount {0} exceeds credit limit {1} for customer {2}").format(
+            doc.grand_total, customer.credit_limit, doc.customer))


### PR DESCRIPTION
Implements a before_submit hook on Sales Order to check credit limit. Creates one_fm/one_fm/validation.py with check_credit_limit function and modifies one_fm/hooks.py to register the hook.