### PR TITLE
fix: TypeError in leave_application_on_cancel date comparison

### DIFF
--- a/one_fm/tests/test_issue_5942.py
+++ b/one_fm/tests/test_issue_5942.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from one_fm.utils import leave_application_on_cancel
+from frappe.utils import getdate, add_days
+
+from unittest.mock import patch
+
+class TestLeaveApplicationCancel(FrappeTestCase):
+    def test_leave_application_on_cancel_comparison(self):
+        # Create a dummy doc with from_date as a date object
+        # This simulates the condition where doc.from_date is a datetime.date object
+        doc = frappe._dict({
+            "from_date": getdate(add_days(frappe.utils.nowdate(), -1)),
+            "employee": "EMP-00001", # Dummy employee
+            "doctype": "Leave Application"
+        })
+        
+        # Mock frappe.db.set_value to avoid side effects if employee doesn't exist
+        # and update_employee_hajj_status to avoid its internal logic
+        with patch("frappe.db.set_value"), \
+             patch("one_fm.utils.update_employee_hajj_status"):
+            try:
+                leave_application_on_cancel(doc, "on_cancel")
+            except TypeError as e:
+                self.fail(f"leave_application_on_cancel raised TypeError: {e}")
+            except Exception as e:
+                self.fail(f"leave_application_on_cancel raised an unexpected exception: {e}")
+
+    def test_leave_application_on_cancel_with_string_date(self):
+        # Also test with string date to ensure getdate() handles it correctly
+        doc = frappe._dict({
+            "from_date": add_days(frappe.utils.nowdate(), -1),
+            "employee": "EMP-00001",
+            "doctype": "Leave Application"
+        })
+        
+        with patch("frappe.db.set_value"), \
+             patch("one_fm.utils.update_employee_hajj_status"):
+            try:
+                leave_application_on_cancel(doc, "on_cancel")
+            except TypeError as e:
+                self.fail(f"leave_application_on_cancel raised TypeError with string date: {e}")

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -633,9 +633,9 @@ def notify_employee(doc, method):
 
 @frappe.whitelist()
 def leave_application_on_cancel(doc, method):
-    today = nowdate()
-    if doc.from_date < today :
-        frappe.db.set_value("Employee",doc.employee, "status","Active")
+    # Use getdate() to ensure comparison between date objects
+    if getdate(doc.from_date) < getdate():
+        frappe.db.set_value("Employee", doc.employee, "status", "Active")
     update_employee_hajj_status(doc, method)
 
 def get_leave_payment_breakdown(leave_type):


### PR DESCRIPTION
## Summary
Fixed `TypeError: '<' not supported between instances of 'datetime.date' and 'str'` in `leave_application_on_cancel` function.

## Changes
- `one_fm/utils.py`: Updated `leave_application_on_cancel` to use `getdate()` for both operands in the date comparison.
- `one_fm/tests/test_issue_5942.py`: Added a new test file with test cases for both `datetime.date` and string date inputs to verify the fix.

## Review Checklist
- [x] validate_doctype_json: N/A (No JSON changes)
- [x] bench migrate: N/A
- [x] run_tests: ✅ PASS (New tests in `one_fm.tests.test_issue_5942` passed)
- [x] hooks.py paths verified: N/A (No hook changes)
- [x] No frappe.db.commit() in controllers: ✅ PASS (None in changed code)
- [x] Indentation: ✅ PASS (Verified 4 spaces in changed code)

## How to Verify
Run the new tests:
`bench --site onefm run-tests --module one_fm.tests.test_issue_5942`

Closes #5942