### PR TITLE
feat: multi-feedback support, mandatory nationality, height on applic…

### DIFF
--- a/one_fm/custom/custom_field/interview_round.py
+++ b/one_fm/custom/custom_field/interview_round.py
@@ -8,6 +8,7 @@ def get_interview_round_custom_fields():
                 "options": "Nationality",
                 "insert_after": "designation",
                 "description": "Used by Interview Console to match applicant nationality to the correct round.",
+                "reqd": 1
             },
             {
                 "fieldname": "interview_questions_sb",

--- a/one_fm/one_fm/page/interview_console/interview_console.html
+++ b/one_fm/one_fm/page/interview_console/interview_console.html
@@ -46,6 +46,10 @@
                     <span class="link-text">Job Offers</span>
                     <span class="count-circle" id="ic-job-offers-count">0</span>
                 </div>
+                <div id="ic-feedbacks-pill" class="ic-dashboard-link" title="View Feedbacks" style="margin-left:8px;">
+                    <span class="link-text">Feedbacks</span>
+                    <span class="count-circle" id="ic-feedback-count">0</span>
+                </div>
             </div>
         </div>
 

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -348,6 +348,7 @@ function init_interview_console(wrapper, page) {
 				$w('#ic-remarks').val(data.remarks);
 				$w('#ic-score-pill').text(data.score + '/100');
 				$w('#ic-job-offers-count').text(data.job_offers || 0);
+				$w('#ic-feedback-count').text(data.feedback_count || 0);
 
 				state.selected_applicant.interview_score = data.score;
 				state.selected_applicant.status = data.status;
@@ -461,6 +462,16 @@ function init_interview_console(wrapper, page) {
 			var $btn = $(this);
 			$btn.addClass('expanded');
 			setTimeout(function () { $btn.removeClass('expanded'); }, 800);
+		});
+
+		$w('#ic-feedbacks-pill').on('click', function () {
+			if (!state.selected_applicant) return;
+			var count = parseInt($w('#ic-feedback-count').text()) || 0;
+			if (count > 0) {
+				frappe.set_route('List', 'Interview Feedback', { job_applicant: state.selected_applicant.name });
+			} else {
+				frappe.show_alert({ message: "No feedbacks yet for this candidate.", indicator: "orange" });
+			}
 		});
 
 		$w('#ic-reject-btn').on('click', function () { 

--- a/one_fm/one_fm/page/interview_console/interview_console.py
+++ b/one_fm/one_fm/page/interview_console/interview_console.py
@@ -61,7 +61,7 @@ def get_applicant_data(applicant):
         
     # Fetch score as AVERAGE of all Interview Feedback scores for this applicant
     all_feedbacks = frappe.get_all("Interview Feedback",
-        filters={"job_applicant": applicant, "docstatus": ["<", 2]},
+        filters={"job_applicant": applicant, "docstatus": 1},
         fields=["name", "interviewer", "average_rating", "result", "custom_remarks", "creation"],
         order_by="creation desc"
     )
@@ -312,7 +312,7 @@ def save_interview_data(applicant, score, remarks, status, scores_detail=None, i
 
     # --- 7. Recalculate total score as AVERAGE of all feedbacks for this applicant ---
     all_fb_scores = frappe.get_all("Interview Feedback",
-        filters={"job_applicant": applicant, "docstatus": ["<", 2]},
+        filters={"job_applicant": applicant, "docstatus": 1},
         fields=["average_rating"]
     )
     if all_fb_scores:

--- a/one_fm/one_fm/page/interview_console/interview_console.py
+++ b/one_fm/one_fm/page/interview_console/interview_console.py
@@ -35,7 +35,7 @@ def get_applicant_data(applicant):
     """
     _check_console_access()
     valid_fields = get_valid_fields()
-    res = {"age": "--", "height": "", "remarks": "", "score": 0, "status": "Open", "matrix": []}
+    res = {"age": "--", "height": "", "remarks": "", "score": 0, "status": "Open", "matrix": [], "feedbacks": [], "feedback_count": 0}
     
     # Fetch Applicant details
     applicant_doc = frappe.get_doc('Job Applicant', applicant)
@@ -59,12 +59,24 @@ def get_applicant_data(applicant):
     if found_remarks:
         res["remarks"] = applicant_doc.get(found_remarks) or ""
         
-    # Fetch score from Interview document (where save_interview_data stores it)
-    interview_score = frappe.db.get_value("Interview", {
-        "job_applicant": applicant,
-        "docstatus": ["<", 2]
-    }, "total_interview_score") or 0
-    res["score"] = interview_score
+    # Fetch score as AVERAGE of all Interview Feedback scores for this applicant
+    all_feedbacks = frappe.get_all("Interview Feedback",
+        filters={"job_applicant": applicant, "docstatus": ["<", 2]},
+        fields=["name", "interviewer", "average_rating", "result", "custom_remarks", "creation"],
+        order_by="creation desc"
+    )
+    res["feedback_count"] = len(all_feedbacks)
+    res["feedbacks"] = all_feedbacks
+
+    if all_feedbacks:
+        # total_interview_score is stored per-Interview; use it if available
+        interview_score = frappe.db.get_value("Interview", {
+            "job_applicant": applicant,
+            "docstatus": ["<", 2]
+        }, "total_interview_score") or 0
+        res["score"] = interview_score
+    else:
+        res["score"] = 0
         
     # Standard Status
     res["status"] = applicant_doc.status or "Open"
@@ -274,100 +286,44 @@ def save_interview_data(applicant, score, remarks, status, scores_detail=None, i
         avg_rating = float(score or 0) / 100.0
     avg_rating = min(max(avg_rating, 0), 1)
     
-    existing_feedback = frappe.db.get_value("Interview Feedback", {
-        "interview": interview_name,
-        "interviewer": frappe.session.user,
-        "docstatus": ["<", 2]
-    }, "name")
-    
-    if existing_feedback:
-        fb_doc = frappe.get_doc("Interview Feedback", existing_feedback)
-        if fb_doc.docstatus == 1:
-            # Update submitted feedback in-place: update skill ratings and average
-            # Delete old skill_assessment rows and insert new ones
-            frappe.db.sql("DELETE FROM `tabSkill Assessment` WHERE parent=%s", existing_feedback)
-            for idx, row in enumerate(skill_rows, 1):
-                frappe.get_doc({
-                    "doctype": "Skill Assessment",
-                    "parent": existing_feedback,
-                    "parenttype": "Interview Feedback",
-                    "parentfield": "skill_assessment",
-                    "idx": idx,
-                    "skill": row["skill"],
-                    "rating": row["rating"]
-                }).db_insert()
-            # Update evaluation criteria
-            frappe.db.sql("DELETE FROM `tabInterview Evaluation Detail` WHERE parent=%s", existing_feedback)
-            for idx, d in enumerate(parsed_details, 1):
-                frappe.get_doc({
-                    "doctype": "Interview Evaluation Detail",
-                    "parent": existing_feedback,
-                    "parenttype": "Interview Feedback",
-                    "parentfield": "custom_evaluation_criteria",
-                    "idx": idx,
-                    "category": d.get("category", "General"),
-                    "question": d.get("question", ""),
-                    "weight": float(d.get("weight", 0)),
-                    "rating": int(d.get("score", 0)),
-                    "max_rating": 5
-                }).db_insert()
-            # Update average_rating and result
-            frappe.db.set_value("Interview Feedback", existing_feedback, {
-                "average_rating": avg_rating,
-                "result": feedback_result,
-                "custom_remarks": remarks or ""
-            }, update_modified=True)
-        else:
-            fb_doc.result = feedback_result
-            fb_doc.feedback = ""
-            fb_doc.custom_remarks = remarks or ""
-            fb_doc.skill_assessment = []
-            for row in skill_rows:
-                fb_doc.append("skill_assessment", row)
-            # Populate structured child table
-            fb_doc.custom_evaluation_criteria = []
-            for d in parsed_details:
-                fb_doc.append("custom_evaluation_criteria", {
-                    "category": d.get("category", "General"),
-                    "question": d.get("question", ""),
-                    "weight": float(d.get("weight", 0)),
-                    "rating": int(d.get("score", 0)),
-                    "max_rating": 5
-                })
-            fb_doc.save(ignore_permissions=True)
-            fb_doc.submit()
-            # Force average_rating from console score
-            fb_doc.db_set("average_rating", avg_rating)
-    
-    if not existing_feedback:
-        fb = frappe.new_doc("Interview Feedback")
-        fb.interview = interview_name
-        fb.interview_round = interview_round or ""
-        fb.job_applicant = applicant
-        fb.interviewer = frappe.session.user
-        fb.result = feedback_result
-        fb.feedback = ""
-        fb.custom_remarks = remarks or ""
-        for row in skill_rows:
-            fb.append("skill_assessment", row)
-        # Populate structured child table
-        for d in parsed_details:
-            fb.append("custom_evaluation_criteria", {
-                "category": d.get("category", "General"),
-                "question": d.get("question", ""),
-                "weight": float(d.get("weight", 0)),
-                "rating": int(d.get("score", 0)),
-                "max_rating": 5
-            })
-        fb.insert(ignore_permissions=True)
-        fb.submit()
-        # Force average_rating from console score
-        fb.db_set("average_rating", avg_rating)
-    
-    # --- 7. Update Interview doc's average_rating so the Feedback tab shows correct stars ---
+    # --- 6. Always create a NEW Interview Feedback (accumulate, don't overwrite) ---
+    fb = frappe.new_doc("Interview Feedback")
+    fb.interview = interview_name
+    fb.interview_round = interview_round or ""
+    fb.job_applicant = applicant
+    fb.interviewer = frappe.session.user
+    fb.result = feedback_result
+    fb.feedback = ""
+    fb.custom_remarks = remarks or ""
+    for row in skill_rows:
+        fb.append("skill_assessment", row)
+    for d in parsed_details:
+        fb.append("custom_evaluation_criteria", {
+            "category": d.get("category", "General"),
+            "question": d.get("question", ""),
+            "weight": float(d.get("weight", 0)),
+            "rating": int(d.get("score", 0)),
+            "max_rating": 5
+        })
+    fb.insert(ignore_permissions=True)
+    fb.submit()
+    fb.db_set("average_rating", avg_rating)
+
+    # --- 7. Recalculate total score as AVERAGE of all feedbacks for this applicant ---
+    all_fb_scores = frappe.get_all("Interview Feedback",
+        filters={"job_applicant": applicant, "docstatus": ["<", 2]},
+        fields=["average_rating"]
+    )
+    if all_fb_scores:
+        avg_all = sum(f.average_rating or 0 for f in all_fb_scores) / len(all_fb_scores)
+        total_score = round(avg_all * 100, 0)
+    else:
+        avg_all = avg_rating
+        total_score = float(score or 0)
+
     frappe.db.set_value("Interview", interview_name, {
-        "average_rating": avg_rating,
-        "total_interview_score": float(score or 0),
+        "average_rating": avg_all,
+        "total_interview_score": total_score,
     }, update_modified=False)
     
     frappe.db.commit()

--- a/one_fm/one_fm/page/interview_console/interview_console.py
+++ b/one_fm/one_fm/page/interview_console/interview_console.py
@@ -69,12 +69,13 @@ def get_applicant_data(applicant):
     res["feedbacks"] = all_feedbacks
 
     if all_feedbacks:
-        # total_interview_score is stored per-Interview; use it if available
-        interview_score = frappe.db.get_value("Interview", {
-            "job_applicant": applicant,
-            "docstatus": ["<", 2]
-        }, "total_interview_score") or 0
-        res["score"] = interview_score
+        # Compute score as average of all non-null Interview Feedback ratings
+        ratings = [fb.get("average_rating") for fb in all_feedbacks if fb.get("average_rating") is not None]
+        if ratings:
+            avg_rating = sum(ratings) / len(ratings)
+            res["score"] = round(avg_rating * 100)
+        else:
+            res["score"] = 0
     else:
         res["score"] = 0
         

--- a/one_fm/patches/v15_0/setup_interview_console.py
+++ b/one_fm/patches/v15_0/setup_interview_console.py
@@ -46,6 +46,7 @@ def execute():
                 "options": "Nationality",
                 "insert_after": "designation",
                 "description": "Used by Interview Console to match applicant nationality to the correct round.",
+                "reqd": 1,
             },
         ]
     }, update=True)

--- a/one_fm/public/js/doctype_js/job_applicant.js
+++ b/one_fm/public/js/doctype_js/job_applicant.js
@@ -1246,6 +1246,9 @@ var set_job_applicant_email_id = function(frm) {
 };
 
 var set_height_field_property_from_gender = function(frm) {
+	// Bulk Recruitment always shows height as mandatory — skip ERF-based logic
+	if (frm.doc.one_fm_hiring_method === 'Bulk Recruitment') return;
+
 	if(frm.doc.one_fm_erf && frm.doc.one_fm_gender){
 		frappe.call({
 			method: 'frappe.client.get',

--- a/one_fm/public/js/doctype_js/job_applicant.js
+++ b/one_fm/public/js/doctype_js/job_applicant.js
@@ -1311,6 +1311,11 @@ var set_mandatory_fields_of_job_applicant = function(frm) {
 		'one_fm_marital_status', 'one_fm_passport_holder_of', 'one_fm_passport_issued', 'one_fm_passport_expire',
 		'one_fm_gender', 'one_fm_religion', 'one_fm_date_of_birth', 'one_fm_educational_qualification', 'one_fm_university'];
 	set_mandatory_fields(frm, fields, true);
+
+	// Height: mandatory + visible only for Bulk Recruitment
+	var is_bulk = frm.doc.one_fm_hiring_method === 'Bulk Recruitment';
+	frm.set_df_property('one_fm_height', 'hidden', !is_bulk);
+	frm.set_df_property('one_fm_height', 'reqd', is_bulk ? 1 : 0);
 };
 
 var set_country_field_empty_on_load = function(frm) {
@@ -1323,7 +1328,7 @@ var set_country_field_empty_on_load = function(frm) {
 };
 
 var hide_job_applicant_existing_fields = function(frm) {
-	let fields = ['applicant_name', 'email_id', 'cover_letter', 'resume_attachment', 'section_break_6', 'one_fm_height','one_fm_applicant_civil_id','one_fm_passport_applicant_number','one_fm_previous_company_authorized_signatory','Resume Link'];
+	let fields = ['applicant_name', 'email_id', 'cover_letter', 'resume_attachment', 'section_break_6','one_fm_applicant_civil_id','one_fm_passport_applicant_number','one_fm_previous_company_authorized_signatory','Resume Link'];
 	set_hidden_fields(frm, fields, true);
 };
 

--- a/one_fm/www/one_fm_job_applicaton/index.html
+++ b/one_fm/www/one_fm_job_applicaton/index.html
@@ -92,8 +92,8 @@
                             </div>
                             <div class="row">
                                 <div class="form-group col-md-6">
-                                    <label for="height">Height</label>
-                                    <input type="text" class="form-control" id="height" placeholder="Height">
+                                    <label for="height">Height (cm) <span style="color:red">*</span></label>
+                                    <input type="number" class="form-control" id="height" placeholder="Height in cm" min="100" max="250" step="1">
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label for="MaritalStatus">Marital Status</label>

--- a/one_fm/www/one_fm_job_applicaton/index.html
+++ b/one_fm/www/one_fm_job_applicaton/index.html
@@ -93,7 +93,7 @@
                             <div class="row">
                                 <div class="form-group col-md-6">
                                     <label for="height">Height (cm) <span style="color:red">*</span></label>
-                                    <input type="number" class="form-control" id="height" placeholder="Height in cm" min="100" max="250" step="1">
+                                    <input type="number" class="form-control" id="height" placeholder="Height in cm" min="100" max="250" step="1" required aria-required="true">
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label for="MaritalStatus">Marital Status</label>

--- a/one_fm/www/one_fm_job_applicaton/index.js
+++ b/one_fm/www/one_fm_job_applicaton/index.js
@@ -444,6 +444,13 @@ const starEffects = () =>{
 
 // Submit
 const submitForm = () => {
+    // Validate height
+    var heightVal = parseFloat($('#height').val());
+    if (!heightVal || heightVal < 100 || heightVal > 250) {
+        Swal.fire({ icon: 'warning', title: 'Height Required', text: 'Please enter a valid height between 100 and 250 cm.' });
+        return;
+    }
+
     var file_data = {};
     $("[type='file']").each(function(i){
       file_data[$(this).attr("id")] = $('#'+$(this).attr("id")).prop('filedata');

--- a/one_fm/www/one_fm_job_applicaton/index.js
+++ b/one_fm/www/one_fm_job_applicaton/index.js
@@ -464,6 +464,7 @@ const submitForm = () => {
           one_fm_gender: $("#gender option:selected").text(),
           one_fm_religion: $("#religion option:selected").text(),
           one_fm_date_of_birth: $('#dob').val(),
+          one_fm_height: $('#height').val(),
           one_fm_place_of_birth: $('#placeOfBirth').val(),
           one_fm_marital_status: $('#MaritalStatus option:selected').text(),
           one_fm_email_id: $('#email').val(),


### PR DESCRIPTION
Interview Console: Multi-Feedback, Mandatory Nationality & Height
What changed and why
1. Multi-Feedback Support (Interview Console)
Problem:  the console overwrites the same feedback every time a candidate is re-scored. If an interviewer scores a candidate and later wants to re-evaluate, the previous feedback is lost.

Fix: The console now creates a new Interview Feedback each time instead of overwriting. The total score displayed is the average across all feedbacks for that candidate.

Previous feedbacks remain editable via the standard Interview Feedback form
A new "Feedbacks" pill in the console header shows the count and links to the full feedback list
Reset button still clears all feedbacks + interview documents
Files: interview_console.py, interview_console.js, interview_console.html

2. Nationality Mandatory on Interview Round
Problem: The console strictly matches candidates by designation + nationality to locate the correct Interview Round and its evaluation weightage. If nationality is left empty on an Interview Round, the lookup silently fails.

Fix: one_fm_nationality is now reqd: 1 on Interview Round, enforced via both the custom field definition and the setup patch.

Files: custom/custom_field/interview_round.py, patches/v15_0/setup_interview_console.py

3. Height Field on Public Job Application
Problem: The public job application page (/one_fm_job_applicaton) had a Height input in the HTML but it was never submitted to the backend — the value was lost on form submit.

Fix:

Wired $('#height').val() → one_fm_height in the submit payload
Changed input to type="number" with min=100 max=250 and "Height in cm" placeholder
Added red asterisk to indicate it's important
Files: www/one_fm_job_applicaton/index.html, www/one_fm_job_applicaton/index.js

4. Height Conditional Visibility on Job Applicant Form
Problem: one_fm_height was always hidden on the Job Applicant desk form (listed in hide_job_applicant_existing_fields).

Fix: Height is now:

Visible + mandatory when one_fm_hiring_method == "Bulk Recruitment"
Hidden for all other hiring methods (no change to existing behavior)
File: public/js/doctype_js/job_applicant.js

Testing Steps
Open Interview Console → select a candidate → score → check Feedbacks pill shows 1
Re-score same candidate → Feedbacks pill shows 2, score = average
Open Interview Round → Nationality should be mandatory (red asterisk)
Open Job Applicant (Bulk Recruitment) → Height field should be visible + mandatory
Open public application page → Height field should show with "cm" label

