### PR TITLE
fix(permissions): ignore user permissions on all link fields in resig…

### DIFF
--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
@@ -77,8 +77,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Employee",
-   "options": "Employee",
-   "ignore_user_permissions": 1
+   "options": "Employee"
   },
   {
    "fieldname": "full_name_in_english",

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
@@ -77,7 +77,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Employee",
-   "options": "Employee"
+   "options": "Employee",
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "full_name_in_english",
@@ -99,7 +100,8 @@
    "hidden": 1,
    "label": "Nationality",
    "options": "Nationality",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "default": "0",
@@ -140,7 +142,8 @@
    "in_standard_filter": 1,
    "label": "Department",
    "options": "Department",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "employment_type",
@@ -149,14 +152,16 @@
    "in_standard_filter": 1,
    "label": "Employment Type",
    "options": "Employment Type",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "designation",
    "fieldtype": "Link",
    "label": "Designation",
    "options": "Designation",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "column_break_pdtv",
@@ -167,28 +172,32 @@
    "fieldtype": "Link",
    "label": "Project Allocation",
    "options": "Project",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "site_allocation",
    "fieldtype": "Link",
    "label": "Site Allocation",
    "options": "Operations Site",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "shift_allocation",
    "fieldtype": "Link",
    "label": "Shift Allocation",
    "options": "Operations Shift",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "operations_role_allocation",
    "fieldtype": "Link",
    "label": "Operations Role Allocation",
    "options": "Operations Role",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "depends_on": "eval: !doc.__islocal",
@@ -201,7 +210,8 @@
    "fieldtype": "Link",
    "label": "Supervisor",
    "options": "User",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "replacement_required",

--- a/one_fm/one_fm/doctype/employee_resignation_item/employee_resignation_item.json
+++ b/one_fm/one_fm/doctype/employee_resignation_item/employee_resignation_item.json
@@ -19,12 +19,10 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
-   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
-   "reqd": 1,
-   "ignore_user_permissions": 1
+   "reqd": 1
   },
   {
    "fieldname": "employee_name",

--- a/one_fm/one_fm/doctype/employee_resignation_item/employee_resignation_item.json
+++ b/one_fm/one_fm/doctype/employee_resignation_item/employee_resignation_item.json
@@ -19,10 +19,12 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
-   "reqd": 1
+   "reqd": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "employee_name",
@@ -37,13 +39,15 @@
    "in_list_view": 1,
    "label": "Designation",
    "options": "Designation",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "employment_type",
    "fieldtype": "Link",
    "label": "Employment Type",
-   "options": "Employment Type"
+   "options": "Employment Type",
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "project_allocation",
@@ -51,7 +55,8 @@
    "in_list_view": 1,
    "label": "Project Allocation",
    "options": "Project",
-   "read_only": 1
+   "read_only": 1,
+   "ignore_user_permissions": 1
   },
   {
    "fieldname": "resignation_letter",


### PR DESCRIPTION

<img width="3136" height="544" alt="resignation_permission_flow_hd" src="https://github.com/user-attachments/assets/8f67b540-cf1a-4fc4-a5f8-0cb25e59e87f" />


Description:

🐛 What's the Issue?
Following the previous patch (which added ignore_user_permissions to the child table), standard employees are still encountering a 403 Forbidden error when trying to save an Employee Resignation document.

While the previous PR fixed the child table, it failed to account for the numerous Link fields on the parent document itself (Employee Resignation). Because standard employees often have strict User Permissions restricting them to their own profile, they lack explicit read access to system-wide DocTypes like Project, Operations Site, Operations Shift, and Department. When Frappe attempts to validate these links during the document save cycle, it rejects the transaction.

🛠️ What's the Fix?
To mirror standard Frappe behavior (like how Leave Application handles restricted link validation), this PR comprehensively updates the Employee Resignation schema.

It explicitly enables "ignore_user_permissions": 1 on all relevant Link fields across the parent document and child table, including:

project_allocation
site_allocation
shift_allocation
operations_role_allocation
department
designation
supervisor
employment_type
This safely bypasses the strict user-level permission validation for these specific fields, ensuring the resignation workflow can be saved and submitted by employees without throwing permission exceptions.