### PR TITLE
[Wi 000230FEAT][Remove the Process Map field in Process and Pathfinder Log doctypes.]

### DIFF
--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -5,9 +5,6 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "process_map_and_guideline_section",
-  "process_map",
-  "column_break_teht",
   "checklist",
   "section_break_wx0s",
   "process_name",
@@ -32,23 +29,6 @@
   "time_log"
  ],
  "fields": [
-  {
-   "fieldname": "process_map_and_guideline_section",
-   "fieldtype": "Section Break",
-   "label": "Process Map and Guideline"
-  },
-  {
-   "fetch_from": "process_name.process_map",
-   "fieldname": "process_map",
-   "fieldtype": "Small Text",
-   "label": "Process Map",
-   "options": "URL",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_teht",
-   "fieldtype": "Column Break"
-  },
   {
    "bold": 1,
    "description": "Click to navigate to the checklist that must be followed for the current task.",
@@ -203,7 +183,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-05 13:02:00.000000",
+ "modified": "2026-04-19 09:58:00.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Pathfinder Log",

--- a/one_fm/operations/doctype/process/process.json
+++ b/one_fm/operations/doctype/process/process.json
@@ -16,8 +16,6 @@
   "process_name",
   "description",
   "is_generic",
-  "column_break_grtk",
-  "process_map",
   "section_break_xvap",
   "is_group",
   "parent_process",
@@ -57,16 +55,6 @@
    "fieldname": "is_generic",
    "fieldtype": "Check",
    "label": "Is Generic"
-  },
-  {
-   "fieldname": "column_break_grtk",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "process_map",
-   "fieldtype": "Small Text",
-   "label": "Process Map",
-   "options": "URL"
   },
   {
    "fieldname": "section_break_xvap",
@@ -181,7 +169,7 @@
    "link_fieldname": "process_name"
   }
  ],
- "modified": "2026-04-14 00:24:00.000000",
+ "modified": "2026-04-19 09:58:00.000000",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Process",


### PR DESCRIPTION
Here are the PR details based on the work completed:

---

## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug

---

## Clearly and concisely describe the feature, chore or bug.

Remove the **Process Map** field from the **Process** and **Pathfinder Log** DocTypes. This field stored a Lucid diagram URL and is being deprecated as Lucid usage is being phased out.

---

## Analysis and design (optional)

N/A — straightforward field removal. The `process_map` field was a `Small Text` field with `options: URL` used to store a Lucid process diagram link. In **Pathfinder Log**, it was a read-only fetch field (`fetch_from: process_name.process_map`) that automatically pulled the URL from the linked Process record.

---

## Solution description

**`one_fm/operations/doctype/process/process.json`**
- Removed `process_map` field definition (`Small Text`, Lucid URL)
- Removed `column_break_grtk` layout field — it was only used to place `process_map` in a right column and became orphaned without it

**`one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json`**
- Removed `process_map` field definition (`read_only`, `fetch_from: process_name.process_map`)
- Removed `process_map_and_guideline_section` Section Break — the section "Process Map and Guideline" existed solely to house the `process_map` field alongside `checklist`; with `process_map` gone the section is no longer needed
- Removed `column_break_teht` — the column break that horizontally separated `process_map` and `checklist`; `checklist` now renders under the "Increment Details" section below

---

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

---

## Output screenshots (optional)

N/A — field removal only, no new UI added.

---

## Areas affected and ensured

| Area | Impact |
|------|--------|
| **Process** DocType form | `Process Map` field no longer visible |
| **Pathfinder Log** DocType form | `Process Map` field and its "Process Map and Guideline" section no longer visible; `Checklist` field now sits under "Increment Details" section |
| **Pathfinder Log** auto-fetch logic | `fetch_from: process_name.process_map` removed — no stale data population |

---

## Is there any existing behavior change of other features due to this code change?

**Yes.** The `checklist` field in **Pathfinder Log** previously appeared on the right side of the "Process Map and Guideline" section header. It now appears at the top of the form under the "Increment Details" section. All other behaviour is unchanged.

---

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

---

## Was a child table created?
- [ ] Is attachment required?

No child table created or modified.

---

## Did you delete a custom field?
- [ ] Yes
- [x] No

These are **native DocType fields** (defined in JSON, not Custom Fields), so no delete patch is required — `bench migrate` drops the DB columns automatically during migration.

---

## Is a patch required?
- [ ] Yes
- [x] No

No patch required. Frappe's migrate process handles dropping native DocType columns when they are removed from the JSON definition.

> **Note:** `bench migrate` currently fails on a **pre-existing unrelated patch** (`add_formal_hearing_process_tasks_and_assignment_rules` — missing "ERP Document: Formal Hearing"). This must be resolved separately before migration can complete and physically drop the `process_map` columns from the DB.

---

## Which browser(s) did you use for testing?
- [ ] Chrome
- [ ] Safari
- [ ] Firefox

*(Pending — requires `bench migrate` to complete successfully before UI testing)*