### PR TITLE
fix: Item Price duplicate check logic for empty fields

### DIFF
--- a/one_fm/api/doc_methods/item_price.py
+++ b/one_fm/api/doc_methods/item_price.py
@@ -37,6 +37,8 @@ def check_duplicates(self):
         else:
             if field in ["packing_unit", "shift_hours"]:
                 conditions += " and ({0} is null or {0} = 0)".format(field)
+            elif field in ["valid_from", "valid_upto"]:
+                conditions += " and {0} is null".format(field)
             else:
                 conditions += " and ({0} is null or {0} = '')".format(field)
 

--- a/one_fm/api/doc_methods/item_price.py
+++ b/one_fm/api/doc_methods/item_price.py
@@ -43,9 +43,10 @@ def check_duplicates(self):
                 conditions += " and ({0} is null or {0} = '')".format(field)
 
     price_list_rate = frappe.db.sql("""
-        SELECT price_list_rate
+        SELECT name
         FROM `tabItem Price`
-            {conditions} """.format(conditions=conditions), self.as_dict())
+            {conditions}
+        LIMIT 1""".format(conditions=conditions), self.as_dict())
 
     if price_list_rate:
         frappe.throw(_(error_description), ItemPriceDuplicateItem)

--- a/one_fm/api/doc_methods/item_price.py
+++ b/one_fm/api/doc_methods/item_price.py
@@ -22,24 +22,28 @@ def validate(self):
 
 def check_duplicates(self):
     error_description = "Item Price appears multiple times based on Price List, Supplier/Customer, Currency, Item, UOM, Qty, Dates"
-    field_list = ['uom', 'valid_from',
-        'valid_upto', 'packing_unit', 'customer', 'supplier']
-    is_service_item, item_group = frappe.get_value('Item',{'item_code': self.item_code},['is_stock_item', 'subitem_group'])
-    if is_service_item == 0 and item_group == 'Service':
-        field_list.remove('valid_from')
-        field_list.remove('valid_upto')
-        field_list += ['gender', 'shift_hours', 'days_off']
+    field_list = ["uom", "valid_from", "valid_upto", "packing_unit", "customer", "supplier", "currency"]
+    is_service_item, item_group = frappe.get_value("Item", {"item_code": self.item_code}, ["is_stock_item", "subitem_group"])
+    if is_service_item == 0 and item_group == "Service":
+        field_list.remove("valid_from")
+        field_list.remove("valid_upto")
+        field_list += ["gender", "shift_hours", "days_off"]
         error_description += ", Gender, Shift Hour, Day off"
     conditions = "where item_code=%(item_code)s and price_list=%(price_list)s and name != %(name)s"
 
     for field in field_list:
         if self.get(field):
             conditions += " and {0} = %({1})s".format(field, field)
+        else:
+            if field in ["packing_unit", "shift_hours"]:
+                conditions += " and ({0} is null or {0} = 0)".format(field)
+            else:
+                conditions += " and ({0} is null or {0} = '')".format(field)
 
     price_list_rate = frappe.db.sql("""
         SELECT price_list_rate
         FROM `tabItem Price`
             {conditions} """.format(conditions=conditions), self.as_dict())
 
-    if price_list_rate :
+    if price_list_rate:
         frappe.throw(_(error_description), ItemPriceDuplicateItem)


### PR DESCRIPTION
### Description
This PR fixes the duplicate check logic for `Item Price` in the `one_fm` app. Previously, the logic omitted empty fields from the `WHERE` clause, causing generic item prices (e.g., without a customer) to conflict with customer-specific prices.

### Changes
- Modified `one_fm/api/doc_methods/item_price.py`:
    - Updated `check_duplicates` to explicitly handle `NULL` or empty values in the database when the current document's field is empty.
    - Added `currency` to the list of fields checked for duplicates.
    - Ensured numeric fields (`packing_unit`, `shift_hours`) check for `0` or `NULL`.

### Verification Results
- Verified that the SQL query now correctly handles empty fields using `(field IS NULL OR field = '')` or `(field IS NULL OR field = 0)`.
- Verified database schema for `tabItem Price` and custom fields.
- Note: `bench migrate` failed due to a pre-existing duplicate in `patches.txt`, which should be addressed separately.

### Review Checklist
- [x] No `frappe.db.commit()` in controllers.
- [x] No N+1 query loops.
- [x] SQL uses parameterized queries.
- [x] Correct file paths and module organization.