### PR TITLE
Add 'gst_number' field to Client DocType with validation

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -43,6 +44,12 @@
    "unique": 1
   },
   {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Registration Number",
+   "reqd": 1
+  },
+  {
    "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",
@@ -63,7 +70,7 @@
  ],
  "has_web_view": 1,
  "links": [],
- "modified": "2024-06-18 16:42:20.352550",
+ "modified": "2024-06-19 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Client",

--- a/one_fm/one_fm/doctype/client/client.py
+++ b/one_fm/one_fm/doctype/client/client.py
@@ -17,6 +17,9 @@ class Client(WebsiteGenerator):
             self.route_hash = self.hash
             self.route = f"client/{frappe.scrub(self.hash)}"
 
+        if self.gst_number and len(self.gst_number) != 15:
+            frappe.throw(_("GST number must be 15 characters."))
+
     def autoname(self):
         self.name = self.hash
 


### PR DESCRIPTION
This PR adds a new mandatory field 'gst_number' to the Client DocType in the one_fm app and enforces validation rules via Python.

Requirements implemented:
1. Added 'gst_number' field (Field Type: Data, Label: "GST Registration Number", Required: Yes) to 'client.json' immediately after 'customer_name' field in both 'fields' and 'field_order' arrays.
2. Implemented validation logic in the 'Client' controller ('client.py'): If 'gst_number' is provided, it must be exactly 15 characters long. If not, a ValidationError is thrown.

Modified files:
- `one_fm/one_fm/doctype/client/client.json`
- `one_fm/one_fm/doctype/client/client.py`