### PR TITLE
feat: timesheet - assignment rule

### DIFF
--- a/one_fm/custom/assignment_rule/approve_timesheet_approver.json
+++ b/one_fm/custom/assignment_rule/approve_timesheet_approver.json
@@ -1,0 +1,45 @@
+{
+    "name": "Approve Timesheet -Approver",
+    "document_type": "Timesheet",
+    "due_date_based_on": "start_date",
+    "priority": 0,
+    "disabled": 0,
+    "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.<br>The details of the request are as follows:<br></p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\"> <thead> <tr> <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th> <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th> </tr> </thead> <tbody> <tr> <td style=\"padding: 10px;\">Employee</td> <td style=\"padding: 10px;\">{{employee}}</td> </tr> </tbody></table><p></p>",
+    "is_assignment_rule_with_workflow": 1,
+    "assign_condition": "workflow_state == \"Pending Approval\"",
+    "unassign_condition": "workflow_state != \"Pending Approval\"",
+    "rule": "Based on Field",
+    "field": "approver",
+    "doctype": "Assignment Rule",
+    "assignment_days": [
+        {
+            "day": "Monday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Tuesday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Wednesday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Thursday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Friday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Saturday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Sunday",
+            "doctype": "Assignment Rule Day"
+        }
+    ],
+    "users": []
+}

--- a/one_fm/custom/assignment_rule/submit_timesheet_employee.json
+++ b/one_fm/custom/assignment_rule/submit_timesheet_employee.json
@@ -1,0 +1,45 @@
+{
+    "name": "Submit Timesheet -Employee",
+    "document_type": "Timesheet",
+    "due_date_based_on": "start_date",
+    "priority": 0,
+    "disabled": 0,
+    "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.<br>The details of the request are as follows:<br></p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\"> <thead> <tr> <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th> <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th> </tr> </thead> <tbody> <tr> <td style=\"padding: 10px;\">Employee</td> <td style=\"padding: 10px;\">{{employee}}</td> </tr> </tbody></table><p></p>",
+    "is_assignment_rule_with_workflow": 1,
+    "assign_condition": "workflow_state == \"Draft\"",
+    "unassign_condition": "workflow_state != \"Draft\"",
+    "rule": "Based on Field",
+    "field": "owner",
+    "doctype": "Assignment Rule",
+    "assignment_days": [
+        {
+            "day": "Monday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Tuesday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Wednesday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Thursday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Friday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Saturday",
+            "doctype": "Assignment Rule Day"
+        },
+        {
+            "day": "Sunday",
+            "doctype": "Assignment Rule Day"
+        }
+    ],
+    "users": []
+}

--- a/one_fm/overrides/timesheet.py
+++ b/one_fm/overrides/timesheet.py
@@ -1,12 +1,11 @@
 import frappe
 import itertools
-from frappe.desk.form.assign_to import add as add_assignment
 from frappe.utils import cstr, flt, add_days, time_diff_in_hours, getdate, get_datetime_in_timezone
 from calendar import monthrange
 from hrms.overrides.employee_timesheet import *
 from frappe import _
 from one_fm.processor import sendemail
-from one_fm.utils import send_workflow_action_email, get_approver_user
+from one_fm.utils import get_approver_user
 
 
 class TimesheetOveride(Timesheet):
@@ -39,7 +38,6 @@ class TimesheetOveride(Timesheet):
             # If any of the above criteria is fulfilled then throw an error.
             if (self.has_value_changed("start_date") and date_in_ast > self.get('start_date')) or (self.has_value_changed("end_date") and date_in_ast > self.get('end_date')):
                 frappe.throw(_("Please note that timesheets cannot be updated to a previous date."), title="Invalid Start Date")
-        self.assign_unassign()
 
     def set_approver(self):
         if self.attendance_by_timesheet:
@@ -54,13 +52,6 @@ class TimesheetOveride(Timesheet):
         if self.total_hours <= 0:
             frappe.throw("Total Hours cannot be 0 or less.")
 
-    def on_update(self):
-        if self.workflow_state == 'Pending Approval':
-            send_workflow_action_email(self, [self.approver])
-            message = "The timesheet {0} of {1}, Open for your Approval".format(self.name, self.employee_name)
-            create_notification_log("Pending - Workflow Action on Timesheet", message, [self.approver], self)
-
-
     def on_submit(self):
         self.validate_mandatory_fields()
         self.update_task_and_project()
@@ -70,7 +61,6 @@ class TimesheetOveride(Timesheet):
         elif self.workflow_state == "Canceled":
             self.check_approver()
             self.notify_the_employee()
-        self.delete_todo()
 
     def notify_the_employee(self):
         timesheet_url = '<a href="{0}">{1}</a>'.format(frappe.utils.get_link_to_form("Timesheet", self.name), self.name)
@@ -125,56 +115,6 @@ class TimesheetOveride(Timesheet):
     def check_approver(self):
         if frappe.session.user not in [self.approver, "Administrator"]:
             frappe.throw(_("Only Approver can Approve/Reject the timesheet"))
-
-    def assign_unassign(self) -> None:
-        previous_doc = self.get_doc_before_save() if not self.is_new() else self
-        if previous_doc.workflow_state != self.workflow_state:
-            self.delete_todo()
-            if self.workflow_state in {"Draft",  "Pending Approval"}:
-                add_assignment({
-                    'doctype': self.doctype,
-                    'name': self.name,
-                    'assign_to': [self.owner if self.workflow_state == "Draft" else self.approver],
-                    'description': (_(self.fetch_description()))
-                })
-
-
-    def delete_todo(self):
-        todos_linked_to_timesheet = frappe.db.get_list('ToDo',
-            filters={'reference_type': self.doctype, 'reference_name': self.name},
-            pluck='name'
-        )
-        if not todos_linked_to_timesheet:
-            return
-        for todo in todos_linked_to_timesheet:
-            try:
-                frappe.delete_doc('ToDo', todo, ignore_permissions=True)
-            except Exception as e:
-                frappe.log_error(message=f"Failed to delete ToDo {todo} on Timesheet update: {e}", title="Timesheet ToDo Deletion Error")
-                continue
-
-    def fetch_description(self):
-        return f"""
-            <p>Here is to inform you that the following { self.doctype }({ self.name }) requires your attention/action.
-            <br>
-            The details of the request are as follows:
-            <br>
-            </p><table border="1" cellpadding="0" cellspacing="0" style="border-collapse: collapse;">
-                <thead>
-                    <tr>
-                        <th style="padding: 10px; text-align: left; background-color: #f2f2f2;">Label</th>
-                        <th style="padding: 10px; text-align: left; background-color: #f2f2f2;">Value</th>
-                    </tr>
-                </thead>
-            <tbody>
-
-                <tr>
-                    <td style="padding: 10px;">Employee</td>
-                    <td style="padding: 10px;">{ self.employee }</td>
-                </tr>
-                </tbody></table><p></p>
-
-        """
 
 def timesheet_automation(start_date=None,end_date=None,project=None):
     filters = {

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -270,6 +270,8 @@ one_fm.patches.v15_0.add_day_off_preference #2
 one_fm.patches.v15_0.update_job_offer_for_ERF_2026_00004
 one_fm.patches.v15_0.add_index_to_leave_application_in_attendance
 one_fm.patches.v15_0.update_attendance_request_assignment_rule
+one_fm.patches.v15_0.add_assignment_rule_submit_timesheet_employee
+one_fm.patches.v15_0.add_assignment_rule_approve_timesheet_approver
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/add_assignment_rule_approve_timesheet_approver.py
+++ b/one_fm/patches/v15_0/add_assignment_rule_approve_timesheet_approver.py
@@ -1,0 +1,4 @@
+from one_fm.custom.assignment_rule.assignment_rule import get_assignment_rule_json_file, create_assignment_rule
+
+def execute():
+	create_assignment_rule(get_assignment_rule_json_file("approve_timesheet_approver.json"))

--- a/one_fm/patches/v15_0/add_assignment_rule_submit_timesheet_employee.py
+++ b/one_fm/patches/v15_0/add_assignment_rule_submit_timesheet_employee.py
@@ -1,0 +1,4 @@
+from one_fm.custom.assignment_rule.assignment_rule import get_assignment_rule_json_file, create_assignment_rule
+
+def execute():
+	create_assignment_rule(get_assignment_rule_json_file("submit_timesheet_employee.json"))

--- a/one_fm/setup/assignment_rule.py
+++ b/one_fm/setup/assignment_rule.py
@@ -62,6 +62,8 @@ def create_assignment_rules():
 	create_assignment_rule(get_assignment_rule_json_file("erf_bulk_recruitment.json"))
 	create_assignment_rule(get_assignment_rule_json_file("assigning_operations_manager_for_approval_temporary_deployment.json"))
 	create_assignment_rule(get_assignment_rule_json_file("returning_to_operations_supervisor_of_temporary_deployment.json"))
+	create_assignment_rule(get_assignment_rule_json_file("submit_timesheet_employee.json"))
+	create_assignment_rule(get_assignment_rule_json_file("approve_timesheet_approver.json"))
 
 def delete_assignment_rules():
 	delete_assignment_rule(get_assignment_rule_json_file("roster_post_action_site_supervisor.json"))

--- a/one_fm/tests/test_timesheet.py
+++ b/one_fm/tests/test_timesheet.py
@@ -1,0 +1,332 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+from unittest.mock import patch
+
+from one_fm.tests.utils import create_test_company, make_employee
+from frappe.workflow.doctype.workflow_action.workflow_action import apply_workflow
+
+
+def make_timesheet(employee, approver_user, start_date=None, attendance_by_timesheet=1):
+    """
+    Create a draft Timesheet document for the given employee.
+
+    - ``employee`` must have a valid ``user_id`` set.
+    - ``approver_user`` is the *user_id* (email) of the line-manager / approver.
+    - A single time-log entry of 8 hours is appended so that total_hours > 0,
+      which is required to pass the before_submit guard.
+    - ``ignore_permissions=True`` is used throughout because the test context
+      runs as Administrator and we are only verifying workflow/assignment logic,
+      not permission checks.
+    """
+    if start_date is None:
+        start_date = nowdate()
+
+    from_time = "{} 08:00:00".format(start_date)
+    to_time   = "{} 16:00:00".format(start_date)
+
+    timesheet = frappe.get_doc({
+        "doctype": "Timesheet",
+        "employee": employee,
+        "start_date": start_date,
+        "end_date": start_date,
+        "approver": approver_user,
+        "attendance_by_timesheet": attendance_by_timesheet,
+        "time_logs": [
+            {
+                "activity_type": frappe.db.get_value("Activity Type", {}, "name")
+                                 or _ensure_activity_type(),
+                "from_time": from_time,
+                "to_time":   to_time,
+                "hours": 8,
+            }
+        ],
+    })
+    timesheet.insert(ignore_permissions=True)
+    return timesheet
+
+
+def _ensure_activity_type():
+    """Create a minimal Activity Type if none exists (required child-table field)."""
+    if not frappe.db.exists("Activity Type", "General"):
+        frappe.get_doc({"doctype": "Activity Type", "activity_type": "General"}).insert(
+            ignore_permissions=True
+        )
+    return "General"
+
+
+class TestTimesheetWorkflow(FrappeTestCase):
+    """
+    Test suite for the Timesheet workflow transitions and the two Assignment Rules:
+
+    * **Submit Timesheet - Employee**
+      assign_condition : workflow_state == "Draft"
+      unassign_condition: workflow_state != "Draft"
+      field : owner
+
+    * **Approve Timesheet - Approver**
+      assign_condition : workflow_state == "Pending Approval"
+      unassign_condition: workflow_state != "Pending Approval"
+      field : approver
+    """
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setUp(self):
+        """
+        Prepare master data required by every test.
+        - Runs as Administrator.
+        - Creates '_Test Company' if missing.
+        - Creates an employee (owner/submitter) and a separate approver employee.
+        - Cleans up any leftover Timesheets from previous runs.
+        """
+        frappe.set_user("Administrator")
+        create_test_company()
+
+        # Employee who owns / submits the timesheet
+        self.employee = make_employee(
+            "ts_owner@testcompany.com", company="_Test Company"
+        )
+        # Employee who is the approver
+        self.approver_employee = make_employee(
+            "ts_approver@testcompany.com", company="_Test Company"
+        )
+
+        # Ensure approver's user_id is set
+        self.approver_user = frappe.db.get_value(
+            "Employee", self.approver_employee.name, "user_id"
+        )
+        self.owner_user = frappe.db.get_value(
+            "Employee", self.employee.name, "user_id"
+        )
+
+        # Point the employee's reports_to to the approver so fetch_approver works
+        frappe.db.set_value(
+            "Employee", self.employee.name, "reports_to", self.approver_employee.name
+        )
+
+        # Clean up stale timesheets from this employee (previous test runs)
+        frappe.db.delete("Timesheet", {"employee": self.employee.name})
+
+        _ensure_activity_type()
+
+    def tearDown(self):
+        """
+        Wipe all Timesheets created during the test and rollback any pending
+        transaction so the next test starts from a clean state.
+        """
+        frappe.db.delete("Timesheet", {"employee": self.employee.name})
+        frappe.db.delete("ToDo", {
+            "reference_type": "Timesheet",
+        })
+        frappe.db.rollback()
+        frappe.set_user("Administrator")
+
+    # ------------------------------------------------------------------
+    # Helper
+    # ------------------------------------------------------------------
+
+    def _create_draft_timesheet(self):
+        """Create and return a fresh Draft timesheet for self.employee."""
+        return make_timesheet(
+            employee=self.employee.name,
+            approver_user=self.approver_user,
+        )
+
+    # ------------------------------------------------------------------
+    # Test 1
+    # ------------------------------------------------------------------
+
+    @patch("frappe.sendmail")
+    def test_submit_for_approval_creates_todo_for_approver(self, mock_sendmail):
+        """
+        Scenario: Employee submits a timesheet for approval.
+
+        Expected:
+        - workflow_state transitions from "Draft" → "Pending Approval".
+        - Assignment Rule 'Approve Timesheet -Approver' fires and creates an
+          Open ToDo allocated to the approver's user account.
+        """
+        mock_sendmail.return_value = None
+
+        timesheet = self._create_draft_timesheet()
+
+        # Transition: Draft → Pending Approval
+        apply_workflow(timesheet, "Submit for Review")
+        timesheet.reload()
+
+        self.assertEqual(
+            timesheet.workflow_state,
+            "Pending Approval",
+            "Workflow state should be 'Pending Approval' after Submit for Review",
+        )
+
+        # Verify ToDo was created for the approver
+        todo = frappe.db.get_value(
+            "ToDo",
+            {
+                "reference_type": "Timesheet",
+                "reference_name": timesheet.name,
+                "allocated_to": self.approver_user,
+                "status": "Open",
+            },
+            "name",
+        )
+        self.assertTrue(
+            todo,
+            "An Open ToDo should be created for the approver when the timesheet "
+            "enters 'Pending Approval' state",
+        )
+
+        # Also verify DB truth
+        db_todo_status = frappe.db.get_value("ToDo", todo, "status")
+        self.assertEqual(
+            db_todo_status,
+            "Open",
+            "The ToDo record in the database should have status 'Open'",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 2
+    # ------------------------------------------------------------------
+
+    @patch("frappe.sendmail")
+    def test_return_to_draft_creates_todo_for_owner(self, mock_sendmail):
+        """
+        Scenario: Approver returns the timesheet to Draft (rejects / requests changes).
+
+        Expected:
+        - workflow_state transitions Draft → Pending Approval → Draft.
+        - When back in 'Draft', Assignment Rule 'Submit Timesheet -Employee' fires
+          and creates (or re-creates) an Open ToDo for the document owner.
+        - The Approver's ToDo (allocated during Pending Approval) should no longer
+          be Open (it is Cancelled by the unassign_condition).
+        """
+        mock_sendmail.return_value = None
+
+        timesheet = self._create_draft_timesheet()
+        owner_user = timesheet.owner  # the frappe user who created the doc
+
+        # Draft → Pending Approval
+        apply_workflow(timesheet, "Submit for Review")
+        timesheet.reload()
+
+        # Pending Approval → Draft (Return To Draft)
+        apply_workflow(timesheet, "Return To Draft")
+        timesheet.reload()
+
+        self.assertEqual(
+            timesheet.workflow_state,
+            "Draft",
+            "Workflow state should return to 'Draft' after 'Return To Draft' action",
+        )
+
+        # A new Open ToDo should now be allocated to the timesheet OWNER
+        todo = frappe.db.get_value(
+            "ToDo",
+            {
+                "reference_type": "Timesheet",
+                "reference_name": timesheet.name,
+                "allocated_to": owner_user,
+                "status": "Open",
+            },
+            "name",
+        )
+        self.assertTrue(
+            todo,
+            "An Open ToDo should be created for the timesheet owner when the "
+            "document is returned to 'Draft' state",
+        )
+
+        # Verify approver's ToDo is NOT open any more (was unassigned)
+        approver_todo_open = frappe.db.get_value(
+            "ToDo",
+            {
+                "reference_type": "Timesheet",
+                "reference_name": timesheet.name,
+                "allocated_to": self.approver_user,
+                "status": "Open",
+            },
+            "name",
+        )
+        self.assertFalse(
+            approver_todo_open,
+            "The approver's ToDo should NOT be Open after the document leaves "
+            "'Pending Approval' (unassign_condition should close it)",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 3
+    # ------------------------------------------------------------------
+
+    @patch("frappe.sendmail")
+    def test_approve_cancels_approver_todo(self, mock_sendmail):
+        """
+        Scenario: Approver approves the timesheet.
+
+        Expected:
+        - workflow_state transitions Draft → Pending Approval → Approved.
+        - Once the document leaves 'Pending Approval', the unassign_condition
+          of 'Approve Timesheet -Approver' triggers and the approver's ToDo
+          status becomes 'Cancelled'.
+        """
+        mock_sendmail.return_value = None
+
+        timesheet = self._create_draft_timesheet()
+
+        # Draft → Pending Approval
+        apply_workflow(timesheet, "Submit for Review")
+        timesheet.reload()
+
+        # Capture the approver ToDo name while it is still in Pending Approval
+        approver_todo = frappe.db.get_value(
+            "ToDo",
+            {
+                "reference_type": "Timesheet",
+                "reference_name": timesheet.name,
+                "allocated_to": self.approver_user,
+            },
+            "name",
+        )
+
+        # Pending Approval → Approved
+        apply_workflow(timesheet, "Approve")
+        timesheet.reload()
+
+        self.assertEqual(
+            timesheet.workflow_state,
+            "Approved",
+            "Workflow state should be 'Approved' after 'Approve' action",
+        )
+
+        # After leaving Pending Approval the ToDo for the approver must be Cancelled
+        self.assertTrue(
+            approver_todo,
+            "A ToDo for the approver must have been created in Pending Approval state",
+        )
+
+        todo_status = frappe.db.get_value("ToDo", approver_todo, "status")
+        self.assertEqual(
+            todo_status,
+            "Cancelled",
+            "The approver's ToDo should be 'Cancelled' once the timesheet is "
+            "approved and leaves 'Pending Approval' state",
+        )
+
+        # Double-check via DB query (no leftover Open todo for approver)
+        open_approver_todo = frappe.db.get_value(
+            "ToDo",
+            {
+                "reference_type": "Timesheet",
+                "reference_name": timesheet.name,
+                "allocated_to": self.approver_user,
+                "status": "Open",
+            },
+            "name",
+        )
+        self.assertFalse(
+            open_approver_todo,
+            "No Open ToDo should remain for the approver after the timesheet is approved",
+        )


### PR DESCRIPTION
This pull request introduces two new Assignment Rules for the Timesheet workflow and removes custom assignment/unassignment logic from the Timesheet Python override. It ensures that ToDo assignments for Timesheet approval and submission are managed through standard Assignment Rules, and adds comprehensive tests to verify correct workflow and assignment behavior.

**Assignment Rule Integration and Workflow Automation:**

* Added two new Assignment Rule JSON definitions for Timesheet submission by employees and approval by approvers, specifying assignment/unassignment conditions and assignment fields. [[1]](diffhunk://#diff-86557b948b5a29a6975345205f7984ab1e6f9172a8d84f008ce952c3b49a1407R1-R45) [[2]](diffhunk://#diff-9d63a89a15a75e23ca685d36e97c2dd90d69514cb093d48ddc8165a65d8bfed6R1-R45)
* Registered these Assignment Rules in the patching system and setup routines to ensure they are created automatically on update or installation. [[1]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R273-R274) [[2]](diffhunk://#diff-fe7873ea3338f4bfbe259747a0a8e3bb7c1baecf0c0067d469b0bfaf6f05fbe8R65-R66) [[3]](diffhunk://#diff-aba5a2e3072a4bec8aea8c6e090f13f83c8cb74b4baceeaca7c1872b60287ca2R1-R4) [[4]](diffhunk://#diff-5e8799403b48a49db85f50a81448078089f8fd5094d073120edf588ad68fbc44R1-R4)

**Codebase Simplification and Cleanup:**

* Removed custom assignment/unassignment and ToDo deletion logic from `one_fm/overrides/timesheet.py`, relying instead on the new Assignment Rules for managing ToDo records. [[1]](diffhunk://#diff-c8176c56082336098f607fe742602f71684ab646f9c886e0c41d34274021bff9L3-R8) [[2]](diffhunk://#diff-c8176c56082336098f607fe742602f71684ab646f9c886e0c41d34274021bff9L42) [[3]](diffhunk://#diff-c8176c56082336098f607fe742602f71684ab646f9c886e0c41d34274021bff9L57-L63) [[4]](diffhunk://#diff-c8176c56082336098f607fe742602f71684ab646f9c886e0c41d34274021bff9L73) [[5]](diffhunk://#diff-c8176c56082336098f607fe742602f71684ab646f9c886e0c41d34274021bff9L129-L178)

**Testing and Verification:**
<img width="1109" height="163" alt="Screenshot 2026-03-23 at 10 33 58 PM" src="https://github.com/user-attachments/assets/abc46f55-f133-4668-a57b-46c97da2b321" />



* Added a new test suite in `one_fm/tests/test_timesheet.py` to verify that ToDo assignments and unassignments occur as expected through the workflow transitions, ensuring Assignment Rules function correctly for both submitters and approvers.

These changes standardize and simplify the Timesheet workflow assignment process, reduce custom code, and provide automated tests for reliability.