### PR TITLE
fix: expose recipients in contract reminder emails

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -1430,7 +1430,8 @@ def send_contract_reminders(is_scheduled_event=True):
                 recipients=[users[0]],
                 cc=users[1:] if len(users) > 1 else None,
                 subject="Contract Internal Notification Period for Expiring Contracts",
-                content=msg, is_scheduler_email=is_scheduled_event
+                content=msg, is_scheduler_email=is_scheduled_event,
+                expose_recipients="header"
             )
     except Exception as e:
         frappe.log_error(message=str(e), title="Contract Reminder Error")

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -12,7 +12,7 @@ from frappe.desk.doctype.notification_settings.notification_settings import(
 @frappe.whitelist()
 def sendemail(recipients, subject, header=None, message=None,
 	content=None, reference_name=None, reference_doctype=None,
-	sender=None, cc=None , attachments=None, delayed=False, args=None, template=None, is_external_mail=False,is_scheduler_email=False):
+	sender=None, cc=None , attachments=None, delayed=False, args=None, template=None, is_external_mail=False,is_scheduler_email=False, expose_recipients=None):
 	logo = "https://one-fm.com/files/ONEFM_Identity.png"
 	template = "default_email"
 	actions=pdf_link=workflow_state=""
@@ -78,7 +78,8 @@ def sendemail(recipients, subject, header=None, message=None,
 				field_labels=field_labels
 			),
 			attachments = attachments,
-			delayed=delayed
+			delayed=delayed,
+			expose_recipients=expose_recipients
 		)
 
 def is_email_notifications_allowed(user):


### PR DESCRIPTION
## Summary
This PR ensures that contract reminder emails expose all recipients in the `To` field, preventing individual emails from being sent to each recipient.

## Changes
- `one_fm/processor.py`: Updated the `sendemail` utility to support the `expose_recipients` parameter, which is passed through to `frappe.sendmail`.
- `one_fm/operations/doctype/contracts/contracts.py`: Updated `send_contract_reminders` to use `expose_recipients="header"` when sending notifications to Action Users.

## Review Checklist
- [x] validate_doctype_json: N/A (No DocType changes)
- [x] bench migrate: ❌ FAILED (Unrelated patch error in `one_fm.patches.v15_0.fix_leave_allocation_carry_forward_hr_emp_02814`)
- [x] run_tests: ✅ PASS
- [x] hooks.py paths verified: N/A
- [x] No frappe.db.commit() in controllers: ✅ PASS

## How to Verify
1. Trigger contract reminders manually: `frappe.call("one_fm.operations.doctype.contracts.contracts.send_contract_reminders", is_scheduled_event=False)`.
2. Check the `Email Queue` and verify that the `To` field contains all recipients (or that the sent email shows all recipients in the header).

Closes #6026