### PR TITLE
Add 'gst_number' field to Client DocType with validation (v3)

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -43,6 +44,12 @@
    "unique": 1
   },
   {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Registration Number",
+   "reqd": 1
+  },
+  {
    "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",
@@ -63,7 +70,7 @@
  ],
  "has_web_view": 1,
  "links": [],
- "modified": "2024-06-18 16:42:20.352550",
+ "modified": "2026-03-17 00:02:44.367103",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Client",

--- a/one_fm/one_fm/doctype/client/client.py
+++ b/one_fm/one_fm/doctype/client/client.py
@@ -17,6 +17,9 @@ class Client(WebsiteGenerator):
             self.route_hash = self.hash
             self.route = f"client/{frappe.scrub(self.hash)}"
 
+        if self.gst_number and len(self.gst_number) != 15:
+            frappe.throw("GST number must be 15 characters.")
+
     def autoname(self):
         self.name = self.hash
 


### PR DESCRIPTION
This PR adds a new mandatory field `gst_number` (GST Registration Number) to the `Client` DocType in the `one_fm` app.

### Changes:
1.  **DocType Modification (`client.json`):**
    *   Added `gst_number` field of type `Data` with the label "GST Registration Number".
    *   Set the field as mandatory (`reqd: 1`).
    *   Inserted the field immediately after `customer_name` in both the `fields` and `field_order` arrays.
2.  **Controller Validation (`client.py`):**
    *   Added a validation rule in the `validate` method to ensure that if `gst_number` is provided, it must be exactly 15 characters long.
    *   Throws a `frappe.ValidationError` if the length is incorrect.

Note: The `modified` timestamp in `client.json` was also updated.