### PR TITLE
[WI-000703][[Yaser] Drag-and-Drop Reordering of Stops in Shipment Details]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -80,6 +80,8 @@ function mountRoutePlannerApp(wrapper, data) {
                 searchQuery: '',
                 collapsedGroups: {},          // { [accommodation]: boolean }
                 canSave: false,
+                stopDragSourceIndex: null,  // drag-reorder: source stop index
+                stopDragOverIndex: null,    // drag-reorder: hovered stop index
 
                 // ── Plan management ──
                 currentPlan: null,        // { name, title, status, effective_from, effective_until }
@@ -264,7 +266,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     // Build merged blocks for each trip group
                     Object.keys(tripGroups).forEach(tripId => {
                         const stops = tripGroups[tripId].sort(
-                            (a, b) => new Date(a.start) - new Date(b.start)
+                            (a, b) => (a.stopIndex || 0) - (b.stopIndex || 0)
                         );
                         const firstItem = stops[0];
                         const lastItem = stops[stops.length - 1];
@@ -363,7 +365,7 @@ function mountRoutePlannerApp(wrapper, data) {
                 const tripId = this.selectedItem.tripId;
                 return this.swimItems
                     .filter(i => i.tripId === tripId)
-                    .sort((a, b) => new Date(a.start) - new Date(b.start))
+                    .sort((a, b) => (a.stopIndex || 0) - (b.stopIndex || 0))
                     .map((item, idx) => ({
                         item,
                         card: this.planData.shipment_cards.find(c => c.id === item.cardId) || {},
@@ -1299,6 +1301,83 @@ function mountRoutePlannerApp(wrapper, data) {
                 d.show();
             },
 
+            // ─ Stop drag-to-reorder handlers ──────────────────────────────
+            onStopDragStart(event, sourceIndex) {
+                this.stopDragSourceIndex = sourceIndex;
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', String(sourceIndex));
+                // Slight delay to allow the drag image to render
+                requestAnimationFrame(() => {
+                    event.target.style.opacity = '0.4';
+                });
+            },
+
+            onStopDragOver(event, targetIndex) {
+                event.dataTransfer.dropEffect = 'move';
+                this.stopDragOverIndex = targetIndex;
+            },
+
+            onStopDrop(event, targetIndex) {
+                const sourceIndex = this.stopDragSourceIndex;
+                if (sourceIndex === null || sourceIndex === targetIndex) {
+                    this.stopDragSourceIndex = null;
+                    this.stopDragOverIndex = null;
+                    return;
+                }
+
+                const tripId = this.selectedItem.tripId;
+                if (!tripId) return;
+
+                // Get trip stops sorted by current stopIndex
+                const tripStops = this.swimItems
+                    .filter(i => i.tripId === tripId)
+                    .sort((a, b) => (a.stopIndex || 0) - (b.stopIndex || 0));
+
+                if (sourceIndex >= tripStops.length || targetIndex >= tripStops.length) return;
+
+                // Perform the reorder: remove source, insert at target
+                const [moved] = tripStops.splice(sourceIndex, 1);
+                tripStops.splice(targetIndex, 0, moved);
+
+                // Capture the original first-stop start time and each stop's duration
+                const baseStart = new Date(Math.min(...tripStops.map(s => new Date(s.start).getTime())));
+                const durations = tripStops.map(s => new Date(s.end).getTime() - new Date(s.start).getTime());
+
+                // Reassign stopIndex + recalculate sequential times
+                let cursor = baseStart.getTime();
+                tripStops.forEach((stop, idx) => {
+                    stop.stopIndex = idx + 1;
+                    stop.start = new Date(cursor);
+                    stop.end = new Date(cursor + durations[idx]);
+                    cursor = cursor + durations[idx]; // next stop starts after this one ends
+                });
+
+                // Update totalStops on all trip items
+                tripStops.forEach(s => { s.totalStops = tripStops.length; });
+
+                // Trigger Vue reactivity
+                this.swimItems = [...this.swimItems];
+
+                // Clear drag state
+                this.stopDragSourceIndex = null;
+                this.stopDragOverIndex = null;
+
+                // Re-check conflicts and persist
+                this.checkConflicts();
+                this.persistAssignments();
+
+                frappe.show_alert({
+                    message: `Stop reordered — now ${tripStops.map((s, i) => `${i + 1}. ${(this.planData.shipment_cards.find(c => c.id === s.cardId) || {}).site_location || 'Unknown'}`).join(' → ')}`,
+                    indicator: 'blue'
+                }, 4);
+            },
+
+            onStopDragEnd(event) {
+                event.target.style.opacity = '';
+                this.stopDragSourceIndex = null;
+                this.stopDragOverIndex = null;
+            },
+
             mergeSelectedBlock() {
                 if (!this.selectedItem || this.selectedItem.tripId) return;
                 const item = this.selectedItem;
@@ -1960,9 +2039,17 @@ function mountRoutePlannerApp(wrapper, data) {
                         seats: v.seats, location: v.accommodation
                     };
 
+                    // Sort vehicle items: trip stops by stopIndex, solo items by start time
                     const vItems = this.swimItems
                         .filter(i => i.vehicleId === v.id)
-                        .sort((a, b) => new Date(a.start) - new Date(b.start));
+                        .sort((a, b) => {
+                            // If both are in the same trip, sort by stopIndex
+                            if (a.tripId && b.tripId && a.tripId === b.tripId) {
+                                return (a.stopIndex || 0) - (b.stopIndex || 0);
+                            }
+                            // Otherwise sort by start time
+                            return new Date(a.start) - new Date(b.start);
+                        });
                     if (!vItems.length) return;
 
                     const visits = [], trans = [];
@@ -2492,11 +2579,18 @@ function injectRPVueTemplate() {
               </div>
             </div>
 
-            <!-- Each stop as a numbered card -->
-            <div v-for="stop in selectedTripStops" :key="stop.item.id"
-                 class="rp-detail-card"
+            <!-- Each stop as a numbered card (draggable for reorder) -->
+            <div v-for="(stop, si) in selectedTripStops" :key="stop.item.id"
+                 class="rp-detail-card rp-stop-draggable"
+                 draggable="true"
+                 @dragstart="onStopDragStart($event, si)"
+                 @dragover.prevent="onStopDragOver($event, si)"
+                 @dragend="onStopDragEnd($event)"
+                 @drop.prevent="onStopDrop($event, si)"
+                 :class="{ 'rp-stop-drag-over': stopDragOverIndex === si && stopDragSourceIndex !== null && stopDragSourceIndex !== si }"
                  :style="'border-left:3px solid ' + (stop.item.id === selectedItem.id ? '#f97316' : '#1565c0')">
               <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+                <span class="rp-icon rp-stop-drag-handle" title="Drag to reorder">drag_indicator</span>
                 <span class="rp-stop-num rp-stop-num-out">{{ stop.stopNum }}</span>
                 <div style="font-size:13px;font-weight:700;color:#111">{{ stop.card.site_location || 'Unknown' }}</div>
               </div>
@@ -2861,6 +2955,20 @@ function injectRPStyles() {
         }
         .rp-stop-num-out { background: var(--rp-color-outbound-container); color: var(--rp-color-outbound); }
         .rp-stop-num-olm { background: var(--rp-color-trip-container); color: var(--rp-color-trip-chain); }
+
+        /* Drag-to-reorder affordances */
+        .rp-stop-drag-handle {
+            cursor: grab; opacity: 0.35; font-size: 18px;
+            transition: opacity 0.15s; flex-shrink: 0;
+            color: var(--md-sys-color-on-surface-variant);
+        }
+        .rp-stop-draggable:hover .rp-stop-drag-handle { opacity: 0.7; }
+        .rp-stop-draggable:active .rp-stop-drag-handle { cursor: grabbing; }
+        .rp-stop-drag-over {
+            border-top: 2.5px solid var(--rp-color-trip-chain) !important;
+            padding-top: 10px;
+            transition: border-top 0.12s, padding-top 0.12s;
+        }
 
         /* Helper: time pill badges */
         .rp-time-pill {

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -1335,21 +1335,56 @@ function mountRoutePlannerApp(wrapper, data) {
 
                 if (sourceIndex >= tripStops.length || targetIndex >= tripStops.length) return;
 
-                // Perform the reorder: remove source, insert at target
+                // Capture durations and inter-stop gaps BEFORE reorder
+                const durations = tripStops.map(s =>
+                    new Date(s.end).getTime() - new Date(s.start).getTime()
+                );
+                const gaps = []; // gaps[i] = gap AFTER stop i (before stop i+1)
+                for (let i = 0; i < tripStops.length - 1; i++) {
+                    const gapMs = new Date(tripStops[i + 1].start).getTime()
+                               - new Date(tripStops[i].end).getTime();
+                    gaps.push(Math.max(0, gapMs));
+                }
+
+                // Fix #2: adjust target index for downward drags.
+                // After splice(sourceIndex, 1), indices above sourceIndex shift down by 1.
+                let insertAt = targetIndex;
+                if (sourceIndex < targetIndex) {
+                    insertAt = targetIndex - 1;
+                }
+
+                // Perform the reorder: remove source, insert at adjusted target
                 const [moved] = tripStops.splice(sourceIndex, 1);
-                tripStops.splice(targetIndex, 0, moved);
+                const movedDuration = durations.splice(sourceIndex, 1)[0];
+                // Remove the gap that was AFTER the source stop (or before it if at start)
+                const removedGapIdx = Math.min(sourceIndex, gaps.length - 1);
+                const removedGap = gaps.length > 0 ? gaps.splice(removedGapIdx, 1)[0] : 0;
 
-                // Capture the original first-stop start time and each stop's duration
-                const baseStart = new Date(Math.min(...tripStops.map(s => new Date(s.start).getTime())));
-                const durations = tripStops.map(s => new Date(s.end).getTime() - new Date(s.start).getTime());
+                tripStops.splice(insertAt, 0, moved);
+                durations.splice(insertAt, 0, movedDuration);
+                // Re-insert the gap before the moved stop's new position
+                if (gaps.length > 0 && insertAt < gaps.length) {
+                    gaps.splice(insertAt, 0, removedGap);
+                } else {
+                    gaps.push(removedGap);
+                }
 
-                // Reassign stopIndex + recalculate sequential times
+                // Rebuild times: preserve durations + inter-stop gaps
+                const baseStart = new Date(Math.min(
+                    ...this.swimItems
+                        .filter(i => i.tripId === tripId)
+                        .map(s => new Date(s.start).getTime())
+                ));
                 let cursor = baseStart.getTime();
                 tripStops.forEach((stop, idx) => {
                     stop.stopIndex = idx + 1;
                     stop.start = new Date(cursor);
                     stop.end = new Date(cursor + durations[idx]);
-                    cursor = cursor + durations[idx]; // next stop starts after this one ends
+                    cursor = cursor + durations[idx];
+                    // Add inter-stop gap (dwell/buffer) if not the last stop
+                    if (idx < gaps.length) {
+                        cursor += gaps[idx];
+                    }
                 });
 
                 // Update totalStops on all trip items


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

**Drag-to-Reorder Trip Stops in Route Planner Detail Panel**

As a Dispatcher, I want to reorder the sequence of stops directly within the Shipment Details side-panel, so I can easily interleave drop-off and pick-up events (e.g., dropping at Site B, going to Site C, coming back to Site B) without relying on automatic rigid time-based sorting.


## Analysis and design (optional)

The existing trip stop ordering was hardcoded to chronological time (`new Date(a.start) - new Date(b.start)`). This prevented dispatchers from customizing stop sequences. The solution pivots all trip-internal sorting to use a `stopIndex` integer field (already present on `swimItems` from the merge/chain feature) and adds HTML5 native drag-and-drop to the detail panel stop cards.

**Key design decisions:**
- **Sorting pivot:** 3 sort locations changed from time-based to `stopIndex`-based
- **Time recalculation:** After reorder, each stop's `start`/`end` times are recalculated sequentially (duration preserved, chained from the trip's base start time) so SVG blocks reposition correctly on the timeline
- **No external libraries:** Uses native HTML5 `draggable` API — no Sortable.js or other dependencies


## Solution description

### File modified: `one_fm/one_fm/page/route_planner/route_planner.js`

**A. Data Properties (line 82–83)**
- Added `stopDragSourceIndex` and `stopDragOverIndex` to track drag state

**B. Sort Pivot — 3 locations:**
1. `selectedTripStops` computed (line 366): `.sort((a,b) => (a.stopIndex||0) - (b.stopIndex||0))` — drives detail panel order
2. `mergedItemsByVehicle` computed (line 268): same change — drives SVG block stop labels and connectors
3. `buildManifestData` method (line 1963): trip-internal items sorted by `stopIndex`, cross-trip items by start time — drives manifest output

**C. Drag Handler Methods (lines 1299–1377):**
- `onStopDragStart(event, si)` — stores source index, sets drag effect, fades card
- `onStopDragOver(event, si)` — updates hover target index for drop indicator
- `onStopDrop(event, si)` — performs array splice reorder, reassigns `stopIndex` 1..N, recalculates sequential `start`/`end` times, triggers Vue reactivity, calls `checkConflicts()` + `persistAssignments()`, shows blue confirmation toast
- `onStopDragEnd(event)` — clears drag state, restores opacity

**D. Template (lines 2490–2505):**
- Stop cards now have `draggable="true"` with `@dragstart`, `@dragover.prevent`, `@drop.prevent`, `@dragend` event bindings
- Added Material `drag_indicator` icon as a grab handle before the stop number
- Purple `border-top` indicator class (`.rp-stop-drag-over`) when hovering over a drop target

**E. CSS (lines 2866–2879):**
- `.rp-stop-drag-handle` — grab cursor, 35% opacity → 70% on hover, 18px icon
- `.rp-stop-drag-over` — 2.5px solid purple top border with smooth transition


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

Pure frontend logic — all changes are in the Frappe Page JS file. No DocType controller, no server-side Python. The reordered `stopIndex` values persist via the existing `persistAssignments()` → `save_assignments` API call.


## Output screenshots

The drag handle (≡⋮) appears on each stop card in the detail panel. When dragging a stop over another, a purple top-border indicator shows the drop position. After drop, stops renumber and times recalculate.


## Areas affected and ensured

| Area | Impact |
|------|--------|
| Detail panel stop cards | Added drag handle icon + drag events |
| SVG timeline merged blocks | Stop labels now follow `stopIndex` order |
| Trip connector lines | Already sorted by `stopIndex` — no change needed |
| Route Manifest | Stop sequence now respects `stopIndex` within same trip |
| Save/Load | `stopIndex` already persisted in `swim_items` JSON — no schema change |


## Is there any existing behavior change of other features due to this code change?

**Yes.** Trip stops that were previously always sorted by chronological start time are now sorted by `stopIndex`. For newly created trips, `stopIndex` is assigned sequentially when stops are chained (matching the old time-based order), so the **default behavior is identical**. Only explicit user drag-reordering changes the sequence.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

Tested with both an existing plan (Test Plan) containing a pre-existing trip chain, and a newly created plan (Test Plan 123) with freshly assigned cards forming a new trip chain.


## Was child table created?
N/A — No child table created.

## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [x] No

Pure frontend change. No DocType schema, no custom fields, no database migrations.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox


https://github.com/user-attachments/assets/a567ee04-260f-409c-b024-b91db9b5e7b6

