### PR TITLE
feat: Visa request - assignment rule

### DIFF
--- a/one_fm/custom/assignment_rule/grd_manager_visa_request.json
+++ b/one_fm/custom/assignment_rule/grd_manager_visa_request.json
@@ -1,0 +1,25 @@
+{
+  "name": "GRD Manager - Visa Request",
+  "document_type": "Visa Request",
+  "priority": 0,
+  "disabled": 0,
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Job Offer</td>\n                <td style=\"padding: 10px;\">{{job_offer}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Job Applicant</td>\n                <td style=\"padding: 10px;\">{{job_applicant}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Request Date </td>\n                <td style=\"padding: 10px;\">{{request_date}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Nationality</td>\n                <td style=\"padding: 10px;\">{{nationality}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Number</td>\n                <td style=\"padding: 10px;\">{{passport_number}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Holder of</td>\n                <td style=\"padding: 10px;\">{{passport_holder_of}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Issued on</td>\n                <td style=\"padding: 10px;\">{{passport_issued_on}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Expires on</td>\n                <td style=\"padding: 10px;\">{{passport_expires_on}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Copy</td>\n                <td style=\"padding: 10px;\">{{passport_copy}}</td>\n            </tr>\n            </tbody></table><p></p>",
+  "is_assignment_rule_with_workflow": 1,
+  "assign_condition": "workflow_state in (\"Pending GRD Manager Approval\")",
+  "unassign_condition": "workflow_state not in (\"Pending GRD Manager Approval\")",
+  "rule": "Based on Process Task",
+  "custom_routine_task": "",
+  "field": "owner",
+  "last_user": "",
+  "doctype": "Assignment Rule",
+  "users": [],
+  "assignment_days": [
+    { "day": "Monday", "doctype": "Assignment Rule Day" },
+    { "day": "Tuesday", "doctype": "Assignment Rule Day" },
+    { "day": "Wednesday", "doctype": "Assignment Rule Day" },
+    { "day": "Thursday", "doctype": "Assignment Rule Day" },
+    { "day": "Friday", "doctype": "Assignment Rule Day" },
+    { "day": "Saturday", "doctype": "Assignment Rule Day" },
+    { "day": "Sunday", "doctype": "Assignment Rule Day" }
+  ]
+}

--- a/one_fm/custom/assignment_rule/groperator_visa_request.json
+++ b/one_fm/custom/assignment_rule/groperator_visa_request.json
@@ -1,0 +1,24 @@
+{
+  "name": "GROperator - Visa Request",
+  "document_type": "Visa Request",
+  "priority": 0,
+  "disabled": 0,
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Job Offer</td>\n                <td style=\"padding: 10px;\">{{job_offer}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Job Applicant</td>\n                <td style=\"padding: 10px;\">{{job_applicant}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Request Date </td>\n                <td style=\"padding: 10px;\">{{request_date}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Nationality</td>\n                <td style=\"padding: 10px;\">{{nationality}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Number</td>\n                <td style=\"padding: 10px;\">{{passport_number}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Holder of</td>\n                <td style=\"padding: 10px;\">{{passport_holder_of}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Issued on</td>\n                <td style=\"padding: 10px;\">{{passport_issued_on}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Expires on</td>\n                <td style=\"padding: 10px;\">{{passport_expires_on}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Copy</td>\n                <td style=\"padding: 10px;\">{{passport_copy}}</td>\n            </tr>\n            </tbody></table><p></p>",
+  "is_assignment_rule_with_workflow": 1,
+  "assign_condition": "workflow_state in (\"Pending Initial Review\", \"Pending By PAM\", \"Pending Visa Request Cancel\")",
+  "unassign_condition": "workflow_state not in (\"Awaiting Quota Availability\", \"Pending By MOI\", \"Pending Visa\", \"Pending Cancel Work Permit\", \"Pending Initial Review\", \"Pending By PAM\", \"Pending Visa Request Cancel\")",
+  "rule": "Based on Process Task",
+  "custom_routine_task": "",
+  "field": "owner",
+  "doctype": "Assignment Rule",
+  "users": [],
+  "assignment_days": [
+    { "day": "Monday", "doctype": "Assignment Rule Day" },
+    { "day": "Tuesday", "doctype": "Assignment Rule Day" },
+    { "day": "Wednesday", "doctype": "Assignment Rule Day" },
+    { "day": "Thursday", "doctype": "Assignment Rule Day" },
+    { "day": "Friday", "doctype": "Assignment Rule Day" },
+    { "day": "Saturday", "doctype": "Assignment Rule Day" },
+    { "day": "Sunday", "doctype": "Assignment Rule Day" }
+  ]
+}

--- a/one_fm/custom/assignment_rule/recruiter_visa_request.json
+++ b/one_fm/custom/assignment_rule/recruiter_visa_request.json
@@ -1,0 +1,44 @@
+{
+  "name": "Recruiter - Visa Request",
+  "document_type": "Visa Request",
+  "priority": 0,
+  "disabled": 0,
+  "description": "<p>Here is to inform you that the following {{ doctype }}({{ name }}) requires your attention/action.\n        <br>\n        The details of the request are as follows:\n        <br>\n        </p><table cellpadding=\"0\" cellspacing=\"0\" border=\"1\" style=\"border-collapse: collapse;\">\n            <thead>\n                <tr>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Label</th>\n                    <th style=\"padding: 10px; text-align: left; background-color: #f2f2f2;\">Value</th>\n                </tr>\n            </thead>\n        <tbody>\n        \n            <tr>\n                <td style=\"padding: 10px;\">Job Offer</td>\n                <td style=\"padding: 10px;\">{{job_offer}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Job Applicant</td>\n                <td style=\"padding: 10px;\">{{job_applicant}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Request Date </td>\n                <td style=\"padding: 10px;\">{{request_date}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Nationality</td>\n                <td style=\"padding: 10px;\">{{nationality}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Number</td>\n                <td style=\"padding: 10px;\">{{passport_number}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Holder of</td>\n                <td style=\"padding: 10px;\">{{passport_holder_of}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Issued on</td>\n                <td style=\"padding: 10px;\">{{passport_issued_on}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Expires on</td>\n                <td style=\"padding: 10px;\">{{passport_expires_on}}</td>\n            </tr>\n            \n            <tr>\n                <td style=\"padding: 10px;\">Passport Copy</td>\n                <td style=\"padding: 10px;\">{{passport_copy}}</td>\n            </tr>\n            </tbody></table><p></p>",
+  "is_assignment_rule_with_workflow": 1,
+  "assign_condition": "workflow_state in (\"Rejected By Operator\", \"Rejected By PAM\", \"Rejected By MOI\", \"Pending Recruiter Confirmation\")",
+  "unassign_condition": "workflow_state not in (\"Rejected By Operator\", \"Rejected By PAM\", \"Rejected By MOI\", \"Pending Recruiter Confirmation\")",
+  "rule": "Based on Field",
+  "field": "owner",
+  "doctype": "Assignment Rule",
+  "assignment_days": [
+    {
+      "day": "Monday",
+      "doctype": "Assignment Rule Day"
+    },
+    {
+      "day": "Tuesday",
+      "doctype": "Assignment Rule Day"
+    },
+    {
+      "day": "Wednesday",
+      "doctype": "Assignment Rule Day"
+    },
+    {
+      "day": "Thursday",
+      "doctype": "Assignment Rule Day"
+    },
+    {
+      "day": "Friday",
+      "doctype": "Assignment Rule Day"
+    },
+    {
+      "day": "Saturday",
+      "doctype": "Assignment Rule Day"
+    },
+    {
+      "day": "Sunday",
+      "doctype": "Assignment Rule Day"
+    }
+  ],
+  "users": []
+}

--- a/one_fm/custom/custom_field/employee.py
+++ b/one_fm/custom/custom_field/employee.py
@@ -70,7 +70,7 @@ def get_employee_custom_fields():
 				"read_only": 1,
 			},
 			{
-				"fieldname": "column_break_heye",
+				"fieldname": "column_break_after_bank_name",
 				"fieldtype": "Column Break",
 				"insert_after": "bank_name",
 			},

--- a/one_fm/custom/workflow/visa_request.json
+++ b/one_fm/custom/workflow/visa_request.json
@@ -257,8 +257,8 @@
     },
     {
       "state": "Pending Cancel Work Permit",
-      "action": "Complete",
-      "next_state": "Completed",
+      "action": "Cancel Work Permit",
+      "next_state": "Canceled",
       "allowed": "Government Relations Operator",
       "allow_self_approval": 1,
       "send_email_to_creator": 0,
@@ -451,10 +451,20 @@
     {
       "state": "Rejected for Re Issue",
       "doc_status": "0",
-      "style": "Success",
+      "style": "Inverse",
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Recruiter",
+      "send_email": 1,
+      "doctype": "Workflow Document State"
+    },
+    {
+      "state": "Canceled",
+      "doc_status": "0",
+      "style": "Danger",
+      "is_optional_state": 0,
+      "avoid_status_override": 0,
+      "allow_edit": "Government Relations Operator",
       "send_email": 1,
       "doctype": "Workflow Document State"
     }

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -367,9 +367,12 @@ one_fm.patches.v15_0.add_assignment_rule_subcontract_ops_manager #2026-04-12
 one_fm.patches.v15_0.add_assignment_rule_subcontract_finance_manager #2026-04-12
 one_fm.patches.v15_0.add_assignment_rule_subcontract_subcontractor #2026-04-12
 one_fm.patches.v15_0.add_subcontractor_contracts_workflow #2026-04-12
-one_fm.patches.v15_0.add_workflow_visa_request
+one_fm.patches.v15_0.add_workflow_visa_request #1
 one_fm.patches.v15_0.create_attendance_query_process_task
 one_fm.patches.v15_0.add_formal_hearing_workflow #2026-04-19
 one_fm.patches.v15_0.add_formal_hearing_process_tasks_and_assignment_rules
 one_fm.patches.v15_0.add_absence_case_hr_officer_process_task_and_assignment_rule #2026-04-16
 one_fm.patches.v15_0.remove_pathfinder_log_type_field #2026-04-19
+one_fm.patches.v15_0.add_assignment_rule_recruiter_visa_request
+one_fm.patches.v15_0.add_assignment_rule_groperator_visa_request
+one_fm.patches.v15_0.add_assignment_rule_grdmanager_visa_request

--- a/one_fm/patches/v15_0/add_assignment_rule_grdmanager_visa_request.py
+++ b/one_fm/patches/v15_0/add_assignment_rule_grdmanager_visa_request.py
@@ -1,0 +1,22 @@
+import frappe
+from one_fm.custom.assignment_rule.assignment_rule import (
+    get_assignment_rule_json_file, create_assignment_rule
+)
+from one_fm.utils import create_process_task
+
+
+def execute():
+    # Create the process task and link it to the assignment rule
+    process_task = create_process_task(
+        process_name="Visa",
+        erp_document="Visa Request",
+        task_description="Assign GRD Manager",
+        employee="HR-EMP-00036",
+        task_type="Repetitive",
+        is_routine_task=0
+    )
+
+    create_assignment_rule(
+        get_assignment_rule_json_file("grd_manager_visa_request.json"),
+        process_task.name
+    )

--- a/one_fm/patches/v15_0/add_assignment_rule_groperator_visa_request.py
+++ b/one_fm/patches/v15_0/add_assignment_rule_groperator_visa_request.py
@@ -1,0 +1,22 @@
+import frappe
+from one_fm.custom.assignment_rule.assignment_rule import (
+    get_assignment_rule_json_file, create_assignment_rule
+)
+from one_fm.utils import create_process_task
+
+
+def execute():
+    # Create the process task and link it to the assignment rule
+    process_task = create_process_task(
+        process_name="Visa",
+        erp_document="Visa Request",
+        task_description="Assign Government Relation Operator",
+        employee="HR-EMP-00775",
+        task_type="Repetitive",
+        is_routine_task=0
+    )
+
+    create_assignment_rule(
+        get_assignment_rule_json_file("groperator_visa_request.json"),
+        process_task.name
+    )

--- a/one_fm/patches/v15_0/add_assignment_rule_groperator_visa_request.py
+++ b/one_fm/patches/v15_0/add_assignment_rule_groperator_visa_request.py
@@ -10,7 +10,7 @@ def execute():
     process_task = create_process_task(
         process_name="Visa",
         erp_document="Visa Request",
-        task_description="Assign Government Relation Operator",
+        task_description="Assign Government Relations Operator",
         employee="HR-EMP-00775",
         task_type="Repetitive",
         is_routine_task=0

--- a/one_fm/patches/v15_0/add_assignment_rule_recruiter_visa_request.py
+++ b/one_fm/patches/v15_0/add_assignment_rule_recruiter_visa_request.py
@@ -1,0 +1,6 @@
+import frappe
+from one_fm.custom.assignment_rule.assignment_rule import get_assignment_rule_json_file, create_assignment_rule
+
+
+def execute():
+    create_assignment_rule(get_assignment_rule_json_file("recruiter_visa_request.json"))

--- a/one_fm/setup/assignment_rule.py
+++ b/one_fm/setup/assignment_rule.py
@@ -73,6 +73,9 @@ def create_assignment_rules():
 	create_assignment_rule(get_assignment_rule_json_file("formal_hearing_hr_manager.json"))
 	create_assignment_rule(get_assignment_rule_json_file("formal_hearing_general_manager.json"))
 	create_assignment_rule(get_assignment_rule_json_file("absence_case_hr_officer.json"))
+	create_assignment_rule(get_assignment_rule_json_file("groperator_visa_request.json"))
+	create_assignment_rule(get_assignment_rule_json_file("recruiter_visa_request.json"))
+	create_assignment_rule(get_assignment_rule_json_file("grd_manager_visa_request.json"))
 
 def delete_assignment_rules():
 	delete_assignment_rule(get_assignment_rule_json_file("roster_post_action_site_supervisor.json"))


### PR DESCRIPTION
This pull request introduces assignment rules for the "Visa Request" workflow, targeting three key roles: Recruiter, Government Relations Operator, and GRD Manager. It also updates the workflow states to add a "Canceled" state and refines transitions and visual cues. The changes ensure that assignment and workflow automation for visa requests are more granular and role-specific.

**Assignment Rules for Visa Request:**
- Added three new assignment rule JSON files for `Recruiter`, `GROperator`, and `GRD Manager`, each detailing when and how tasks are assigned based on workflow state and including a notification template. [[1]](diffhunk://#diff-1c07fff0785d3bcee0700badeeac0f6dac41f6a5ff50096237c7ac0d580d09e3R1-R44) [[2]](diffhunk://#diff-fcb162b874f82a4b2b9ea3beec910967246ad2dad0bfedbf9d39c6fc1d34a8adR1-R24) [[3]](diffhunk://#diff-1fed6c8c2ff2394dba3c23a5e22a3f21c37e126406002251676717983fa7e346R1-R25)
- Added corresponding patch scripts to programmatically create these assignment rules and link them to process tasks where applicable. [[1]](diffhunk://#diff-366d1d195026de1c80fe9fe769d93cdd713593aa5743f7b0bab15ea6042c007aR1-R6) [[2]](diffhunk://#diff-952af70737ede821d728982368986fc63cf8dcbc16b668caa774aef2fc14b197R1-R22) [[3]](diffhunk://#diff-70e1518de192aa508345e91e4de654b9ed9ba164c9057f1c7dd046112637688eR1-R22)
- Registered the new patch scripts in `patches.txt` for deployment and migration.
- Updated `create_assignment_rules` to include the new assignment rules for setup consistency.

**Workflow and State Updates:**
- Modified the "Pending Cancel Work Permit" action to "Cancel Work Permit" and its next state to "Canceled" in the visa request workflow, aligning with the new state.
- Changed the style of the "Rejected for Re Issue" state and added a new "Canceled" state to the workflow, with appropriate permissions and notifications.