### PR TITLE
fix: handling empty operations roles in mark attendance

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -1164,10 +1164,10 @@ class AttendanceMarking():
         if self.attendance_type:
             client_shifts =  frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
-                JOIN `tabOperations Role` op ON sa.operations_role=op.name
+                LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.start_date='{self.start.date()}'
-                AND op.attendance_by_client=1 AND op.docstatus=1
+                AND (op.attendance_by_client=1 AND op.docstatus=1 OR sa.operations_role IS NULL OR sa.operations_role = '')
                 ;
             """, as_dict=1)
             for i in client_shifts:
@@ -1195,10 +1195,10 @@ class AttendanceMarking():
         else:
             client_shifts =  frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
-                JOIN `tabOperations Role` op ON sa.operations_role=op.name
+                LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.end_datetime BETWEEN '{self.start}' AND  '{self.end}'
-                AND op.attendance_by_client=1 AND op.status='Active'
+                AND (op.attendance_by_client=1 AND op.status='Active' OR sa.operations_role IS NULL OR sa.operations_role = '')
                 ;
                 """, as_dict=1)
             for i in client_shifts:


### PR DESCRIPTION
This pull request updates the logic for selecting shift assignments in the `mark_shift_attendance` method in `one_fm/overrides/attendance.py`. The main change is to ensure that shift assignments without an associated operations role are included in attendance marking, improving coverage and correctness.

**Attendance logic improvements:**

* Changed SQL queries from `JOIN` to `LEFT JOIN` with `tabOperations Role` to include shift assignments that do not have an associated operations role. [[1]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1167-R1170) [[2]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1198-R1201)
* Updated the `WHERE` clause to include shift assignments where `operations_role` is `NULL` or an empty string, ensuring these are not excluded from attendance marking. [[1]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1167-R1170) [[2]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1198-R1201)