### PR TITLE
fix: comprehensive patch for all interview custom fields + defensive …

### DIFF
--- a/one_fm/one_fm/page/interview_console/interview_console.py
+++ b/one_fm/one_fm/page/interview_console/interview_console.py
@@ -85,7 +85,10 @@ def get_applicant_data(applicant):
     
     if applicant_designation:
         interview_round = None
-        if nationality:
+        # Only filter by nationality if the custom field exists on Interview Round
+        round_meta = frappe.get_meta("Interview Round")
+        has_nationality = round_meta.has_field("one_fm_nationality")
+        if nationality and has_nationality:
             interview_round = frappe.db.get_value("Interview Round", {
                 "designation": applicant_designation,
                 "one_fm_nationality": nationality

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -342,4 +342,4 @@ one_fm.patches.v15_0.populate_expected_arrival_time_at_site
 one_fm.patches.v15_0.sync_contract_item_type_to_operations
 one_fm.patches.v15_0.delete_pending_off_day_attendance_checks
 one_fm.patches.v15_0.add_stock_entry_custom_fields
-one_fm.patches.v15_0.setup_interview_console
+one_fm.patches.v15_0.setup_interview_console #2026-04-02

--- a/one_fm/patches/v15_0/setup_interview_console.py
+++ b/one_fm/patches/v15_0/setup_interview_console.py
@@ -1,14 +1,103 @@
 """
 Patch: Setup Interview Console Custom Fields
-Adds custom fields on Interview Feedback and Interview doctypes
-needed by the Interview Console page.
+
+Comprehensive patch that adds ALL custom fields needed by:
+  - Interview Console page
+  - Interview override (interview.py)
+  - Interview Feedback override (interview_feedback.py)
+  - Hiring utils (hiring/utils.py)
+
+Covers three hrms doctypes:
+  - Interview Round  (interview_question table, one_fm_nationality)
+  - Interview        (total_interview_score, interview_summary_render,
+                      custom_hiring_method, career_history, interview_round_child_ref)
+  - Interview Feedback (custom_evaluation_criteria, custom_remarks,
+                        interview_question_assessment, career_history)
+
+Safe to re-run — uses create_custom_fields(update=True).
 """
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 
 def execute():
-    # --- Custom Fields on Interview Feedback ---
+    # ─── Interview Round ──────────────────────────────────────────────
+    # Console reads round_doc.interview_question (child table of
+    # "Interview Questions") and filters by one_fm_nationality + designation.
+    create_custom_fields({
+        "Interview Round": [
+            {
+                "fieldname": "interview_questions_sb",
+                "fieldtype": "Section Break",
+                "label": "Interview Questions",
+                "insert_after": "expected_skill_set",
+            },
+            {
+                "fieldname": "interview_question",
+                "fieldtype": "Table",
+                "label": "Interview Question",
+                "options": "Interview Questions",
+                "insert_after": "interview_questions_sb",
+            },
+            {
+                "fieldname": "one_fm_nationality",
+                "fieldtype": "Link",
+                "label": "Nationality",
+                "options": "Nationality",
+                "insert_after": "designation",
+                "description": "Used by Interview Console to match applicant nationality to the correct round.",
+            },
+        ]
+    }, update=True)
+
+    # ─── Interview ────────────────────────────────────────────────────
+    # Console: total_interview_score, interview_summary_render
+    # interview.py override: custom_hiring_method, career_history, interview_round_child_ref
+    create_custom_fields({
+        "Interview": [
+            {
+                "fieldname": "interview_summary_render",
+                "fieldtype": "HTML",
+                "label": "Interview Summary",
+                "insert_after": "interview_details",
+            },
+            {
+                "fieldname": "total_interview_score",
+                "fieldtype": "Float",
+                "label": "Total Score",
+                "insert_after": "average_rating",
+            },
+            {
+                "fieldname": "custom_hiring_method",
+                "fieldtype": "Data",
+                "label": "Hiring Method",
+                "insert_after": "job_applicant",
+                "fetch_from": "job_applicant.one_fm_hiring_method",
+                "read_only": 1,
+                "translatable": 1,
+            },
+            {
+                "fieldname": "career_history",
+                "fieldtype": "Link",
+                "label": "Career History",
+                "options": "Career History",
+                "insert_after": "custom_hiring_method",
+                "read_only": 1,
+            },
+            {
+                "fieldname": "interview_round_child_ref",
+                "fieldtype": "Link",
+                "label": "Interview Round Child Ref",
+                "options": "Job Applicant Interview Round",
+                "insert_after": "career_history",
+                "hidden": 1,
+            },
+        ]
+    }, update=True)
+
+    # ─── Interview Feedback ───────────────────────────────────────────
+    # Console: custom_evaluation_criteria (Interview Evaluation Detail), custom_remarks
+    # interview_feedback.py override + hiring/utils.py: interview_question_assessment (Interview Question Result)
     create_custom_fields({
         "Interview Feedback": [
             {
@@ -25,25 +114,28 @@ def execute():
                 "label": "Remarks",
                 "insert_after": "custom_evaluation_criteria",
             },
+            {
+                "fieldname": "interview_question_assessment_sb",
+                "fieldtype": "Section Break",
+                "insert_after": "skill_assessment",
+            },
+            {
+                "fieldname": "interview_question_assessment",
+                "fieldtype": "Table",
+                "label": "Interview Question Assessment",
+                "options": "Interview Question Result",
+                "insert_after": "interview_question_assessment_sb",
+            },
+            {
+                "fieldname": "career_history",
+                "fieldtype": "Link",
+                "label": "Career History",
+                "options": "Career History",
+                "insert_after": "interview_round",
+                "read_only": 1,
+            },
         ]
     }, update=True)
 
-    # --- Custom Fields on Interview ---
-    create_custom_fields({
-        "Interview": [
-            {
-                "fieldname": "interview_summary_render",
-                "fieldtype": "HTML",
-                "label": "Interview Summary",
-                "insert_after": "interview_details",
-            },
-            {
-                "fieldname": "total_interview_score",
-                "fieldtype": "Float",
-                "label": "Total Score",
-                "insert_after": "average_rating",
-            },
-        ]
-    }, update=True)
-
-    print("Interview Console custom fields installed!")
+    frappe.db.commit()
+    print("✅ All interview custom fields installed on Interview Round, Interview, and Interview Feedback!")


### PR DESCRIPTION
…nationality check

- setup_interview_console.py now adds ALL 14 custom fields across 3 doctypes: Interview Round (3), Interview (5), Interview Feedback (5)
- Includes fields needed by interview.py override, interview_feedback.py override, and hiring/utils.py — not just the console
- Adds missing one_fm_nationality on Interview Round (was causing MySQL crash)
- interview_console.py now checks has_field() before querying nationality to prevent crash if patch hasn't run yet

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
