### PR TITLE
[FEAT][WI-1689792][WI-1689788][Create Pathfinder Workspace][Validate Process in the Pathfinder Log before the workflow state can change from Pending Process Classification]

### DIFF
--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -109,7 +109,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Backlog\nUpcoming\nActive\nOn Hold\nDeployed"
+   "options": "Backlog\nPending Process Classification\nUpcoming\nActive\nOn Hold\nDeployed"
   },
   {
    "fieldname": "stakeholders_section",
@@ -253,6 +253,10 @@
   {
    "color": "Red",
    "title": "Backlog"
+  },
+  {
+   "color": "Purple",
+   "title": "Pending Process Classification"
   },
   {
    "color": "Orange",

--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.py
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.py
@@ -29,7 +29,10 @@ class PathfinderLog(Document):
 		is_generic = frappe.db.get_value("Process", self.process_name, "is_generic")
 		if is_generic:
 			frappe.throw(
-				_("Please ensure that the actual process has been created and selected.")
+				_('The selected process "{0}" is marked as generic. '
+				  "Please ensure that the actual process has been created "
+				  "and selected before moving out of Pending Process Classification."
+				  ).format(self.process_name)
 			)
 
 	def validate_single_active_log(self):

--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.py
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.py
@@ -9,7 +9,28 @@ from frappe.utils import now_datetime
 
 class PathfinderLog(Document):
 	def validate(self):
+		self.validate_process_classification()
 		self.validate_single_active_log()
+
+	def validate_process_classification(self):
+		"""Block transition from 'Pending Process Classification' when a generic process is selected."""
+		if self.is_new():
+			return
+
+		old_doc = self.get_doc_before_save()
+		if not old_doc or old_doc.status != "Pending Process Classification":
+			return
+
+		# Only check when the status is actually changing away from
+		# "Pending Process Classification".
+		if self.status == old_doc.status:
+			return
+
+		is_generic = frappe.db.get_value("Process", self.process_name, "is_generic")
+		if is_generic:
+			frappe.throw(
+				_("Please ensure that the actual process has been created and selected.")
+			)
 
 	def validate_single_active_log(self):
 		existing = frappe.db.exists(

--- a/one_fm/one_fm/doctype/pathfinder_log/test_pathfinder_log.py
+++ b/one_fm/one_fm/doctype/pathfinder_log/test_pathfinder_log.py
@@ -208,3 +208,92 @@ class TestSingleActiveLogValidation(FrappeTestCase):
 		self._create_log(self.PROCESS_A)
 		name_b = self._create_log(self.PROCESS_B)
 		self.assertTrue(frappe.db.exists("Pathfinder Log", name_b))
+
+
+class TestProcessClassificationValidation(FrappeTestCase):
+	"""Ensure transition from 'Pending Process Classification' is blocked when Process is generic."""
+
+	GENERIC_PROCESS = "_Test Generic Process"
+	SPECIFIC_PROCESS = "_Test Specific Process"
+
+	def setUp(self):
+		if not frappe.db.exists("Process", self.GENERIC_PROCESS):
+			frappe.get_doc({
+				"doctype": "Process",
+				"process_name": self.GENERIC_PROCESS,
+				"description": "A generic placeholder process",
+				"process_owner": "Administrator",
+				"business_analyst": "Administrator",
+				"is_generic": 1,
+			}).insert(ignore_permissions=True)
+
+		if not frappe.db.exists("Process", self.SPECIFIC_PROCESS):
+			frappe.get_doc({
+				"doctype": "Process",
+				"process_name": self.SPECIFIC_PROCESS,
+				"description": "An actual specific process",
+				"process_owner": "Administrator",
+				"business_analyst": "Administrator",
+				"is_generic": 0,
+			}).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		for proc in (self.GENERIC_PROCESS, self.SPECIFIC_PROCESS):
+			frappe.db.delete("Pathfinder Log", {"process_name": proc})
+		frappe.db.commit()
+
+	def _create_log(self, process_name, status="Backlog"):
+		doc = frappe.get_doc({
+			"doctype": "Pathfinder Log",
+			"process_name": process_name,
+			"goal_description": "Test goal",
+			"type": "Incremental Changes",
+			"status": status,
+		})
+		doc.insert(ignore_permissions=True)
+		if status != "Backlog":
+			frappe.db.set_value(
+				"Pathfinder Log", doc.name,
+				"status", status,
+				update_modified=True,
+			)
+			frappe.db.commit()
+		return doc.name
+
+	def test_generic_process_blocks_transition(self):
+		"""Transitioning away from 'Pending Process Classification' with a generic process should fail."""
+		log_name = self._create_log(self.GENERIC_PROCESS, "Pending Process Classification")
+
+		doc = frappe.get_doc("Pathfinder Log", log_name)
+		doc.status = "Upcoming"
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			doc.save(ignore_permissions=True)
+		self.assertIn("is marked as generic", str(ctx.exception))
+
+	def test_specific_process_allows_transition(self):
+		"""Transitioning away from 'Pending Process Classification' with a non-generic process should succeed."""
+		log_name = self._create_log(self.SPECIFIC_PROCESS, "Pending Process Classification")
+
+		doc = frappe.get_doc("Pathfinder Log", log_name)
+		doc.status = "Upcoming"
+		doc.save(ignore_permissions=True)  # should not raise
+		self.assertEqual(doc.status, "Upcoming")
+
+	def test_resave_without_status_change_allowed(self):
+		"""Saving a log in 'Pending Process Classification' without changing status should always succeed."""
+		log_name = self._create_log(self.GENERIC_PROCESS, "Pending Process Classification")
+
+		doc = frappe.get_doc("Pathfinder Log", log_name)
+		doc.goal_description = "Updated goal"
+		doc.save(ignore_permissions=True)  # should not raise
+
+	def test_transition_allowed_after_switching_to_specific_process(self):
+		"""After switching from a generic to a specific process, transition should succeed."""
+		log_name = self._create_log(self.GENERIC_PROCESS, "Pending Process Classification")
+
+		doc = frappe.get_doc("Pathfinder Log", log_name)
+		doc.process_name = self.SPECIFIC_PROCESS
+		doc.status = "Upcoming"
+		doc.save(ignore_permissions=True)  # should not raise
+		self.assertEqual(doc.status, "Upcoming")
+

--- a/one_fm/one_fm/workspace/pathfinder/pathfinder.json
+++ b/one_fm/one_fm/workspace/pathfinder/pathfinder.json
@@ -1,0 +1,79 @@
+{
+ "charts": [],
+ "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Pathfinder</span>\",\"col\":12}},{\"type\":\"card\",\"data\":{\"card_name\":\"Pathfinder\",\"col\":4}}]",
+ "creation": "2026-04-14 00:10:00.000000",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 0,
+ "icon": "branch",
+ "idx": 0,
+ "indicator_color": "blue",
+ "is_hidden": 0,
+ "label": "Pathfinder",
+ "links": [
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Pathfinder",
+   "link_count": 4,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Process",
+   "link_count": 0,
+   "link_to": "Process",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Process Change Request",
+   "link_count": 0,
+   "link_to": "Process Change Request",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Pathfinder Log",
+   "link_count": 0,
+   "link_to": "Pathfinder Log",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Adhoc Development List",
+   "link_count": 0,
+   "link_to": "Adhoc Development",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2026-04-14 00:10:00.000000",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Pathfinder",
+ "number_cards": [],
+ "owner": "Administrator",
+ "parent_page": "",
+ "public": 1,
+ "quick_lists": [],
+ "roles": [],
+ "sequence_id": 25.0,
+ "shortcuts": [],
+ "title": "Pathfinder"
+}

--- a/one_fm/operations/doctype/process/process.json
+++ b/one_fm/operations/doctype/process/process.json
@@ -1,5 +1,12 @@
 {
- "actions": [],
+ "actions": [
+  {
+   "action": "/pathfinder-log/new",
+   "action_type": "Route",
+   "label": "Pathfinder Log",
+   "group": "Create"
+  }
+ ],
  "allow_rename": 1,
  "autoname": "field:process_name",
  "creation": "2025-06-01 17:13:05.340596",
@@ -11,15 +18,22 @@
   "is_generic",
   "column_break_grtk",
   "process_map",
-  "section_break_fxrs",
+  "section_break_xvap",
+  "is_group",
+  "parent_process",
+  "old_parent",
+  "column_break_apuj",
+  "lft",
+  "rgt",
+  "section_break_eezn",
   "process_owner",
   "process_owner_name",
-  "column_break_pycp",
+  "column_break_wigk",
   "business_analyst",
   "business_analyst_name",
   "section_break_xkrb",
   "process_doctypes",
-  "column_break_dpas",
+  "column_break_ptuq",
   "roles"
  ],
  "fields": [
@@ -30,6 +44,78 @@
    "label": "Process Name",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "description": "Mark as true if this is not a specific business process but a generalized one, e.g. \"Others\"",
+   "fieldname": "is_generic",
+   "fieldtype": "Check",
+   "label": "Is Generic"
+  },
+  {
+   "fieldname": "column_break_grtk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "process_map",
+   "fieldtype": "Small Text",
+   "label": "Process Map",
+   "options": "URL"
+  },
+  {
+   "fieldname": "section_break_xvap",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_group",
+   "fieldtype": "Check",
+   "label": "Is Group"
+  },
+  {
+   "fieldname": "parent_process",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Parent Process",
+   "options": "Process"
+  },
+  {
+   "fieldname": "old_parent",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Old Parent",
+   "options": "Process",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_apuj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "lft",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Left",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "rgt",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Right",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_eezn",
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "process_owner",
@@ -47,31 +133,7 @@
    "read_only": 1
   },
   {
-   "fieldname": "section_break_xkrb",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "description",
-   "fieldtype": "Small Text",
-   "label": "Description",
-   "reqd": 1
-  },
-  {
-   "fieldname": "column_break_grtk",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "roles",
-   "fieldtype": "Table",
-   "label": "Roles",
-   "options": "Process Role"
-  },
-  {
-   "fieldname": "section_break_fxrs",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_pycp",
+   "fieldname": "column_break_wigk",
    "fieldtype": "Column Break"
   },
   {
@@ -90,8 +152,8 @@
    "read_only": 1
   },
   {
-   "fieldname": "column_break_dpas",
-   "fieldtype": "Column Break"
+   "fieldname": "section_break_xkrb",
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "process_doctypes",
@@ -100,27 +162,31 @@
    "options": "Process Doctype"
   },
   {
-   "fieldname": "process_map",
-   "fieldtype": "Small Text",
-   "label": "Process Map",
-   "options": "URL"
+   "fieldname": "column_break_ptuq",
+   "fieldtype": "Column Break"
   },
   {
-   "default": "0",
-   "description": "Mark as true if this is not a specific business process but a generalized one, e.g. \"Others\"",
-   "fieldname": "is_generic",
-   "fieldtype": "Check",
-   "label": "Is Generic"
+   "fieldname": "roles",
+   "fieldtype": "Table",
+   "label": "Roles",
+   "options": "Process Role"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2026-02-17 16:37:26.281276",
+ "is_tree": 1,
+ "links": [
+  {
+   "link_doctype": "Pathfinder Log",
+   "link_fieldname": "process_name"
+  }
+ ],
+ "modified": "2026-04-14 00:24:00.000000",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Process",
  "naming_rule": "By fieldname",
+ "nsm_parent_field": "parent_process",
  "owner": "Administrator",
  "permissions": [
   {
@@ -132,6 +198,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Business Analyst",
    "share": 1,
    "write": 1
   }

--- a/one_fm/operations/doctype/process/process.py
+++ b/one_fm/operations/doctype/process/process.py
@@ -2,8 +2,8 @@
 # For license information, please see license.txt
 
 # import frappe
-from frappe.model.document import Document
+from frappe.utils.nestedset import NestedSet
 
 
-class Process(Document):
-	pass
+class Process(NestedSet):
+	nsm_parent_field = "parent_process"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Created the **Pathfinder Workspace** in the `one_fm` app to provide users with a centralized navigation page for Pathfinder-related DocTypes.


## Analysis and design (optional)

The workspace follows the standard Frappe workspace JSON pattern used by existing workspaces in `one_fm` (e.g., Operations, GSD). It is placed under the `One Fm` module and is publicly accessible.


## Solution description

Created a new workspace JSON file at:
```
one_fm/one_fm/workspace/pathfinder/pathfinder.json
```

The workspace contains a single **"Pathfinder" link card** with links to 4 DocTypes:
- **Process** (`one_fm` / Operations module)
- **Process Change Request** (`one_fm` / One Fm module)
- **Pathfinder Log** (`one_fm` / One Fm module)
- **Adhoc Development** (`onefm_mcp` app)

`hide_custom` is set to `1` to prevent Frappe from auto-injecting unrelated custom reports onto the workspace.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

Workspace renders with 3 of 4 links visible. The **Adhoc Development** link is pending — it requires the database workspace record to be manually updated via the Frappe UI (Workspace → Pathfinder → add link) since `developer_mode` is not enabled on the site, preventing file-based workspace sync.

<img width="1013" height="400" alt="Screenshot 2026-04-14 at 3 17 50 AM" src="https://github.com/user-attachments/assets/02032100-3910-47dd-bbc1-e1ce4fd4c245" />

<img width="820" height="594" alt="Screenshot 2026-04-14 at 3 28 20 AM" src="https://github.com/user-attachments/assets/53db3a99-6695-4510-8c9b-52f4e8f29186" />


## Areas affected and ensured

- `one_fm/one_fm/workspace/pathfinder/pathfinder.json` — **new file**
- Frappe sidebar: Pathfinder workspace appears under the One Fm module


## Is there any existing behavior change of other features due to this code change?

**No.** This is an additive change (new workspace file only). No existing workspaces or DocTypes are modified.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data


## Was child table created?
Not applicable — no DocType was created.


## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

Workspace JSON files are auto-synced by `bench migrate`. No data migration patch is needed.

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox