### PR TITLE
fix: Attendance check created for employees with both check-ins #5780

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -542,19 +542,28 @@ def get_attendance_not_marked_shift_employees(attendance_date):
     # Fetch all the employees who is shift working but no attendance marked
     return frappe.db.sql("""
         SELECT
-            sa.employee
+            sa.employee, sa.roster_type, sa.name as shift_assignment
         FROM
             `tabShift Assignment` sa
         LEFT JOIN
             `tabAttendance` att
         ON
             sa.employee = att.employee AND att.attendance_date = %(attendance_date)s
+            AND sa.roster_type = att.roster_type
         WHERE
             sa.start_date <= %(attendance_date)s
             AND sa.end_date >= %(attendance_date)s
             AND sa.docstatus = 1
             AND sa.status = 'Active'
             AND att.name IS NULL
+            AND sa.name NOT IN (
+                SELECT ec.shift_assignment
+                FROM `tabEmployee Checkin` ec
+                WHERE ec.log_type IN ('IN', 'OUT')
+                AND ec.shift_assignment IS NOT NULL
+                GROUP BY ec.shift_assignment
+                HAVING COUNT(DISTINCT ec.log_type) = 2
+            )
     """, {"attendance_date": attendance_date}, as_dict=1)
 
 def insert_attendance_check_records(details, attendance_date):


### PR DESCRIPTION
This PR addresses GitHub issue #5780 where Attendance Check records were being created for employees who had already checked in and out.

Changes:
- Modified `get_attendance_not_marked_shift_employees` in `attendance_check.py` to:
    - Join `Shift Assignment` with `Attendance` on `roster_type` to ensure accuracy for employees with multiple shift types on the same day.
    - Added a filter to exclude employees who have both 'IN' and 'OUT' check-ins for their specific `Shift Assignment`.
    - Included `roster_type` and `shift_assignment` in the returned results to ensure the created `Attendance Check` records are correctly linked and categorized.

These changes ensure that Attendance Check records are only created when there is a genuine lack of check-in data or a failure to mark attendance despite missing check-ins, avoiding redundant manual approval for employees who followed the standard check-in/out process.