### PR TITLE
Add 'gst_number' field to Client DocType with validation

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -43,6 +44,12 @@
    "unique": 1
   },
   {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Registration Number",
+   "reqd": 1
+  },
+  {
    "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",
@@ -63,7 +70,7 @@
  ],
  "has_web_view": 1,
  "links": [],
- "modified": "2024-06-18 16:42:20.352550",
+ "modified": "2026-03-16 23:01:23.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Client",

--- a/one_fm/one_fm/doctype/client/client.py
+++ b/one_fm/one_fm/doctype/client/client.py
@@ -17,6 +17,9 @@ class Client(WebsiteGenerator):
             self.route_hash = self.hash
             self.route = f"client/{frappe.scrub(self.hash)}"
 
+        if self.gst_number and len(self.gst_number) != 15:
+            frappe.throw(_("GST number must be 15 characters."))
+
     def autoname(self):
         self.name = self.hash
 


### PR DESCRIPTION
This pull request adds the 'gst_number' field to the Client DocType with validation.

- Added 'gst_number' field (Field Type: Data, Label: "GST Registration Number", Required: Yes) to `client.json` immediately after the `customer_name` field.
- Implemented validation logic in the `Client` controller (`client.py`) to ensure the `gst_number` is exactly 15 characters long if provided.

Closes #5319