### PR TITLE
[WI-1690634][bug][Ignore User Permission In Employee Weekly Action]

### DIFF
--- a/one_fm/one_fm/doctype/employee_weekly_action/employee_weekly_action.json
+++ b/one_fm/one_fm/doctype/employee_weekly_action/employee_weekly_action.json
@@ -94,6 +94,7 @@
   {
    "fieldname": "reports_to",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Reports To",
    "options": "Employee",
    "read_only": 1


### PR DESCRIPTION
Here is the completed PR template for the change we just made:

---

## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug

---

## Clearly and concisely describe the feature, chore or bug.

Ignore User Permission on the `reports_to` Link field in the **Employee Weekly Action** DocType. Employees were unable to create or submit their weekly report because Frappe's permission engine blocked access to the manager's Employee record via User Permissions — even though the field is read-only and auto-populated from the Employee record.

---

## Analysis and design (optional)

HD Ticket #1108 — resolution confirmed: _"Ignored User Permission for Report User field."_

The `reports_to` field is a read-only Link field fetched from the employee's own record. It should never be editable by the employee, and its value is always their direct manager. There is no security concern in bypassing the User Permission check here — the field is display-only and not user-controlled.

The sibling fields `designation` and `department` already carry `ignore_user_permissions: 1` for the same reason (both are read-only, fetched from Employee). This change brings `reports_to` in line with that existing pattern.

---

## Solution description

Added `"ignore_user_permissions": 1` to the `reports_to` field definition in:

```
one_fm/one_fm/doctype/employee_weekly_action/employee_weekly_action.json
```

**Diff:**
```diff
  {
   "fieldname": "reports_to",
   "fieldtype": "Link",
+  "ignore_user_permissions": 1,
   "label": "Reports To",
   "options": "Employee",
   "read_only": 1
  }
```

No controller logic, no patch, no migration data change — metadata only.

---

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

---

## Output screenshots (optional)

Refer to the HD Ticket #1108 screenshot attached by the reporter — the **Ignore User Permissions** checkbox is now checked on the `Reports To` field in the Form Builder, matching the applied JSON change.

---

## Areas affected and ensured

| Area | Impact |
|---|---|
| Employee Weekly Action — Create | ✅ Employees can now create the document without permission error |
| Employee Weekly Action — Submit | ✅ Employees can now submit without permission error |
| `designation` / `department` fields | No change — already had `ignore_user_permissions: 1` |
| User Permissions enforcement | No regression — field remains `read_only`, value is still system-controlled |

---

## Is there any existing behavior change of other features due to this code change?

**No.** The `reports_to` field is `read_only` — employees cannot edit it. The only behavioral change is that Frappe no longer blocks save/submit when the manager's Employee record is outside the user's configured User Permissions.

---

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

---

## Was child table created?
- N/A

## Did you delete custom field?
- [ ] Yes
- [x] No

---

## Is patch required?
- [ ] Yes
- [x] No

> DocType JSON metadata changes are applied via `bench migrate`. No data migration is required.

---

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox