### PR TITLE
fix(MOMFollowup): use proper workflow API in auto-escalation schedule…

### DIFF
--- a/one_fm/operations/doctype/mom_followup/mom_followup.py
+++ b/one_fm/operations/doctype/mom_followup/mom_followup.py
@@ -68,26 +68,47 @@ def mom_sites_followup():
 						'assign_to': [user_id],
 						'description': _('Please explain your reason of missing the MOM for this site/POC within 48 hours')
 					})
+
 def mom_followup_reminder():
-	
 	reminder = frappe.db.sql("""
 	SELECT name 
 	FROM `tabMOM Followup` 
 	WHERE (creation < DATE_SUB(NOW(), INTERVAL 48 HOUR)) AND (workflow_state = 'Assign to Site Supervisor')
 	""", as_dict=1)
 	for re in reminder:
-		doc = frappe.get_doc('MOM Followup', re.name)
-		doc.workflow_state = 'Review by Projects Manager'
-		doc.save()
-		
-		user_id = frappe.db.get_value('Employee', doc.project_manager, 'user_id')
-		if user_id:
-			add_assignment({
-						'doctype': 'MOM Followup',
-						'name': doc.name,
-						'assign_to': [user_id],
-						'description': _('Please take Action')
-			})
+		try:
+			doc = frappe.get_doc('MOM Followup', re.name)
+			original_user = frappe.session.user
+			
+			# Auto-populate reason if not already filled
+			if not doc.reason_for_missed_mom:
+				automated_reason_for_missed_mom = 'Automated Reminder - Auto-escalated after 48 hours'
+				frappe.db.set_value('MOM Followup', doc.name, 'reason_for_missed_mom', automated_reason_for_missed_mom, update_modified=False)
+			
+			# Temporarily elevate to Administrator to bypass role validation
+			frappe.set_user("Administrator")
+			
+			# Apply proper workflow transition instead of direct state assignment
+			from frappe.model.workflow import apply_workflow
+			apply_workflow(doc, "Submit for Review")
+			
+			# Restore original user context
+			frappe.set_user(original_user)
+			
+			# Assign to project manager
+			user_id = frappe.db.get_value('Employee', doc.project_manager, 'user_id')
+			if user_id:
+				add_assignment({
+							'doctype': 'MOM Followup',
+							'name': doc.name,
+							'assign_to': [user_id],
+							'description': _('Please take Action')
+				})
+		except Exception as e:
+			frappe.log_error(
+				"MOM Followup Auto-escalation Error",
+				f"Error auto-escalating MOM Followup {re.name}: {str(e)}"
+			)
 
 @frappe.whitelist()
 def mom_followup_penalty():

--- a/one_fm/operations/doctype/mom_followup/mom_followup.py
+++ b/one_fm/operations/doctype/mom_followup/mom_followup.py
@@ -11,6 +11,7 @@ from frappe import _
 from one_fm.api.tasks import issue_penalty
 from frappe.utils.data import nowdate
 from datetime import datetime
+from one_fm.overrides.workflow import apply_workflow_ignore_permissions
 
 class MOMFollowup(Document):
 	def on_update(self):
@@ -78,20 +79,14 @@ def mom_followup_reminder():
 	for re in reminder:
 		try:
 			doc = frappe.get_doc('MOM Followup', re.name)
-			original_user = frappe.session.user
 			
 			# Auto-populate reason if not already filled
 			if not doc.reason_for_missed_mom:
 				automated_reason_for_missed_mom = 'Automated Reminder - Auto-escalated after 48 hours'
 				frappe.db.set_value('MOM Followup', doc.name, 'reason_for_missed_mom', automated_reason_for_missed_mom, update_modified=False)
 			
-			# Apply proper workflow transition with role bypass, guaranteed user context restoration
-			try:
-				frappe.set_user("Administrator")
-				from frappe.model.workflow import apply_workflow
-				apply_workflow(doc, "Submit for Review")
-			finally:
-				frappe.set_user(original_user)
+			# Apply proper workflow transition, bypassing role validation using shared utility
+			apply_workflow_ignore_permissions(doc, "Submit for Review")
 			
 			# Assign to project manager
 			user_id = frappe.db.get_value('Employee', doc.project_manager, 'user_id')

--- a/one_fm/operations/doctype/mom_followup/mom_followup.py
+++ b/one_fm/operations/doctype/mom_followup/mom_followup.py
@@ -85,15 +85,13 @@ def mom_followup_reminder():
 				automated_reason_for_missed_mom = 'Automated Reminder - Auto-escalated after 48 hours'
 				frappe.db.set_value('MOM Followup', doc.name, 'reason_for_missed_mom', automated_reason_for_missed_mom, update_modified=False)
 			
-			# Temporarily elevate to Administrator to bypass role validation
-			frappe.set_user("Administrator")
-			
-			# Apply proper workflow transition instead of direct state assignment
-			from frappe.model.workflow import apply_workflow
-			apply_workflow(doc, "Submit for Review")
-			
-			# Restore original user context
-			frappe.set_user(original_user)
+			# Apply proper workflow transition with role bypass, guaranteed user context restoration
+			try:
+				frappe.set_user("Administrator")
+				from frappe.model.workflow import apply_workflow
+				apply_workflow(doc, "Submit for Review")
+			finally:
+				frappe.set_user(original_user)
 			
 			# Assign to project manager
 			user_id = frappe.db.get_value('Employee', doc.project_manager, 'user_id')


### PR DESCRIPTION
…d job

This pull request improves the `mom_followup_reminder` function in `mom_followup.py` to make the MOM follow-up escalation process more robust and auditable. The main changes include using the workflow system for state transitions, auto-populating missing reasons for escalation, temporarily elevating permissions to perform workflow actions, and adding error handling and logging.

**Enhancements to MOM Follow-up Escalation:**

* The function now uses `apply_workflow` to transition the document state instead of directly setting the `workflow_state`, ensuring proper workflow tracking and auditability.
* If the "reason for missed MOM" is not provided, it is auto-populated with a standard message during escalation.
* The code temporarily elevates permissions to "Administrator" to bypass role validation when applying the workflow, then restores the original user context.

**Error handling improvements:**

* Added a try/except block to log any errors that occur during the escalation process, making failures easier to diagnose.