### PR TITLE
[WI-000239][chore][ Process Classification Structure]

### DIFF
--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.js
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.js
@@ -3,6 +3,15 @@
 
 frappe.ui.form.on("Pathfinder Log", {
 	refresh(frm) {
+		// Restrict Epic link field to Work Items of type "Epic" only
+		frm.set_query("epic", function () {
+			return {
+				filters: {
+					work_item_type: "Epic",
+				},
+			};
+		});
+
 		if (!frm.is_new()) {
 			frm.add_custom_button(
 				__("Get Open Change Requests"),

--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -5,12 +5,15 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "process_map_and_guideline_section",
-  "process_map",
-  "column_break_teht",
   "checklist",
-  "section_break_wx0s",
+  "process_map_and_guideline_section",
   "process_name",
+  "process_is_generic",
+  "column_break_iarv",
+  "epic",
+  "column_break_cccw",
+  "process_folder_link",
+  "section_break_wx0s",
   "goal_description",
   "column_break_ojgt",
   "initiated_on",
@@ -33,23 +36,6 @@
  ],
  "fields": [
   {
-   "fieldname": "process_map_and_guideline_section",
-   "fieldtype": "Section Break",
-   "label": "Process Map and Guideline"
-  },
-  {
-   "fetch_from": "process_name.process_map",
-   "fieldname": "process_map",
-   "fieldtype": "Small Text",
-   "label": "Process Map",
-   "options": "URL",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_teht",
-   "fieldtype": "Column Break"
-  },
-  {
    "bold": 1,
    "description": "Click to navigate to the checklist that must be followed for the current task.",
    "fieldname": "checklist",
@@ -59,9 +45,9 @@
    "read_only": 1
   },
   {
-   "fieldname": "section_break_wx0s",
+   "fieldname": "process_map_and_guideline_section",
    "fieldtype": "Section Break",
-   "label": "Increment Details"
+   "label": "Process Classification"
   },
   {
    "description": "Only the processes that have gone through Pathfinder are listed. If your process is not listed in the options, select \"Others\".",
@@ -73,6 +59,40 @@
    "options": "Process",
    "remember_last_selected_value": 1,
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "fetch_from": "process_name.is_generic",
+   "fieldname": "process_is_generic",
+   "fieldtype": "Check",
+   "label": "Process is Generic",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_iarv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "All user stories under this process needs to be added under this epic.",
+   "fieldname": "epic",
+   "fieldtype": "Link",
+   "label": "Epic",
+   "options": "Work Item"
+  },
+  {
+   "fieldname": "column_break_cccw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Add the link to the process folder in the shared Google Drive.",
+   "fieldname": "process_folder_link",
+   "fieldtype": "Data",
+   "label": "Process Folder Link"
+  },
+  {
+   "fieldname": "section_break_wx0s",
+   "fieldtype": "Section Break",
+   "label": "Increment Details"
   },
   {
    "description": "A brief description of what this update is meant to achieve.",
@@ -109,7 +129,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Backlog\nPending Process Classification\nUpcoming\nActive\nOn Hold\nDeployed"
+   "options": "Backlog\nPending Process Classification\nUpcoming\nActive\nOn Hold\nDeployed",
+   "read_only_depends_on": "eval: doc.process_is_generic || !doc.epic || !doc.process_folder_link"
   },
   {
    "fieldname": "stakeholders_section",
@@ -203,7 +224,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-05 13:02:00.000000",
+ "modified": "2026-04-19 09:58:00.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Pathfinder Log",

--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -6,7 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "checklist",
-  "process_map_and_guideline_section",
+  "section_break_esrh",
   "process_name",
   "process_is_generic",
   "column_break_iarv",
@@ -45,7 +45,7 @@
    "read_only": 1
   },
   {
-   "fieldname": "process_map_and_guideline_section",
+   "fieldname": "section_break_esrh",
    "fieldtype": "Section Break",
    "label": "Process Classification"
   },
@@ -73,7 +73,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "All user stories under this process needs to be added under this epic.",
+   "description": "All user stories under this process need to be added under this epic.",
    "fieldname": "epic",
    "fieldtype": "Link",
    "label": "Epic",
@@ -87,7 +87,8 @@
    "description": "Add the link to the process folder in the shared Google Drive.",
    "fieldname": "process_folder_link",
    "fieldtype": "Data",
-   "label": "Process Folder Link"
+   "label": "Process Folder Link",
+   "options": "URL"
   },
   {
    "fieldname": "section_break_wx0s",
@@ -129,8 +130,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Backlog\nPending Process Classification\nUpcoming\nActive\nOn Hold\nDeployed",
-   "read_only_depends_on": "eval: doc.process_is_generic || !doc.epic || !doc.process_folder_link"
+   "options": "Backlog\nPending Process Classification\nUpcoming\nActive\nOn Hold\nDeployed"
   },
   {
    "fieldname": "stakeholders_section",


### PR DESCRIPTION
Here is the filled-out PR template based on the changes made:

---

## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.

Added three **Process Classification** fields to the `Pathfinder Log` DocType — **Process Name** (existing, moved into a dedicated section), **Epic** (new — Link to Work Item, filtered to type "Epic" only), and **Process Folder Link** (new — Data field for a Google Drive URL). These fields allow Business Analysts to capture process classification data directly on the Pathfinder Log form.

## Analysis and design (optional)

Fields are laid out in a 3-column section labelled "Process Classification", matching the BA site design. The `Status` field is locked read-only until both `epic` and `process_folder_link` are filled in AND the linked process is not generic — enforced client-side via `read_only_depends_on`.

## Solution description

**`pathfinder_log.json`**
- Added a `process_map_and_guideline_section` Section Break (labelled "Process Classification") above the existing "Increment Details" section.
- Moved `process_name` into this new section.
- Added `process_is_generic` (Check, read-only, fetched from `process_name.is_generic`).
- Added `epic` (Link → Work Item) in column 2.
- Added `process_folder_link` (Data) in column 3.
- Updated `status` field with `read_only_depends_on: "eval: doc.process_is_generic || !doc.epic || !doc.process_folder_link"`.

**`pathfinder_log.js`**
- Added `frm.set_query("epic", ...)` in the `refresh` hook, filtering Work Items to `work_item_type = "Epic"` only.

## Is there a business logic within a doctype?
- [x] Yes
- [ ] No

> The `status` field becomes read-only when the process is generic or when `epic`/`process_folder_link` are not filled — enforced via `read_only_depends_on` on the `Status` Select field.

## Output screenshots (optional)

<img width="1321" height="254" alt="Screenshot 2026-04-19 at 11 36 22 AM" src="https://github.com/user-attachments/assets/5637a437-ee84-4922-98a1-651d6b7d753c" />

## Areas affected and ensured

- `Pathfinder Log` form — Process Classification section layout
- `Pathfinder Log` Status field editability (now gated on epic + process folder + non-generic process)
- Epic link field picker (now filtered to Work Items of type "Epic" only)

## Is there any existing behavior change of other features due to this code change?

**Yes.** The `Status` field on existing Pathfinder Log records that do not yet have an `epic` or `process_folder_link` value will display as **read-only** until those fields are populated. Existing records are not data-migrated, so BAs will need to fill in these new fields before they can change the status.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
No child table was created.
- [ ] is attachment required? — N/A

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

> No patch required. `Pathfinder Log` is a custom DocType owned by `one_fm`; changes to its JSON are applied automatically by `bench migrate`.

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox