### PR TITLE
Add 'gst_number' field to Client DocType with validation (#5319)

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -43,6 +44,12 @@
    "unique": 1
   },
   {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Registration Number",
+   "reqd": 1
+  },
+  {
    "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",
@@ -63,7 +70,7 @@
  ],
  "has_web_view": 1,
  "links": [],
- "modified": "2024-06-18 16:42:20.352550",
+ "modified": "2026-03-16 23:11:23.916536",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Client",

--- a/one_fm/one_fm/doctype/client/client.py
+++ b/one_fm/one_fm/doctype/client/client.py
@@ -17,6 +17,9 @@ class Client(WebsiteGenerator):
             self.route_hash = self.hash
             self.route = f"client/{frappe.scrub(self.hash)}"
 
+        if self.gst_number and len(self.gst_number) != 15:
+            frappe.throw(_("GST number must be 15 characters."))
+
     def autoname(self):
         self.name = self.hash
 


### PR DESCRIPTION
This PR adds a mandatory 'gst_number' field to the Client DocType with a 15-character validation in the controller.

Changes:
- Modified `one_fm/one_fm/doctype/client/client.json` to add the `gst_number` field after `customer_name`.
- Modified `one_fm/one_fm/doctype/client/client.py` to add validation in the `validate` method.
- Updated `modified` and `modified_by` in `client.json`.

Closes #5319