### PR TITLE
Add 'gst_number' field to Client DocType with validation

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -41,6 +42,12 @@
    "fieldtype": "Data",
    "label": "Customer Name",
    "unique": 1
+  },
+  {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Registration Number",
+   "reqd": 1
   },
   {
    "default": "0",

--- a/one_fm/one_fm/doctype/client/client.py
+++ b/one_fm/one_fm/doctype/client/client.py
@@ -17,6 +17,9 @@ class Client(WebsiteGenerator):
             self.route_hash = self.hash
             self.route = f"client/{frappe.scrub(self.hash)}"
 
+        if self.gst_number and len(self.gst_number) != 15:
+            frappe.throw(_("GST number must be 15 characters."), frappe.ValidationError)
+
     def autoname(self):
         self.name = self.hash
 

--- a/one_fm/one_fm/doctype/client/test_client.py
+++ b/one_fm/one_fm/doctype/client/test_client.py
@@ -1,9 +1,43 @@
 # Copyright (c) 2024, ONE FM and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestClient(FrappeTestCase):
-	pass
+	def test_gst_number_validation(self):
+		# Create a customer if it doesn't exist
+		customer_name = "Test Customer for GST"
+		if not frappe.db.exists("Customer", customer_name):
+			frappe.get_doc({
+				"doctype": "Customer",
+				"customer_name": customer_name,
+				"customer_group": "All Customer Groups",
+				"territory": "All Territories"
+			}).insert()
+
+		# Test valid GST (15 chars)
+		client = frappe.get_doc({
+			"doctype": "Client",
+			"customer": customer_name,
+			"gst_number": "123456789012345"
+		})
+		client.insert()
+		self.assertEqual(len(client.gst_number), 15)
+
+		# Test invalid GST (too short)
+		client2 = frappe.get_doc({
+			"doctype": "Client",
+			"customer": customer_name,
+			"gst_number": "12345"
+		})
+		self.assertRaises(frappe.ValidationError, client2.insert)
+
+		# Test invalid GST (too long)
+		client3 = frappe.get_doc({
+			"doctype": "Client",
+			"customer": customer_name,
+			"gst_number": "1234567890123456"
+		})
+		self.assertRaises(frappe.ValidationError, client3.insert)


### PR DESCRIPTION
Added 'gst_number' field to Client DocType and implemented Python validation in the controller.

Changes:
- Modified `one_fm/one_fm/doctype/client/client.json` to add `gst_number` (Data, required) after `customer_name`.
- Modified `one_fm/one_fm/doctype/client/client.py` to add validation in `validate` hook to ensure `gst_number` is 15 characters long if provided.
- Added a test case in `one_fm/one_fm/doctype/client/test_client.py` to verify the validation logic.

Note: Attempts to run tests locally failed with "Site onefm does not exist!", but the site name was used as per instructions.
Issue: #5319