### PR TITLE
ci: add backport-staging workflow for auto back-merging hotfixes

### DIFF
--- a/.github/workflows/backport-staging.yml
+++ b/.github/workflows/backport-staging.yml
@@ -1,4 +1,4 @@
-name: Back-merge hotfix to staging
+name: Backport hotfix to staging
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  backmerge:
+  backport:
     # Only run when PR is merged AND has the hotfix-backport label
     if: |
       github.event.pull_request.merged == true &&
@@ -21,44 +21,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Attempt back-merge
-        id: merge
-        run: |
-          git checkout staging
-          git pull origin staging
-
-          # Try to merge version-15 into staging
-          if git merge origin/version-15 --no-edit; then
-            echo "conflict=false" >> "$GITHUB_OUTPUT"
-            git push origin staging
-            echo "✅ Clean merge — pushed directly to staging"
-          else
-            git merge --abort
-            echo "conflict=true" >> "$GITHUB_OUTPUT"
-            echo "⚠️ Merge conflicts detected — will create PR for manual resolution"
-          fi
-
-      - name: Create PR if conflicts exist
-        if: steps.merge.outputs.conflict == 'true'
+      - name: Check for existing back-merge PR
+        id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          # Check if a back-merge PR already exists
           EXISTING_PR=$(gh pr list \
+            --repo ${{ github.repository }} \
             --base staging \
             --head version-15 \
             --state open \
@@ -66,22 +35,30 @@ jobs:
             --jq '.[0].number // empty')
 
           if [ -n "$EXISTING_PR" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "ℹ️ Back-merge PR #${EXISTING_PR} already exists — skipping"
-            exit 0
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Create back-merge PR
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
           gh pr create \
+            --repo ${{ github.repository }} \
             --base staging \
             --head version-15 \
-            --title "⬅️ Back-merge: ${PR_TITLE} (#${PR_NUMBER})" \
-            --body "## Auto Back-merge
+            --title "⬅️ Backport: ${PR_TITLE} (#${PR_NUMBER})" \
+            --body "## Auto Backport
 
           Hotfix PR #${PR_NUMBER} was merged to \`version-15\` by @${PR_AUTHOR}.
 
           This PR brings those changes into \`staging\` to keep branches in sync.
-
-          > [!WARNING]
-          > **Merge conflicts detected.** Please resolve manually before merging.
 
           ---
           Original PR: #${PR_NUMBER}" \


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically creates a backport PR from `version-15` → `staging` when a hotfix PR with the `hotfix-backport` label is merged.

### How it works

1. Hotfix PR merged to `version-15` with `hotfix-backport` label
2. Workflow creates a PR: `version-15` → `staging`
3. Team reviews and merges the backport PR through normal process

### Key details

- **No direct push** — respects branch protection on `staging`
- **Deduplication** — skips if an open backport PR already exists
- **Label after merge** — also triggers if label is added after the PR is already merged
- **Requires** the `hotfix-backport` label to be created in this repo