### PR TITLE
[FEAT][WI-1689792][Create Pathfinder Workspace]

### DIFF
--- a/one_fm/one_fm/workspace/pathfinder/pathfinder.json
+++ b/one_fm/one_fm/workspace/pathfinder/pathfinder.json
@@ -1,0 +1,79 @@
+{
+ "charts": [],
+ "content": "[{\"id\":\"pf_header\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Pathfinder</span>\",\"col\":12}},{\"id\":\"pf_card_main\",\"type\":\"card\",\"data\":{\"card_name\":\"Pathfinder\",\"col\":4}}]",
+ "creation": "2026-04-09 19:00:00.000000",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 1,
+ "icon": "file",
+ "idx": 0,
+ "indicator_color": "blue",
+ "is_hidden": 0,
+ "label": "Pathfinder",
+ "links": [
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Pathfinder",
+   "link_count": 4,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Process",
+   "link_count": 0,
+   "link_to": "Process",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Process Change Request",
+   "link_count": 0,
+   "link_to": "Process Change Request",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Pathfinder Log",
+   "link_count": 0,
+   "link_to": "Pathfinder Log",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Adhoc Development",
+   "link_count": 0,
+   "link_to": "Adhoc Development",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2026-04-09 19:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Pathfinder",
+ "number_cards": [],
+ "owner": "Administrator",
+ "parent_page": "",
+ "public": 1,
+ "quick_lists": [],
+ "roles": [],
+ "sequence_id": 25.0,
+ "shortcuts": [],
+ "title": "Pathfinder"
+}


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Created the **Pathfinder Workspace** in the `one_fm` app to provide users with a centralized navigation page for Pathfinder-related DocTypes.


## Analysis and design (optional)

The workspace follows the standard Frappe workspace JSON pattern used by existing workspaces in `one_fm` (e.g., Operations, GSD). It is placed under the `One Fm` module and is publicly accessible.


## Solution description

Created a new workspace JSON file at:
```
one_fm/one_fm/workspace/pathfinder/pathfinder.json
```

The workspace contains a single **"Pathfinder" link card** with links to 4 DocTypes:
- **Process** (`one_fm` / Operations module)
- **Process Change Request** (`one_fm` / One Fm module)
- **Pathfinder Log** (`one_fm` / One Fm module)
- **Adhoc Development** (`onefm_mcp` app)

`hide_custom` is set to `1` to prevent Frappe from auto-injecting unrelated custom reports onto the workspace.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

Workspace renders with 3 of 4 links visible. The **Adhoc Development** link is pending — it requires the database workspace record to be manually updated via the Frappe UI (Workspace → Pathfinder → add link) since `developer_mode` is not enabled on the site, preventing file-based workspace sync.

<img width="1235" height="495" alt="Screenshot 2026-04-11 at 12 43 57 PM" src="https://github.com/user-attachments/assets/6b8521ce-b98d-4c45-8456-0f0d681aeca9" />


## Areas affected and ensured

- `one_fm/one_fm/workspace/pathfinder/pathfinder.json` — **new file**
- Frappe sidebar: Pathfinder workspace appears under the One Fm module


## Is there any existing behavior change of other features due to this code change?

**No.** This is an additive change (new workspace file only). No existing workspaces or DocTypes are modified.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data


## Was child table created?
Not applicable — no DocType was created.


## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

Workspace JSON files are auto-synced by `bench migrate`. No data migration patch is needed.

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox