### PR TITLE
fix: PermissionError on Email Queue

### DIFF
--- a/one_fm/events/email_queue.py
+++ b/one_fm/events/email_queue.py
@@ -13,11 +13,19 @@ def after_insert(doc, event):
 	if found:
 		# Enqueue it safely in the background rather than blocking the main transaction
 		frappe.enqueue(
-			send_now,
+			"one_fm.events.email_queue.send_email_as_admin",
 			name=doc.name,
 			now=frappe.flags.in_test,
 			enqueue_after_commit=True
 		)
+
+def send_email_as_admin(name):
+	"""
+	Wrapper to run send_now as Administrator to avoid PermissionError
+	for non-admin users who trigger email creation.
+	"""
+	frappe.set_user("Administrator")
+	send_now(name=name)
 
 def flush_emails():
     """
@@ -27,8 +35,10 @@ def flush_emails():
     delete_eid_emails()
     emails_in_queue = frappe.get_list('Email Queue', filters={'status': 'Not Sent'})
     for row in emails_in_queue:
-        try:send_now(name=row.name)
-        except:pass
+        try:
+            send_email_as_admin(name=row.name)
+        except:
+            pass
     frappe.db.commit()
 
 def delete_eid_emails():

--- a/test_email_fix.py
+++ b/test_email_fix.py
@@ -1,0 +1,33 @@
+import frappe
+from one_fm.events.email_queue import send_email_as_admin
+
+def test_send_email_as_admin():
+    # Create a dummy email queue record
+    email_queue = frappe.get_doc({
+        "doctype": "Email Queue",
+        "sender": "test@example.com",
+        "subject": "Test Subject",
+        "message": "Test Message",
+        "status": "Not Sent",
+        "recipients": [
+            {"recipient": "recipient@example.com"}
+        ]
+    }).insert(ignore_permissions=True)
+    
+    frappe.db.commit()
+    
+    print(f"Created Email Queue: {email_queue.name}")
+    
+    # Try to send it as admin
+    try:
+        send_email_as_admin(email_queue.name)
+        print("Successfully called send_email_as_admin")
+        
+        # Check status
+        email_queue.reload()
+        print(f"Email Queue Status: {email_queue.status}")
+    except Exception as e:
+        print(f"Failed to send email: {e}")
+
+if __name__ == "__main__":
+    test_send_email_as_admin()


### PR DESCRIPTION
Fix PermissionError on Email Queue for non-admin users. Closes #6020