### PR TITLE
WI-000740 Add missing ignore rules Wi 000740

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,13 +63,16 @@ ignore = [
     "E402", # module level import not at top of file
     "E501", # line too long
     "E741", # ambiguous variable name
-    "F401", # "unused" imports
+    "F401", # unused imports
     "F403", # can't detect undefined names from * import
     "F405", # can't detect undefined names from * import
     "F722", # syntax error in forward type annotation
     "W191", # indentation contains tabs
+    "RUF001", # string contains ambiguous unicode character
+    "UP030", # Use implicit references for positional format fields
+    "UP031", # Use format specifiers instead of percent format
+    "UP032", # Use f-string instead of format call
 ]
-typing-modules = ["frappe.types.DF"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
Add missing ignore rules to match frappe/frappe version-15:
- RUF001: string contains ambiguous unicode character
- UP030: Use implicit references for positional format fields (translations)
- UP031: Use format specifiers instead of percent format
- UP032: Use f-string instead of format call (translations)

Task: WI-000740

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
