### PR TITLE
fix: NameError in LeaveApplicationOverride.update_attendance_recods

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -1,7 +1,7 @@
 from ast import literal_eval
 import frappe,json
 import pandas as pd
-from datetime import date
+from datetime import date, timedelta
 
 from frappe import _
 from frappe.desk.form.assign_to import add as add_assignment
@@ -661,6 +661,12 @@ class LeaveApplicationOverride(LeaveApplication):
         leave_extension_request.save()
 
         return leave_extension_request
+
+
+
+def daterange(start_date, end_date):
+	for n in range(int((end_date - start_date).days) + 1):
+		yield start_date + timedelta(n)
 
 
 def update_attendance_recods(self):


### PR DESCRIPTION
## Summary
Fixes `NameError: name 'daterange' is not defined` in `LeaveApplicationOverride.update_attendance_recods` which prevented attendance creation for approved Leave Extension Requests.

## Changes
- `one_fm/overrides/leave_application.py`:
    - Added `timedelta` to `datetime` imports.
    - Added `daterange` helper function to iterate through leave dates.

## Review Checklist
- [x] validate_doctype_json: N/A (No DocType JSON changes)
- [x] bench migrate: ✅ PASS
- [x] run_tests: ✅ PASS
- [x] hooks.py paths verified: N/A (No hooks.py changes)
- [x] No frappe.db.commit() in controllers: ⚠️ Existing `frappe.db.commit()` calls found in `update_attendance_recods` and other methods, but no new ones added.

## How to Verify
1. Create a `Leave Extension Request` for an existing `Leave Application`.
2. Approve (Submit) the `Leave Extension Request`.
3. Verify that `Leave Application` records are created and submitted.
4. Verify that `Attendance` records are created for the extended leave period.

Closes #5876