### PR TITLE
[WI-000237][FEAT][Set Naming Series for Pathfinder Log]

### DIFF
--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "format:PAT-LOG-{initiated_on}-{##}",
+ "autoname": "naming_series:",
  "creation": "2025-10-06 12:34:11.847152",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -20,6 +20,7 @@
   "business_analyst_user",
   "business_analyst_name",
   "section_break_qrox",
+  "naming_series",
   "amended_from",
   "change_requests_tab",
   "section_break_gamf",
@@ -139,6 +140,14 @@
    "fieldtype": "Section Break"
   },
   {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Naming Series",
+   "no_copy": 1,
+   "options": "PAT-LOG-.YYYY.-.MM.-.####",
+   "set_only_once": 1
+  },
+  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -187,7 +196,7 @@
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Pathfinder Log",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Set a structured **Naming Series** for the **Pathfinder Log** DocType so that every new record receives a human-readable, month-scoped ID in the format:

```
PAT-LOG-YYYY-MM-####
```

Examples:
- `PAT-LOG-2026-04-0001` — first record created in April 2026
- `PAT-LOG-2026-04-0002` — second record created in April 2026
- `PAT-LOG-2026-05-0001` — first record created in May 2026 (counter resets monthly)


## Analysis and design (optional)

The DocType previously used an old-style format expression:

```
autoname: "format:PAT-LOG-{initiated_on}-{##}"
naming_rule: "Expression (old style)"
```

This produced names like `PAT-LOG-2026-04-19-01` (full date, 2-digit counter, no zero-padding) and exposed no user-facing Naming Series field.

The new approach uses Frappe's built-in **Naming Series** mechanism with the token pattern:

```
PAT-LOG-.YYYY.-.MM.-.####
```

| Token | Output |
|---|---|
| `PAT-LOG-` | Static prefix |
| `.YYYY.` | 4-digit year (e.g., `2026`) |
| `-` | Static separator |
| `.MM.` | 2-digit month (e.g., `04`) |
| `-` | Static separator |
| `.####` | 4-digit zero-padded counter — resets per unique prefix (i.e., monthly) |

Frappe's naming engine tracks each unique prefix independently, so the counter automatically resets to `0001` every new month.


## Solution description

**File changed:** `one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json`

Three targeted changes:

1. **`autoname`** — changed from `"format:PAT-LOG-{initiated_on}-{##}"` → `"naming_series:"`
2. **`naming_rule`** — changed from `"Expression (old style)"` → `"By \"Naming Series\" field"`
3. **New field added** — `naming_series` (Select, `set_only_once`, `no_copy`) with options `PAT-LOG-.YYYY.-.MM.-.####`, placed in the unlabelled section alongside `amended_from`

No Python controller changes were required — Frappe's naming engine handles series resolution automatically.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

_The Naming Series field appears in the form's unlabelled section (alongside Amended From) and displays `PAT-LOG-.YYYY.-.MM.-.####` as the only option. After saving, the document name follows the `PAT-LOG-YYYY-MM-####` pattern._


## Areas affected and ensured

- **Pathfinder Log** — naming of all new records
- No other DocTypes are affected
- Existing records retain their current names (naming series only applies to new documents)


## Is there any existing behavior change of other features due to this code change?

**No.** Existing Pathfinder Log records are not renamed. Only newly created records will receive the new naming series format. No linked documents, reports, or workflows reference the raw document name in a way that would be affected.


## Did you test with the following dataset?
- [ ] Existing Data
- [x] New Data


## Was child table created?
No child table was created or modified.

- [ ] is attachment required?


## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [ ] Yes
- [x] No

Existing records keep their current names. The new naming series only governs records created after this change is deployed. No data migration is needed.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox