### PR TITLE
Add Employee Leave Balance Summary Report

### DIFF
--- a/one_fm/one_fm/report/employee_leave_balance_summary/employee_leave_balance_summary.js
+++ b/one_fm/one_fm/report/employee_leave_balance_summary/employee_leave_balance_summary.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2024, ONE FM and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Employee Leave Balance Summary"] = {
+	"filters": [
+		{
+			"fieldname": "company",
+			"label": __("Company"),
+			"fieldtype": "Link",
+			"options": "Company",
+			"mandatory": 1,
+			"default": frappe.defaults.get_user_default("Company")
+		}
+	]
+};

--- a/one_fm/one_fm/report/employee_leave_balance_summary/employee_leave_balance_summary.json
+++ b/one_fm/one_fm/report/employee_leave_balance_summary/employee_leave_balance_summary.json
@@ -1,0 +1,38 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2024-03-24 10:00:00.000000",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "mandatory": 1,
+   "options": "Company"
+  }
+ ],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "ONE FM",
+ "modified": "2024-03-24 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Employee Leave Balance Summary",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Employee",
+ "report_name": "Employee Leave Balance Summary",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "HR User"
+  },
+  {
+   "role": "HR Manager"
+  }
+ ]
+}

--- a/one_fm/one_fm/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/one_fm/one_fm/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024, ONE FM and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from hrms.hr.doctype.leave_application.leave_application import get_leave_balance_on
+
+def execute(filters=None):
+	columns = get_columns()
+	data = get_data(filters)
+	return columns, data
+
+def get_columns():
+	return [
+		{
+			"label": _("Employee ID"),
+			"fieldname": "employee_id",
+			"fieldtype": "Link",
+			"options": "Employee",
+			"width": 150
+		},
+		{
+			"label": _("Employee Name"),
+			"fieldname": "employee_name",
+			"fieldtype": "Data",
+			"width": 200
+		},
+		{
+			"label": _("Available Sick Leave Days"),
+			"fieldname": "available_sick_leave_days",
+			"fieldtype": "float",
+			"width": 200
+		}
+	]
+
+def get_data(filters):
+	data = []
+	company = filters.get("company")
+	
+	employees = frappe.get_all("Employee", 
+		filters={"company": company, "status": "Active"}, 
+		fields=["name", "employee_name"]
+	)
+	
+	leave_type = "Sick Leave"
+	date = frappe.utils.today()
+	
+	for employee in employees:
+		leave_balance = get_leave_balance_on(employee.name, leave_type, date)
+		data.append({
+			"employee_id": employee.name,
+			"employee_name": employee.employee_name,
+			"available_sick_leave_days": leave_balance
+		})
+	
+	return data


### PR DESCRIPTION
Created a new Script Report named "Employee Leave Balance Summary" in the "One Fm" module of the `one_fm` app.

Requirements:
1. Files: Generated the report's main JSON file, Python logic file, and JS filter file in `one_fm/one_fm/report/employee_leave_balance_summary/`.
2. Data Logic: The Python file executes a query to retrieve a list of active employees and their total available "Sick Leave" balance using `get_leave_balance_on`.
3. Output Columns: Displaying `Employee ID`, `Employee Name`, and `Available Sick Leave Days`.
4. Filters: Mandatory filter for `Company`.

The report is accessible to users with "HR User" and "HR Manager" roles.

Ref: #5329