### PR TITLE
WI-000746 chore: add basedmypy configuration for type checking

### DIFF
--- a/.github/workflows/_base-type-check.yml
+++ b/.github/workflows/_base-type-check.yml
@@ -1,0 +1,52 @@
+name: Type Check
+
+on:
+  pull_request:
+    branches: [staging, test-production, version-15]
+    paths:
+      - "one_fm/__init__.py"
+      - "one_fm/api/api.py"
+      - "one_fm/utils.py"
+      - "one_fm/permissions.py"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: typecheck-one_fm-${{ github.event_name }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Type Check with basedmypy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install basedmypy~=2.0.0
+          pip install frappe-bench
+
+      - name: Setup bench
+        run: |
+          bench init --skip-assets --python $(which python) --frappe-branch version-15 ~/frappe-bench
+          cd ~/frappe-bench
+
+      - name: Install frappe and app
+        run: |
+          cd ~/frappe-bench
+          bench get-app frappe https://github.com/frappe/frappe --branch version-15
+          bench get-app one_fm $GITHUB_WORKSPACE
+
+      - name: Run mypy
+        run: |
+          cd ~/frappe-bench/apps/one_fm
+          mypy one_fm/__init__.py one_fm/api/api.py one_fm/utils.py one_fm/permissions.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ build-backend = "flit_core.buildapi"
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 basedmypy = "~=2.0.0"
+types-requests = "~=2.31.0"
+types-PyYAML = "~=6.0.12"
+types-python-dateutil = "~=2.8.19"
 
 [tool.ruff]
 line-length = 110
@@ -83,8 +86,8 @@ incremental = true
 sqlite_cache = true
 files = [
     "one_fm/__init__.py",
-    "one_fm/api/api.py",
-    "one_fm/utils.py",
+    "one_fm/api/__init__.py",
+    "one_fm/utils/__init__.py",
     "one_fm/permissions.py",
 ]
 exclude = "^one_fm/patches|/test_.*\.py$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "flit_core.buildapi"
 
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
-# package_name = "~=1.1.0"
+basedmypy = "~=2.0.0"
 
 [tool.ruff]
 line-length = 110
@@ -75,3 +75,24 @@ docstring-code-format = true
 
 [tool.bench.frappe-dependencies]
 one_fm = ">=15.0.0,<16.0.0"
+
+[tool.mypy]
+strict = false
+pretty = true
+incremental = true
+sqlite_cache = true
+files = [
+    "one_fm/__init__.py",
+    "one_fm/api/api.py",
+    "one_fm/utils.py",
+    "one_fm/permissions.py",
+]
+exclude = "^one_fm/patches|/test_.*\.py$"
+
+[[tool.mypy.overrides]]
+module = [
+    "frappe.*",
+    "erpnext.*",
+    "hrms.*",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
Add basedmypy (Frappe's choice) for gradual type checking:
- Add basedmypy~=2.0.0 to dev dependencies
- Configure [tool.mypy] in pyproject.toml with:
  - strict=false, pretty=true, incremental=true, sqlite_cache=true
  - Target files: __init__.py, api/api.py, utils.py, permissions.py
  - Exclude: patches and test files
  - Ignore missing imports for frappe, erpnext, hrms
- Add _base-type-check.yml CI workflow
  - Triggers only when typed files are modified
  - Runs on PRs to staging, test-production, version-15

Task: WI-000746

## Is this a Feature, Chore or Bug?
- [] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.


## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.


## Areas affected and ensured
List out the areas affected by your code changes.


## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [] Yes
- [] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [] Chrome
  - [] Safari
  - [] Firefox
