### PR TITLE
WI-000742 chore: add commitlint.config.js aligned with Frappe v15

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+	parserPreset: "conventional-changelog-conventionalcommits",
+	rules: {
+		"subject-empty": [2, "never"],
+		"type-case": [2, "always", "lower-case"],
+		"type-empty": [2, "never"],
+		"type-enum": [
+			2,
+			"always",
+			[
+				"build",
+				"chore",
+				"ci",
+				"docs",
+				"feat",
+				"fix",
+				"perf",
+				"refactor",
+				"revert",
+				"style",
+				"test",
+			],
+		],
+	},
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "one_fm",
+  "private": true,
+  "devDependencies": {
+    "@commitlint/cli": "^20.1.0",
+    "conventional-changelog-conventionalcommits": "^9.1.0"
+  }
+}


### PR DESCRIPTION
Add commitlint configuration based on frappe/frappe version-15:
- Uses conventional-changelog-conventionalcommits preset
- Enforces non-empty subjects and types
- Valid types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test

Enforced via:
- Local pre-commit hook (commit-msg stage)
- CI linters.yml workflow (commit-lint job)

Task: WI-000742

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
