### PR TITLE
fix: attendance marking and item code sequence issues

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -1176,10 +1176,11 @@ class AttendanceMarking():
 
             shifts =  frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
-                JOIN `tabOperations Role` op ON sa.operations_role=op.name
+                LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.start_date='{self.start.date()}'
-                AND op.attendance_by_client=0 AND op.status='Active'
+                AND IFNULL(op.attendance_by_client, 0)=0 
+                AND (op.status='Active' OR sa.operations_role IS NULL OR sa.operations_role='')
             """, as_dict=1)
             non_shifts = frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
@@ -1187,7 +1188,10 @@ class AttendanceMarking():
                 WHERE sa.is_replaced = 0
                 AND sa.end_datetime BETWEEN '{self.start}' AND  '{self.end}'
                 AND e.shift_working=0""", as_dict=1)
-            shifts.extend(non_shifts)
+            shifts_dict = {d.name: d for d in shifts}
+            for d in non_shifts:
+                shifts_dict[d.name] = d
+            shifts = list(shifts_dict.values())
         else:
             client_shifts =  frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
@@ -1203,10 +1207,11 @@ class AttendanceMarking():
 
             shifts =  frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
-                JOIN `tabOperations Role` op ON sa.operations_role=op.name
+                LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.end_datetime BETWEEN '{self.start}' AND  '{self.end}'
-                AND op.attendance_by_client=0 AND op.status='Active'
+                AND IFNULL(op.attendance_by_client, 0)=0 
+                AND (op.status='Active' OR sa.operations_role IS NULL OR sa.operations_role='')
             """, as_dict=1)
             non_shifts = frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
@@ -1214,7 +1219,10 @@ class AttendanceMarking():
                 WHERE sa.is_replaced = 0
                 AND sa.end_datetime BETWEEN '{self.start}' AND  '{self.end}'
                 AND e.shift_working=0""", as_dict=1)
-            shifts.extend(non_shifts)
+            shifts_dict = {d.name: d for d in shifts}
+            for d in non_shifts:
+                shifts_dict[d.name] = d
+            shifts = list(shifts_dict.values())
 
 
 

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -328,3 +328,4 @@ one_fm.patches.v15_0.delete_attendance_checks_mar18_2026 #3
 one_fm.patches.v15_0.sync_contract_item_type_to_operations
 one_fm.patches.v15_0.delete_pending_off_day_attendance_checks
 one_fm.patches.v15_0.remove_pathfinder_log_workflow #2026-04-09
+one_fm.patches.v15_0.rename_item_int_civ_000033

--- a/one_fm/patches/v15_0/rename_item_int_civ_000033.py
+++ b/one_fm/patches/v15_0/rename_item_int_civ_000033.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+    if frappe.db.exists("Item", "INT-CIV-000033") and not frappe.db.exists("Item", "INT-CIV-000002"):
+        frappe.rename_doc("Item", "INT-CIV-000033", "INT-CIV-000002", ignore_permissions=True)
+        frappe.db.set_value("Item", "INT-CIV-000002", "item_code", "INT-CIV-000002", update_modified=False)
+        frappe.db.set_value("Item", "INT-CIV-000002", "item_id", "000002", update_modified=False)

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1478,14 +1478,14 @@ def get_item_id_series(subitem_group, item_group):
             item_id_list = []
             for abbr_item_group in abbr_item_group_list:
                 # IMPORTANT: We must filter by subitem_group to prevent pulling item_id's from other subitem sequences (e.g. SER-CIV)
-                item_id = frappe.db.sql("select item_id from `tabItem` where subitem_group='{0}' and item_group='{1}' order by item_id desc".format(subitem_group, abbr_item_group['name']))
+                item_id = frappe.db.sql("select item_id from `tabItem` where subitem_group='{0}' and item_group='{1}' order by item_id desc limit 1".format(subitem_group, abbr_item_group['name']))
                 if item_id:
                     item_id_list.append(item_id[0][0])
             if item_id_list:
                 return get_sorted_item_id(item_id_list)
 
     # Fallback to the current subitem_group & item_group if it doesn't have an abbreviation but has items
-    previous_item_id = frappe.db.sql("select item_id from `tabItem` where subitem_group='{0}' and item_group='{1}' order by item_id desc".format(subitem_group, item_group))
+    previous_item_id = frappe.db.sql("select item_id from `tabItem` where subitem_group='{0}' and item_group='{1}' order by item_id desc limit 1".format(subitem_group, item_group))
     if previous_item_id:
         return previous_item_id[0][0]
     

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1470,21 +1470,26 @@ def validate_get_item_group_parent(doc, method):
 
 @frappe.whitelist(allow_guest=True)
 def get_item_id_series(subitem_group, item_group):
+    # Check all item groups that share the same abbreviation within the same subitem_group
+    item_group_abbr = frappe.db.get_value('Item Group', item_group, 'one_fm_item_group_abbr')
+    if item_group_abbr:
+        abbr_item_group_list = frappe.db.get_list('Item Group', {'one_fm_item_group_abbr': item_group_abbr})
+        if abbr_item_group_list:
+            item_id_list = []
+            for abbr_item_group in abbr_item_group_list:
+                # IMPORTANT: We must filter by subitem_group to prevent pulling item_id's from other subitem sequences (e.g. SER-CIV)
+                item_id = frappe.db.sql("select item_id from `tabItem` where subitem_group='{0}' and item_group='{1}' order by item_id desc".format(subitem_group, abbr_item_group['name']))
+                if item_id:
+                    item_id_list.append(item_id[0][0])
+            if item_id_list:
+                return get_sorted_item_id(item_id_list)
+
+    # Fallback to the current subitem_group & item_group if it doesn't have an abbreviation but has items
     previous_item_id = frappe.db.sql("select item_id from `tabItem` where subitem_group='{0}' and item_group='{1}' order by item_id desc".format(subitem_group, item_group))
     if previous_item_id:
-        item_group_abbr = frappe.db.get_value('Item Group', item_group, 'one_fm_item_group_abbr')
-        if item_group_abbr:
-            abbr_item_group_list = frappe.db.get_list('Item Group', {'one_fm_item_group_abbr': item_group_abbr})
-            if abbr_item_group_list and len(abbr_item_group_list) > 1:
-                item_id_list = []
-                for abbr_item_group in abbr_item_group_list:
-                    item_id = frappe.db.sql("select item_id from `tabItem` where item_group='{0}' order by item_id desc".format(abbr_item_group['name']))
-                    if item_id:
-                        item_id_list.append(item_id[0][0])
-                return get_sorted_item_id(item_id_list)
         return previous_item_id[0][0]
-    else:
-        return '0000'
+    
+    return '0000'
 
 def get_sorted_item_id(item_id_list):
     max = item_id_list[0]


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to item management and shift attendance logic. The main changes include a new patch to rename an item, enhancements to item ID generation logic to better handle item group abbreviations, and updates to shift attendance queries for improved data accuracy and deduplication.

**Item management improvements:**

* Added a new patch script `rename_item_int_civ_000033.py` to rename the item with code `INT-CIV-000033` to `INT-CIV-000002`, and update its `item_code` and `item_id` fields accordingly. [[1]](diffhunk://#diff-6c2e530e155eed7ab391f7b3e7b799b1cd53da4ccb1eb95d399ed2229bf9b4f1R1-R7) [[2]](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7R331)
* Improved the `get_item_id_series` function in `one_fm/utils.py` to ensure item IDs are generated considering all item groups sharing the same abbreviation within a subitem group, and added a fallback for cases without abbreviations. The query now properly filters by both `subitem_group` and `item_group` to prevent cross-sequence conflicts.

**Attendance logic updates:**

* Updated SQL queries in `mark_shift_attendance` (in `attendance.py`) to use `LEFT JOIN` for `tabOperations Role`, handle `NULL` or empty `operations_role`, and deduplicate shift assignments by merging `shifts` and `non_shifts` into a dictionary keyed by assignment name. This ensures more accurate attendance processing and prevents duplicate entries. [[1]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1179-R1194) [[2]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1206-R1225)