### PR TITLE
Fix interview console workflow

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -377,3 +377,4 @@ one_fm.patches.v15_0.remove_pathfinder_log_type_field #2026-04-19
 one_fm.patches.v15_0.add_assignment_rule_recruiter_visa_request
 one_fm.patches.v15_0.add_assignment_rule_groperator_visa_request
 one_fm.patches.v15_0.add_assignment_rule_grdmanager_visa_request
+one_fm.patches.v15_4.grant_interviewer_workflow_rights.execute

--- a/one_fm/patches/v15_4/grant_interviewer_workflow_rights.py
+++ b/one_fm/patches/v15_4/grant_interviewer_workflow_rights.py
@@ -1,0 +1,20 @@
+import frappe
+from frappe.permissions import add_permission
+
+def execute():
+    # Attempt to use natively provided add_permission utility if available
+    try:
+        add_permission("Workflow", "Interviewer", 0)
+        frappe.db.commit()
+    except Exception:
+        # Fallback to direct insertion in Custom DocPerm if add_permission fails
+        if not frappe.db.exists("Custom DocPerm", {"parent": "Workflow", "role": "Interviewer"}):
+            doc = frappe.new_doc("Custom DocPerm")
+            doc.parent = "Workflow"
+            doc.parenttype = "DocType"
+            doc.parentfield = "permissions"
+            doc.role = "Interviewer"
+            doc.read = 1
+            doc.permlevel = 0
+            doc.insert(ignore_permissions=True)
+            frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
Standard users who are assigned the `Interviewer` role currently lack native database permission to interact with Frappe's core `Workflow` DocType, physically preventing them from rendering or triggering workflow transitions.

## Analysis and design (optional)
N/A

## Solution description
Authored an upgrade-safe python Patch (`one_fm.patches.v15_4.grant_interviewer_workflow_rights.execute`). When executed upon production deployment, it natively injects a Custom DocPerm giving the `Interviewer` Role explicit `read` access at Permission Level 0 for the `Workflow` system DocType.

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

## Areas affected and ensured
- Role Permissions tied to the core `Workflow` matrix. 

## Is there any existing behavior change of other features due to this code change?
No. Standard users with the Interviewer role simply securely gain read visibility onto their authorized workflow transition panels.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
- [ ] is attachment required?
   - did you test attachment
*(No child tables created)*

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [x] Yes
- [ ] No
    ## Was the patch tested?
    Yes. Extensively tested via `bench execute` on the local database to verify it seamlessly activates the permission securely.

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [ ] Firefox
