### PR TITLE
fix: resolve Copilot PR feedback and bypass ERF automated constraint

### DIFF
--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
@@ -159,7 +159,7 @@ class EmployeeResignation(Document):
 					row_dict.pop(field, None)
 				new_row.update(row_dict)
 				
-			pmr.insert(ignore_permissions=True, ignore_mandatory=True)
+			pmr.insert(ignore_permissions=True)
 			
 			frappe.msgprint(
 				_("Project Manpower Request generated successfully: <a href='/app/project-manpower-request/{0}'><b>{0}</b></a> (Click to open)").format(pmr.name),

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
@@ -159,7 +159,7 @@ class EmployeeResignation(Document):
 					row_dict.pop(field, None)
 				new_row.update(row_dict)
 				
-			pmr.insert(ignore_permissions=True)
+			pmr.insert(ignore_permissions=True, ignore_mandatory=True)
 			
 			frappe.msgprint(
 				_("Project Manpower Request generated successfully: <a href='/app/project-manpower-request/{0}'><b>{0}</b></a> (Click to open)").format(pmr.name),

--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
@@ -142,9 +142,9 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "ERF",
+   "mandatory_depends_on": "eval:in_list(['Awaiting Recruiter Approval', 'In Process', 'Completed'], doc.workflow_state)",
    "options": "ERF",
-   "search_index": 1,
-   "mandatory_depends_on": "eval:doc.workflow_state == 'Draft' || doc.workflow_state == 'Pending OM Approval'"
+   "search_index": 1
   },
   {
    "description": "The number of on-the-job-training days as agreed with the client.",

--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.py
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.py
@@ -43,7 +43,7 @@ class ProjectManpowerRequest(Document):
 		self.validate_completion()
 
 	def validate_erf_presence(self):
-		if getattr(self, "workflow_state", None) in ["Pending OM Approval", "Awaiting Recruiter Approval", "In Process", "Completed"]:
+		if getattr(self, "workflow_state", None) in ["Awaiting Recruiter Approval", "In Process", "Completed"]:
 			if not self.erf:
 				frappe.throw(
 					_("Please select an ERF before sending this Project Manpower Request for Recruitment.")

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -320,7 +320,17 @@ function init_interview_console(wrapper, page) {
         
         $w('#ic-root').addClass('has-selection');
 		$w('.ic-item').removeClass('selected');
-		$w('.ic-item[data-name="' + app.name + '"]').addClass("selected");
+		var $selected_item = $w('.ic-item[data-name="' + app.name + '"]');
+		$selected_item.addClass("selected");
+		
+		// Auto-scroll the sidebar to ensure the candidate is physically visible on the screen
+		if ($selected_item.length) {
+			var container = $w('.ic-left');
+			if (container.length) {
+				var offset = $selected_item.position().top + container.scrollTop() - (container.height() / 2) + ($selected_item.height() / 2);
+				container.animate({ scrollTop: offset }, 300);
+			}
+		}
 
 		// Reset buttons, then set state based on existing status
 		enable_action_buttons();


### PR DESCRIPTION
This PR rolls up the fixes to resolve the Copilot workflow state mismatch feedback, standardizes the child table schemas, exports the missing Withdrawal Item link table, and explicitly bypasses the JSON-level `ignore_mandatory` constraint on PMR background generation to fix the Operations Manager resignation block.