### PR TITLE
fix: make "Improve" button open in a new tab (#5932)

### DIFF
--- a/one_fm/public/js/desk.js
+++ b/one_fm/public/js/desk.js
@@ -39,11 +39,16 @@ var show_change_log=function() {
 };
 
 let improve_my_erp = () => {
-	let improveBTN = document.createElement('a');
-	improveBTN.classList = "btn btn-default btn-xs improve-my-erp";
-	improveBTN.textContent = "Improve";
-  improveBTN.href = '/helpdesk/tickets/new'
-	document.querySelector(".form-inline.fill-width.justify-content-end").prepend(improveBTN);
+	let container = document.querySelector(".form-inline.fill-width.justify-content-end");
+	if (container) {
+		let improveBTN = document.createElement("a");
+		improveBTN.classList = "btn btn-default btn-xs improve-my-erp";
+		improveBTN.textContent = "Improve";
+		improveBTN.href = "/helpdesk/tickets/new";
+		improveBTN.target = "_blank";
+		improveBTN.rel = "noopener noreferrer";
+		container.prepend(improveBTN);
+	}
 }
 
 // KNOWLEDGE BASE


### PR DESCRIPTION
## Summary
This PR updates the "Improve" button in the desk to open the web form in a new tab.

## Changes
- `one_fm/public/js/desk.js` — Updated `improve_my_erp` function to:
    - Select the target container and verify its existence before prepending the button.
    - Add `target="_blank"` and `rel="noopener noreferrer"` attributes to the "Improve" button anchor element.
    - Standardize string quotes and indentation.

## Review Checklist
- [x] validate_doctype_json: N/A (No JSON changed)
- [x] bench migrate: N/A (No JSON changed)
- [x] run_tests: ✅ PASS
- [x] hooks.py paths verified: N/A
- [x] No frappe.db.commit() in controllers: ✅ PASS

## How to Verify
1. Log in to the desk.
2. Locate the "Improve" button in the top right container (if visible).
3. Click the button and verify it opens `/helpdesk/tickets/new` in a new tab.

Closes #5932