### PR TITLE
[WI-000233][FEAT][Link Pathfinder Log to Process doctype]

### DIFF
--- a/one_fm/operations/doctype/process/process_dashboard.py
+++ b/one_fm/operations/doctype/process/process_dashboard.py
@@ -1,0 +1,14 @@
+from __future__ import unicode_literals
+from frappe import _
+
+
+def get_data():
+	return {
+		"fieldname": "process_name",
+		"transactions": [
+			{
+				"label": _("Pathfinder"),
+				"items": ["Pathfinder Log"]
+			}
+		]
+	}

--- a/one_fm/operations/doctype/process/process_dashboard.py
+++ b/one_fm/operations/doctype/process/process_dashboard.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from frappe import _
 
 
 def get_data():
@@ -7,7 +6,6 @@ def get_data():
 		"fieldname": "process_name",
 		"transactions": [
 			{
-				"label": _("Pathfinder"),
 				"items": ["Pathfinder Log"]
 			}
 		]


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Link the **Pathfinder Log** DocType to the **Process** form dashboard so that permitted users can see a count of existing Pathfinder Log records for a given Process and navigate directly to the filtered list.


## Analysis and design (optional)

The `Process` DocType already had the `links` array entry (`link_doctype: "Pathfinder Log"`, `link_fieldname: "process_name"`) in its JSON schema, and the client script already had a "Create → Pathfinder Log" custom button. However, Frappe also requires a `<doctype>_dashboard.py` file with a `get_data()` function to render the Connections count badge — this file was absent, leaving the links entry inert.


## Solution description

Added a single new file:

**`one_fm/operations/doctype/process/process_dashboard.py`**

Implements the `get_data()` function that Frappe calls when rendering the Process form's Connections section. It declares `fieldname: "process_name"` (the field on Pathfinder Log that links back to Process) and registers `"Pathfinder Log"` under the `transactions` list. Frappe automatically queries the count and renders a clickable badge — no custom SQL or API endpoint required.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

The Connections section on the Process form will display a **Pathfinder Log** badge showing the count of linked records. Clicking the badge navigates to the Pathfinder Log list pre-filtered by the current Process.


## Areas affected and ensured

- **Process** form — Connections/dashboard section now shows Pathfinder Log count badge
- No other DocTypes, reports, or workflows are affected


## Is there any existing behavior change of other features due to this code change?

No. The change is purely additive — a new dashboard module file. The existing "Create → Pathfinder Log" custom button and all other Process form behaviour remain unchanged.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Was child table created?
- N/A — no child table involved.
    - [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [ ] Yes
- [x] No

> No schema changes were made. The `process_dashboard.py` file is a pure Python module that Frappe discovers at runtime — no migration or data patch needed.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
