### PR TITLE
Add 'gst_number' field to Client DocType with validation

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -41,6 +42,12 @@
    "fieldtype": "Data",
    "label": "Customer Name",
    "unique": 1
+  },
+  {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Registration Number",
+   "reqd": 1
   },
   {
    "default": "0",

--- a/one_fm/one_fm/doctype/client/client.py
+++ b/one_fm/one_fm/doctype/client/client.py
@@ -17,6 +17,9 @@ class Client(WebsiteGenerator):
             self.route_hash = self.hash
             self.route = f"client/{frappe.scrub(self.hash)}"
 
+        if self.gst_number and len(self.gst_number) != 15:
+            frappe.throw(_("GST number must be 15 characters."))
+
     def autoname(self):
         self.name = self.hash
 


### PR DESCRIPTION
This PR adds a new mandatory field 'gst_number' to the 'Client' DocType and enforces a 15-character validation rule in its controller.

Changes:
- Added 'gst_number' to 'Client.json' after 'customer_name' field in 'fields' and 'field_order' arrays.
- Implemented 'validate' hook in 'client.py' to check the length of 'gst_number'.
- The GST number must be exactly 15 characters long; otherwise, a 'ValidationError' is raised.
- Fields updated: 'gst_number' (Data, Label: "GST Registration Number", Required: Yes).