### PR TITLE
fix: carry forward unused leaves in new leave allocation #6021

### DIFF
--- a/one_fm/patches/v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py
+++ b/one_fm/patches/v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py
@@ -40,68 +40,67 @@ def execute():
 	)
 	
 	# ===== STEP 2: Recalculate 2024-2025 allocation's carry-forward with clean ledger =====
-	alloc_2024 = frappe.get_doc("Leave Allocation", allocation_2024)
-	
-	# Recalculate using HRMS function with clean ledger
-	corrected_carry_forward_2024 = get_carry_forwarded_leaves(
-		employee, leave_type, alloc_2024.from_date, carry_forward=alloc_2024.carry_forward
-	)
-	
-	# Recalculate total leaves
-	corrected_total_2024 = flt(alloc_2024.new_leaves_allocated) + flt(corrected_carry_forward_2024)
-	
-	# Update 2024-2025 allocation via DB (bypasses submit restrictions)
-	# IMPORTANT: Update unused_leaves alongside total_leaves_allocated to maintain consistency
-	# with one_fm/utils.py which recalculates: total_leaves_allocated = new_leaves_allocated + unused_leaves
-	frappe.db.set_value("Leave Allocation", allocation_2024, {
-		"carry_forwarded_leaves_count": corrected_carry_forward_2024,
-		"unused_leaves": corrected_carry_forward_2024,  # Update the field used by recalculation logic
-		"total_leaves_allocated": corrected_total_2024,
-		"modified": now()
-	})
-	
-	frappe.logger().info(
-		f"[Fix Leave Allocation Carry-Forward] Updated {allocation_2024}: "
-		f"carry_forwarded_leaves_count: {alloc_2024.carry_forwarded_leaves_count} → {corrected_carry_forward_2024}, "
-		f"unused_leaves: {alloc_2024.unused_leaves} → {corrected_carry_forward_2024}, "
-		f"total_leaves_allocated: {alloc_2024.total_leaves_allocated} → {corrected_total_2024}"
-	)
+	if frappe.db.exists("Leave Allocation", allocation_2024):
+		alloc_2024 = frappe.get_doc("Leave Allocation", allocation_2024)
+		
+		# Recalculate using HRMS function with clean ledger
+		corrected_carry_forward_2024 = get_carry_forwarded_leaves(
+			employee, leave_type, alloc_2024.from_date, carry_forward=alloc_2024.carry_forward
+		)
+		
+		# Recalculate total leaves
+		corrected_total_2024 = flt(alloc_2024.new_leaves_allocated) + flt(corrected_carry_forward_2024)
+		
+		# Update 2024-2025 allocation via DB (bypasses submit restrictions)
+		# IMPORTANT: Update unused_leaves alongside total_leaves_allocated to maintain consistency
+		# with one_fm/utils.py which recalculates: total_leaves_allocated = new_leaves_allocated + unused_leaves
+		frappe.db.set_value("Leave Allocation", allocation_2024, {
+			"carry_forwarded_leaves_count": corrected_carry_forward_2024,
+			"unused_leaves": corrected_carry_forward_2024,  # Update the field used by recalculation logic
+			"total_leaves_allocated": corrected_total_2024,
+			"modified": now()
+		})
+		
+		frappe.logger().info(
+			f"[Fix Leave Allocation Carry-Forward] Updated {allocation_2024}: "
+			f"carry_forwarded_leaves_count: {alloc_2024.carry_forwarded_leaves_count} → {corrected_carry_forward_2024}, "
+			f"unused_leaves: {alloc_2024.unused_leaves} → {corrected_carry_forward_2024}, "
+			f"total_leaves_allocated: {alloc_2024.total_leaves_allocated} → {corrected_total_2024}"
+		)
 
-	# Re-fetch the allocation to pick up the DB-updated values (db.set_value doesn't update the doc in memory)
-	alloc_2024 = frappe.get_doc("Leave Allocation", allocation_2024)
-	
 	# ===== STEP 3: Recalculate 2025-2026 allocation's carry-forward from corrected 2024-2025 =====
-	alloc_2025 = frappe.get_doc("Leave Allocation", allocation_2025)
-	
-	# Target: total allocation should be 43 days
-	target_total_2025 = 43.0
-	
-	# Calculate required carry-forward to reach target total
-	# carry_forward + new_leaves_allocated = target_total
-	# carry_forward = target_total - new_leaves_allocated
-	earned_2025 = flt(alloc_2025.new_leaves_allocated)
-	corrected_carry_forward_2025 = target_total_2025 - earned_2025
-	
-	# Ensure carry-forward is not negative
-	if corrected_carry_forward_2025 < 0:
-		corrected_carry_forward_2025 = 0.0
-	
-	corrected_total_2025 = earned_2025 + corrected_carry_forward_2025
-	
-	# Update 2025-2026 allocation via DB (bypasses submit restrictions)
-	# IMPORTANT: Update unused_leaves alongside total_leaves_allocated to maintain consistency
-	# with one_fm/utils.py which recalculates: total_leaves_allocated = new_leaves_allocated + unused_leaves
-	frappe.db.set_value("Leave Allocation", allocation_2025, {
-		"carry_forwarded_leaves_count": corrected_carry_forward_2025,
-		"unused_leaves": corrected_carry_forward_2025,  # Update the field used by recalculation logic
-		"carry_forward": 1,
-		"total_leaves_allocated": corrected_total_2025,
-		"modified": now()
-	})
-	
-	frappe.logger().info(
-		f"[Fix Leave Allocation Carry-Forward] Updated {allocation_2025}: "
-		f"earned_leaves: {earned_2025:.2f}, "
-		f"carry_forwarded_leaves: {alloc_2025.unused_leaves} → {corrected_carry_forward_2025:.2f}, "
-		f"total_leaves_allocated: {alloc_2025.total_leaves_allocated} → {corrected_total_2025:.2f} (target: {target_total_2025})"
-	)
+	if frappe.db.exists("Leave Allocation", allocation_2025):
+		alloc_2025 = frappe.get_doc("Leave Allocation", allocation_2025)
+		
+		# Target: total allocation should be 43 days
+		target_total_2025 = 43.0
+		
+		# Calculate required carry-forward to reach target total
+		# carry_forward + new_leaves_allocated = target_total
+		# carry_forward = target_total - new_leaves_allocated
+		earned_2025 = flt(alloc_2025.new_leaves_allocated)
+		corrected_carry_forward_2025 = target_total_2025 - earned_2025
+		
+		# Ensure carry-forward is not negative
+		if corrected_carry_forward_2025 < 0:
+			corrected_carry_forward_2025 = 0.0
+		
+		corrected_total_2025 = earned_2025 + corrected_carry_forward_2025
+		
+		# Update 2025-2026 allocation via DB (bypasses submit restrictions)
+		# IMPORTANT: Update unused_leaves alongside total_leaves_allocated to maintain consistency
+		# with one_fm/utils.py which recalculates: total_leaves_allocated = new_leaves_allocated + unused_leaves
+		frappe.db.set_value("Leave Allocation", allocation_2025, {
+			"carry_forwarded_leaves_count": corrected_carry_forward_2025,
+			"unused_leaves": corrected_carry_forward_2025,  # Update the field used by recalculation logic
+			"carry_forward": 1,
+			"total_leaves_allocated": corrected_total_2025,
+			"modified": now()
+		})
+		
+		frappe.logger().info(
+			f"[Fix Leave Allocation Carry-Forward] Updated {allocation_2025}: "
+			f"earned_leaves: {earned_2025:.2f}, "
+			f"carry_forwarded_leaves: {alloc_2025.unused_leaves} → {corrected_carry_forward_2025:.2f}, "
+			f"total_leaves_allocated: {alloc_2025.total_leaves_allocated} → {corrected_total_2025:.2f} (target: {target_total_2025})"
+		)

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -864,6 +864,7 @@ def create_leave_allocation(employee, policy_detail, leave_type_details, from_da
 	leave_type = policy_detail.leave_type
 	new_leaves_allocated = policy_detail.annual_allocation
 	carry_forward = 0
+	unused_leaves = 0
 	if leave_type_details.get(leave_type).is_carry_forward:
 		carry_forward = 1
 
@@ -875,6 +876,18 @@ def create_leave_allocation(employee, policy_detail, leave_type_details, from_da
 	if leave_type_details.get(leave_type).one_fm_is_paid_annual_leave == 1:
 		default_annual_leave_balance = frappe.db.get_value('Company', {"name": frappe.defaults.get_user_default("company")}, 'default_annual_leave_balance')
 		new_leaves_allocated = default_annual_leave_balance/365
+
+		# Fetch previous allocation balance
+		previous_allocation = frappe.db.get_value("Leave Allocation",
+			{"employee": employee.name, "leave_type": leave_type, "to_date": add_days(from_date, -1), "docstatus": 1},
+			["name", "total_leaves_allocated", "from_date", "to_date"], as_dict=1)
+
+		if previous_allocation:
+			leaves_taken = get_approved_leaves_for_period(employee.name, leave_type,
+				previous_allocation.from_date, previous_allocation.to_date)
+			unused_leaves = flt(previous_allocation.total_leaves_allocated) - flt(leaves_taken)
+			unused_leaves = max(unused_leaves, 0)
+			carry_forward = 1
 
 	allocate_leave = True
 	# Hajj Leave is allocated for employees who do not perform hajj before
@@ -889,6 +902,7 @@ def create_leave_allocation(employee, policy_detail, leave_type_details, from_da
 			from_date=from_date,
 			to_date=to_date,
 			new_leaves_allocated=new_leaves_allocated,
+			unused_leaves=unused_leaves,
 			carry_forward=carry_forward
 		))
 		try:


### PR DESCRIPTION
## Summary
This PR fixes the issue where unused leave balances from previous allocation periods were not being carried forward when a new `Leave Allocation` was created for "Annual Leave". It also improves the robustness of a specific leave allocation patch.

## Changes
- `one_fm/utils.py`: Updated `create_leave_allocation` to fetch and set `unused_leaves` from the previous period's balance for "Annual Leave" (or any leave type marked as `one_fm_is_paid_annual_leave`).
- `one_fm/patches/v15_0/fix_leave_allocation_carry_forward_hr_emp_02814.py`: Added `frappe.db.exists` checks to prevent `DoesNotExistError` during migration.

## Review Checklist
- [x] validate_doctype_json: N/A (No JSON changes)
- [x] bench migrate: ✅ PASS
- [x] run_tests: ✅ PASS
- [x] hooks.py paths verified: N/A
- [x] No frappe.db.commit() in controllers: ✅ (No new commits added)
- [x] SQL uses `AND docstatus = 1`: ✅

## How to Verify
1. Ensure an employee has an existing `Leave Allocation` with a remaining balance.
2. Trigger `leave_allocation_builder` (e.g., via `hooked_leave_allocation_builder`) for the next period.
3. Verify the new `Leave Allocation` has `unused_leaves` equal to the previous balance and `carry_forward` is set to 1.

Closes #6021