### PR TITLE
fix: Attendance check and checkin issue for multi-day shifts

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -69,7 +69,8 @@ class AttendanceCheck(Document):
             "Shift Assignment",
             {
                 "employee":self.employee,
-                "start_date":self.date,
+                "start_date": ["<=", self.date],
+                "end_date": [">=", self.date],
                 "roster_type":self.roster_type,
                 "status":"Active",
                 "docstatus":1
@@ -481,7 +482,11 @@ class AttendanceCheck(Document):
                 attendance.shift_assignment = self.shift_assignment
             else:
                 shift_assignment = frappe.db.exists("Shift Assignment", {
-                        'employee':self.employee, 'start_date':self.date, 'roster_type':self.roster_type
+                        'employee':self.employee,
+                        'start_date': ['<=', self.date],
+                        'end_date': [">=", self.date],
+                        'roster_type':self.roster_type,
+                        'docstatus': 1
                     })
                 if shift_assignment:
                     attendance.shift_assignment = shift_assignment

--- a/one_fm/one_fm/report/summary_attendance_report/summary_attendance_report.py
+++ b/one_fm/one_fm/report/summary_attendance_report/summary_attendance_report.py
@@ -52,7 +52,7 @@ def get_scheduled_employees(date):
     
 
 def get_assigned_shift(date):
-    value = frappe.db.sql(f"""SELECT DISTINCT employee from `tabShift Assignment` where start_date = '{date}'  """,as_dict=1)
+    value = frappe.db.sql(f"""SELECT DISTINCT employee from `tabShift Assignment` where start_date <= '{date}' and end_date >= '{date}'  """,as_dict=1)
     return [each.employee for each in value] if value else list() 
 
 

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -90,7 +90,8 @@ class AttendanceOverride(Attendance):
         if not self.shift_assignment and self.status=='Present':
             shift_assignment = frappe.db.get_value("Shift Assignment", {
                 'employee':self.employee,
-                'start_date':self.attendance_date,
+                'start_date': ['<=', self.attendance_date],
+                'end_date': ['>=', self.attendance_date],
                 'status':'Active',
                 'roster_type':'Basic',
                 'docstatus':1
@@ -239,7 +240,8 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
                     "Shift Assignment",
                     {
                         "employee": employee.name,
-                        "start_date": att_date,
+                        "start_date": ["<=", att_date],
+                        "end_date": [">=", att_date],
                         "status": "Active",
                         "docstatus": 1,
                         "shift_type": att_req.shift,
@@ -288,7 +290,8 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
 def mark_for_shift_assignment(employee, att_date, roster_type='Basic'):
     shift_assignment = frappe.db.get_value("Shift Assignment", {
         'employee':employee,
-        'start_date':att_date.date(),
+        'start_date': ['<=', att_date.date()],
+        'end_date': ['>=', att_date.date()],
         'roster_type':roster_type,
         'docstatus':1
         }, ["*"], as_dict=1
@@ -496,7 +499,8 @@ def mark_attendance_for_unscheduled_employees(employees, date):
         
         # Get employees with shift assignments
         shift_assigned_employees = frappe.get_all("Shift Assignment", {
-            'start_date': date,
+            'start_date': ['<=', date],
+            'end_date': ['>=', date],
             'employee': ['IN', [e.name for e in employees]],
             'docstatus': 1
         }, pluck="employee")
@@ -665,8 +669,8 @@ def remark_absent_for_employees(employees, date):
 
 def mark_overtime_attendance(from_date, to_date):
     shift_assignments = frappe.db.get_list("Shift Assignment", filters={
-        'start_date':from_date,
-        'end_date':to_date,
+        'start_date': ['<=', from_date],
+        'end_date': ['>=', to_date],
         'roster_type': 'Over-Time',
         'docstatus':1
     }, fields=["employee"])
@@ -816,7 +820,8 @@ def mark_daily_attendance(start_date, end_date):
         for i in attendance_request:
             shift_assignment = frappe.db.get_value("Shift Assignment", {
                 'employee':i.name,
-                'start_date': start_date,
+                'start_date': ['<=', start_date],
+                'end_date': ['>=', start_date],
                 "status": "Active",
                 "docstatus":1}) or ""
             
@@ -1163,7 +1168,8 @@ class AttendanceMarking():
                 SELECT sa.* FROM `tabShift Assignment` sa
                 JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
-                AND sa.start_date='{self.start.date()}'
+                AND sa.start_date <= '{self.start.date()}'
+                AND sa.end_date >= '{self.start.date()}'
                 AND op.attendance_by_client=1 AND op.docstatus=1
                 ;
             """, as_dict=1)
@@ -1175,7 +1181,8 @@ class AttendanceMarking():
                 SELECT sa.* FROM `tabShift Assignment` sa
                 JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
-                AND sa.start_date='{self.start.date()}'
+                AND sa.start_date <= '{self.start.date()}'
+                AND sa.end_date >= '{self.start.date()}'
                 AND op.attendance_by_client=0 AND op.status='Active'
             """, as_dict=1)
             non_shifts = frappe.db.sql(f"""

--- a/one_fm/overrides/attendance_request.py
+++ b/one_fm/overrides/attendance_request.py
@@ -95,7 +95,13 @@ class AttendanceRequestOverride(AttendanceRequest):
 		"""
 			Check if shift exist for employee
 		"""
-		shift_check = frappe.db.exists("Shift Assignment",{'employee':self.employee, 'docstatus':1, 'status':'Active', 'start_date':attendance_date})
+		shift_check = frappe.db.exists("Shift Assignment", {
+			'employee': self.employee,
+			'docstatus': 1,
+			'status': 'Active',
+			'start_date': ['<=', attendance_date],
+			'end_date': ['>=', attendance_date]
+		})
 		return frappe.get_doc("Shift Assignment", shift_check) if shift_check else False
 
 	def create_attendance(self):


### PR DESCRIPTION
This PR fixes GitHub issue #5780: "Attendance check and checkin issue".

The root cause was that `Shift Assignment` was being filtered strictly by `start_date == target_date` in many places across the attendance system. This meant that if a `Shift Assignment` spanned multiple days (e.g. 1 month), it was only recognized on its first day.

Consequences fixed by this PR:
1.  **Attendance Marking**: Attendance was not being automatically marked for employees in the middle of a multi-day shift assignment, leading to missing attendance or incorrect 'Absent' status.
2.  **Attendance Check Creation**: `Attendance Check` records were being created for these employees because they lacked an `Attendance` record.
3.  **Attendance Check Review**: The `Attendance Check` document failed to show the employee's check-in/out records because it also couldn't find the `Shift Assignment` due to the same bug. This made it look like the employee hadn't checked in even when they had.
4.  **Reports and Validation**: Reports and other validations (like in `Attendance Request`) were also failing to recognize active shifts for the same reason.

Changes made:
-   Updated `one_fm/one_fm/doctype/attendance_check/attendance_check.py` to use range check for `Shift Assignment`.
-   Updated `one_fm/overrides/attendance.py` (multiple functions) to use range check for `Shift Assignment`.
-   Updated `one_fm/overrides/attendance_request.py` to use range check for `Shift Assignment`.
-   Updated `one_fm/one_fm/report/summary_attendance_report/summary_attendance_report.py` to use range check for `Shift Assignment`.