### PR TITLE
[WI-000698][[Yaser] Consolidated Cross-Plan Daily Manifest]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -272,7 +272,7 @@ function mountRoutePlannerApp(wrapper, data) {
 
                         const stopLabels = stops.map(s => {
                             const card = this.planData.shipment_cards.find(c => c.id === s.cardId);
-                            return card ? card.site_location : (s._site || s._stopLocation || s.cardId);
+                            return card ? card.site_location : (s._stopLocation || s._site || s.cardId);
                         });
 
                         entries.push({
@@ -365,7 +365,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     return {
                         id: item.cardId,
                         site: item._site || '',
-                        site_location: item._site || item._stopLocation || 'Unknown Site',
+                        site_location: item._stopLocation || item._site || 'Unknown Site',
                         shift_name: item._shift || '—',
                         accommodation: item._accommodation || '—',
                         stop_location: item._stopLocation || '—',
@@ -391,7 +391,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         if (!card && (item._site || item._shift || item._accommodation || item._stopLocation)) {
                             card = {
                                 id: item.cardId,
-                                site_location: item._site || item._stopLocation || 'Unknown Site',
+                                site_location: item._stopLocation || item._site || 'Unknown Site',
                                 shift_name: item._shift || '—',
                                 accommodation: item._accommodation || '—',
                                 stop_location: item._stopLocation || '—',
@@ -1863,7 +1863,7 @@ function mountRoutePlannerApp(wrapper, data) {
                 // Fallback for loaded plan items
                 if (item._site || item._stopLocation) {
                     return {
-                        site_location: item._site || item._stopLocation || '—',
+                        site_location: item._stopLocation || item._site || '—',
                         shift_name: item._shift || '—',
                         stop_location: item._stopLocation || '—',
                     };

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -272,12 +272,13 @@ function mountRoutePlannerApp(wrapper, data) {
 
                         const stopLabels = stops.map(s => {
                             const card = this.planData.shipment_cards.find(c => c.id === s.cardId);
-                            return card ? card.site_location : s.cardId;
+                            return card ? card.site_location : (s._site || s._stopLocation || s.cardId);
                         });
 
                         entries.push({
                             type: 'merged',
                             tripId,
+                            tripName: stops.find(s => s.tripName)?.tripName || null,
                             direction: firstItem.direction,
                             start: firstItem.start,
                             end: lastItem.end,
@@ -354,21 +355,52 @@ function mountRoutePlannerApp(wrapper, data) {
 
             selectedCard() {
                 if (!this.selectedItem) return null;
-                return this.planData.shipment_cards.find(c => c.id === this.selectedItem.cardId) || null;
+                const found = this.planData.shipment_cards.find(c => c.id === this.selectedItem.cardId);
+                if (found) return found;
+                // Fallback: build a synthetic card from saved metadata on the swim item
+                // This allows the detail panel to open for loaded plans even when
+                // the underlying employee/shift data has changed since the plan was saved.
+                const item = this.selectedItem;
+                if (item._site || item._shift || item._accommodation || item._stopLocation) {
+                    return {
+                        id: item.cardId,
+                        site: item._site || '',
+                        site_location: item._site || item._stopLocation || 'Unknown Site',
+                        shift_name: item._shift || '—',
+                        accommodation: item._accommodation || '—',
+                        stop_location: item._stopLocation || '—',
+                        headcount: item.headcount || 0,
+                        employees: [],
+                        direction: item.direction || 'OUTBOUND',
+                        type: 'LOADED',
+                    };
+                }
+                return null;
             },
 
             // All stops in the selected trip chain (empty if not a trip)
             selectedTripStops() {
                 if (!this.selectedItem || !this.selectedItem.tripId) return [];
                 const tripId = this.selectedItem.tripId;
+                const self = this;
                 return this.swimItems
                     .filter(i => i.tripId === tripId)
                     .sort((a, b) => new Date(a.start) - new Date(b.start))
-                    .map((item, idx) => ({
-                        item,
-                        card: this.planData.shipment_cards.find(c => c.id === item.cardId) || {},
-                        stopNum: idx + 1
-                    }));
+                    .map((item, idx) => {
+                        let card = self.planData.shipment_cards.find(c => c.id === item.cardId);
+                        if (!card && (item._site || item._shift || item._accommodation || item._stopLocation)) {
+                            card = {
+                                id: item.cardId,
+                                site_location: item._site || item._stopLocation || 'Unknown Site',
+                                shift_name: item._shift || '—',
+                                accommodation: item._accommodation || '—',
+                                stop_location: item._stopLocation || '—',
+                                headcount: item.headcount || 0,
+                                employees: [],
+                            };
+                        }
+                        return { item, card: card || {}, stopNum: idx + 1 };
+                    });
             },
         },
 
@@ -606,9 +638,11 @@ function mountRoutePlannerApp(wrapper, data) {
                                 return c ? c.site_location : i.cardId;
                             });
                             const timeRange = self.fmtTime(items[0].start) + '–' + self.fmtTime(items[items.length - 1].end);
+                            const tName = items.find(i => i.tripName)?.tripName;
+                            const tripLabel = tName || `Trip ${idx + 1}`;
                             return {
                                 key,
-                                label: `Trip ${idx + 1}: ${sites.join(' → ')} (${timeRange})`,
+                                label: `${tripLabel}: ${sites.join(' → ')} (${timeRange})`,
                                 items
                             };
                         });
@@ -714,6 +748,13 @@ function mountRoutePlannerApp(wrapper, data) {
                                 ${existingHtml}`
                         },
                         {
+                            fieldtype: 'Data', fieldname: 'trip_name',
+                            label: 'Trip Name', reqd: 1,
+                            description: 'Name this trip (e.g. "Morning Run 2", "Evening Pickup B")',
+                            placeholder: 'e.g. Morning Run 2'
+                        },
+                        { fieldtype: 'Section Break' },
+                        {
                             fieldtype: 'Int', fieldname: 'duration_min',
                             label: 'Trip Duration (minutes)', default: 60, reqd: 1
                         }
@@ -722,7 +763,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     primary_action(vals) {
                         d.hide();
                         const durMs = (vals.duration_min || 60) * 60000;
-                        self._doPlace(card, vehicleId, durMs, isOutbound, !isOutbound);
+                        self._doPlace(card, vehicleId, durMs, isOutbound, !isOutbound, 0, vals.trip_name || '');
                     }
                 });
                 d.show();
@@ -750,6 +791,7 @@ function mountRoutePlannerApp(wrapper, data) {
 
                 // Find or create trip ID
                 let tripId = existingItems.find(i => i.tripId)?.tripId;
+                const existingTripName = existingItems.find(i => i.tripName)?.tripName || null;
                 if (!tripId) {
                     tripId = `TRIP_${vehicleId}_${Math.random().toString(36).slice(2, 8)}`;
                     existingItems
@@ -778,7 +820,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         id: `${newCard.id}_${newCard.direction === 'RETURN' ? 'RET' : 'OUT'}_${uid}`, cardId: newCard.id, vehicleId,
                         direction: newCard.direction || 'OUTBOUND', start: segStart, end: segEnd,
                         headcount: newCard.headcount, conflict: false,
-                        tripId, stopIndex: totalStops + 1
+                        tripId, tripName: existingTripName, stopIndex: totalStops + 1
                     });
 
                     const allTrip = self.swimItems.filter(i => i.tripId === tripId);
@@ -927,6 +969,13 @@ function mountRoutePlannerApp(wrapper, data) {
                                 Direction: <strong>${dirLabel}</strong></p>`
                         },
                         {
+                            fieldtype: 'Data', fieldname: 'trip_name',
+                            label: 'Trip Name',
+                            description: 'Give this trip a name (e.g. "Morning Shift A")',
+                            placeholder: 'e.g. Morning Shift A'
+                        },
+                        { fieldtype: 'Section Break' },
+                        {
                             fieldtype: 'Int', fieldname: 'buffer_min',
                             label: 'Buffer Time (minutes)',
                             description: isOutbound
@@ -951,14 +1000,15 @@ function mountRoutePlannerApp(wrapper, data) {
                         d.hide();
                         const bufferMs = (vals.buffer_min || 15) * 60000;
                         const transitMs = (vals.duration_min || 60) * 60000;
-                        self._doPlace(card, vehicleId, transitMs, isOutbound, !isOutbound, bufferMs);
+                        self._doPlace(card, vehicleId, transitMs, isOutbound, !isOutbound, bufferMs, vals.trip_name || '');
                     }
                 });
                 d.show();
             },
 
-            _doPlace(card, vehicleId, durMs, placeOutbound, placeReturn, bufferMs) {
+            _doPlace(card, vehicleId, durMs, placeOutbound, placeReturn, bufferMs, tripName) {
                 bufferMs = bufferMs || 0;
+                tripName = tripName || '';
                 const totalMs = bufferMs + durMs;
                 const outEnd = new Date(card.outbound_window_end);
                 const outStart = new Date(outEnd.getTime() - totalMs);
@@ -966,13 +1016,18 @@ function mountRoutePlannerApp(wrapper, data) {
                 const retEnd = new Date(retStart.getTime() + totalMs);
                 const uid = Math.random().toString(36).slice(2, 10);
 
+                // Auto-generate a tripId if a trip name was given
+                const autoTripId = tripName ? `TRIP_${vehicleId}_${uid}` : null;
+
                 if (placeOutbound) {
                     this.swimItems.push({
                         id: `${card.id}_OUT_${uid}`, cardId: card.id, vehicleId,
                         direction: 'OUTBOUND', start: outStart, end: outEnd,
                         headcount: card.headcount, conflict: false,
                         bufferMin: Math.round(bufferMs / 60000),
-                        transitMin: Math.round(durMs / 60000)
+                        transitMin: Math.round(durMs / 60000),
+                        tripId: autoTripId, tripName: tripName || null,
+                        stopIndex: 1
                     });
                 }
                 if (placeReturn) {
@@ -981,7 +1036,9 @@ function mountRoutePlannerApp(wrapper, data) {
                         direction: 'RETURN', start: retStart, end: retEnd,
                         headcount: card.headcount, conflict: false,
                         bufferMin: Math.round(bufferMs / 60000),
-                        transitMin: Math.round(durMs / 60000)
+                        transitMin: Math.round(durMs / 60000),
+                        tripId: autoTripId, tripName: tripName || null,
+                        stopIndex: 1
                     });
                 }
 
@@ -994,8 +1051,9 @@ function mountRoutePlannerApp(wrapper, data) {
                 const bufferNote = bufferMs > 0 ? ` + ${Math.round(bufferMs/60000)}min buffer` : '';
                 const dirLabel = (placeOutbound && placeReturn) ? 'Both trips'
                     : placeOutbound ? 'Outbound (→)' : 'Return (←)';
+                const tripNote = tripName ? ` · Trip: ${tripName}` : '';
                 frappe.show_alert({
-                    message: `${dirLabel} placed on ${this.vehicleLabelForItem({ vehicleId })} (${Math.round(durMs/60000)}min transit${bufferNote})`,
+                    message: `${dirLabel} placed on ${this.vehicleLabelForItem({ vehicleId })} (${Math.round(durMs/60000)}min transit${bufferNote})${tripNote}`,
                     indicator: 'green'
                 }, 4);
             },
@@ -1323,11 +1381,13 @@ function mountRoutePlannerApp(wrapper, data) {
                     const vehicle = this.planData.vehicles.find(v => v.id === t.vehicleId);
 
                     if (vehicle && lastCard && lastItem.direction === item.direction) {
-                        const prefix = t.isSolo ? 'Single stop' : 'Trip';
+                        const tName = t.items.find(i => i.tripName)?.tripName;
+                        const prefix = tName ? tName : (t.isSolo ? 'Single stop' : 'Trip');
                         tripOptions.push({
                             label: `[${vehicle.label}] ${prefix} ending at ${lastCard.site_location}`,
                             value: tid,
-                            lastItem, lastCard, vehicle
+                            lastItem, lastCard, vehicle,
+                            tripName: tName || null
                         });
                     }
                 });
@@ -1407,6 +1467,8 @@ function mountRoutePlannerApp(wrapper, data) {
                         const segEnd = new Date(segStart.getTime() + transitMs);
                         const totalStops = targetTripItems.length;
 
+                        const existingTripName = targetTripItems.find(i => i.tripName)?.tripName || selectedOpt.tripName || null;
+
                         self.swimItems.push({
                             id: item.id, // keep original ID
                             cardId: card.id, 
@@ -1417,6 +1479,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             headcount: item.headcount, 
                             conflict: false,
                             tripId: targetTripId, 
+                            tripName: existingTripName,
                             stopIndex: totalStops + 1,
                             bufferMin: vals.dwell_min || 0,
                             transitMin: vals.transit_min || 30
@@ -1795,7 +1858,17 @@ function mountRoutePlannerApp(wrapper, data) {
             },
 
             bcard(item) {
-                return this.planData.shipment_cards.find(c => c.id === item.cardId) || {};
+                const found = this.planData.shipment_cards.find(c => c.id === item.cardId);
+                if (found) return found;
+                // Fallback for loaded plan items
+                if (item._site || item._stopLocation) {
+                    return {
+                        site_location: item._site || item._stopLocation || '—',
+                        shift_name: item._shift || '—',
+                        stop_location: item._stopLocation || '—',
+                    };
+                }
+                return {};
             },
 
             bsel(item) {
@@ -1981,6 +2054,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             shipmentIndex: sIdx, isPickup: true, startTime: iS,
                             loadDemands: { seats: { amount: String(hc) } },
                             tripId: item.tripId || null,
+                            tripName: item.tripName || null,
                             stopIndex: item.stopIndex || 0
                         });
                         trans.push({
@@ -1991,6 +2065,7 @@ function mountRoutePlannerApp(wrapper, data) {
                             shipmentIndex: sIdx, isPickup: false, startTime: iE,
                             loadDemands: { seats: { amount: String(-hc) } },
                             tripId: item.tripId || null,
+                            tripName: item.tripName || null,
                             stopIndex: item.stopIndex || 0
                         });
 
@@ -2326,13 +2401,13 @@ function injectRPVueTemplate() {
                     <!-- Clipped text group -->
                     <g :clip-path="'url(#sclip-' + entry.item.id + ')'">
 
-                      <!-- Line 1: Direction arrow -->
+                      <!-- Line 1: Direction arrow + trip name -->
                       <text v-if="bw(entry.item) >= 18"
                             :x="bx(entry.item) + 8" :y="by(entry.item) + 18"
                             fill="white" font-size="12"
                             font-weight="700" dominant-baseline="middle"
                             style="user-select:none;pointer-events:none">
-                        {{ entry.item.direction === 'OUTBOUND' ? '\u2192' : '\u2190' }}{{ entry.item.direction === 'OUTBOUND' ? ' To' : ' From' }}
+                        {{ entry.item.direction === 'OUTBOUND' ? '\u2192' : '\u2190' }}{{ entry.item.tripName ? ' ' + entry.item.tripName : (entry.item.direction === 'OUTBOUND' ? ' To' : ' From') }}
                       </text>
 
                       <!-- Line 2: Site name (bold, large) -->
@@ -2368,7 +2443,7 @@ function injectRPVueTemplate() {
                      @click.stop="onBlockClick(entry.primaryItem, $event)">
 
                     <!-- Native tooltip showing all stops + time -->
-                    <title>{{ entry.stopLabels.join(' → ') }} | {{ fmtTime(entry.start) }}–{{ fmtTime(entry.end) }} · {{ entry.headcount }} pax</title>
+                    <title>{{ entry.tripName ? entry.tripName + ' — ' : '' }}{{ entry.stopLabels.join(' → ') }} | {{ fmtTime(entry.start) }}–{{ fmtTime(entry.end) }} · {{ entry.headcount }} pax</title>
 
                     <!-- Clip path scoped to block bounds -->
                     <defs>
@@ -2392,13 +2467,13 @@ function injectRPVueTemplate() {
                     <!-- Clipped content group -->
                     <g :clip-path="'url(#mclip-' + entry.tripId + ')'">
 
-                      <!-- Line 1: Direction arrow -->
+                      <!-- Line 1: Trip name + direction arrow -->
                       <text v-if="mbw(entry) >= 18"
                             :x="mbx(entry) + 8" :y="mby(entry) + 16"
                             fill="white" font-size="12"
                             font-weight="700" dominant-baseline="middle"
                             style="user-select:none;pointer-events:none">
-                        {{ entry.direction === 'OUTBOUND' ? '\u2192' : '\u2190' }} {{ entry.direction === 'OUTBOUND' ? 'To' : 'From' }}
+                        {{ entry.direction === 'OUTBOUND' ? '\u2192' : '\u2190' }} {{ entry.tripName || (entry.direction === 'OUTBOUND' ? 'To' : 'From') }}
                       </text>
 
                       <!-- Stop names — listed vertically, capped by available height -->
@@ -2470,6 +2545,9 @@ function injectRPVueTemplate() {
             <span :class="['rp-dir-badge', selectedItem.direction === 'OUTBOUND' ? 'rp-dir-out' : 'rp-dir-ret']">
               {{ selectedItem.direction === 'OUTBOUND' ? '\u2192 Outbound' : '\u2190 Return' }}
             </span>
+            <span v-if="selectedItem.tripName" class="rp-dir-badge" style="background:#e8f5e9;color:#2e7d32">
+              {{ selectedItem.tripName }}
+            </span>
             <span v-if="selectedTripStops.length > 0" class="rp-dir-badge" style="background:#f3e8fd;color:#7c3aed">
               {{ selectedTripStops.length }} Stops
             </span>
@@ -2483,7 +2561,7 @@ function injectRPVueTemplate() {
 
             <!-- Trip time summary -->
             <div class="rp-detail-card">
-              <div class="rp-detail-row-label" style="padding:0 0 6px 0">Trip Timeline</div>
+              <div class="rp-detail-row-label" style="padding:0 0 6px 0">{{ selectedItem.tripName ? selectedItem.tripName + ' — ' : '' }}Trip Timeline</div>
               <div class="rp-detail-time-display">
                 {{ fmtISO(new Date(selectedTripStops[0].item.start).toISOString()) }}
                 <span class="rp-detail-time-arrow">\u2192</span>

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -1167,6 +1167,7 @@ def save_assignments(plan_name: str, swim_items: str, assigned_cards: str):
             "direction":     item.get("direction", ""),
             "stop_index":    item.get("stopIndex", 0),
             "trip_group":    item.get("tripId", ""),
+            "trip_name":     item.get("tripName", ""),
             "headcount":     item.get("headcount", 0),
             "start_time":    item.get("start", ""),
             "end_time":      item.get("end", ""),
@@ -1217,8 +1218,14 @@ def load_assignments(plan_name: str = ""):
             "headcount": row.headcount or 0,
             "conflict":  False,
             "tripId":    row.trip_group or None,
+            "tripName":  row.trip_name or None,
             "stopIndex": row.stop_index or 0,
             "totalStops": 0,  # recalculated client-side
+            # Saved metadata for detail panel fallback
+            "_site":          row.site or "",
+            "_shift":         row.shift or "",
+            "_accommodation": row.accommodation or "",
+            "_stopLocation":  row.stop_location or "",
         })
         assigned_card_ids.add(row.card_id)
 

--- a/one_fm/operations/doctype/route_plan_assignment/route_plan_assignment.json
+++ b/one_fm/operations/doctype/route_plan_assignment/route_plan_assignment.json
@@ -11,6 +11,7 @@
     "column_break_1",
     "stop_index",
     "trip_group",
+    "trip_name",
     "headcount",
     "section_break_details",
     "site",
@@ -62,6 +63,12 @@
       "fieldtype": "Data",
       "label": "Trip Group",
       "description": "Groups multi-stop blocks into one trip"
+    },
+    {
+      "fieldname": "trip_name",
+      "fieldtype": "Data",
+      "label": "Trip Name",
+      "description": "User-defined name for the trip"
     },
     {
       "fieldname": "headcount",

--- a/one_fm/public/html/route_manifest_template.html
+++ b/one_fm/public/html/route_manifest_template.html
@@ -1084,6 +1084,7 @@
                     delta: delta,
                     transition: trans[i + 1],
                     tripId: v.tripId || null,
+                    tripName: v.tripName || null,
                     stopIndex: v.stopIndex || 0
                 });
             });
@@ -1253,7 +1254,9 @@
             // Group solo stops into a pseudo-trip if they exist
             const allTrips = [];
             tripIds.forEach((tid, i) => {
-                allTrips.push({ id: tid, label: `Trip ${i + 1}`, stops: tripMap[tid] });
+                const tripStops = tripMap[tid];
+                const name = tripStops.find(s => s.tripName)?.tripName || `Trip ${i + 1}`;
+                allTrips.push({ id: tid, label: name, stops: tripStops });
             });
             if (soloStops.length > 0) {
                 allTrips.push({ id: null, label: allTrips.length > 0 ? `Trip ${allTrips.length + 1} (Independent)` : 'Trip 1', stops: soloStops });


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.

### Feature: Trip Naming in Route Planner
Dispatchers need the ability to label new, independent trips with human-readable names (e.g. "Morning Shift A", "Evening Pickup B") instead of relying on system-generated `TRIP_xxx` identifiers. This improves clarity when managing multiple trips per vehicle on the timeline.

### Bug: Detail Panel Not Opening for Loaded Plans
When opening an existing saved plan, clicking on assigned blocks on vehicle lanes did not open the shipment detail side panel. The root cause was a `cardId` mismatch — loaded swim items referenced card IDs that could not be found in the freshly-regenerated `planData.shipment_cards` (e.g. if employee accommodations or shift assignments changed since the plan was saved). The `selectedCard` computed returned `null`, preventing the panel from rendering.


## Analysis and design (optional)

**Trip Naming Flow:**
- When placing a card via `placeCard` (first placement), an optional "Trip Name" field is shown
- When creating a new independent trip via `_doPlaceWithDialog` (declining merge), a **required** "Trip Name" field is shown
- Trip name is stored on each swim item as `tripName` and auto-generates a `tripId` when provided
- Chaining (`_chainToTrip`) and merging (`mergeSelectedBlock`) inherit `tripName` from existing trip items

**Detail Panel Bug Fix:**
- `load_assignments` in Python now returns saved metadata (`_site`, `_shift`, `_accommodation`, `_stopLocation`) with each swim item
- `selectedCard`, `selectedTripStops`, `bcard()`, and `stopLabels` all fall back to building synthetic card objects from this metadata when the real card can't be found


## Solution description

### Files Modified

#### `route_planner.js` (Frontend)
1. **`placeCard` dialog** — Added optional "Trip Name" `Data` field with section break
2. **`_doPlaceWithDialog` dialog** — Added required "Trip Name" `Data` field for new independent trips
3. **`_doPlace` method** — Accepts `tripName` parameter; auto-generates `tripId` + stores `tripName` on swim items when provided
4. **`_chainToTrip`** — New stops inherit `tripName` from existing trip items via `existingTripName` lookup
5. **`mergeSelectedBlock`** — Merged stops inherit `tripName` from target trip; merge dialog shows trip names in options
6. **`mergedItemsByVehicle` computed** — Propagates `tripName` onto merged entry objects
7. **`selectedCard` computed** — Falls back to synthetic card from saved `_site`/`_shift`/`_accommodation`/`_stopLocation` metadata
8. **`selectedTripStops` computed** — Same fallback for trip stop cards
9. **`bcard()` helper** — Same fallback for SVG block text rendering
10. **`stopLabels` generation** — Uses `_site`/`_stopLocation` metadata when card not found
11. **SVG templates** — Single + merged blocks show trip name on direction label line; tooltips include trip name prefix
12. **Detail panel** — Green badge with trip name; "Trip Timeline" header shows trip name
13. **Multi-trip picker** — Shows trip names instead of "Trip 1", "Trip 2"
14. **`persistAssignments`** — Includes `tripName` in visit data sent to server

#### `route_planner.py` (Backend)
1. **`save_assignments`** — Stores `tripName` as `trip_name` in Route Plan Assignment child rows
2. **`load_assignments`** — Returns `tripName`, `_site`, `_shift`, `_accommodation`, `_stopLocation` with each swim item

#### `route_plan_assignment.json` (DocType Schema)
1. Added `trip_name` Data field after `trip_group` in the Route Plan Assignment child table


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

Business logic is within the Frappe Page controller (`route_planner.js` / `route_planner.py`), not within a DocType controller.


## Output screenshots (optional)

### Placement Dialog — Trip Name Field
- `placeCard`: Optional "Trip Name" input above buffer/transit fields
- `_doPlaceWithDialog`: Required "Trip Name" input with placeholder text

### SVG Timeline Blocks
- Direction label shows trip name (e.g. `→ Morning Shift A`) instead of generic `→ To`
- Tooltip prefixed with trip name

### Detail Panel
- Green badge with trip name between direction badge and stop count
- Trip Timeline header: "Morning Shift A — Trip Timeline"

### Multi-Trip Picker
- Options show: `Morning Shift A: Site1 → Site2 (06:00–07:30)` instead of `Trip 1: Site1 → Site2 (06:00–07:30)`


## Areas affected and ensured

| Area | Impact |
|------|--------|
| Card placement (first drop) | Trip Name field added to dialog |
| Independent trip creation | Trip Name field added (required) |
| Trip chaining (append stop) | Inherits trip name from existing trip |
| Merge into trip | Inherits trip name; shows names in picker |
| SVG timeline rendering | Shows trip name on blocks + tooltips |
| Detail panel | Shows trip name badge + in timeline header |
| Multi-trip picker dialog | Shows trip names in selection labels |
| Data persistence (save/load) | `trip_name` field added to child table and serialization |
| Loaded plan detail panel | **Bug fix**: now opens even when card data changed since save |


## Is there any existing behavior change of other features due to this code change?

**Yes** — Two minor behavioral changes:

1. **Loaded plans**: The detail panel will now open for ALL loaded plan items, even if the underlying employee/shift data has changed. Previously it silently failed (panel wouldn't open). Now it shows a synthetic card with the saved metadata.

2. **SVG block labels**: Single blocks that have a `tripName` will show the trip name instead of "To"/"From" on the direction line. Existing blocks without trip names are unaffected (they still show "To"/"From").


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data


## Was child table created?
No new child table was created. An existing child table (`Route Plan Assignment`) was modified.

- [x] is attachment required?
    No — only a `Data` field was added
- Field added: `trip_name` (Data type, optional)


## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [ ] Yes
- [x] No

The new `trip_name` field is optional (not required) and defaults to empty. `bench migrate` adds the column automatically. Existing saved plans will load with `tripName: null`, which is handled gracefully throughout the UI (falls back to default "To"/"From" labels).


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox

https://github.com/user-attachments/assets/c69a2002-701f-4a0f-910c-2ac9cd8c4d7d

