### PR TITLE
Fix interview console UI

### DIFF
--- a/one_fm/one_fm/page/interview_console/interview_console.css
+++ b/one_fm/one_fm/page/interview_console/interview_console.css
@@ -68,6 +68,15 @@ body[data-route="interview_console"] .ic-search-wrap {
 body[data-route="interview_console"] .ic-search-input { border: none; background: transparent; width: 100%; font-size: 13px; font-weight: 400; outline: none; font-family: 'Roboto', sans-serif; }
 body[data-route="interview_console"] .ic-sidebar-header { margin-right: 12px; display: flex; justify-content: space-between; padding: 0 5px 8px 5px; font-size: 11px; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.05em; flex-shrink: 0; }
 
+body[data-route="interview_console"] .ic-list {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 4px; /* Scrollbar padding */
+}
+body[data-route="interview_console"] .ic-list::-webkit-scrollbar { width: 3px; }
+body[data-route="interview_console"] .ic-list::-webkit-scrollbar-track { background: transparent; }
+body[data-route="interview_console"] .ic-list::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }
+
 /* ── Sidebar Items – M3 Standard Navigation Drawer Item ──────────────── */
 body[data-route="interview_console"] .ic-item {
     padding: 8px 12px; margin-bottom: 2px; border-radius: 50px; margin-right: 12px;

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -325,10 +325,15 @@ function init_interview_console(wrapper, page) {
 		
 		// Auto-scroll the sidebar to ensure the candidate is physically visible on the screen
 		if ($selected_item.length) {
-			var container = $w('.ic-left');
+			var container = $w('.ic-list'); // Changed from .ic-left to correctly target the candidate list
 			if (container.length) {
-				var offset = $selected_item.position().top + container.scrollTop() - (container.height() / 2) + ($selected_item.height() / 2);
-				container.animate({ scrollTop: offset }, 300);
+				var container_offset = container.offset();
+				var item_offset = $selected_item.offset();
+				if (container_offset && item_offset) {
+					var item_top_in_container = item_offset.top - container_offset.top + container.scrollTop();
+					var offset = item_top_in_container - (container.height() / 2) + ($selected_item.height() / 2);
+					container.animate({ scrollTop: offset }, 300);
+				}
 			}
 		}
 


### PR DESCRIPTION
Is this a Feature, Chore or Bug?
 Feature
 Chore
 Bug
Clearly and concisely describe the feature, chore or bug.
A recent structural architecture refactor of the Interview Console (.ic-sidebar) wiped out the CSS handling that kept the search bar sticky on the top, and deleted the old container class (.ic-left) which was used by the JS to automatically auto-scroll and bring newly selected candidates into view.

Analysis and design (optional)
N/A - Restoring explicit legacy UI layout styling.

Solution description
JavaScript Update: Updated the programmatic animation target in interview_console.js from .ic-left (which no longer exists) to correctly target the inner .ic-list wrapper.
CSS Hierarchy Adjustment: Added dedicated flex: 1 and overflow-y: auto styling properties natively to .ic-list in interview_console.css. This intercepts the scrolling mechanism so that applicant overflow correctly scrolls strictly within the list body, thus elegantly leaving the outer .ic-search-wrap permanently pinned/sticky to the top of the sidebar.
Is there a business logic within a doctype?
 Yes
 No
Output screenshots (optional)
(Feel free to drop a quick screenshot here of the search bar successfully sticky at the top!)

Areas affected and ensured
Interview Console Page UI (interview_console.css & interview_console.js)
Is there any existing behavior change of other features due to this code change?
No. Strictly visually isolates scrolling exclusively to the element list so the search utility remains accessible at all times, restoring the intended usability.

Did you test with the following dataset?
 Existing Data
 New Data
Was child table created?
N/A

 is attachment required?
did you test attachment? N/A
Did you delete custom field?
 Yes
 No
Is patch required?
 Yes
 No
Which browser(s) did you use for testing?
 Chrome
 Safari
 Firefox