### PR TITLE
fix: operations item - contracts

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -8,6 +8,7 @@ import frappe, json
 from datetime import datetime
 import calendar
 from frappe.model.document import Document
+from collections import deque
 
 from frappe.utils import (
     cstr,month_diff,today,getdate,date_diff,add_years, cint, add_to_date, get_first_day,
@@ -343,7 +344,7 @@ class Contracts(Document):
         existing_ops_pool = {}
         for row in (self.contract_items_operation or []):
             if row.item_code not in existing_ops_pool:
-                existing_ops_pool[row.item_code] = []
+                existing_ops_pool[row.item_code] = deque()
             existing_ops_pool[row.item_code].append(row)
 
         new_ops = []
@@ -354,7 +355,7 @@ class Contracts(Document):
 
             ops_row = None
             if item.item_code in existing_ops_pool and existing_ops_pool[item.item_code]:
-                ops_row = existing_ops_pool[item.item_code].pop(0)
+                ops_row = existing_ops_pool[item.item_code].popleft()
 
             if ops_row:
                 ops_row.count = item.count

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -333,36 +333,43 @@ class Contracts(Document):
         Auto-populate the Contract Items Operation table from the Contract Item table.
         Each row in the items table is mapped to a corresponding row in contract_items_operation
         by item_code. Existing rows in contract_items_operation are preserved/updated; new ones
-        are appended, while obsolete ones are removed.
+        are appended, while obsolete ones are removed. Duplicate item_codes are also supported.
         """
         if not self.items:
             self.set('contract_items_operation', [])
             return
 
-        current_item_codes = {item.item_code for item in self.items if item.item_code}
+        # Create a pool of existing operations grouped by item_code
+        existing_ops_pool = {}
+        for row in (self.contract_items_operation or []):
+            if row.item_code not in existing_ops_pool:
+                existing_ops_pool[row.item_code] = []
+            existing_ops_pool[row.item_code].append(row)
 
-        if self.contract_items_operation:
-            valid_ops = [row for row in self.contract_items_operation if row.item_code in current_item_codes]
-            self.set('contract_items_operation', valid_ops)
-
-        existing_ops_map = {row.item_code: row for row in (self.contract_items_operation or [])}
+        new_ops = []
 
         for item in self.items:
             if not item.item_code:
                 continue
-            if item.item_code in existing_ops_map:
-                ops_row = existing_ops_map[item.item_code]
+
+            ops_row = None
+            if item.item_code in existing_ops_pool and existing_ops_pool[item.item_code]:
+                ops_row = existing_ops_pool[item.item_code].pop(0)
+
+            if ops_row:
                 ops_row.count = item.count
                 ops_row.rate_type = item.rate_type
                 ops_row.item_type = item.item_type
+                new_ops.append(ops_row)
             else:
-                self.append('contract_items_operation', {
+                new_ops.append({
                     'item_code': item.item_code,
                     'count': item.count,
                     'rate_type': item.rate_type,
                     'item_type': item.item_type,
                 })
-                existing_ops_map[item.item_code] = self.contract_items_operation[-1]
+
+        self.set('contract_items_operation', new_ops)
 
     def submit_to_operations_admin(self):
         """


### PR DESCRIPTION
This pull request updates the `sync_contract_item_operations` method in `contracts.py` to improve how contract item operations are synchronized, particularly to handle duplicate `item_code` values. The main logic has been refactored to better support multiple entries with the same `item_code` and to simplify the update and removal of obsolete operations.

**Improvements to contract item operation synchronization:**

* The method now supports duplicate `item_code` values by grouping existing operations by `item_code` and matching them sequentially, ensuring that each item is mapped to a corresponding operation row if available.
* The update logic has been refactored to use a pool (`existing_ops_pool`) of existing operations, allowing for more accurate updates and removals, and ensuring obsolete rows are not preserved.
* The method now builds a new list of operation rows (`new_ops`) and sets it at the end, which simplifies the logic and ensures the `contract_items_operation` table is always in sync with the current items.