### PR TITLE
check shift assignment

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -951,7 +951,7 @@ def create_shift_assignment(roster, date, time):
 		if roster:
 			query_head = """
 				INSERT INTO `tabShift Assignment` (`name`, `company`, `docstatus`, `employee`, `employee_name`, `shift_type`, `site`, `project`, `status`,
-				`shift_classification`, `site_location`, `start_date`, `start_datetime`, `end_datetime`, `department`,
+				`shift_classification`, `site_location`, `start_date`, `end_date`, `start_datetime`, `end_datetime`, `department`,
 				`shift`, `operations_role`, `post_abbrv`, `roster_type`, `owner`, `modified_by`, `creation`, `modified`,
 				`shift_request`, `check_in_site`, `check_out_site`,`custom_day_off_ot`, `employee_schedule`, `custom_on_the_job_training`)
 				VALUES
@@ -977,7 +977,7 @@ def create_shift_assignment(roster, date, time):
 						query_body += f"""
 						(
 							"HR-SHA-{date}-{r.employee}", "{frappe.defaults.get_user_default('company')}", 1, "{r.employee}", "{r.employee_name}", '{_shift_request.shift_type}',
-							"{_shift_request.site or ''}", "{_project_r or ''}", 'Active', '{_shift_request.shift_type}', "{sites_list_dict.get(_shift_request.site) or ''}", "{date}",
+							"{_shift_request.site or ''}", "{_project_r or ''}", 'Active', '{_shift_request.shift_type}', "{sites_list_dict.get(_shift_request.site) or ''}", "{date}", "{add_days(date, 1) if _shift_type.start_time > _shift_type.end_time else date}",
 							"{shift_r_start_time or str(date)+' 08:00:00'}", "{shift_r_end_time or str(date)+' 17:00:00'}", "{r.department}",
 							"{_shift_request.operations_shift or ''}", "{_shift_request.operations_role or ''}", "{r.post_abbrv or ''}", "{_shift_request.roster_type}",
 							"{owner}", "{owner}", "{creation}", "{creation}", "{_shift_request.name}", "{_shift_request.check_in_site}", "{_shift_request.check_out_site}","{_day_off_ot}", "{r.name}", "{r.on_the_job_training if r.employee_availability == 'On-the-job Training' else ''}"),"""
@@ -986,7 +986,7 @@ def create_shift_assignment(roster, date, time):
 						query_body += f"""
 						(
 							"HR-SHA-{date}-{r.employee}", "{frappe.defaults.get_user_default('company')}", 1, "{r.employee}", "{r.employee_name}", '{r.shift_type}',
-							"{r.site or ''}", "{r.project or ''}", 'Active', '{_shift_type.shift_type}', "{sites_list_dict.get(r.site) or ''}", "{date}",
+							"{r.site or ''}", "{r.project or ''}", 'Active', '{_shift_type.shift_type}', "{sites_list_dict.get(r.site) or ''}", "{date}", "{add_days(date, 1) if _shift_type.end_time.total_seconds() < _shift_type.start_time.total_seconds() else date}",
 							"{_shift_type.start_datetime or str(date)+' 08:00:00'}",
 							"{_shift_type.end_datetime or str(date)+' 17:00:00'}", "{r.department}", "{r.shift or ''}", "{r.operations_role or ''}", "{r.post_abbrv or ''}", "{r.roster_type}",
 							"{owner}", "{owner}", "{creation}", "{creation}", '', '', '',"{_day_off_ot}", '{r.name}', "{r.on_the_job_training if r.employee_availability == 'On-the-job Training' else ''}"),"""
@@ -1012,6 +1012,7 @@ def create_shift_assignment(roster, date, time):
 					site_location = VALUES(site_location),
 					start_datetime = VALUES(start_datetime),
 					end_datetime = VALUES(end_datetime),
+					end_date = VALUES(end_date),
 					department = VALUES(department),
 					shift_request = VALUES(shift_request),
 					check_in_site = VALUES(check_in_site),

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -968,7 +968,19 @@ def create_shift_assignment(roster, date, time):
 							"{_shift_request.operations_shift or ''}", "{_shift_request.operations_role or ''}", "{r.post_abbrv or ''}", "{_shift_request.roster_type}",
 							"{owner}", "{owner}", "{creation}", "{creation}", "{_shift_request.name}", "{_shift_request.check_in_site}", "{_shift_request.check_out_site}","{_day_off_ot}", "{r.name}", "{r.on_the_job_training if r.employee_availability == 'On-the-job Training' else ''}"),"""
 					else:
-						_shift_type = shift_types_dict.get(r.shift_type) or default_shift
+						_shift_type = shift_types_dict.get(r.shift_type)
+						if not _shift_type:
+							# Shift type not in pre-filtered dict — look up actual shift type and compute datetime
+							_st = frappe.db.get_value("Shift Type", r.shift_type, ["name", "shift_type", "start_time", "end_time"], as_dict=True)
+							if _st:
+								_st.start_datetime = f"{date} {(datetime.min + _st.start_time).time()}"
+								if _st.end_time.total_seconds() < _st.start_time.total_seconds():
+									_st.end_datetime = f"{add_days(date, 1)} {(datetime.min + _st.end_time).time()}"
+								else:
+									_st.end_datetime = f"{date} {(datetime.min + _st.end_time).time()}"
+								_shift_type = _st
+							else:
+								_shift_type = default_shift
 						query_body += f"""
 						(
 							"HR-SHA-{date}-{r.employee}", "{frappe.defaults.get_user_default('company')}", 1, "{r.employee}", "{r.employee_name}", '{r.shift_type}',

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -870,7 +870,7 @@ def get_shift_type(time):
 		shift_type = frappe.get_list("Shift Type", {"start_time": [">=", "13:00"]},['name'], pluck='name')
 	return shift_type
 
-def _resolve_shift_type(shift_type_name, shift_types_dict, default_shift, date):
+def resolve_shift_type(shift_type_name, shift_types_dict, default_shift, date):
 	"""Resolve a shift type with computed start_datetime/end_datetime.
 	First checks the pre-filtered dict, then looks up from DB (and caches), then falls back to default.
 	"""
@@ -964,7 +964,7 @@ def create_shift_assignment(roster, date, time):
 				if not r.employee in existing_shift_list:
 					if shift_request_dict.get(r.employee):
 						_shift_request = shift_request_dict.get(r.employee)
-						_shift_type = _resolve_shift_type(_shift_request.shift_type, shift_types_dict, default_shift, date)
+						_shift_type = resolve_shift_type(_shift_request.shift_type, shift_types_dict, default_shift, date)
 						_project_r = frappe.db.get_value("Operations Shift", {'name':_shift_request.operations_shift}, ['project'])
 						shift_r_start_time = date+ " " + str(_shift_type.start_time)
 						_day_off_ot = 1 if  shift_request_dict.get(r.employee).get('purpose') == 'Day Off Overtime' else 0
@@ -982,7 +982,7 @@ def create_shift_assignment(roster, date, time):
 							"{_shift_request.operations_shift or ''}", "{_shift_request.operations_role or ''}", "{r.post_abbrv or ''}", "{_shift_request.roster_type}",
 							"{owner}", "{owner}", "{creation}", "{creation}", "{_shift_request.name}", "{_shift_request.check_in_site}", "{_shift_request.check_out_site}","{_day_off_ot}", "{r.name}", "{r.on_the_job_training if r.employee_availability == 'On-the-job Training' else ''}"),"""
 					else:
-						_shift_type = _resolve_shift_type(r.shift_type, shift_types_dict, default_shift, date)
+						_shift_type = resolve_shift_type(r.shift_type, shift_types_dict, default_shift, date)
 						query_body += f"""
 						(
 							"HR-SHA-{date}-{r.employee}", "{frappe.defaults.get_user_default('company')}", 1, "{r.employee}", "{r.employee_name}", '{r.shift_type}',

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -870,6 +870,26 @@ def get_shift_type(time):
 		shift_type = frappe.get_list("Shift Type", {"start_time": [">=", "13:00"]},['name'], pluck='name')
 	return shift_type
 
+def _resolve_shift_type(shift_type_name, shift_types_dict, default_shift, date):
+	"""Resolve a shift type with computed start_datetime/end_datetime.
+	First checks the pre-filtered dict, then looks up from DB (and caches), then falls back to default.
+	"""
+	_shift_type = shift_types_dict.get(shift_type_name)
+	if not _shift_type:
+		_st = frappe.db.get_value("Shift Type", shift_type_name, ["name", "shift_type", "start_time", "end_time"], as_dict=True)
+		if _st:
+			_st.start_datetime = f"{date} {(datetime.min + _st.start_time).time()}"
+			if _st.end_time.total_seconds() < _st.start_time.total_seconds():
+				_st.end_datetime = f"{add_days(date, 1)} {(datetime.min + _st.end_time).time()}"
+			else:
+				_st.end_datetime = f"{date} {(datetime.min + _st.end_time).time()}"
+			_shift_type = _st
+		else:
+			_shift_type = default_shift
+		# Cache so the same shift type is not looked up again
+		shift_types_dict[shift_type_name] = _shift_type
+	return _shift_type
+
 def create_shift_assignment(roster, date, time):
 	try:
 		owner = frappe.session.user
@@ -886,12 +906,6 @@ def create_shift_assignment(roster, date, time):
 				i.end_datetime = f"{date} {(datetime.min + i.end_time).time()}"
 			shift_types_dict[i.name] = i
 		default_shift = frappe.get_doc("Shift Type", '"Standard|Morning|08:00:00-17:00:00|9 hours"').as_dict()
-		# Compute start_datetime/end_datetime for default_shift so the fallback uses actual shift times
-		default_shift.start_datetime = f"{date} {(datetime.min + default_shift.start_time).time()}"
-		if default_shift.end_time.total_seconds() < default_shift.start_time.total_seconds():
-			default_shift.end_datetime = f"{add_days(date, 1)} {(datetime.min + default_shift.end_time).time()}"
-		else:
-			default_shift.end_datetime = f"{date} {(datetime.min + default_shift.end_time).time()}"
 
 
 		existing_shift = frappe.db.get_list("Shift Assignment", filters={
@@ -950,7 +964,7 @@ def create_shift_assignment(roster, date, time):
 				if not r.employee in existing_shift_list:
 					if shift_request_dict.get(r.employee):
 						_shift_request = shift_request_dict.get(r.employee)
-						_shift_type = shift_types_dict.get(_shift_request.shift_type) or default_shift
+						_shift_type = _resolve_shift_type(_shift_request.shift_type, shift_types_dict, default_shift, date)
 						_project_r = frappe.db.get_value("Operations Shift", {'name':_shift_request.operations_shift}, ['project'])
 						shift_r_start_time = date+ " " + str(_shift_type.start_time)
 						_day_off_ot = 1 if  shift_request_dict.get(r.employee).get('purpose') == 'Day Off Overtime' else 0
@@ -968,19 +982,7 @@ def create_shift_assignment(roster, date, time):
 							"{_shift_request.operations_shift or ''}", "{_shift_request.operations_role or ''}", "{r.post_abbrv or ''}", "{_shift_request.roster_type}",
 							"{owner}", "{owner}", "{creation}", "{creation}", "{_shift_request.name}", "{_shift_request.check_in_site}", "{_shift_request.check_out_site}","{_day_off_ot}", "{r.name}", "{r.on_the_job_training if r.employee_availability == 'On-the-job Training' else ''}"),"""
 					else:
-						_shift_type = shift_types_dict.get(r.shift_type)
-						if not _shift_type:
-							# Shift type not in pre-filtered dict — look up actual shift type and compute datetime
-							_st = frappe.db.get_value("Shift Type", r.shift_type, ["name", "shift_type", "start_time", "end_time"], as_dict=True)
-							if _st:
-								_st.start_datetime = f"{date} {(datetime.min + _st.start_time).time()}"
-								if _st.end_time.total_seconds() < _st.start_time.total_seconds():
-									_st.end_datetime = f"{add_days(date, 1)} {(datetime.min + _st.end_time).time()}"
-								else:
-									_st.end_datetime = f"{date} {(datetime.min + _st.end_time).time()}"
-								_shift_type = _st
-							else:
-								_shift_type = default_shift
+						_shift_type = _resolve_shift_type(r.shift_type, shift_types_dict, default_shift, date)
 						query_body += f"""
 						(
 							"HR-SHA-{date}-{r.employee}", "{frappe.defaults.get_user_default('company')}", 1, "{r.employee}", "{r.employee_name}", '{r.shift_type}',

--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -874,21 +874,21 @@ def resolve_shift_type(shift_type_name, shift_types_dict, default_shift, date):
 	"""Resolve a shift type with computed start_datetime/end_datetime.
 	First checks the pre-filtered dict, then looks up from DB (and caches), then falls back to default.
 	"""
-	_shift_type = shift_types_dict.get(shift_type_name)
-	if not _shift_type:
-		_st = frappe.db.get_value("Shift Type", shift_type_name, ["name", "shift_type", "start_time", "end_time"], as_dict=True)
-		if _st:
-			_st.start_datetime = f"{date} {(datetime.min + _st.start_time).time()}"
-			if _st.end_time.total_seconds() < _st.start_time.total_seconds():
-				_st.end_datetime = f"{add_days(date, 1)} {(datetime.min + _st.end_time).time()}"
+	matched_shift = shift_types_dict.get(shift_type_name)
+	if not matched_shift:
+		fetched_shift = frappe.db.get_value("Shift Type", shift_type_name, ["name", "shift_type", "start_time", "end_time"], as_dict=True)
+		if fetched_shift:
+			fetched_shift.start_datetime = f"{date} {(datetime.min + fetched_shift.start_time).time()}"
+			if fetched_shift.end_time.total_seconds() < fetched_shift.start_time.total_seconds():
+				fetched_shift.end_datetime = f"{add_days(date, 1)} {(datetime.min + fetched_shift.end_time).time()}"
 			else:
-				_st.end_datetime = f"{date} {(datetime.min + _st.end_time).time()}"
-			_shift_type = _st
+				fetched_shift.end_datetime = f"{date} {(datetime.min + fetched_shift.end_time).time()}"
+			matched_shift = fetched_shift
 		else:
-			_shift_type = default_shift
+			matched_shift = default_shift
 		# Cache so the same shift type is not looked up again
-		shift_types_dict[shift_type_name] = _shift_type
-	return _shift_type
+		shift_types_dict[shift_type_name] = matched_shift
+	return matched_shift
 
 def create_shift_assignment(roster, date, time):
 	try:

--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
@@ -6,9 +6,7 @@ frappe.ui.form.on('Fingerprint Appointment', {
         set_field_visibility_and_requirements(frm);
     },
     employee: function(frm){
-        set_employee_details(frm);
         set_employee_supervisor(frm);
-        
     },
     pickup_location: function(frm) {
         set_field_visibility_and_requirements(frm);
@@ -101,36 +99,7 @@ function clear_all_overlays() {
     $('.frappe-overlay').remove();
 }
 
-var set_employee_details = function(frm){
-    if(frm.doc.employee){
-        frappe.call({
-            method:"frappe.client.get_value",//api calls
-            args: {
-                doctype:"Employee",
-                filters: {
-                name: frm.doc.employee
-                },
-                fieldname:["employee_name","one_fm_duration_of_work_permit","employee_name","one_fm_nationality","one_fm_civil_id","gender","date_of_birth","work_permit_salary","pam_file_number","employee_id","valid_upto"]
-            }, 
-            callback: function(r) { 
-        
-                // set the returned value in a field
-                frm.set_value('civil_id', r.message.one_fm_civil_id);
-                frm.set_value('full_name', r.message.employee_name);
-				frm.set_value('first_name_arabic', r.message.one_fm_first_name_in_arabic);
-                frm.set_value('second_name_arabic', r.message.one_fm_second_name_in_arabic);
-                frm.set_value('third_name_arabic', r.message.one_fm_third_name_in_arabic);
-                frm.set_value('last_name_arabic', r.message.one_fm_last_name_in_arabic);
-                frm.set_value('employee_id',r.message.employee_id);
-                frm.set_value('first_name_english', r.message.first_name);
-                frm.set_value('second_name_english', r.message.middle_name);
-                frm.set_value('third_name_english', r.message.one_fm_third_name);
-                frm.set_value('last_name_english', r.message.last_name);
-                frm.set_value('nationality', r.message.one_fm_nationality);
-            }
-        })
-    }
-};
+
 
 var set_employee_supervisor = function(frm){
     if(frm.doc.employee){

--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
@@ -6,7 +6,9 @@ frappe.ui.form.on('Fingerprint Appointment', {
         set_field_visibility_and_requirements(frm);
     },
     employee: function(frm){
+        set_employee_details(frm);
         set_employee_supervisor(frm);
+        
     },
     pickup_location: function(frm) {
         set_field_visibility_and_requirements(frm);
@@ -99,7 +101,36 @@ function clear_all_overlays() {
     $('.frappe-overlay').remove();
 }
 
-
+var set_employee_details = function(frm){
+    if(frm.doc.employee){
+        frappe.call({
+            method:"frappe.client.get_value",//api calls
+            args: {
+                doctype:"Employee",
+                filters: {
+                name: frm.doc.employee
+                },
+                fieldname:["employee_name","one_fm_duration_of_work_permit","employee_name","one_fm_nationality","one_fm_civil_id","gender","date_of_birth","work_permit_salary","pam_file_number","employee_id","valid_upto"]
+            }, 
+            callback: function(r) { 
+        
+                // set the returned value in a field
+                frm.set_value('civil_id', r.message.one_fm_civil_id);
+                frm.set_value('full_name', r.message.employee_name);
+				frm.set_value('first_name_arabic', r.message.one_fm_first_name_in_arabic);
+                frm.set_value('second_name_arabic', r.message.one_fm_second_name_in_arabic);
+                frm.set_value('third_name_arabic', r.message.one_fm_third_name_in_arabic);
+                frm.set_value('last_name_arabic', r.message.one_fm_last_name_in_arabic);
+                frm.set_value('employee_id',r.message.employee_id);
+                frm.set_value('first_name_english', r.message.first_name);
+                frm.set_value('second_name_english', r.message.middle_name);
+                frm.set_value('third_name_english', r.message.one_fm_third_name);
+                frm.set_value('last_name_english', r.message.last_name);
+                frm.set_value('nationality', r.message.one_fm_nationality);
+            }
+        })
+    }
+};
 
 var set_employee_supervisor = function(frm){
     if(frm.doc.employee){


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/11260

**Bug 1 — Shift Assignment start/end datetime mismatch:**
Shift Assignments created via the scheduled `create_shift_assignment()` function show incorrect `start_datetime` and `end_datetime`. For example, an "Afternoon|14:00:00-22:00:00" shift type shows `start_datetime: 08:00:00` and `end_datetime: 17:00:00`. This is because the `default_shift` fallback object does not have `start_datetime`/`end_datetime` computed, causing the code to fall back to hardcoded `08:00:00`/`17:00:00`.


## Analysis and design (optional)

**Bug 1:** In `tasks.py`, the `create_shift_assignment()` function uses raw SQL INSERT (bypassing the ORM `set_datetime()` hook). It pre-computes `start_datetime`/`end_datetime` for shift types in a loop, but the `default_shift` loaded via `.as_dict()` is not included in that computation. When `shift_types_dict.get(r.shift_type)` returns `None`, the code falls back to `default_shift` which lacks these properties, triggering the hardcoded `08:00-17:00` fallback in the f-string.


## Solution description

**Bug 1 — `tasks.py`:**
- Added 5 lines after `default_shift` is loaded to compute `start_datetime` and `end_datetime` using the exact same logic already applied to all other shift types in the loop above (lines 882–886)
- This ensures the fallback produces the actual shift times from the Shift Type document instead of hardcoded `08:00:00`/`17:00:00`


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)
<img width="1438" height="744" alt="Screenshot 2026-03-30 at 3 58 11 PM" src="https://github.com/user-attachments/assets/02b1cbb2-7ef9-4988-822e-0b0b902447f9" />



## Areas affected and ensured

2. **Shift Assignment creation** — `start_datetime`/`end_datetime` values for assignments created via the scheduled `assign_am_shift()`/`assign_pm_shift()` tasks when the employee's shift type falls back to the default shift


## Is there any existing behavior change of other features due to this code change?

No. 

- Bug 1: The `fetch_from` mechanism was already populating the fields correctly; removing the JS function simply stops the incorrect overwrite. No other DocType or feature references `set_employee_details`.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
N/A — No child table was created or modified.

![Uploading Screenshot 2026-03-30 at 12.09.43 PM.png…]()

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox


