### PR TITLE
[FIX][Different job offer to same mail id and the name capture]

### DIFF
--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -205,6 +205,15 @@ class JobOfferOverride(JobOffer):
         if auto_email_settings.auto_email_hiring_method not in [hiring_method, 'All Recruitment']:
             return
 
+        # Guard: skip if a sent Communication already exists for this Job Offer
+        # to avoid missing or double-sending when multiple applicants share the same email.
+        if frappe.db.exists('Communication', {
+            'reference_doctype': 'Job Offer',
+            'reference_name': self.name,
+            'sent_or_received': 'Sent'
+        }):
+            return
+
         message = self.get_message_for_job_offer_email(auto_email_settings.job_offer_email_template)
         attachment = frappe.attach_print(
             'Job Offer', self.name, file_name=self.name, print_format=auto_email_settings.job_offer_print_format
@@ -215,7 +224,8 @@ class JobOfferOverride(JobOffer):
             "subject": 'Job Offer: {0} [{1}]'.format(self.applicant_name, self.job_applicant),
             "attachments": [attachment],
             "reference_doctype": 'Job Offer',
-            "reference_name": self.name
+            "reference_name": self.name,
+            "now": True
         }
         frappe.sendmail(**email_args)
 

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -205,8 +205,8 @@ class JobOfferOverride(JobOffer):
         if auto_email_settings.auto_email_hiring_method not in [hiring_method, 'All Recruitment']:
             return
 
-        # Guard: skip if a sent Communication already exists for this Job Offer
-        # to avoid missing or double-sending when multiple applicants share the same email.
+        # Guard: skip if a sent Communication already exists for this specific Job Offer
+        # to prevent duplicate emails when on_update fires multiple times for the same document.
         if frappe.db.exists('Communication', {
             'reference_doctype': 'Job Offer',
             'reference_name': self.name,
@@ -224,8 +224,7 @@ class JobOfferOverride(JobOffer):
             "subject": 'Job Offer: {0} [{1}]'.format(self.applicant_name, self.job_applicant),
             "attachments": [attachment],
             "reference_doctype": 'Job Offer',
-            "reference_name": self.name,
-            "now": True
+            "reference_name": self.name
         }
         frappe.sendmail(**email_args)
 

--- a/one_fm/www/job_applicant_magic_link/index.py
+++ b/one_fm/www/job_applicant_magic_link/index.py
@@ -206,7 +206,8 @@ def upload_image():
                 if(k=="given_names" and v):
                     # Mindee V2 may return given_names as a list (e.g. ['JOHN', 'DOE'])
                     # or as a space-separated string — handle both to avoid AttributeError
-                    # that would silently prevent gender and passport_holder_of from being saved.
+                    # that would abort passport processing and prevent later fields
+                    # (gender, passport_holder_of) from being saved.
                     if isinstance(v, list):
                         given_names = [str(n) for n in v if n]
                     else:

--- a/one_fm/www/job_applicant_magic_link/index.py
+++ b/one_fm/www/job_applicant_magic_link/index.py
@@ -204,8 +204,13 @@ def upload_image():
                 if(k=="expiry_date" and v):
                     frappe.db.set_value(reference_doctype, reference_docname, 'one_fm_passport_expire', v)
                 if(k=="given_names" and v):
-                    #given_names is a space separated string, split by space and allocate each name to first second third and fourth names
-                    given_names = v.split()
+                    # Mindee V2 may return given_names as a list (e.g. ['JOHN', 'DOE'])
+                    # or as a space-separated string — handle both to avoid AttributeError
+                    # that would silently prevent gender and passport_holder_of from being saved.
+                    if isinstance(v, list):
+                        given_names = [str(n) for n in v if n]
+                    else:
+                        given_names = str(v).split()
                     if len(given_names) >= 1:
                         frappe.db.set_value(reference_doctype, reference_docname, 'one_fm_first_name', given_names[0].title())
                     if len(given_names) >= 2:


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/18402

## Analysis and design (optional)
Root cause traced for both bugs with call-flow diagrams
OFP-1352 identified as the contributing change for the email timing issue
Mindee V2 list vs string mismatch identified for OCR
Design decisions table with rationale and rejected alternatives

## Solution description
Email fix: Communication-based idempotency guard + now=True for immediate SMTP delivery, with risk assessment for each change
OCR fix: isinstance(v, list) type check before .split(), with explanation of why the crash silently blocked gender/passport_holder_of

## Is there a business logic within a doctype?
    - [] Yes
    - [x] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
Job offer

## Is there any existing behavior change of other features due to this code change?
No

## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox
