### PR TITLE
feat: auto fetch site details in rfm

### DIFF
--- a/one_fm/purchase/doctype/request_for_material/request_for_material.js
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.js
@@ -718,20 +718,6 @@ var set_filters = function(frm) {
 			]
 		};
 	});
-	frm.set_query("project", function() {
-		return {
-			filters: [
-				['customer', '=', frm.doc.customer]
-			]
-		};
-	});
-	frm.set_query("site", function() {
-		return {
-			filters: [
-				['project', '=', frm.doc.project]
-			]
-		};
-	});
 };
 
 

--- a/one_fm/purchase/doctype/request_for_material/request_for_material.json
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.json
@@ -25,9 +25,9 @@
   "request_for_material_accepter",
   "request_for_material_approver",
   "type_details_section",
-  "customer",
-  "project",
   "site",
+  "project",
+  "customer",
   "erf",
   "contract_number",
   "project_details",
@@ -98,6 +98,7 @@
   },
   {
    "depends_on": "eval: doc.type== 'Project'",
+   "fetch_from": "project.customer",
    "fieldname": "customer",
    "fieldtype": "Link",
    "in_standard_filter": 1,
@@ -351,6 +352,7 @@
   },
   {
    "depends_on": "eval: doc.type == 'Project'",
+   "fetch_from": "site.project",
    "fieldname": "project",
    "fieldtype": "Link",
    "in_standard_filter": 1,
@@ -577,7 +579,7 @@
    "link_fieldname": "linked_rfm"
   }
  ],
- "modified": "2025-12-01 15:48:58.598882",
+ "modified": "2026-03-24 09:45:34.137096",
  "modified_by": "Administrator",
  "module": "Purchase",
  "name": "Request for Material",


### PR DESCRIPTION
This pull request makes improvements to the `Request for Material` doctype by updating field dependencies, reordering fields, and simplifying client-side query logic. The main focus is to streamline how the `customer` and `project` fields are populated and displayed, ensuring they are automatically fetched based on related selections and reducing redundant code.

Field dependency and fetching improvements:

* Added `fetch_from` properties so that the `customer` field is auto-filled from `project.customer` and the `project` field is auto-filled from `site.project`, improving data consistency and reducing manual entry. [[1]](diffhunk://#diff-6b2aa4ef7b1c35a985336dcc006a999d8adf0bfccd61d2fea9f7a9d54a0659e6R101) [[2]](diffhunk://#diff-6b2aa4ef7b1c35a985336dcc006a999d8adf0bfccd61d2fea9f7a9d54a0659e6R355)

Field reordering:

* Reordered the `customer`, `project`, and `site` fields in the form layout to better reflect their logical relationship and improve user experience.

Client-side code simplification:

* Removed custom `set_query` filters for the `project` and `site` fields in the JavaScript file, as these are now handled by the new `fetch_from` properties.

Other:

* Updated the `modified` timestamp in the doctype JSON to reflect the latest changes.