### PR TITLE
fix: patch item code change

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -328,4 +328,4 @@ one_fm.patches.v15_0.delete_attendance_checks_mar18_2026 #3
 one_fm.patches.v15_0.sync_contract_item_type_to_operations
 one_fm.patches.v15_0.delete_pending_off_day_attendance_checks
 one_fm.patches.v15_0.remove_pathfinder_log_workflow #2026-04-09
-one_fm.patches.v15_0.rename_item_int_civ_000033
+one_fm.patches.v15_0.rename_item_int_civ_000033 #1

--- a/one_fm/patches/v15_0/rename_item_int_civ_000033.py
+++ b/one_fm/patches/v15_0/rename_item_int_civ_000033.py
@@ -1,7 +1,9 @@
 import frappe
 
 def execute():
-    if frappe.db.exists("Item", "INT-CIV-000033") and not frappe.db.exists("Item", "INT-CIV-000002"):
-        frappe.rename_doc("Item", "INT-CIV-000033", "INT-CIV-000002", ignore_permissions=True)
-        frappe.db.set_value("Item", "INT-CIV-000002", "item_code", "INT-CIV-000002", update_modified=False)
-        frappe.db.set_value("Item", "INT-CIV-000002", "item_id", "000002", update_modified=False)
+    existing_item_name = "INT-CIV-000033"
+    new_item_name = "INT-CIV-000002"
+    if frappe.db.exists("Item", existing_item_name) and not frappe.db.exists("Item", new_item_name):
+        frappe.rename_doc("Item", existing_item_name, new_item_name)
+        frappe.db.set_value("Item", new_item_name, "item_code", new_item_name, update_modified=False)
+        frappe.db.set_value("Item", new_item_name, "item_id", "000002", update_modified=False)


### PR DESCRIPTION
This pull request refactors the patch script for renaming an item in the database to improve code readability and maintainability. It also updates the patch reference in the patch list to include an identifier.

**Patch script improvements:**

* [`one_fm/patches/v15_0/rename_item_int_civ_000033.py`](diffhunk://#diff-6c2e530e155eed7ab391f7b3e7b799b1cd53da4ccb1eb95d399ed2229bf9b4f1L4-R9): Refactored variable names for clarity, replacing hardcoded strings with `existing_item_name` and `new_item_name`, and removed the unnecessary `ignore_permissions=True` argument from `frappe.rename_doc`.

**Patch list update:**

* [`one_fm/patches.txt`](diffhunk://#diff-cb9d96c797454e462c1d27abde3f0421955a6949711457d1aeb0e4590b94a7d7L331-R331): Added a reference number (`#1`) to the `one_fm.patches.v15_0.rename_item_int_civ_000033` entry.

<img width="874" height="391" alt="Screenshot 2026-04-13 at 8 58 46 PM" src="https://github.com/user-attachments/assets/d6f8cd5f-9742-46a7-b04d-260b4beb6be5" />
