### PR TITLE
fix: recompute leave allocation and update contract renewal recipients

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -1398,6 +1398,9 @@ def send_contract_reminders(is_scheduled_event=True):
 
         action_users = frappe.get_all("Action User", {"parent": "ONEFM General Setting", "parenttype": "ONEFM General Setting"}, pluck="user")
         users = list(set(action_users))
+        if not users:
+            return
+
         if contracts_due_internal_notification:
             contracts_due_internal_notification_list = [[i.contract_termination_decision_period,i.contract_end_internal_notification,\
                 get_date_str(i.contract_termination_decision_period_date) if i.contract_termination_decision_period_date else None,i.name,get_date_str(i.start_date),get_date_str(i.contract_end_internal_notification_date) if i.contract_end_internal_notification_date else None,\
@@ -1423,7 +1426,12 @@ def send_contract_reminders(is_scheduled_event=True):
             # Render all expiring contracts into a single email and send once to all recipients
             context = {"contracts_list": contracts_list}
             msg = frappe.render_template('one_fm/templates/emails/contracts_reminder.html', context=context)
-            sendemail(recipients=users, subject="Contract Internal Notification Period for Expiring Contracts", content=msg, is_scheduler_email=is_scheduled_event)
+            sendemail(
+                recipients=[users[0]],
+                cc=users[1:] if len(users) > 1 else None,
+                subject="Contract Internal Notification Period for Expiring Contracts",
+                content=msg, is_scheduler_email=is_scheduled_event
+            )
     except Exception as e:
         frappe.log_error(message=str(e), title="Contract Reminder Error")
 

--- a/one_fm/public/js/doctype_js/leave_allocation.js
+++ b/one_fm/public/js/doctype_js/leave_allocation.js
@@ -8,7 +8,8 @@ frappe.ui.form.on("Leave Allocation", {
             frappe.db.get_list("Leave Allocation", {
                 filters: {
                     "employee": employee, 
-                    "leave_type": "Annual Leave"
+                    "leave_type": "Annual Leave",
+                    "docstatus": 1
                 }, 
                 fields: ["name"], 
                 order_by: "to_date desc", 


### PR DESCRIPTION
This pull request introduces improvements to contract reminder notifications and refines the filtering of leave allocations. The main changes ensure that contract reminder emails are sent with proper recipient handling and that only submitted leave allocations are considered in related queries.

**Contract Reminder Notification Improvements:**

* Updated the contract reminder email logic to send the email directly to the first user and CC any additional users, instead of sending to all users as primary recipients. This provides better email clarity and tracking.
* Added a check to ensure that if there are no users to notify, the contract reminder function exits early, preventing unnecessary processing and potential errors.

**Leave Allocation Filtering:**

* Modified the leave allocation query in `leave_allocation.js` to include only records with `docstatus` set to 1, ensuring only submitted leave allocations are retrieved.