### PR TITLE
fix: birthday and work anniversary notification crash #5761

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3720,8 +3720,8 @@ def get_users_for_reminders(birthday=False, anniversary=False, user_id=False):
 
 @frappe.whitelist()
 def send_work_anniversary_reminders():
-    from hrms.controllers.employee_reminders import send_work_anniversary_reminder, get_employees_having_an_event_today,get_work_anniversary_reminder_text
     """Send Employee Work Anniversary Reminders if 'Send Work Anniversary Reminders' is checked"""
+    from hrms.controllers.employee_reminders import send_work_anniversary_reminder, get_employees_having_an_event_today,get_work_anniversary_reminder_text
     to_send = cint(frappe.db.get_single_value("HR Settings", "send_work_anniversary_reminders")) or is_scheduler_emails_enabled()
     if not to_send:
         return

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3659,7 +3659,7 @@ def get_sender_email() -> str | None:
 
 @frappe.whitelist()
 def send_birthday_reminders():
-    """Send Employee birthday reminders if no 'Stop Birthday Reminders' is not set."""
+    """Send employee birthday reminders when birthday reminders are enabled."""
     from hrms.controllers.employee_reminders import send_birthday_reminder, get_employees_who_are_born_today, get_birthday_reminder_text_and_message
 
     to_send = cint(frappe.db.get_single_value("HR Settings", "send_birthday_reminders")) or is_scheduler_emails_enabled()

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3662,7 +3662,7 @@ def send_birthday_reminders():
     """Send Employee birthday reminders if no 'Stop Birthday Reminders' is not set."""
     from hrms.controllers.employee_reminders import send_birthday_reminder, get_employees_who_are_born_today, get_birthday_reminder_text_and_message
 
-    to_send = int(frappe.db.get_single_value("HR Settings", "send_birthday_reminders")) or is_scheduler_emails_enabled()
+    to_send = cint(frappe.db.get_single_value("HR Settings", "send_birthday_reminders")) or is_scheduler_emails_enabled()
     if not to_send:
         return
 
@@ -3722,7 +3722,7 @@ def get_users_for_reminders(birthday=False, anniversary=False, user_id=False):
 def send_work_anniversary_reminders():
     from hrms.controllers.employee_reminders import send_work_anniversary_reminder, get_employees_having_an_event_today,get_work_anniversary_reminder_text
     """Send Employee Work Anniversary Reminders if 'Send Work Anniversary Reminders' is checked"""
-    to_send = int(frappe.db.get_single_value("HR Settings", "send_work_anniversary_reminders")) or is_scheduler_emails_enabled()
+    to_send = cint(frappe.db.get_single_value("HR Settings", "send_work_anniversary_reminders")) or is_scheduler_emails_enabled()
     if not to_send:
         return
 


### PR DESCRIPTION
This PR fixes GitHub issue #5761 where birthday and work anniversary notifications stopped working.

The issue was caused by calling `int()` on `None` values for `send_birthday_reminders` and `send_work_anniversary_reminders` in `HR Settings`. According to the issue description, these values were recently changed to `None`, leading to a `TypeError` and causing the notification tasks to fail.

Changes:
- Replaced `int()` with `cint()` in `send_birthday_reminders` and `send_work_anniversary_reminders` within `one_fm/utils.py`. `cint()` safely handles `None` values by returning `0`, preventing the crash and allowing the scheduler emails check to proceed correctly.