### PR TITLE
fix: mom_followup scheduled jobs errors

### DIFF
--- a/one_fm/operations/doctype/mom_followup/mom_followup.py
+++ b/one_fm/operations/doctype/mom_followup/mom_followup.py
@@ -60,28 +60,34 @@ def mom_sites_followup():
 			followup.site = site.name 
 			followup.site_supervisor = site.site_supervisor
 			followup.insert()
-			add_assignment({
-					'doctype': 'MOM Followup',
-					'name': followup.name,
-					'assign_to': [frappe.db.get_value('Employee',site.site_supervisor, 'user_id')],
-					'description': _('Please explain your reason of missing the MOM for this site/POC within 48 hours')
-				})
+			user_id = frappe.db.get_value('Employee', site.site_supervisor, 'user_id')
+			if user_id:
+				add_assignment({
+						'doctype': 'MOM Followup',
+						'name': followup.name,
+						'assign_to': [user_id],
+						'description': _('Please explain your reason of missing the MOM for this site/POC within 48 hours')
+					})
 def mom_followup_reminder():
 	
 	reminder = frappe.db.sql("""
-	SELECT * 
+	SELECT name 
 	FROM `tabMOM Followup` 
 	WHERE (creation < DATE_SUB(NOW(), INTERVAL 48 HOUR)) AND (workflow_state = 'Assign to Site Supervisor')
 	""", as_dict=1)
 	for re in reminder:
-		re.workflow_state = 'Review by Projects Manager'
-		re.save()
-		add_assignment({
-					'doctype': 'MOM Followup',
-					'name': re.name,
-					'assign_to': [frappe.db.get_value('Employee',re.project_manager, 'user_id')],
-					'description': _('Please take Action')
-		})
+		doc = frappe.get_doc('MOM Followup', re.name)
+		doc.workflow_state = 'Review by Projects Manager'
+		doc.save()
+		
+		user_id = frappe.db.get_value('Employee', doc.project_manager, 'user_id')
+		if user_id:
+			add_assignment({
+						'doctype': 'MOM Followup',
+						'name': doc.name,
+						'assign_to': [user_id],
+						'description': _('Please take Action')
+			})
 
 @frappe.whitelist()
 def mom_followup_penalty():


### PR DESCRIPTION
## Summary
Fixes `MandatoryError` and logic errors in `MOM Followup` scheduled jobs.

## Changes
- `one_fm/operations/doctype/mom_followup/mom_followup.py`:
    - In `mom_sites_followup`: Added a check for `user_id` before calling `add_assignment` to prevent `MandatoryError` when an employee has no linked user.
    - In `mom_followup_reminder`: Fixed a bug where `.save()` was called on a dictionary. Now fetches the document using `frappe.get_doc` before saving. Also added a check for `user_id` before assignment.

## Review Checklist
- [x] validate_doctype_json: N/A (No JSON changes)
- [x] bench migrate: FAILED (Unrelated environment error: `Unknown column 'is_routine_task'`)
- [x] run_tests: ✅ PASS
- [x] hooks.py paths verified: N/A
- [x] No frappe.db.commit() in controllers: ✅ PASS

## How to Verify
1. Ensure some `Employee` records do not have a `user_id`.
2. Run `bench execute one_fm.operations.doctype.mom_followup.mom_followup.mom_sites_followup`. It should not crash.
3. Create a `MOM Followup` record with `workflow_state = 'Assign to Site Supervisor'` and backdate its creation.
4. Run `bench execute one_fm.operations.doctype.mom_followup.mom_followup.mom_followup_reminder`. It should update the workflow state and create an assignment if the project manager has a user ID.

Closes #5892