### PR TITLE
fix: Attendance check not updating attendance

### DIFF
--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -427,7 +427,14 @@ class AttendanceCheck(Document):
     def mark_attendance(self):
         attendance = None
         if getattr(self, "attendance", None):
-            attendance = frappe.db.get_value("Attendance", self.attendance, ["status", "name"], as_dict=1)
+            linked_attendance = frappe.db.get_value(
+                "Attendance",
+                self.attendance,
+                ["status", "name", "docstatus"],
+                as_dict=1
+            )
+            if linked_attendance and linked_attendance.docstatus < 2:
+                attendance = linked_attendance
 
         if not attendance:
             attendance = self.get_existing_attendance()

--- a/one_fm/one_fm/doctype/attendance_check/attendance_check.py
+++ b/one_fm/one_fm/doctype/attendance_check/attendance_check.py
@@ -425,12 +425,17 @@ class AttendanceCheck(Document):
         )
 
     def mark_attendance(self):
-        if self.workflow_state == 'Approved':
+        attendance = None
+        if getattr(self, "attendance", None):
+            attendance = frappe.db.get_value("Attendance", self.attendance, ["status", "name"], as_dict=1)
+
+        if not attendance:
             attendance = self.get_existing_attendance()
-            if attendance and len(attendance) > 0:
-                self.update_existing_attendance_record(attendance)
-            else:
-                self.create_new_attendance_record()
+
+        if attendance:
+            self.update_existing_attendance_record(attendance)
+        else:
+            self.create_new_attendance_record()
 
     def get_existing_attendance(self):
         return frappe.db.get_value(
@@ -448,21 +453,13 @@ class AttendanceCheck(Document):
     def update_existing_attendance_record(self, attendance):
         if attendance.status != self.attendance_status:
             working_hours = self.get_shift_working_hours(self.shift_assignment)
-            frappe.db.sql(f"""
-                update
-                    `tabAttendance`
-                set
-                    status = '{self.attendance_status}',
-                    reference_doctype='{self.doctype}',
-                    reference_docname='{self.name}',
-                    modified='{str(now())}',
-                    working_hours={working_hours},
-                    modified_by='{frappe.session.user}',
-                    comment="Created from Attendance Check"
-                where
-                    name = '{attendance.name}'
-            """)
-            frappe.db.commit()
+            frappe.db.set_value("Attendance", attendance.name, {
+                "status": self.attendance_status,
+                "reference_doctype": self.doctype,
+                "reference_docname": self.name,
+                "working_hours": working_hours,
+                "comment": "Updated from Attendance Check"
+            }, update_modified=True)
 
     def create_new_attendance_record(self):
         attendance = frappe.new_doc("Attendance")

--- a/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
+++ b/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
@@ -31,7 +31,8 @@ class TestAttendanceCheckLogic(FrappeTestCase):
             "employee": self.employee,
             "attendance_date": "2024-01-01",
             "status": "Absent",
-            "company": "ONE FM"
+            "company": "ONE FM",
+            "roster_type": "Basic"
         })
         attendance.insert(ignore_permissions=True)
         attendance.submit()

--- a/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
+++ b/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
@@ -1,7 +1,6 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from one_fm.one_fm.doctype.attendance_check.attendance_check import AttendanceCheck
 
 class TestAttendanceCheckLogic(FrappeTestCase):
     def setUp(self):

--- a/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
+++ b/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
@@ -1,0 +1,63 @@
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from one_fm.one_fm.doctype.attendance_check.attendance_check import AttendanceCheck
+
+class TestAttendanceCheckLogic(FrappeTestCase):
+    def setUp(self):
+        super().setUp()
+        # Create a test employee if not exists
+        if not frappe.db.exists("Employee", "TEST-EMP-001"):
+            emp = frappe.get_doc({
+                "doctype": "Employee",
+                "employee_number": "TEST-EMP-001",
+                "first_name": "Test",
+                "last_name": "Employee",
+                "gender": "Male",
+                "date_of_birth": "1990-01-01",
+                "date_of_joining": "2020-01-01",
+                "company": "ONE FM",
+                "status": "Active"
+            })
+            emp.insert(ignore_permissions=True)
+            self.employee = emp.name
+        else:
+            self.employee = "TEST-EMP-001"
+
+    def test_mark_attendance_updates_existing(self):
+        # Create an Attendance record
+        attendance = frappe.get_doc({
+            "doctype": "Attendance",
+            "employee": self.employee,
+            "attendance_date": "2024-01-01",
+            "status": "Absent",
+            "company": "ONE FM"
+        })
+        attendance.insert(ignore_permissions=True)
+        attendance.submit()
+        
+        # Create an Attendance Check record
+        ac = frappe.get_doc({
+            "doctype": "Attendance Check",
+            "employee": self.employee,
+            "date": "2024-01-01",
+            "attendance_status": "Present",
+            "roster_type": "Basic",
+            "justification": "Other",
+            "other_reason": "Test",
+            "workflow_state": "Some Other State" # Should still work now
+        })
+        ac.insert(ignore_permissions=True)
+        
+        # Manually call mark_attendance
+        ac.mark_attendance()
+        
+        # Verify Attendance record is updated
+        updated_attendance = frappe.get_doc("Attendance", attendance.name)
+        self.assertEqual(updated_attendance.status, "Present")
+        self.assertEqual(updated_attendance.reference_docname, ac.name)
+        self.assertEqual(updated_attendance.comment, "Updated from Attendance Check")
+
+    def tearDown(self):
+        frappe.db.rollback()
+        super().tearDown()

--- a/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
+++ b/one_fm/one_fm/doctype/attendance_check/test_attendance_check_logic.py
@@ -46,7 +46,7 @@ class TestAttendanceCheckLogic(FrappeTestCase):
             "roster_type": "Basic",
             "justification": "Other",
             "other_reason": "Test",
-            "workflow_state": "Some Other State" # Should still work now
+            "workflow_state": "Pending Approval" # Valid non-approved workflow state
         })
         ac.insert(ignore_permissions=True)
         


### PR DESCRIPTION
## Summary
Refactored `mark_attendance` and `update_existing_attendance_record` in `AttendanceCheck` controller to ensure attendance records are correctly updated when an attendance check is submitted, regardless of the specific workflow state name.

## Changes
- `one_fm/one_fm/doctype/attendance_check/attendance_check.py` — Refactored `mark_attendance` to remove restrictive workflow state check and prioritize `attendance` link field. Refactored `update_existing_attendance_record` to use `frappe.db.set_value` instead of raw SQL.

## Review Checklist
- [x] validate_doctype_json: ✅ PASS (No JSON changes)
- [x] bench migrate: ✅ PASS
- [x] run_tests: ❌ FAIL (Unrelated existing bug in `one_fm/overrides/todo.py`)
- [x] hooks.py paths verified
- [x] No frappe.db.commit() in controllers

## How to Verify
1. Create an `Attendance` record with status "Absent".
2. Create an `Attendance Check` for that employee and date.
3. Set `Attendance Status` to "Present" in `Attendance Check`.
4. Submit the `Attendance Check`.
5. Verify that the linked `Attendance` record's status is now "Present" and `working_hours` are updated.

## Note on Test Failure
The test suite failed with `AttributeError: 'ToDo' object has no attribute 'custom_google_task_title'` in `one_fm/overrides/todo.py`. This is an existing bug in the codebase and is unrelated to the changes in this PR.

Closes #5886