### PR TITLE
fix(console): add debounce to prevent timestamp mismatch on rapid sco…

### DIFF
--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -76,13 +76,36 @@ function init_interview_console(wrapper, page) {
 	const SAVE_DEBOUNCE_MS = 500;
 	let saveTimeoutId = null;
 	let pendingSaveFn = null;
+	let save_in_flight = false;
+	let queued_save_fn = null;
+
+	function run_serialized_save(saveFn) {
+		if (!saveFn) return;
+		if (save_in_flight) {
+			queued_save_fn = saveFn;
+			return;
+		}
+		save_in_flight = true;
+		Promise.resolve(saveFn())
+			.catch(function (err) {
+				console.error("Interview score save failed:", err);
+			})
+			.finally(function () {
+				save_in_flight = false;
+				if (queued_save_fn) {
+					var nextFn = queued_save_fn;
+					queued_save_fn = null;
+					run_serialized_save(nextFn);
+				}
+			});
+	}
 
 	function flush_pending_save() {
 		if (saveTimeoutId) {
 			clearTimeout(saveTimeoutId);
 			saveTimeoutId = null;
 			if (pendingSaveFn) {
-				pendingSaveFn();
+				run_serialized_save(pendingSaveFn);
 				pendingSaveFn = null;
 			}
 		}
@@ -773,18 +796,19 @@ function init_interview_console(wrapper, page) {
 		if (saveTimeoutId) clearTimeout(saveTimeoutId);
 		
 		pendingSaveFn = function() {
-			save_to_db(percentage, status);
+			return save_to_db(percentage, status);
 		};
 
 		saveTimeoutId = setTimeout(function() {
 			saveTimeoutId = null;
 			if (state.selected_applicant && state.selected_applicant.name === currentApplicantName) {
 				if (pendingSaveFn) {
-					pendingSaveFn();
+					run_serialized_save(pendingSaveFn);
 					pendingSaveFn = null;
 				}
 			} else {
 				pendingSaveFn = null;
+				queued_save_fn = null;
 			}
 		}, SAVE_DEBOUNCE_MS);
 
@@ -842,7 +866,7 @@ function init_interview_console(wrapper, page) {
 				});
 			}
 		}
-		frappe.call({
+		return frappe.call({
 			method: "one_fm.one_fm.page.interview_console.interview_console.save_interview_data",
 			args: {
 				applicant: state.selected_applicant.name,
@@ -888,7 +912,10 @@ function init_interview_console(wrapper, page) {
 		var score = parseInt(score_text) || 0;
 
 		state.selected_applicant.status = status;
-		save_to_db(score, status);
+		
+		run_serialized_save(function() {
+			return save_to_db(score, status);
+		});
 
 		// Immediate UI update
 		var display_status = status;

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -73,6 +73,7 @@ function init_interview_console(wrapper, page) {
 		matrix: [],
 		applicants: []
 	};
+	var save_timeout = null;
 
 	function init() {
 		// Check for deep-link: if arriving from Job Applicant with applicant route_option
@@ -750,7 +751,10 @@ function init_interview_console(wrapper, page) {
 		$w('#ic-score-pill').text(percentage + '/100').css({ 'background': '#e0f2fe', 'color': '#0369a1' });
 		if (percentage > 0 && status === "Open") status = "Replied";
 
-		save_to_db(percentage, status);
+		if (save_timeout) clearTimeout(save_timeout);
+		save_timeout = setTimeout(function() {
+			save_to_db(percentage, status);
+		}, 500);
 
 		state.selected_applicant.interview_score = percentage;
 		state.selected_applicant.status = status;

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -119,8 +119,15 @@ function init_interview_console(wrapper, page) {
 			frappe.route_options = null; // Consume the option
 		}
 		
-		window.addEventListener('beforeunload', flush_pending_save);
-		if (frappe.router) frappe.router.on('change', flush_pending_save);
+		if (!wrapper._ic_handlers_bound) {
+			window.addEventListener('visibilitychange', function() {
+				if (document.visibilityState === 'hidden') {
+					flush_pending_save();
+				}
+			});
+			if (frappe.router) frappe.router.on('change', flush_pending_save);
+			wrapper._ic_handlers_bound = true;
+		}
 
 		fetch_applicants(auto_select_applicant);
 		setup_handlers();

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -75,6 +75,18 @@ function init_interview_console(wrapper, page) {
 	};
 	const SAVE_DEBOUNCE_MS = 500;
 	let saveTimeoutId = null;
+	let pendingSaveFn = null;
+
+	function flush_pending_save() {
+		if (saveTimeoutId) {
+			clearTimeout(saveTimeoutId);
+			saveTimeoutId = null;
+			if (pendingSaveFn) {
+				pendingSaveFn();
+				pendingSaveFn = null;
+			}
+		}
+	}
 
 	function init() {
 		// Check for deep-link: if arriving from Job Applicant with applicant route_option
@@ -83,6 +95,10 @@ function init_interview_console(wrapper, page) {
 			auto_select_applicant = frappe.route_options.applicant;
 			frappe.route_options = null; // Consume the option
 		}
+		
+		window.addEventListener('beforeunload', flush_pending_save);
+		if (frappe.router) frappe.router.on('change', flush_pending_save);
+
 		fetch_applicants(auto_select_applicant);
 		setup_handlers();
 
@@ -318,6 +334,7 @@ function init_interview_console(wrapper, page) {
 	}
 
 	function select_applicant(app) {
+		flush_pending_save();
 		state.selected_applicant = app;
         
         $w('#ic-root').addClass('has-selection');
@@ -754,9 +771,20 @@ function init_interview_console(wrapper, page) {
 
 		const currentApplicantName = state.selected_applicant && state.selected_applicant.name;
 		if (saveTimeoutId) clearTimeout(saveTimeoutId);
+		
+		pendingSaveFn = function() {
+			save_to_db(percentage, status);
+		};
+
 		saveTimeoutId = setTimeout(function() {
+			saveTimeoutId = null;
 			if (state.selected_applicant && state.selected_applicant.name === currentApplicantName) {
-				save_to_db(percentage, status);
+				if (pendingSaveFn) {
+					pendingSaveFn();
+					pendingSaveFn = null;
+				}
+			} else {
+				pendingSaveFn = null;
 			}
 		}, SAVE_DEBOUNCE_MS);
 

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -73,7 +73,8 @@ function init_interview_console(wrapper, page) {
 		matrix: [],
 		applicants: []
 	};
-	var save_timeout = null;
+	const SAVE_DEBOUNCE_MS = 500;
+	let saveTimeoutId = null;
 
 	function init() {
 		// Check for deep-link: if arriving from Job Applicant with applicant route_option
@@ -751,10 +752,10 @@ function init_interview_console(wrapper, page) {
 		$w('#ic-score-pill').text(percentage + '/100').css({ 'background': '#e0f2fe', 'color': '#0369a1' });
 		if (percentage > 0 && status === "Open") status = "Replied";
 
-		if (save_timeout) clearTimeout(save_timeout);
-		save_timeout = setTimeout(function() {
+		if (saveTimeoutId) clearTimeout(saveTimeoutId);
+		saveTimeoutId = setTimeout(function() {
 			save_to_db(percentage, status);
-		}, 500);
+		}, SAVE_DEBOUNCE_MS);
 
 		state.selected_applicant.interview_score = percentage;
 		state.selected_applicant.status = status;

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -752,9 +752,12 @@ function init_interview_console(wrapper, page) {
 		$w('#ic-score-pill').text(percentage + '/100').css({ 'background': '#e0f2fe', 'color': '#0369a1' });
 		if (percentage > 0 && status === "Open") status = "Replied";
 
+		const currentApplicantName = state.selected_applicant && state.selected_applicant.name;
 		if (saveTimeoutId) clearTimeout(saveTimeoutId);
 		saveTimeoutId = setTimeout(function() {
-			save_to_db(percentage, status);
+			if (state.selected_applicant && state.selected_applicant.name === currentApplicantName) {
+				save_to_db(percentage, status);
+			}
 		}, SAVE_DEBOUNCE_MS);
 
 		state.selected_applicant.interview_score = percentage;

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -876,6 +876,14 @@ function init_interview_console(wrapper, page) {
 
 	function update_status(status) {
 		if (!state.selected_applicant) return frappe.msgprint("Select a candidate");
+		
+		// Cancel any pending debounced save to prevent it from overwriting this hard save in the future
+		if (saveTimeoutId) {
+			clearTimeout(saveTimeoutId);
+			saveTimeoutId = null;
+			pendingSaveFn = null;
+		}
+
 		var score_text = $w('#ic-score-pill').text();
 		var score = parseInt(score_text) || 0;
 

--- a/one_fm/one_fm/page/interview_console/interview_console.js
+++ b/one_fm/one_fm/page/interview_console/interview_console.js
@@ -101,7 +101,7 @@ function init_interview_console(wrapper, page) {
 	}
 
 	function flush_pending_save() {
-		if (saveTimeoutId) {
+		if (saveTimeoutId !== null) {
 			clearTimeout(saveTimeoutId);
 			saveTimeoutId = null;
 			if (pendingSaveFn) {
@@ -793,7 +793,7 @@ function init_interview_console(wrapper, page) {
 		if (percentage > 0 && status === "Open") status = "Replied";
 
 		const currentApplicantName = state.selected_applicant && state.selected_applicant.name;
-		if (saveTimeoutId) clearTimeout(saveTimeoutId);
+		if (saveTimeoutId !== null) clearTimeout(saveTimeoutId);
 		
 		pendingSaveFn = function() {
 			return save_to_db(percentage, status);
@@ -902,7 +902,7 @@ function init_interview_console(wrapper, page) {
 		if (!state.selected_applicant) return frappe.msgprint("Select a candidate");
 		
 		// Cancel any pending debounced save to prevent it from overwriting this hard save in the future
-		if (saveTimeoutId) {
+		if (saveTimeoutId !== null) {
 			clearTimeout(saveTimeoutId);
 			saveTimeoutId = null;
 			pendingSaveFn = null;


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug
## Clearly and concisely describe the feature, chore or bug.
A `TimestampMismatchError` is frequently thrown on the Staging server when recruiters rapidly click cells in the Interview Console evaluation matrix to score candidates.
## Analysis and design (optional)
When a recruiter clicks consecutive scoring cells rapidly, the `save_to_db` `frappe.call` was being dispatching instantly on every click. Because trailing network latency spaces the requests out, multiple asynchronous `doc.save()` transactions overlap on the same `Job Applicant` document simultaneously, causing Frappe's overwrite protection to reject the save.
## Solution description
Introduced a 500ms `setTimeout` debounce wrapper inside the JavaScript `update_and_save()` function. The UI state (cell colors and active aggregated score pill) updates synchronously and instantly to maintain a snappy user experience, while the expensive backend database write is delayed and grouped into a single, unified API call half a second after the recruiter stops clicking.
## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No
## Output screenshots (optional)
N/A (Invisible optimization. UI remains identical, bypassing the global error alerts).
## Areas affected and ensured
- Interview Console Custom Page (`one_fm/one_fm/page/interview_console/interview_console.js`)
## Is there any existing behavior change of other features due to this code change?
No. The scoring calculation logic and JSON data being passed to exactly the same backend endpoints remain untouched. Only the frequency/timing of the API network dispatch was altered.
## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data
## Was child table created?
    - [ ] is attachment required?
        did you test attachment
*(Not Applicable)*
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?
## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?
## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [ ] Firefox