### PR TITLE
fix: strict nationality+designation matching, handle duplicate feedba…

### DIFF
--- a/one_fm/custom/custom_field/interview_round.py
+++ b/one_fm/custom/custom_field/interview_round.py
@@ -8,7 +8,7 @@ def get_interview_round_custom_fields():
                 "options": "Nationality",
                 "insert_after": "designation",
                 "description": "Used by Interview Console to match applicant nationality to the correct round.",
-                "reqd": 1
+                "reqd": 1,
                 "module": "one_fm",
             },
             {

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -116,10 +116,12 @@ function init_interview_console(wrapper, page) {
 		wrapper._ic_fetch_applicants = fetch_applicants;
 	}
 
-	function render_dynamic_matrix(matrix) {
+	function render_dynamic_matrix(matrix, errorMsg) {
 		if (!matrix || matrix.length === 0) {
 			$w('.ic-table').hide();
-			$w('#ic-no-matrix-msg').show();
+			$w('#ic-no-matrix-msg').text(
+				errorMsg || 'No Interview Round setup found for this nationality and designation.'
+			).show();
 			return;
 		}
 
@@ -356,8 +358,8 @@ function init_interview_console(wrapper, page) {
 				state.matrix = data.matrix || [];
 				state.interview_round = data.interview_round || null;
 				
-				// Render dynamic matrix
-				render_dynamic_matrix(state.matrix);
+				// Render dynamic matrix (pass error message if any)
+				render_dynamic_matrix(state.matrix, data.matrix_error || null);
 
 				// Reset state scores for this matrix
 				state.scores = new Array(state.matrix.length).fill(0);

--- a/one_fm/one_fm/page/interview_console/interview_console.py
+++ b/one_fm/one_fm/page/interview_console/interview_console.py
@@ -90,32 +90,28 @@ def get_applicant_data(applicant):
                 res["status"] = custom_status
             
     # Fetch Dynamic Matrix from Interview Round
-    # Lookup priority: designation + nationality → designation only → round_name
+    # STRICT: require BOTH designation AND nationality to match
     
     applicant_designation = applicant_doc.get('designation') or applicant_doc.get('one_fm_designation')
     
     matrix_data = []
+    interview_round = None
     
-    if applicant_designation:
-        interview_round = None
-        # Only filter by nationality if the custom field exists on Interview Round
-        round_meta = frappe.get_meta("Interview Round")
-        has_nationality = round_meta.has_field("one_fm_nationality")
-        if nationality and has_nationality:
-            interview_round = frappe.db.get_value("Interview Round", {
-                "designation": applicant_designation,
-                "one_fm_nationality": nationality
-            }, "name")
-        
-        if not interview_round:
-            interview_round = frappe.db.get_value("Interview Round", {
-                "designation": applicant_designation
-            }, "name")
-            
-        if not interview_round:
-            interview_round = frappe.db.get_value("Interview Round", {
-                "round_name": applicant_designation
-            }, "name")
+    if not applicant_designation or not nationality:
+        # Missing one of the required pair — show error
+        missing = []
+        if not applicant_designation:
+            missing.append("Designation")
+        if not nationality:
+            missing.append("Nationality")
+        res["matrix"] = []
+        res["interview_round"] = None
+        res["matrix_error"] = "Cannot load evaluation matrix: {} missing on the Job Applicant.".format(" and ".join(missing))
+    else:
+        interview_round = frappe.db.get_value("Interview Round", {
+            "designation": applicant_designation,
+            "one_fm_nationality": nationality
+        }, "name")
 
         if interview_round:
             round_doc = frappe.get_doc("Interview Round", interview_round)
@@ -134,9 +130,13 @@ def get_applicant_data(applicant):
                             q.answer_1 or "Very Poor"
                         ]
                     })
-    
-    res["matrix"] = matrix_data
-    res["interview_round"] = interview_round if applicant_designation else None
+        else:
+            res["matrix_error"] = "No Interview Round found for Designation '{}' + Nationality '{}'.".format(
+                applicant_designation, nationality
+            )
+
+        res["matrix"] = matrix_data
+        res["interview_round"] = interview_round
     
     # Check for Job Offers
     try:
@@ -287,7 +287,16 @@ def save_interview_data(applicant, score, remarks, status, scores_detail=None, i
         avg_rating = float(score or 0) / 100.0
     avg_rating = min(max(avg_rating, 0), 1)
     
-    # --- 6. Always create a NEW Interview Feedback (accumulate, don't overwrite) ---
+    # --- 6. Clean up drafts, then create a NEW Interview Feedback ---
+    # Delete any draft (docstatus=0) feedbacks from this user for this interview
+    draft_feedbacks = frappe.get_all("Interview Feedback", filters={
+        "interview": interview_name,
+        "interviewer": frappe.session.user,
+        "docstatus": 0
+    }, pluck="name")
+    for dfb in draft_feedbacks:
+        frappe.delete_doc("Interview Feedback", dfb, force=True, ignore_permissions=True)
+
     fb = frappe.new_doc("Interview Feedback")
     fb.interview = interview_name
     fb.interview_round = interview_round or ""
@@ -306,6 +315,8 @@ def save_interview_data(applicant, score, remarks, status, scores_detail=None, i
             "rating": int(d.get("score", 0)),
             "max_rating": 5
         })
+    # Skip HRMS duplicate validation — we intentionally accumulate feedbacks
+    fb.flags.ignore_validate = True
     fb.insert(ignore_permissions=True)
     fb.submit()
     fb.db_set("average_rating", avg_rating)


### PR DESCRIPTION
…ck error

1. Nationality matching: removed fallback lookups. Both nationality AND designation must be present on the Job Applicant AND match an Interview Round. Specific error messages shown when either is missing or no matching round exists.

2. Feedback duplicate: HRMS validate_duplicate() blocks multiple feedbacks from same interviewer per Interview. Fixed by:
   - Deleting any draft (docstatus=0) feedbacks before creating new one
   - Setting flags.ignore_validate=True to skip HRMS duplicate check
   - This allows accumulating multiple submitted feedbacks per candidate

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
