### PR TITLE
fix(attendance): exclude empty operations_role from client shifts path

### DIFF
--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -1210,7 +1210,7 @@ class AttendanceMarking():
                 LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.start_date='{self.start.date()}'
-                AND (op.attendance_by_client=1 AND op.docstatus=1 OR sa.operations_role IS NULL OR sa.operations_role = '')
+                AND op.attendance_by_client=1 AND op.docstatus=1
                 ;
             """, as_dict=1)
             for i in client_shifts:
@@ -1241,7 +1241,7 @@ class AttendanceMarking():
                 LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.end_datetime BETWEEN '{self.start}' AND  '{self.end}'
-                AND (op.attendance_by_client=1 AND op.status='Active' OR sa.operations_role IS NULL OR sa.operations_role = '')
+                AND op.attendance_by_client=1 AND op.status='Active'
                 ;
                 """, as_dict=1)
             for i in client_shifts:

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -207,7 +207,7 @@ def mark_single_attendance(emp, att_date, roster_type="Basic"):
         }):
         open_leaves = frappe.db.sql(f"""
             SELECT name, employee FROM `tabLeave Application`
-            WHERE employee='{emp}' AND status='Open' AND '{att_date}' BETWEEN from_date AND to_date;
+            WHERE employee='{emp}' AND status='Open' AND '{att_date}' BETWEEN from_date AND to_date
         """, as_dict=1)
         if not open_leaves: # continue if no open leaves
             employee = frappe.get_value("Employee", emp, {"name", "holiday_list", "employee_name"}, as_dict=1)
@@ -1207,11 +1207,10 @@ class AttendanceMarking():
         if self.attendance_type:
             client_shifts =  frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
-                LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
+                INNER JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.start_date='{self.start.date()}'
                 AND op.attendance_by_client=1 AND op.status='Active'
-                ;
             """, as_dict=1)
             for i in client_shifts:
                 self.create_attendance(frappe._dict({**i, **{
@@ -1238,11 +1237,10 @@ class AttendanceMarking():
         else:
             client_shifts =  frappe.db.sql(f"""
                 SELECT sa.* FROM `tabShift Assignment` sa
-                LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
+                INNER JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.end_datetime BETWEEN '{self.start}' AND  '{self.end}'
                 AND op.attendance_by_client=1 AND op.status='Active'
-                ;
                 """, as_dict=1)
             for i in client_shifts:
                 self.create_attendance(frappe._dict({**i, **{
@@ -1418,7 +1416,7 @@ class AttendanceMarking():
             ec.shift_assignment in ({placeholders})
             AND ec.is_replaced = 0
         GROUP BY
-            ec.shift_assignment;
+            ec.shift_assignment
         """
         return frappe.db.sql(query, tuple(shift_assignments), as_dict=1)
 

--- a/one_fm/overrides/attendance.py
+++ b/one_fm/overrides/attendance.py
@@ -1210,7 +1210,7 @@ class AttendanceMarking():
                 LEFT JOIN `tabOperations Role` op ON sa.operations_role=op.name
                 WHERE sa.is_replaced = 0
                 AND sa.start_date='{self.start.date()}'
-                AND op.attendance_by_client=1 AND op.docstatus=1
+                AND op.attendance_by_client=1 AND op.status='Active'
                 ;
             """, as_dict=1)
             for i in client_shifts:


### PR DESCRIPTION
## Reason for PR
Assignments without operations_role were matched by both client_shifts and shifts queries, causing them to be marked "On Hold" instead of auto-marked by checkins. Removed NULL/empty check from client_shifts.

## Summary
This pull request refines several SQL queries in the `one_fm/overrides/attendance.py` file to improve data accuracy and query performance, particularly around shift attendance and check-ins. The main changes involve tightening join conditions, clarifying status checks, and removing unnecessary query components.

**Attendance and Shift Assignment Query Improvements:**

* Changed SQL joins from `LEFT JOIN` to `INNER JOIN` between `tabShift Assignment` and `tabOperations Role` in both attendance type branches, ensuring only matching roles are included and improving query accuracy. [[1]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1210-R1213) [[2]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1241-R1243)
* Updated query conditions to require `op.attendance_by_client=1` and `op.status='Active'` (instead of a more permissive or ambiguous condition), ensuring only active roles marked for client attendance are considered. [[1]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1210-R1213) [[2]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1241-R1243)

**SQL Syntax and Formatting Clean-up:**

* Removed unnecessary trailing semicolons and clarified SQL formatting in attendance and check-in queries for better readability and to prevent potential issues. [[1]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL210-R210) [[2]](diffhunk://#diff-7fad46e2461ec3fc18c7895366686a4c16cc51031e9d53a947c44e5154cb924eL1421-R1419)