### PR TITLE
[WI-000706][[Yaser] "Reassign Vehicle" Duplicates Cards ]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -1299,6 +1299,143 @@ function mountRoutePlannerApp(wrapper, data) {
                 d.show();
             },
 
+            mergeSelectedBlock() {
+                if (!this.selectedItem || this.selectedItem.tripId) return;
+                const item = this.selectedItem;
+                const card = this.selectedCard;
+
+                // Find all existing chained trips across all vehicles
+                const tripOptions = [];
+                const tripsMap = {};
+
+                this.swimItems.forEach(i => {
+                    if (i.id === item.id) return; // Exclude the block we are moving
+                    const key = i.tripId || `solo_${i.id}`;
+                    if (!tripsMap[key]) tripsMap[key] = { vehicleId: i.vehicleId, items: [], isSolo: !i.tripId };
+                    tripsMap[key].items.push(i);
+                });
+
+                Object.keys(tripsMap).forEach(tid => {
+                    const t = tripsMap[tid];
+                    t.items.sort((a, b) => new Date(a.start) - new Date(b.start));
+                    const lastItem = t.items[t.items.length - 1];
+                    const lastCard = this.planData.shipment_cards.find(c => c.id === lastItem.cardId);
+                    const vehicle = this.planData.vehicles.find(v => v.id === t.vehicleId);
+
+                    if (vehicle && lastCard && lastItem.direction === item.direction) {
+                        const prefix = t.isSolo ? 'Single stop' : 'Trip';
+                        tripOptions.push({
+                            label: `[${vehicle.label}] ${prefix} ending at ${lastCard.site_location}`,
+                            value: tid,
+                            lastItem, lastCard, vehicle
+                        });
+                    }
+                });
+
+                if (tripOptions.length === 0) {
+                    frappe.show_alert({ message: 'No existing trips available in the same direction', indicator: 'orange' });
+                    return;
+                }
+
+                const self = this;
+                const d = new frappe.ui.Dialog({
+                    title: `Merge ${card.site_location}`,
+                    fields: [
+                        {
+                            fieldtype: 'HTML',
+                            options: `<p style="margin:0 0 12px;color:#555;font-size:13px">Select an existing trip to merge this stop into. It will be appended to the end of the selected trip.</p>`
+                        },
+                        {
+                            fieldtype: 'Select', fieldname: 'target_trip',
+                            label: 'Select Target Trip', reqd: 1,
+                            options: tripOptions.map(o => o.label).join('\n')
+                        },
+                        { fieldtype: 'Section Break' },
+                        {
+                            fieldtype: 'Int', fieldname: 'transit_min',
+                            label: 'Transit Time (minutes)',
+                            default: 30, reqd: 1,
+                            description: 'Driving time from previous stop'
+                        },
+                        { fieldtype: 'Column Break' },
+                        {
+                            fieldtype: 'Int', fieldname: 'dwell_min',
+                            label: 'Dwell/Buffer Time (minutes)',
+                            default: 10,
+                            description: 'Loading/unloading time at previous stop'
+                        }
+                    ],
+                    primary_action_label: 'Merge',
+                    primary_action(vals) {
+                        const selectedOpt = tripOptions.find(o => o.label === vals.target_trip);
+                        if (!selectedOpt) return;
+
+                        let targetTripId = selectedOpt.value;
+                        const targetTripItems = tripsMap[targetTripId].items;
+                        const targetVehicleId = selectedOpt.vehicle.id;
+
+                        // Check logical trip capacity directly instead of peakLoadDuringCardWindows 
+                        // because we want to know the target trip's total capacity + new card
+                        const tripLoad = targetTripItems.reduce((sum, i) => sum + (i.headcount || 0), 0);
+                        if (tripLoad + card.headcount > selectedOpt.vehicle.seats) {
+                            frappe.msgprint({
+                                title: __('Capacity Exceeded'),
+                                indicator: 'red',
+                                message: __(`Capacity Exceeded: Cannot assign ${card.headcount} employees to a ${selectedOpt.vehicle.seats}-seater vehicle.`)
+                            });
+                            return;
+                        }
+
+                        d.hide();
+
+                        // Remove original solo block
+                        self.swimItems = self.swimItems.filter(i => i.id !== item.id);
+
+                        // If merging into a solo block, convert it to a trip first
+                        if (tripsMap[targetTripId].isSolo) {
+                            targetTripId = `TRIP_${targetVehicleId}_${Math.random().toString(36).slice(2, 8)}`;
+                            targetTripItems[0].tripId = targetTripId;
+                            targetTripItems[0].stopIndex = 1;
+                        }
+
+                        // Append logic
+                        const dwellMs = (vals.dwell_min || 0) * 60000;
+                        const transitMs = (vals.transit_min || 30) * 60000;
+                        const lastEnd = new Date(Math.max(...targetTripItems.map(i => new Date(i.end).getTime())));
+
+                        const segStart = new Date(lastEnd.getTime() + dwellMs);
+                        const segEnd = new Date(segStart.getTime() + transitMs);
+                        const totalStops = targetTripItems.length;
+
+                        self.swimItems.push({
+                            id: item.id, // keep original ID
+                            cardId: card.id, 
+                            vehicleId: targetVehicleId,
+                            direction: item.direction, 
+                            start: segStart, 
+                            end: segEnd,
+                            headcount: item.headcount, 
+                            conflict: false,
+                            tripId: targetTripId, 
+                            stopIndex: totalStops + 1,
+                            bufferMin: vals.dwell_min || 0,
+                            transitMin: vals.transit_min || 30
+                        });
+
+                        const allTrip = self.swimItems.filter(i => i.tripId === targetTripId);
+                        allTrip.forEach(i => { i.totalStops = allTrip.length; });
+
+                        self.selectedItem = null;
+                        self.checkConflicts();
+                        self.canSave = self.assignedCards.size > 0;
+                        self.persistAssignments();
+
+                        frappe.show_alert({ message: `Merged into ${selectedOpt.vehicle.label} trip`, indicator: 'green' });
+                    }
+                });
+                d.show();
+            },
+
             vehicleLabelForItem(item) {
                 const v = this.planData.vehicles.find(v => v.id === item.vehicleId);
                 return v ? v.label : item.vehicleId;
@@ -2501,6 +2638,9 @@ function injectRPVueTemplate() {
         </div>
 
         <div id="rp-detail-footer">
+          <button v-if="!selectedItem.tripId" class="rp-detail-btn rp-detail-btn-primary" @click="mergeSelectedBlock" style="background-color: var(--rp-color-trip-chain); border-color: var(--rp-color-trip-chain);">
+            <span class="rp-icon">merge_type</span> Merge into Trip
+          </button>
           <button class="rp-detail-btn rp-detail-btn-primary" @click="reassignSelectedBlock">
             <span class="rp-icon">directions_bus</span> Reassign Vehicle
           </button>


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
Implemented strict vehicle capacity validation for trip chaining and cross-lane assignments, and added a new "Merge into Trip" workflow to allow dispatchers to append standalone shipments to existing trip chains seamlessly.

## Analysis and design (optional)
N/A

## Solution description
- **Aggregated Capacity Validation**: Replaced isolated block checks with logical trip aggregation (`_getLogicalTrips`) to accurately calculate total cumulative passenger headcount across sequential stops that share a `tripId`.
- **Strict Cross-Lane Enforcement**: Updated the drag-and-drop `onUp` handler and "Reassign Vehicle" actions to block over-capacity moves using a strict `frappe.msgprint` alert. This properly halts the move while ensuring UI state flags (like purple overcapacity indicators) are cleanly recalculated.
- **Merge into Trip Workflow**: Added a new "Merge into Trip" action button to the block detail panel for standalone stops. The workflow dynamically groups both existing chained trips and solo blocks into a selection dialog, prompts the dispatcher for Transit/Dwell times, strictly verifies target capacity, and natively appends the block into the chosen trip timeline.

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

## Output screenshots (optional)
*(Reviewer: Please see attached screenshots of the new Merge dialog and the red UI capacity-exceeded warnings)*

## Areas affected and ensured
- `one_fm/page/route_planner/route_planner.js`: 
  - `mergeSelectedBlock()`
  - Drag-and-drop `onUp` handler
  - `_getLogicalTrips()` capacity helpers
  - Block detail panel HTML template

## Is there any existing behavior change of other features due to this code change?
Yes. 
1. Dragging a shipment card to a vehicle lane without sufficient seats now strictly blocks the assignment (reverts the move) rather than allowing it with just a silent warning. 
2. Dispatchers can now merge shipments already placed on the timeline directly into other trips without having to delete and re-assign from the unassigned pool.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
*(N/A - No child table created)*

## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?

## Which browser(s) did you use for testing?
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox

https://github.com/user-attachments/assets/0ad4b059-56ee-4031-b5b7-ac5f3e1e22c0

