### PR TITLE
feat(WI-000737): sort workspaces alphabetically

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -101,3 +101,8 @@ AssignmentRule.get_user = get_user
 
 from one_fm.overrides.reports.stock_balance_override import override_stock_balance
 override_stock_balance()
+
+# Override workspace sidebar to sort alphabetically
+from one_fm.overrides.workspace import get_workspace_sidebar_items
+import frappe.desk.desktop
+frappe.desk.desktop.get_workspace_sidebar_items = get_workspace_sidebar_items

--- a/one_fm/overrides/__init__.py
+++ b/one_fm/overrides/__init__.py
@@ -1,0 +1,1 @@
+"""Overrides for Frappe core functionality."""

--- a/one_fm/overrides/workspace.py
+++ b/one_fm/overrides/workspace.py
@@ -1,0 +1,81 @@
+"""
+Override for Frappe workspace functionality.
+Sorts workspaces alphabetically by title instead of sequence_id.
+"""
+
+import frappe
+from frappe import _
+from frappe.desk.desktop import Workspace
+
+
+@frappe.whitelist()
+def get_workspace_sidebar_items():
+	"""Get list of sidebar items for desk, sorted alphabetically by title."""
+	has_access = "Workspace Manager" in frappe.get_roles()
+
+	# don't get domain restricted pages
+	blocked_modules = frappe.get_cached_doc("User", frappe.session.user).get_blocked_modules()
+	blocked_modules.append("Dummy Module")
+
+	# adding None to allowed_domains to include pages without domain restriction
+	allowed_domains = [None, *frappe.get_active_domains()]
+
+	filters = {
+		"restrict_to_domain": ["in", allowed_domains],
+		"module": ["not in", blocked_modules],
+	}
+
+	if has_access:
+		filters = []
+
+	# pages sorted alphabetically by title instead of sequence_id
+	order_by = "title asc"
+	fields = [
+		"name",
+		"title",
+		"for_user",
+		"parent_page",
+		"content",
+		"public",
+		"module",
+		"icon",
+		"indicator_color",
+		"is_hidden",
+	]
+	all_pages = frappe.get_all(
+		"Workspace", fields=fields, filters=filters, order_by=order_by, ignore_permissions=True
+	)
+	pages = []
+	private_pages = []
+
+	# Filter Page based on Permission
+	for page in all_pages:
+		try:
+			workspace = Workspace(page, True)
+			if has_access or workspace.is_permitted():
+				if page.public and (has_access or not page.is_hidden) and page.title != "Welcome Workspace":
+					pages.append(page)
+				elif page.for_user == frappe.session.user:
+					private_pages.append(page)
+				page["label"] = _(page.get("name"))
+		except frappe.PermissionError:
+			pass
+
+	if private_pages:
+		pages.extend(private_pages)
+
+	if len(pages) == 0:
+		pages = [frappe.get_doc("Workspace", "Welcome Workspace").as_dict()]
+		pages[0]["label"] = _("Welcome Workspace")
+
+	return {
+		"pages": pages,
+		"has_access": has_access,
+		"has_create_access": frappe.has_permission(doctype="Workspace", ptype="create"),
+	}
+
+
+def override_workspace_sidebar():
+	"""Monkey patch the original function."""
+	import frappe.desk.desktop
+	frappe.desk.desktop.get_workspace_sidebar_items = get_workspace_sidebar_items


### PR DESCRIPTION
## Changes
- Override get_workspace_sidebar_items() to sort workspaces alphabetically by title instead of sequence_id
- Add @frappe.whitelist() decorator for frontend API access
- Import override in one_fm/__init__.py for reliable loading at module import time
- Remove from app_startup hook (less reliable method)

## Benefits
- Workspaces display in alphabetical order across all apps (ERPNext, HRMS, ONE-FM, etc.)
- No database patches required
- New workspaces automatically sorted without updates
- Runtime customization via monkey patching

## Technical Details
- Uses frappe.desk.desktop.Workspace for permission checking
- Returns same dict structure: {pages, has_access, has_create_access}
- Follows existing one_fm override patterns

## Testing
After bench restart, workspaces should appear alphabetically sorted in the desk sidebar.

Task: WI-000737

## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Solution description
Monkey patches frappe.desk.desktop.get_workspace_sidebar_items to sort by title asc instead of sequence_id. The override is applied in one_fm/__init__.py when the module is imported, ensuring it's active before any workspace requests.

## Is there any existing behavior change of other features due to this code change?
No - only the display order of workspaces in the sidebar changes.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Is patch required?
- [ ] Yes
- [x] No

## Which browser(s) did you use for testing?
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [x] N/A - Backend change