### PR TITLE
ci: add backport-staging workflow for auto back-merging hotfixes

### DIFF
--- a/.github/workflows/backport-staging.yml
+++ b/.github/workflows/backport-staging.yml
@@ -19,7 +19,6 @@ jobs:
       github.event.pull_request.merged == true &&
       contains(toJSON(github.event.pull_request.labels.*.name), 'hotfix-backport')
     runs-on: ubuntu-latest
-
     steps:
       - name: Check for existing back-merge PR
         id: check
@@ -62,4 +61,4 @@ jobs:
 
           ---
           Original PR: #${PR_NUMBER}" \
-            --label "backmerge"
+            --label "backport-staging"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically creates a backport PR from `version-15` → `staging` when a hotfix PR with the `hotfix-backport` label is merged.

### How it works

1. Hotfix PR merged to `version-15` with `hotfix-backport` label
2. Workflow creates a PR: `version-15` → `staging` (labeled `backport-staging`)
3. Team reviews and merges the backport PR through normal process

### Key details

- **No direct push** — respects branch protection on `staging`
- **Deduplication** — skips if an open backport PR already exists
- **Label after merge** — also triggers if label is added after the PR is already merged
- **Requires** the `hotfix-backport` and `backport-staging` labels to exist in this repo