### PR TITLE
feat: Add 'gst_number' field to Client DocType

### DIFF
--- a/one_fm/one_fm/doctype/client/client.json
+++ b/one_fm/one_fm/doctype/client/client.json
@@ -8,6 +8,7 @@
  "field_order": [
   "customer",
   "customer_name",
+  "gst_number",
   "route_hash",
   "column_break_jhym",
   "published",
@@ -41,6 +42,12 @@
    "fieldtype": "Data",
    "label": "Customer Name",
    "unique": 1
+  },
+  {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "label": "GST Number",
+   "reqd": 1
   },
   {
    "default": "0",


### PR DESCRIPTION
This PR adds a new mandatory field 'gst_number' to the Client DocType in the one_fm app.

Changes:
- Modified `one_fm/one_fm/doctype/client/client.json` to include the `gst_number` field.
- The field is added after `customer_name` in the field order and fields array.
- Field properties: `fieldtype: "Data"`, `label: "GST Number"`, `reqd: 1`.

Verification:
- Ran `bench migrate` to update the database schema.
- Verified the field presence and properties using `frappe.get_meta('Client')`.
- Confirmed that the field is mandatory as requested.