### PR TITLE
finger_appoint

### DIFF
--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
@@ -6,9 +6,7 @@ frappe.ui.form.on('Fingerprint Appointment', {
         set_field_visibility_and_requirements(frm);
     },
     employee: function(frm){
-        set_employee_details(frm);
         set_employee_supervisor(frm);
-        
     },
     pickup_location: function(frm) {
         set_field_visibility_and_requirements(frm);
@@ -101,36 +99,7 @@ function clear_all_overlays() {
     $('.frappe-overlay').remove();
 }
 
-var set_employee_details = function(frm){
-    if(frm.doc.employee){
-        frappe.call({
-            method:"frappe.client.get_value",//api calls
-            args: {
-                doctype:"Employee",
-                filters: {
-                name: frm.doc.employee
-                },
-                fieldname:["employee_name","one_fm_duration_of_work_permit","employee_name","one_fm_nationality","one_fm_civil_id","gender","date_of_birth","work_permit_salary","pam_file_number","employee_id","valid_upto"]
-            }, 
-            callback: function(r) { 
-        
-                // set the returned value in a field
-                frm.set_value('civil_id', r.message.one_fm_civil_id);
-                frm.set_value('full_name', r.message.employee_name);
-				frm.set_value('first_name_arabic', r.message.one_fm_first_name_in_arabic);
-                frm.set_value('second_name_arabic', r.message.one_fm_second_name_in_arabic);
-                frm.set_value('third_name_arabic', r.message.one_fm_third_name_in_arabic);
-                frm.set_value('last_name_arabic', r.message.one_fm_last_name_in_arabic);
-                frm.set_value('employee_id',r.message.employee_id);
-                frm.set_value('first_name_english', r.message.first_name);
-                frm.set_value('second_name_english', r.message.middle_name);
-                frm.set_value('third_name_english', r.message.one_fm_third_name);
-                frm.set_value('last_name_english', r.message.last_name);
-                frm.set_value('nationality', r.message.one_fm_nationality);
-            }
-        })
-    }
-};
+
 
 var set_employee_supervisor = function(frm){
     if(frm.doc.employee){


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/hd-ticket/11260

**Bug 1 — Fingerprint Appointment fetches wrong employee data:**
When creating a new Fingerprint Appointment and selecting an employee, the employee detail fields (Arabic names, English names) are blanked out. The `set_employee_details()` JS function requests 11 fields from the Employee doctype but attempts to `set_value()` on 8 additional fields that were never included in the request, resulting in `undefined` overwriting the correct values already populated by Frappe's `fetch_from` mechanism.

## Analysis and design (optional)

**Bug 1:** The DocType JSON (`fingerprint_appointment.json`) already has `fetch_from` mappings for all 12 employee detail fields. The `set_employee_details()` JS function is redundant and harmful — it fires an async API call that overwrites the correct `fetch_from` values with `undefined` for fields not included in the request.


## Solution description

**Bug 1 — `fingerprint_appointment.js`:**
- Removed the `set_employee_details(frm)` call from the `employee` event handler
- Deleted the entire `set_employee_details` function definition (30 lines)
- The `set_employee_supervisor(frm)` call remains intact — it calls a Python API not covered by `fetch_from`
- All employee detail fields are now populated solely by Frappe's built-in `fetch_from` mechanism defined in the DocType JSON

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

N/A — Testing instructions provided for local verification via bench console and browser.


## Areas affected and ensured

1. **Fingerprint Appointment form** — Employee detail field population when selecting an employee


## Is there any existing behavior change of other features due to this code change?

No. 

- Bug 1: The `fetch_from` mechanism was already populating the fields correctly; removing the JS function simply stops the incorrect overwrite. No other DocType or feature references `set_employee_details`.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
N/A — No child table was created or modified.

![Uploading Screenshot 2026-03-30 at 12.09.43 PM.png…]()

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox


