### PR TITLE
Add GST Number Field to Client DocType

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -43,6 +44,15 @@
    "unique": 1
   },
   {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "GST Number",
+   "length": 15,
+   "search_index": 1
+  },
+  {
    "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",
@@ -63,7 +73,7 @@
  ],
  "has_web_view": 1,
  "links": [],
- "modified": "2024-06-18 16:42:20.352550",
+ "modified": "2025-02-14 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Client",


### PR DESCRIPTION
This pull request adds a new field `gst_number` to the `Client` DocType in the `one_fm` app.

Changes:
- Added `gst_number` to `field_order` and `fields` in `client.json`.
- The field is of type `Data` with a length of 15.
- Included `in_list_view`, `in_standard_filter`, and `search_index` for the new field.
- Updated `modified` timestamp.

Verification:
- Ran `bench migrate` to update the database.
- Verified that the `gst_number` column exists in `tabClient` table.
- Verified metadata in the site.