### PR TITLE
fix: document url in notification

### DIFF
--- a/one_fm/overrides/notification_log.py
+++ b/one_fm/overrides/notification_log.py
@@ -27,9 +27,9 @@ def custom_send_notification_email(doc):
         return
 
     if doc.document_type == "HD Ticket":
-        doc_link = frappe.utils.get_url(f"/helpdesk/tickets/{doc.name}")
+        doc_link = frappe.utils.get_url(f"/helpdesk/tickets/{doc.document_name}")
     else:
-        doc_link = doc.link or get_url_to_form(doc.document_type, doc.name)
+        doc_link = get_url_to_form(doc.document_type, doc.document_name)
     header = get_email_header(doc)
     email_subject = strip_html(doc.subject)
     context = {


### PR DESCRIPTION
This pull request updates the logic for generating document links in notification emails within the `custom_send_notification_email` function. The main change is to consistently use the `document_name` field instead of `name` or a fallback to `doc.link`, ensuring that links point to the correct document.

Link generation improvements:

* Updated the HD Ticket link to use `doc.document_name` instead of `doc.name`, ensuring the link points to the correct ticket.
* For other document types, replaced usage of `doc.link` or `doc.name` with `doc.document_name` for generating the form URL, improving consistency and accuracy of links.