### PR TITLE
[FIX][added warehouse supervisor role]

### DIFF
--- a/one_fm/public/js/doctype_js/item.js
+++ b/one_fm/public/js/doctype_js/item.js
@@ -364,7 +364,7 @@ function set_change_request_btn(frm) {
 };
 
 function set_field_access_for_unauthorized_users(frm) {
-	if(frm.doc.workflow_state == 'Approved' && !(frappe.user.has_role('Finance Manager') || frappe.user.has_role('Purchase Manager'))){
+	if(frm.doc.workflow_state == 'Approved' && !(frappe.user.has_role('Finance Manager') || frappe.user.has_role('Purchase Manager') || frappe.user.has_role('Warehouse Supervisor'))){
 		// Set all fields (other than UOM) as read only
 		Object.keys(frm.fields_dict || {}).filter(f => f != "uoms").forEach(f => frm.set_df_property(f, "read_only", 1));
 


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [X] Bug


## Clearly and concisely describe the feature, chore or bug.
Users with the **Warehouse Supervisor** role are unable to edit any fields (including Item Name) on Approved Items. The form renders entirely read-only for them, despite the Item workflow granting Warehouse Supervisors edit access on Approved items.


## Analysis and design (optional)
The `set_field_access_for_unauthorized_users()` function in `item.js` enforces a client-side read-only lock on all fields when the Item's `workflow_state` is "Approved". It checks whether the current user has one of the allowed roles before applying the lock. However, the **Warehouse Supervisor** role was missing from the allowlist — only Finance Manager and Purchase Manager were included. This caused all fields to be set as `read_only: 1` for Warehouse Supervisors, contradicting the workflow configuration which explicitly grants them `allow_edit` on Approved items.


## Solution description
Added `frappe.user.has_role('Warehouse Supervisor')` to the role check condition in the `set_field_access_for_unauthorized_users()` function in `one_fm/public/js/doctype_js/item.js` (line 367).

**Before:**
```javascript
if(frm.doc.workflow_state == 'Approved' && !(frappe.user.has_role('Finance Manager') || frappe.user.has_role('Purchase Manager'))){
```

**After:**
```javascript
if(frm.doc.workflow_state == 'Approved' && !(frappe.user.has_role('Finance Manager') || frappe.user.has_role('Purchase Manager') || frappe.user.has_role('Warehouse Supervisor'))){
```

This ensures Warehouse Supervisors are recognized as authorized users and are not locked out of editing Approved Items.


## Is there a business logic within a doctype?
- [ ] Yes
- [X] No


## Output screenshots (optional)
N/A — No UI change. The form fields that were previously read-only for Warehouse Supervisors will now be editable, matching the existing behavior for Finance Manager and Purchase Manager roles.


## Areas affected and ensured
- **Item DocType form** — Field editability for users with the Warehouse Supervisor role on Approved items.
- **Item workflow** — No changes to the workflow itself; the fix aligns the client-side JS guard with the existing workflow configuration.


## Is there any existing behavior change of other features due to this code change?
No. The change only affects users with the Warehouse Supervisor role viewing Approved Items. All other roles and workflow states remain unchanged.


## Did you test with the following dataset?
- [X] Existing Data
- [ ] New Data

## Was child table created?
N/A — No child table changes.

## Did you delete custom field?
- [ ] Yes
- [X] No

## Is patch required?
- [ ] Yes
- [X] No


## Which browser(s) did you use for testing?
- [X] Chrome
- [ ] Safari
- [ ] Firefox