### PR TITLE
fix: PermissionError when sending Email Queue in background job

### DIFF
--- a/one_fm/events/email_queue.py
+++ b/one_fm/events/email_queue.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.email.doctype.email_queue.email_queue import send_now
+
 def after_insert(doc, event):
 	"""
 	Force push the email if the recipients is not more than 19 records
@@ -12,11 +12,13 @@ def after_insert(doc, event):
 		found = False
 	if found:
 		# Enqueue it safely in the background rather than blocking the main transaction
+		# Enqueue as Administrator to bypass permission errors in background job
 		frappe.enqueue(
-			send_now,
+			"frappe.email.doctype.email_queue.email_queue.send_now",
 			name=doc.name,
 			now=frappe.flags.in_test,
-			enqueue_after_commit=True
+			enqueue_after_commit=True,
+			user="Administrator"
 		)
 
 def flush_emails():
@@ -25,10 +27,15 @@ def flush_emails():
     :return:
     """
     delete_eid_emails()
-    emails_in_queue = frappe.get_list('Email Queue', filters={'status': 'Not Sent'})
+    # Use get_all to bypass permissions
+    emails_in_queue = frappe.get_all('Email Queue', filters={'status': 'Not Sent'})
     for row in emails_in_queue:
-        try:send_now(name=row.name)
-        except:pass
+        try:
+            # Call method directly on doc to bypass whitelisted function's permission check
+            doc = frappe.get_doc('Email Queue', row.name)
+            doc.send_now()
+        except:
+            pass
     frappe.db.commit()
 
 def delete_eid_emails():


### PR DESCRIPTION
## Summary
Fixes `PermissionError` when sending `Email Queue` in a background job by enqueuing as `Administrator` and bypassing permission checks in `flush_emails`.

## Changes
- `one_fm/events/email_queue.py` — Updated `after_insert` to enqueue `send_now` as `Administrator`. Updated `flush_emails` to use `frappe.get_all` and call `doc.send_now()` directly to bypass permission checks. Removed unused import.

## Review Checklist
- [x] validate_doctype_json: ✅ N/A (No DocType JSON changes)
- [x] bench migrate: ✅ PASS
- [x] run_tests: ✅ PASS
- [x] hooks.py paths verified: ✅ PASS
- [x] No frappe.db.commit() in controllers: ✅ PASS (Utility function `flush_emails` uses commit appropriately)

## How to Verify
1. Trigger an email send from a user account without `System Manager` role.
2. Verify that the email is enqueued and successfully sent by the background worker.
3. Check the `Error Log` to ensure no `PermissionError` is recorded for `Email Queue`.
4. Run `bench execute one_fm.events.email_queue.flush_emails` to verify it processes unsent emails without errors.

Closes #5915