### PR TITLE
Add GST Number field to Client DocType

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -59,6 +60,12 @@
    "label": "Route Hash",
    "read_only": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Number",
+   "insert_after": "customer_name"
   }
  ],
  "has_web_view": 1,


### PR DESCRIPTION
This PR adds a GST Number field to the Client DocType in the one_fm app.

Files modified:
- one_fm/one_fm/doctype/client/client.json

How to verify:
1.  Install the one_fm app.
2.  Go to the Client DocType.
3.  Verify that the GST Number field is present.

Checklist:
-   [x] All new fields added to both `fields[]` AND `field_order[]` in DocType JSON
-   [ ] No `frappe.db.commit()` in controllers or @whitelist methods
-   [ ] Every `execute()` report function starts with `filters = frappe._dict(filters or {})`
-   [ ] No N+1 query loops — single grouped queries with lookup dicts
-   [ ] All SQL uses `AND docstatus = 1`
-   [ ] No `import` statements inside functions
-   [ ] Correct module directory (e.g., `one_fm/<module>/report/`)
-   [x] Files only inside `apps/one_fm/`

validate_doctype_json output:
```
✅ DocType JSON is valid: 'one_fm/one_fm/doctype/client/client.json'
   fields[]: 7 entries  |  field_order[]: 7 entries
   All fieldnames are correctly present in field_order.```