### PR TITLE
feat(hiring): auto-generate Candidate Country Process from Job Offer

### DIFF
--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -144,6 +144,52 @@ class JobOfferOverride(JobOffer):
         if self.workflow_state == 'Submit to Onboarding Officer' and not self.one_fm_offer_accepted_date:
             self.one_fm_offer_accepted_date = nowdate()
             self.save(ignore_permissions=True)
+            
+        # Auto-create Candidate Country Process if applicable
+        if self.workflow_state in ['Submit to Onboarding Officer', 'Accepted']:
+            self.create_candidate_country_process()
+
+    def create_candidate_country_process(self):
+        if not getattr(self, "agency_country_process", None):
+            return
+
+        # Check if already exists
+        if frappe.db.exists("Candidate Country Process", {"job_offer": self.name}):
+            return
+
+        # Create Candidate Country Process
+        ccp = frappe.new_doc("Candidate Country Process")
+        ccp.job_offer = self.name
+        ccp.job_applicant = self.job_applicant
+        ccp.agency_country_process = self.agency_country_process
+        ccp.start_date = self.one_fm_offer_accepted_date or nowdate()
+
+        # Get Agency template to pull steps
+        acp = frappe.get_doc("Agency Country Process", self.agency_country_process)
+        
+        # Copy tracking rows
+        if hasattr(acp, "agency_process_details"):
+            for row in acp.agency_process_details:
+                d = ccp.append("agency_process_details", {})
+                d.process_name = row.process_name
+                d.responsible = row.responsible
+                d.duration_in_days = row.duration_in_days
+                d.attachment_required = row.attachment_required
+                d.notes_required = row.notes_required
+                d.reference_type = row.reference_type
+                d.reference_complete_status_field = row.reference_complete_status_field
+                d.reference_complete_status_value = row.reference_complete_status_value
+                if ccp.start_date and row.duration_in_days:
+                    d.expected_date = frappe.utils.add_days(ccp.start_date, row.duration_in_days)
+
+        if ccp.start_date and getattr(acp, "total_duration", 0):
+            ccp.planned_eta = frappe.utils.add_days(ccp.start_date, acp.total_duration)
+            ccp.live_plan_eta = ccp.planned_eta
+
+        ccp.insert(ignore_permissions=True)
+        frappe.msgprint(_("Candidate Country Process Tracker ({0}) automatically generated.").format(
+            get_link_to_form("Candidate Country Process", ccp.name)
+        ), alert=True)
 
     def validate_job_offer_mandatory_fields(self):
         if self.workflow_state == 'Submit for Candidate Response':

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -157,39 +157,43 @@ class JobOfferOverride(JobOffer):
         if frappe.db.exists("Candidate Country Process", {"job_offer": self.name}):
             return
 
-        # Create Candidate Country Process
-        ccp = frappe.new_doc("Candidate Country Process")
-        ccp.job_offer = self.name
-        ccp.job_applicant = self.job_applicant
-        ccp.agency_country_process = self.agency_country_process
-        ccp.start_date = self.one_fm_offer_accepted_date or nowdate()
+        try:
+            # Create Candidate Country Process
+            ccp = frappe.new_doc("Candidate Country Process")
+            ccp.job_offer = self.name
+            ccp.job_applicant = self.job_applicant
+            ccp.agency_country_process = self.agency_country_process
+            ccp.start_date = self.one_fm_offer_accepted_date or nowdate()
 
-        # Get Agency template to pull steps
-        acp = frappe.get_doc("Agency Country Process", self.agency_country_process)
-        
-        # Copy tracking rows
-        if hasattr(acp, "agency_process_details"):
-            for row in acp.agency_process_details:
-                d = ccp.append("agency_process_details", {})
-                d.process_name = row.process_name
-                d.responsible = row.responsible
-                d.duration_in_days = row.duration_in_days
-                d.attachment_required = row.attachment_required
-                d.notes_required = row.notes_required
-                d.reference_type = row.reference_type
-                d.reference_complete_status_field = row.reference_complete_status_field
-                d.reference_complete_status_value = row.reference_complete_status_value
-                if ccp.start_date and row.duration_in_days:
-                    d.expected_date = frappe.utils.add_days(ccp.start_date, row.duration_in_days)
+            # Get Agency template to pull steps
+            acp = frappe.get_doc("Agency Country Process", self.agency_country_process)
 
-        if ccp.start_date and getattr(acp, "total_duration", 0):
-            ccp.planned_eta = frappe.utils.add_days(ccp.start_date, acp.total_duration)
-            ccp.live_plan_eta = ccp.planned_eta
+            # Copy tracking rows
+            if hasattr(acp, "agency_process_details"):
+                for row in acp.agency_process_details:
+                    d = ccp.append("agency_process_details", {})
+                    d.process_name = row.process_name
+                    d.responsible = row.responsible
+                    d.duration_in_days = row.duration_in_days
+                    d.attachment_required = row.attachment_required
+                    d.notes_required = row.notes_required
+                    d.reference_type = row.reference_type
+                    d.reference_complete_status_field = row.reference_complete_status_field
+                    d.reference_complete_status_value = row.reference_complete_status_value
+                    if ccp.start_date and row.duration_in_days:
+                        d.expected_date = frappe.utils.add_days(ccp.start_date, row.duration_in_days)
 
-        ccp.insert(ignore_permissions=True)
-        frappe.msgprint(_("Candidate Country Process Tracker ({0}) automatically generated.").format(
-            get_link_to_form("Candidate Country Process", ccp.name)
-        ), alert=True)
+            if ccp.start_date and getattr(acp, "total_duration", 0):
+                ccp.planned_eta = frappe.utils.add_days(ccp.start_date, acp.total_duration)
+                ccp.live_plan_eta = ccp.planned_eta
+
+            ccp.insert(ignore_permissions=True)
+            frappe.msgprint(_("Candidate Country Process Tracker ({0}) automatically generated.").format(
+                get_link_to_form("Candidate Country Process", ccp.name)
+            ), alert=True)
+        except Exception as e:
+            frappe.log_error(title="Failed to Auto-Generate CCP", message=frappe.get_traceback())
+            frappe.msgprint(_("Warning: Could not automatically generate the Candidate Country Process tracker. Please create it manually. ({0})").format(str(e)), alert=True, indicator='orange')
 
     def validate_job_offer_mandatory_fields(self):
         if self.workflow_state == 'Submit for Candidate Response':


### PR DESCRIPTION

<img width="3136" height="668" alt="hiring_workflow_hd" src="https://github.com/user-attachments/assets/05cc0332-1d13-473b-8d09-6547bfe74e46" />
Currently on staging, when a Job Offer with an assigned Agency Country Process (Template) is accepted and submitted to the Onboarding Officer, the system does not automatically create the resulting Candidate Country Process draft. HR officers were required to manually create the tracker and sync the steps.

This PR automates that entire handoff by hooking directly into the Job Offer lifecycle.

Technical Changes
Job Offer Override: Added a new method create_candidate_country_process triggered inside on_update_after_submit.
Trigger Condition: Fires automatically when the Job Offer transitions to the Accepted or Submit to Onboarding Officer workflow state.
Auto-Generation:
Creates a new Candidate Country Process in the background linked to the Applicant and Job Offer.
Reads the assigned Agency Country Process template and completely auto-populates the tracking rows (agency_process_details) without requiring the user to click the manual JS "Sync Process Steps" button.
Automatically sets the start_date based on the offer acceptance date and calculates the planned_eta and live_plan_eta.
UX: Displays a success alert with a direct link to the newly generated tracker document upon successful Job Offer submission.
How to Test
Create a Job Opening and assign an Agency and an Agency Country Process template.
Push a Job Applicant through to the Job Offer stage.
Submit the Job Offer to Onboarding.
Verify that the success popup appears.
Navigate to the Candidate Country Process List and verify the new draft is automatically generated and fully populated with the correct tracking steps (Visa, Medical, etc.).
