### PR TITLE
fix(permissions): ignore user permissions for employee link in resignation item

### DIFF
--- a/one_fm/one_fm/doctype/employee_resignation_item/employee_resignation_item.json
+++ b/one_fm/one_fm/doctype/employee_resignation_item/employee_resignation_item.json
@@ -19,6 +19,7 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",


### PR DESCRIPTION
Description:

🐛 What's the Issue?
Users are encountering a 403 Forbidden permission error when attempting to save or submit an Employee Resignation document. This occurs because the standard Frappe permission engine validates User Permissions against every linked DocType, and standard users do not have full read visibility across all Employees listed in the Employee Resignation Item child table.

🛠️ What's the Fix?
Following the investigation and proposed solution from Samdani, this PR modifies the Employee Resignation Item (Child Table) schema to explicitly set "ignore_user_permissions": 1 on the employee Link field.

This correctly forces Frappe to bypass the strict user-level permission validation for this specific field during the document save cycle, allowing the resignation workflow to proceed smoothly without triggering a 403 error.