### PR TITLE
 feat: add phone validation option to Job Applicant contact number field

### DIFF
--- a/one_fm/custom/custom_field/job_applicant.py
+++ b/one_fm/custom/custom_field/job_applicant.py
@@ -438,6 +438,7 @@ def get_job_applicant_custom_fields():
                 "fieldtype": "Data",
                 "insert_after": "one_fm_country_code",
                 "label": "Contact Number",
+                "options": "Phone",
                 "translatable": 1
             },
             {

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -299,6 +299,7 @@ one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
 one_fm.patches.v15_0.update_vehicle_naming_series
 one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
 one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants
+one_fm.patches.v15_0.add_phone_option_to_job_applicant_contact_number
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/add_phone_option_to_job_applicant_contact_number.py
+++ b/one_fm/patches/v15_0/add_phone_option_to_job_applicant_contact_number.py
@@ -1,0 +1,17 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+	"""Add Phone validation option to Job Applicant contact_number field"""
+	custom_fields = {
+		"Job Applicant": [
+			{
+				"fieldname": "one_fm_contact_number",
+				"fieldtype": "Data",
+				"label": "Contact Number",
+				"options": "Phone",
+				"translatable": 1
+			},
+		]
+	}
+	# Use update=True to ensure the options are applied to the existing field
+	create_custom_fields(custom_fields, update=True)


### PR DESCRIPTION
This pull request adds a validation option to the "Contact Number" field for job applicants, ensuring that phone numbers are properly validated. The main changes include updating the field definition, adding a database patch to apply this change, and registering the patch for execution.

**Job Applicant "Contact Number" field improvements:**

* Added the `"options": "Phone"` property to the `one_fm_contact_number` field in `get_job_applicant_custom_fields()` to enable phone number validation.

**Database migration:**

* Introduced a new patch script `add_phone_option_to_job_applicant_contact_number.py` that updates the `one_fm_contact_number` field to include the "Phone" option, ensuring the change is applied to existing fields.
* Registered the new patch in `patches.txt` so it will run during the next migration.