### PR TITLE
[WI-000244][FEAT][ Add Process Roadmap doctype link to Pathfinder workspace.]

### DIFF
--- a/one_fm/one_fm/workspace/pathfinder/pathfinder.json
+++ b/one_fm/one_fm/workspace/pathfinder/pathfinder.json
@@ -17,7 +17,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Pathfinder",
-   "link_count": 4,
+   "link_count": 5,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
@@ -48,6 +48,16 @@
    "label": "Pathfinder Log",
    "link_count": 0,
    "link_to": "Pathfinder Log",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Process Roadmap",
+   "link_count": 0,
+   "link_to": "Process Roadmap",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Add a **Process Roadmap** link card entry to the **Pathfinder Workspace** so that Business Analysts can navigate directly to the Process Roadmap list view from the workspace sidebar.


## Analysis and design (optional)

The Pathfinder workspace (`one_fm/one_fm/workspace/pathfinder/pathfinder.json`) already contains a single "Pathfinder" link card grouping DocType shortcuts (Process, Process Change Request, Pathfinder Log, Adhoc Development). The new Process Roadmap DocType (introduced in a prior task) was missing from this card, making it inaccessible from the workspace landing page.

No new DocType or database schema changes are required — the Process Roadmap DocType already exists.


## Solution description

**File changed:** `one_fm/one_fm/workspace/pathfinder/pathfinder.json`

- Added a new `"type": "Link"` entry to the `links` array:
  ```json
  {
    "hidden": 0,
    "is_query_report": 0,
    "label": "Process Roadmap",
    "link_count": 0,
    "link_to": "Process Roadmap",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
  }
  ```
- Incremented the parent `"Card Break"` entry's `link_count` from `4` to `5` to keep workspace metadata consistent.
- The link is inserted between "Pathfinder Log" and "Adhoc Development List" for logical grouping (process-related items together).
- `bench migrate` syncs the updated JSON to the database on deploy.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

After migration, the Pathfinder workspace card displays 5 links in this order:
1. Process
2. Process Change Request
3. Pathfinder Log
4. **Process Roadmap** ← new
5. Adhoc Development List


## Areas affected and ensured

- **Pathfinder Workspace** — the only area changed. The new link appears in the workspace card and navigates to the Process Roadmap list view.
- No other workspaces, DocTypes, controllers, or reports are affected.


## Is there any existing behavior change of other features due to this code change?

No. This is a purely additive change — one new link entry in the workspace JSON. All existing links remain unchanged.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

Verified via `bench migrate` against the existing site. The workspace synced successfully.


## Was child table created?
- [ ] is attachment required?  
  N/A — no child table created.


## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [ ] Yes
- [x] No

`bench migrate` automatically syncs workspace JSON fixture files — no explicit patch needed.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
