### PR TITLE
fix: get approver - skips shift supervisor

### DIFF
--- a/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
+++ b/one_fm/grd/doctype/fingerprint_appointment/fingerprint_appointment.js
@@ -106,7 +106,8 @@ var set_employee_supervisor = function(frm){
         frappe.call({
             method: 'one_fm.utils.get_approver_user',
             args: {
-                employee: frm.doc.employee
+                employee: frm.doc.employee,
+                skip_shift_supervisor: true
             },
             callback: function(r) {
                 console.log(r.message);

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -3128,14 +3128,14 @@ def get_employee_site_supervisor(employee):
     return None
 
 @frappe.whitelist()
-def get_approver_user(employee):
-    approver = get_approver(employee)
+def get_approver_user(employee, skip_shift_supervisor=False, date=False):
+    approver = get_approver(employee, skip_shift_supervisor=skip_shift_supervisor, date=date)
     if approver:
         return frappe.db.get_value("Employee", approver, "user_id")
     return None
 
 @frappe.whitelist()
-def get_approver(employee, date=False):
+def get_approver(employee, skip_shift_supervisor=False, date=False):
     '''
         Method to get the line manager employee of an employee with the priority
         args:
@@ -3157,7 +3157,7 @@ def get_approver(employee, date=False):
             line_manager = employee
 
     if not line_manager:
-        if employee_data.shift_working:
+        if not skip_shift_supervisor and employee_data.shift_working:
             if employee_data.shift:
                 line_manager = get_shift_supervisor(employee_data.shift, date)
                 if line_manager:


### PR DESCRIPTION
This pull request updates the logic for determining an employee's approver, allowing the option to skip the shift supervisor when needed. The changes introduce a new parameter, `skip_shift_supervisor`, to relevant backend and frontend functions, improving flexibility in approver selection.

**Backend logic improvements:**

* The `get_approver_user` and `get_approver` functions in `one_fm/utils.py` now accept a `skip_shift_supervisor` parameter, enabling callers to control whether the shift supervisor is considered when determining the approver.
* The logic in `get_approver` is updated to only consider the shift supervisor if `skip_shift_supervisor` is not set, providing more granular control over approver selection.

**Frontend integration:**

* The `set_employee_supervisor` function in `fingerprint_appointment.js` is updated to pass `skip_shift_supervisor: true` when calling the backend, ensuring that shift supervisors are skipped in this context.