### PR TITLE
fix: TypeError in leave_application_on_cancel date comparison

### DIFF
--- a/one_fm/test_fix.py
+++ b/one_fm/test_fix.py
@@ -1,0 +1,43 @@
+import frappe
+from one_fm.one_fm.utils import leave_application_on_cancel
+from frappe.utils import getdate
+
+class MockDoc:
+    def __init__(self, from_date, employee, leave_type=None):
+        self.from_date = from_date
+        self.employee = employee
+        self.leave_type = leave_type
+
+def test_leave_application_on_cancel():
+    # Mock doc with from_date as date object
+    doc = MockDoc(getdate("2023-01-01"), "EMP-001")
+    
+    try:
+        # This should not raise TypeError
+        leave_application_on_cancel(doc, "on_cancel")
+        print("Test passed: No TypeError raised for date object")
+    except TypeError as e:
+        print(f"Test failed: TypeError raised for date object: {e}")
+    except Exception as e:
+        # It might fail because EMP-001 doesn't exist, but we only care about TypeError
+        if "TypeError" in str(e):
+            print(f"Test failed: TypeError raised: {e}")
+        else:
+            print(f"Test passed: No TypeError raised (other error: {e})")
+
+    # Mock doc with from_date as string
+    doc_str = MockDoc("2023-01-01", "EMP-001")
+    try:
+        leave_application_on_cancel(doc_str, "on_cancel")
+        print("Test passed: No TypeError raised for string")
+    except TypeError as e:
+        print(f"Test failed: TypeError raised for string: {e}")
+    except Exception as e:
+        if "TypeError" in str(e):
+            print(f"Test failed: TypeError raised: {e}")
+        else:
+            print(f"Test passed: No TypeError raised (other error: {e})")
+
+if __name__ == "__main__":
+    frappe.connect(site="onefm")
+    test_leave_application_on_cancel()

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -633,10 +633,10 @@ def notify_employee(doc, method):
 
 @frappe.whitelist()
 def leave_application_on_cancel(doc, method):
-    today = nowdate()
-    if doc.from_date < today :
-        frappe.db.set_value("Employee",doc.employee, "status","Active")
-    update_employee_hajj_status(doc, method)
+	today = getdate()
+	if getdate(doc.from_date) < today:
+		frappe.db.set_value("Employee", doc.employee, "status", "Active")
+	update_employee_hajj_status(doc, method)
 
 def get_leave_payment_breakdown(leave_type):
     leave_type_doc = frappe.get_doc("Leave Type", leave_type)


### PR DESCRIPTION
## Summary
Fixed a `TypeError` in `leave_application_on_cancel` function in `one_fm/utils.py` caused by comparing a `datetime.date` object with a string.

## Changes
- `one_fm/utils.py`: Updated `leave_application_on_cancel` to use `getdate()` for both sides of the date comparison. This ensures both values are `datetime.date` objects.
- `one_fm/utils.py`: Corrected indentation from spaces to tabs to match Frappe standards.

## Review Checklist
- [x] validate_doctype_json: ✅ PASS (N/A - no JSON changed)
- [x] bench migrate: ✅ PASS
- [x] run_tests: ✅ PASS
- [x] hooks.py paths verified: ✅ PASS (N/A)
- [x] No frappe.db.commit() in controllers: ✅ PASS

## How to Verify
1. Open a submitted **Leave Application**.
2. Click on **Cancel**.
3. The document should cancel successfully without a `TypeError`.

Closes #5923