### PR TITLE
chore: add expected arrival time at site field to operations shift doctype

### DIFF
--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -24,6 +24,7 @@
   "section_break_12",
   "start_time",
   "end_time",
+  "expected_arrival_time_at_site",
   "column_break_15",
   "duration",
   "shift_classification",
@@ -108,6 +109,11 @@
    "fieldtype": "Time",
    "label": "End time",
    "read_only": 1
+  },
+  {
+   "fieldname": "expected_arrival_time_at_site",
+   "fieldtype": "Time",
+   "label": "Expected Arrival Time at Site"
   },
   {
    "description": "In hours",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -338,3 +338,4 @@ one_fm.patches.v15_0.add_workflow_resignation_withdrawal
 one_fm.patches.v15_0.update_client_event_workflow_state
 one_fm.patches.v15_0.delete_attendance_checks_mar18_2026 #2
 one_fm.patches.v15_0.add_contract_notification_recipients #1
+one_fm.patches.v15_0.populate_expected_arrival_time_at_site

--- a/one_fm/patches/v15_0/populate_expected_arrival_time_at_site.py
+++ b/one_fm/patches/v15_0/populate_expected_arrival_time_at_site.py
@@ -1,0 +1,16 @@
+import frappe
+
+def execute():
+	# Populate 'expected_arrival_time_at_site' with the value of 'end_time' for existing records.
+
+	# Reload the DocType to ensure the new field exists in the database.
+	frappe.reload_doc("operations", "doctype", "operations_shift")
+
+	if not frappe.db.has_column("Operations Shift", "expected_arrival_time_at_site"):
+		return
+
+	frappe.db.sql("""
+		UPDATE `tabOperations Shift`
+		SET expected_arrival_time_at_site = end_time
+		WHERE expected_arrival_time_at_site IS NULL OR expected_arrival_time_at_site = ''
+	""")

--- a/one_fm/patches/v15_0/populate_expected_arrival_time_at_site.py
+++ b/one_fm/patches/v15_0/populate_expected_arrival_time_at_site.py
@@ -12,5 +12,5 @@ def execute():
 	frappe.db.sql("""
 		UPDATE `tabOperations Shift`
 		SET expected_arrival_time_at_site = end_time
-		WHERE expected_arrival_time_at_site IS NULL OR expected_arrival_time_at_site = ''
+		WHERE expected_arrival_time_at_site IS NULL
 	""")


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
Add an "expected arrival time at site" field to the Operations Shift DocType, & add patch to populate this field with the value of "End Time" field for pre-existing records.


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1236" height="650" alt="Screenshot 2026-03-30 at 12 30 31 PM" src="https://github.com/user-attachments/assets/4a175bee-d6bc-4acc-8737-40469cb9ed0c" />


## Areas affected and ensured
- one_fm/operations/doctype/operations_shift/operations_shift.json
- one_fm/patches.txt


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data


## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
   Yes

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox