### PR TITLE
[WI-000234][FEAT][ Remove the Type field in Pathfinder Log]

### DIFF
--- a/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
+++ b/one_fm/one_fm/doctype/pathfinder_log/pathfinder_log.json
@@ -11,7 +11,6 @@
   "goal_description",
   "column_break_ojgt",
   "initiated_on",
-  "type",
   "status",
   "stakeholders_section",
   "process_owner_user",
@@ -73,14 +72,6 @@
    "in_list_view": 1,
    "label": "Initiated On",
    "read_only": 1
-  },
-  {
-   "description": "(1) Initial Process Implementation: The process is being taken through Pathfinder for the first time. (2) Major Update: May include the addition or deletion of tasks and/or activities. (3) Incremental Changes: Involves small changes, usually within a task.",
-   "fieldname": "type",
-   "fieldtype": "Select",
-   "label": "Type",
-   "options": "\nInitial Process Implementation\nMajor Update\nIncremental Changes",
-   "reqd": 1
   },
   {
    "default": "Backlog",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -372,3 +372,4 @@ one_fm.patches.v15_0.create_attendance_query_process_task
 one_fm.patches.v15_0.add_formal_hearing_workflow
 one_fm.patches.v15_0.add_formal_hearing_process_tasks_and_assignment_rules
 one_fm.patches.v15_0.add_absence_case_hr_officer_process_task_and_assignment_rule #2026-04-16
+one_fm.patches.v15_0.remove_pathfinder_log_type_field #2026-04-19

--- a/one_fm/patches/v15_0/remove_pathfinder_log_type_field.py
+++ b/one_fm/patches/v15_0/remove_pathfinder_log_type_field.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	"""Drop the legacy 'type' column from Pathfinder Log."""
+	if frappe.db.has_column("Pathfinder Log", "type"):
+		frappe.db.sql("ALTER TABLE `tabPathfinder Log` DROP COLUMN `type`")
+	frappe.db.commit()


### PR DESCRIPTION
Here is the filled-out PR template for the work completed:

---

## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.

Remove the **Type** field from the **Pathfinder Log** DocType. The field (a required Select with options `Initial Process Implementation / Major Update / Incremental Changes`) is no longer needed by the business and was not referenced in any backend controller, client script, or report.

## Analysis and design (optional)

N/A — straightforward field removal with no dependent logic.

## Solution description

1. **`pathfinder_log.json`** — Removed `"type"` from `field_order` and removed the full field definition block from the `fields` array.
2. **`patches/v15_0/remove_pathfinder_log_type_field.py`** *(new)* — Migration patch that drops the `type` column from `tabPathfinder Log` if it exists.
3. **`patches.txt`** — Registered the new patch: `one_fm.patches.v15_0.remove_pathfinder_log_type_field #2026-04-19`.

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

## Output screenshots (optional)

N/A — field is removed from the form; no UI additions.

## Areas affected and ensured

- **Pathfinder Log** form view — Type field no longer appears.
- **Pathfinder Log** list view — no change (Type was not in list view).
- **`pathfinder_log.py`** — unaffected; `type` was never referenced.
- **`pathfinder_log.js`** — unaffected; `type` was never referenced.
- **`pathfinder_api.py`** — unaffected; `type` was never referenced.

## Is there any existing behavior change of other features due to this code change?

No. The `type` field was not consumed by any controller, client script, API method, report, or workflow in the codebase.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
- N/A

## Did you delete custom field?
- [ ] Yes
- [x] No *(this is a DocType field, not a Custom Field — removed via schema + drop patch)*

## Is patch required?
- [x] Yes
- [ ] No

### Was the patch tested?
Yes — `bench migrate` ran successfully. Patch output:
```
Executing one_fm.patches.v15_0.remove_pathfinder_log_type_field #2026-04-19
    Drop the legacy 'type' column from Pathfinder Log.
Success: Done in 0.21s
```

## Which browser(s) did you use for testing?
- [ ] Chrome
- [ ] Safari
- [ ] Firefox