### PR TITLE
fix: update day off comparison logic to include ot days

### DIFF
--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
@@ -394,12 +394,13 @@ def get_employee_day_off_comparison(employee, start_date, end_date, calculated_d
 	day_off_diff = ""
 	employee_number_of_days_off = calculated_day_offs
 
+	total_days_off_count = off_days + ot_days
 
-	if employee_number_of_days_off != off_days: # If has any discrepency
-		if off_days > employee_number_of_days_off:
-			day_off_diff = f"{off_days - employee_number_of_days_off} day(s) off scheduled more, please reduce by {off_days - employee_number_of_days_off}"
-		elif off_days < employee_number_of_days_off:
-			day_off_diff = f"{employee_number_of_days_off - off_days} day(s) off scheduled less, please schedule {employee_number_of_days_off - off_days} more day off"
+	if employee_number_of_days_off != total_days_off_count: # If has any discrepency
+		if total_days_off_count > employee_number_of_days_off:
+			day_off_diff = f"{total_days_off_count - employee_number_of_days_off} day(s) off scheduled more, please reduce by {total_days_off_count - employee_number_of_days_off}"
+		elif total_days_off_count < employee_number_of_days_off:
+			day_off_diff = f"{employee_number_of_days_off - total_days_off_count} day(s) off scheduled less, please schedule {employee_number_of_days_off - total_days_off_count} more day off"
 
 	start_date_split = str(start_date).split("-")
 	end_date_split = str(end_date).split("-")


### PR DESCRIPTION
This pull request updates the logic in the `get_employee_day_off_comparison` function to improve the calculation of discrepancies in scheduled days off for employees. The function now considers both regular off days and OT days when determining if there is a mismatch between scheduled and calculated days off.

**Improvement to day off comparison logic:**

* The function now sums both `off_days` and `ot_days` into `total_days_off_count` and uses this total when comparing against `calculated_day_offs`, ensuring that discrepancies account for all types of days off.
* The discrepancy messages have been updated to reflect the new comparison logic, providing clearer and more accurate feedback.