### PR TITLE
[WI-1690634][FEAT][Ignore User Permission In Employee Weekly Action]

### DIFF
--- a/one_fm/operations/doctype/process/process.js
+++ b/one_fm/operations/doctype/process/process.js
@@ -1,8 +1,18 @@
 // Copyright (c) 2025, ONE FM and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Process", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Process", {
+	refresh(frm) {
+		if (!frm.is_new()) {
+			frm.add_custom_button(
+				__("Pathfinder Log"),
+				function () {
+					frappe.new_doc("Pathfinder Log", {
+						process_name: frm.doc.name,
+					});
+				},
+				__("Create")
+			);
+		}
+	},
+});

--- a/one_fm/operations/doctype/process/process.json
+++ b/one_fm/operations/doctype/process/process.json
@@ -1,12 +1,5 @@
 {
- "actions": [
-  {
-   "action": "/pathfinder-log/new",
-   "action_type": "Route",
-   "label": "Pathfinder Log",
-   "group": "Create"
-  }
- ],
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:process_name",
  "creation": "2025-06-01 17:13:05.340596",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Add a **"Pathfinder Log"** option to the **Create** button group on the **Process** doctype form. When clicked, it opens a new Pathfinder Log form with the `Process Name` field pre-populated with the current process, removing the need for the user to navigate away and manually search for the process.


## Analysis and design (optional)

The Process doctype already declared a static `DocType Action` (`action_type: "Route"`) pointing to `/pathfinder-log/new`. However, a static route cannot pass query parameters or prefilled values to the destination form.

The correct Frappe pattern is to use `frappe.new_doc("Pathfinder Log", { process_name: frm.doc.name })` inside a client-side custom button, which instructs the form controller to prefill the specified fields before rendering.

The existing static action was removed from `process.json` to prevent a duplicate "Pathfinder Log" entry appearing in the Create group alongside the new JS-driven button.


## Solution description

**`one_fm/operations/doctype/process/process.js`**
- Activated the previously commented-out `frappe.ui.form.on("Process", { ... })` controller.
- Added a `refresh` handler that injects a `"Pathfinder Log"` button into the `"Create"` button group using `frm.add_custom_button`.
- The button calls `frappe.new_doc("Pathfinder Log", { process_name: frm.doc.name })` to open a blank Pathfinder Log with the process name already filled in.
- The button is conditionally rendered only when `!frm.is_new()`, since there is no valid process name to prefill on an unsaved record.

**`one_fm/operations/doctype/process/process.json`**
- Removed the static `DocType Action` entry (`action_type: "Route"`, `action: "/pathfinder-log/new"`) that previously created a non-prefilling button in the same Create group, avoiding duplication.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

> The logic is purely UI/navigation — no server-side validation or data transformation is involved.


## Output screenshots (optional)

_Test by opening a saved Process record → click **Create** → confirm **"Pathfinder Log"** appears → confirm the new form opens with Process Name pre-populated._


## Areas affected and ensured

| Area | Impact |
|---|---|
| **Process** form toolbar | "Pathfinder Log" button now appears in the Create group with prefill behaviour |
| **Pathfinder Log** new form | `process_name` field is pre-populated on open — no other fields are affected |
| Static DocType Action (removed) | The old plain-route action is removed; replaced entirely by the JS button |


## Is there any existing behavior change of other features due to this code change?

**No.** The only removed element is the static route action that previously opened `/pathfinder-log/new` without any prefill — which was incomplete behaviour. The new button replicates and improves that behaviour. No other forms, reports, or workflows are affected.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Was child table created?
- No child table was created or modified.
    - [ ] is attachment required? — N/A

## Did you delete custom field?
- [ ] Yes
- [x] No

> A **DocType Action** (not a custom field) was removed from `process.json`. No patch is required for this — DocType Action changes are applied via `bench migrate`.


## Is patch required?
- [ ] Yes
- [x] No

> No data migration is needed. The change is purely structural (DocType JSON + client JS). Running `bench migrate` is sufficient to sync the removed action.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
