### PR TITLE
[WI-000705][[Yaser] Displaying Contact Info for All  Staff]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -364,11 +364,12 @@ function mountRoutePlannerApp(wrapper, data) {
                 // the underlying employee/shift data has changed since the plan was saved.
                 const item = this.selectedItem;
                 if (item._site || item._shift || item._accommodation || item._stopLocation) {
-                    // Fuzzy-match: find a current card with same accommodation + stop + direction
+                    // Fuzzy-match: find a current card with same accommodation + stop + direction + shift
                     const fuzzy = this.planData.shipment_cards.find(c =>
                         c.accommodation === item._accommodation &&
                         c.stop_location === item._stopLocation &&
-                        c.direction === (item.direction || 'OUTBOUND')
+                        c.direction === (item.direction || 'OUTBOUND') &&
+                        (!item._shift || c.shift_name === item._shift)
                     );
                     return {
                         id: item.cardId,
@@ -404,7 +405,8 @@ function mountRoutePlannerApp(wrapper, data) {
                             const fuzzy = self.planData.shipment_cards.find(c =>
                                 c.accommodation === item._accommodation &&
                                 c.stop_location === item._stopLocation &&
-                                c.direction === (item.direction || 'OUTBOUND')
+                                c.direction === (item.direction || 'OUTBOUND') &&
+                                (!item._shift || c.shift_name === item._shift)
                             );
                             card = {
                                 id: item.cardId,
@@ -2168,7 +2170,8 @@ function mountRoutePlannerApp(wrapper, data) {
                         card = this.planData.shipment_cards.find(c =>
                             c.accommodation === item._accommodation &&
                             c.stop_location === item._stopLocation &&
-                            c.direction === (item.direction || 'OUTBOUND')
+                            c.direction === (item.direction || 'OUTBOUND') &&
+                            (!item._shift || c.shift_name === item._shift)
                         );
                     }
                     if (!card) return;

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -364,17 +364,26 @@ function mountRoutePlannerApp(wrapper, data) {
                 // the underlying employee/shift data has changed since the plan was saved.
                 const item = this.selectedItem;
                 if (item._site || item._shift || item._accommodation || item._stopLocation) {
+                    // Fuzzy-match: find a current card with same accommodation + stop + direction
+                    const fuzzy = this.planData.shipment_cards.find(c =>
+                        c.accommodation === item._accommodation &&
+                        c.stop_location === item._stopLocation &&
+                        c.direction === (item.direction || 'OUTBOUND')
+                    );
                     return {
                         id: item.cardId,
                         site: item._site || '',
                         site_location: item._stopLocation || item._site || 'Unknown Site',
-                        shift_name: item._shift || '—',
-                        accommodation: item._accommodation || '—',
-                        stop_location: item._stopLocation || '—',
-                        headcount: item.headcount || 0,
-                        employees: [],
+                        shift_name: fuzzy ? fuzzy.shift_name : (item._shift || '\u2014'),
+                        accommodation: item._accommodation || '\u2014',
+                        stop_location: item._stopLocation || '\u2014',
+                        headcount: fuzzy ? fuzzy.headcount : (item.headcount || 0),
+                        employees: fuzzy ? fuzzy.employees : [],
+                        return_employees: fuzzy ? (fuzzy.return_employees || []) : [],
                         direction: item.direction || 'OUTBOUND',
-                        type: 'LOADED',
+                        shift_start: fuzzy ? fuzzy.shift_start : null,
+                        shift_end: fuzzy ? fuzzy.shift_end : null,
+                        type: fuzzy ? fuzzy.type : 'LOADED',
                     };
                 }
                 return null;
@@ -391,14 +400,20 @@ function mountRoutePlannerApp(wrapper, data) {
                     .map((item, idx) => {
                         let card = self.planData.shipment_cards.find(c => c.id === item.cardId);
                         if (!card && (item._site || item._shift || item._accommodation || item._stopLocation)) {
+                            // Fuzzy-match for trip stops too
+                            const fuzzy = self.planData.shipment_cards.find(c =>
+                                c.accommodation === item._accommodation &&
+                                c.stop_location === item._stopLocation &&
+                                c.direction === (item.direction || 'OUTBOUND')
+                            );
                             card = {
                                 id: item.cardId,
                                 site_location: item._stopLocation || item._site || 'Unknown Site',
-                                shift_name: item._shift || '—',
-                                accommodation: item._accommodation || '—',
-                                stop_location: item._stopLocation || '—',
-                                headcount: item.headcount || 0,
-                                employees: [],
+                                shift_name: fuzzy ? fuzzy.shift_name : (item._shift || '\u2014'),
+                                accommodation: item._accommodation || '\u2014',
+                                stop_location: item._stopLocation || '\u2014',
+                                headcount: fuzzy ? fuzzy.headcount : (item.headcount || 0),
+                                employees: fuzzy ? fuzzy.employees : [],
                             };
                         }
                         return { item, card: card || {}, stopNum: idx + 1 };
@@ -436,6 +451,36 @@ function mountRoutePlannerApp(wrapper, data) {
 
             durMin(item) {
                 return Math.round((new Date(item.end) - new Date(item.start)) / 60000);
+            },
+
+            /** Safe accessor: extract display name from employee (object or legacy string). */
+            empName(e) {
+                return (typeof e === 'object' && e !== null) ? (e.name || '—') : (e || '—');
+            },
+
+            /** Safe accessor: extract mobile from employee object. */
+            empMobile(e) {
+                return (typeof e === 'object' && e !== null) ? (e.mobile || '') : '';
+            },
+
+            /** Handle click on employee phone icon — tel: on mobile, clipboard on desktop. */
+            handleEmployeeCall(e) {
+                const name = this.empName(e);
+                const mobile = this.empMobile(e);
+                if (!mobile) {
+                    frappe.show_alert({ message: __('No mobile number on file for ' + name), indicator: 'orange' }, 3);
+                    return;
+                }
+                const isMobile = /Android|iPhone|iPad|iPod|webOS|BlackBerry/i.test(navigator.userAgent);
+                if (isMobile) {
+                    window.location.href = 'tel:' + mobile;
+                } else {
+                    navigator.clipboard.writeText(mobile).then(() => {
+                        frappe.show_alert({ message: __('Number Copied: ') + mobile, indicator: 'green' }, 3);
+                    }).catch(() => {
+                        frappe.show_alert({ message: mobile, indicator: 'blue' }, 5);
+                    });
+                }
             },
 
             // ─ Zoom / Pan ──────────────────────────────────────────────────
@@ -2117,7 +2162,15 @@ function mountRoutePlannerApp(wrapper, data) {
                 // Fix #6: Build shipments from swimItems (per direction actually placed)
                 // instead of from assignedCards, to avoid phantom shipments
                 this.swimItems.forEach(item => {
-                    const card = this.planData.shipment_cards.find(c => c.id === item.cardId);
+                    let card = this.planData.shipment_cards.find(c => c.id === item.cardId);
+                    // Fuzzy-match for loaded plans where card IDs may have shifted
+                    if (!card && (item._accommodation || item._stopLocation)) {
+                        card = this.planData.shipment_cards.find(c =>
+                            c.accommodation === item._accommodation &&
+                            c.stop_location === item._stopLocation &&
+                            c.direction === (item.direction || 'OUTBOUND')
+                        );
+                    }
                     if (!card) return;
 
                     const dirKey = `${item.cardId}_${item.direction}`;
@@ -2382,7 +2435,10 @@ function injectRPVueTemplate() {
                 </div>
               </div>
               <div class="rp-card-employees">
-                <span v-for="e in card.employees.slice(0,3)" :key="e" class="rp-emp-chip">{{ e }}</span>
+                <span v-for="(e, ei) in card.employees.slice(0,3)" :key="card.id + '_' + ei" class="rp-emp-chip rp-emp-chip-call" @click.stop="handleEmployeeCall(e)" :title="empMobile(e) ? 'Call ' + empMobile(e) : 'No mobile number'">
+                  {{ empName(e) }}
+                  <span class="rp-icon rp-call-icon" :class="empMobile(e) ? '' : 'rp-call-disabled'">call</span>
+                </span>
                 <span v-if="card.employees.length > 3" class="rp-emp-chip rp-emp-more">+{{ card.employees.length - 3 }} more</span>
               </div>
             </div>
@@ -2754,8 +2810,11 @@ function injectRPVueTemplate() {
             <div class="rp-detail-card">
               <div class="rp-detail-row-label" style="padding:0 0 8px 0"><span class="rp-icon" style="font-size:16px">group</span> All Employees ({{ selectedTripStops.reduce((sum, s) => sum + (s.item.headcount || 0), 0) }})</div>
               <div class="rp-detail-emp-list">
-                <template v-for="stop in selectedTripStops">
-                  <span v-for="e in stop.card.employees" :key="stop.item.id + '_' + e" class="rp-emp-chip">{{ e }}</span>
+                <template v-for="(stop, si) in selectedTripStops">
+                  <span v-for="(e, ei) in stop.card.employees" :key="si + '_' + ei" class="rp-emp-chip rp-emp-chip-call" @click.stop="handleEmployeeCall(e)" :title="empMobile(e) ? 'Call ' + empMobile(e) : 'No mobile number'">
+                    {{ empName(e) }}
+                    <span class="rp-icon rp-call-icon" :class="empMobile(e) ? '' : 'rp-call-disabled'">call</span>
+                  </span>
                 </template>
               </div>
             </div>
@@ -2858,7 +2917,10 @@ function injectRPVueTemplate() {
             <div class="rp-detail-card">
               <div class="rp-detail-row-label" style="padding:0 0 8px 0"><span class="rp-icon" style="font-size:16px">group</span> Employees ({{ selectedCard.headcount }})</div>
               <div class="rp-detail-emp-list">
-                <span v-for="e in selectedCard.employees" :key="e" class="rp-emp-chip">{{ e }}</span>
+                <span v-for="(e, ei) in selectedCard.employees" :key="'emp_' + ei" class="rp-emp-chip rp-emp-chip-call" @click.stop="handleEmployeeCall(e)" :title="empMobile(e) ? 'Call ' + empMobile(e) : 'No mobile number'">
+                  {{ empName(e) }}
+                  <span class="rp-icon rp-call-icon" :class="empMobile(e) ? '' : 'rp-call-disabled'">call</span>
+                </span>
               </div>
             </div>
 
@@ -3177,8 +3239,13 @@ function injectRPStyles() {
         .rp-window-label{ display: block; font-size: 11px; font-weight: 700; letter-spacing: .08em; color: var(--md-sys-color-on-surface-variant); }
         .rp-window-time { display: block; font-size: 12px; font-weight: 600; color: var(--md-sys-color-on-surface); }
         .rp-card-employees { display: flex; flex-wrap: wrap; gap: 3px; }
-        .rp-emp-chip    { font-size: 11px; background: var(--md-sys-color-surface-container); border: 1px solid var(--md-sys-color-outline-variant); border-radius: 4px; padding: 2px 6px; color: var(--md-sys-color-on-surface-variant); }
+        .rp-emp-chip    { font-size: 11px; background: var(--md-sys-color-surface-container); border: 1px solid var(--md-sys-color-outline-variant); border-radius: 4px; padding: 2px 6px; color: var(--md-sys-color-on-surface-variant); display: inline-flex; align-items: center; gap: 3px; }
         .rp-emp-more    { background: var(--md-sys-color-surface-container-high); color: var(--md-sys-color-outline); }
+        .rp-emp-chip-call { cursor: pointer; transition: border-color 0.15s, background 0.15s; }
+        .rp-emp-chip-call:hover { border-color: var(--rp-color-success); background: rgba(34,197,94,0.06); }
+        .rp-call-icon { font-size: 13px !important; color: var(--rp-color-success); transition: color 0.15s; }
+        .rp-emp-chip-call:hover .rp-call-icon { color: #16a34a; }
+        .rp-call-disabled { color: var(--md-sys-color-outline) !important; opacity: 0.35; cursor: default; }
 
         /* ── Timeline Panel ── */
         #rp-timeline-panel {

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -92,19 +92,26 @@ def get_route_planner_data():
         # ── 2. Shipment cards ────────────────────────────────────────────
         nested_map = get_grouped_employees_by_accommodation()
 
-        # Batch resolve all employee names up front
+        # Batch resolve all employee names + mobile numbers up front
         all_emp_ids = set()
         for acc_data in nested_map.values():
             for emp_list in acc_data["shifts"].values():
                 all_emp_ids.update(emp_list)
 
         emp_name_map = {
-            e.name: e.employee_name
+            e.name: {"employee_name": e.employee_name, "cell_number": e.cell_number or ""}
             for e in frappe.get_all("Employee",
                 filters={"name": ["in", list(all_emp_ids)]},
-                fields=["name", "employee_name"]
+                fields=["name", "employee_name", "cell_number"]
             )
         }
+
+        def emp_to_obj(emp_id):
+            """Convert employee ID to {name, mobile} dict for frontend call action."""
+            info = emp_name_map.get(emp_id, {})
+            if isinstance(info, dict):
+                return {"name": info.get("employee_name", emp_id), "mobile": info.get("cell_number", "")}
+            return {"name": info or emp_id, "mobile": ""}
 
         # Batch-fetch all shift docs in one query (instead of per-shift frappe.get_doc)
         all_shift_names = set()
@@ -208,7 +215,7 @@ def get_route_planner_data():
                     outbound_window_start = fmt(start_utc - timedelta(minutes=PICKUP_BUFFER))
                     outbound_window_end   = fmt(start_utc)
 
-                employees_named = [emp_name_map.get(e, e) for e in employee_list]
+                employees_named = [emp_to_obj(e) for e in employee_list]
 
                 handled = False
 
@@ -242,7 +249,7 @@ def get_route_planner_data():
                             "stop_location":        loc["name"],
                             "stop_coords":          {"lat": loc["coords"][0], "lng": loc["coords"][1]},
                             "headcount":            current_h,
-                            "employees":            [emp_name_map.get(e, e) for e in loc_employees],
+                            "employees":            [emp_to_obj(e) for e in loc_employees],
                             "outbound_window_start": outbound_window_start,
                             "outbound_window_end":   outbound_window_end,
                             "return_window_start":   fmt(end_utc),
@@ -359,7 +366,7 @@ def get_route_planner_data():
                     "stop_location":        stop_location,
                     "stop_coords":          {"lat": stop_coords[0], "lng": stop_coords[1]},
                     "headcount":            group_data["headcount"],
-                    "employees":            [emp_name_map.get(e, e) for e in group_data["employees"]],
+                    "employees":            [emp_to_obj(e) for e in group_data["employees"]],
                     "outbound_window_start": fmt(start_utc - timedelta(minutes=PICKUP_BUFFER)),
                     "outbound_window_end":   fmt(start_utc),
                     "return_window_start":   fmt(end_utc),
@@ -769,14 +776,17 @@ def build_shipments_from_nested_map(nested_map: dict, config: object, global_bou
     
     all_emp_ids  = {eid for emps in all_shipment_employees.values() for eid in emps}
     emp_name_map = {
-        e.name: e.employee_name
+        e.name: {"employee_name": e.employee_name, "cell_number": e.cell_number or ""}
         for e in frappe.get_all("Employee",
             filters={"name": ["in", list(all_emp_ids)]},
-            fields=["name", "employee_name"]
+            fields=["name", "employee_name", "cell_number"]
         )
     }
     shipment_employees_named = {
-        label: [emp_name_map.get(eid, eid) for eid in eids]
+        label: [
+            {"name": emp_name_map.get(eid, {}).get("employee_name", eid), "mobile": emp_name_map.get(eid, {}).get("cell_number", "")}
+            for eid in eids
+        ]
         for label, eids in all_shipment_employees.items()
     }
 

--- a/one_fm/public/html/route_manifest_template.html
+++ b/one_fm/public/html/route_manifest_template.html
@@ -1054,21 +1054,26 @@
         /** Build an employee chip with call icon for manifest display. */
         function empChipHtml(e, chipStyle) {
             const name = (typeof e === 'object' && e !== null) ? (e.name || '—') : (e || '—');
-            const mobile = (typeof e === 'object' && e !== null) ? (e.mobile || '') : '';
+            const rawMobile = (typeof e === 'object' && e !== null) ? (e.mobile || '') : '';
+            // Normalize: strip everything except digits, +, -, (, ), space for tel: URI
+            const mobile = rawMobile.replace(/[^\d+\-() ]/g, '');
             const styleAttr = chipStyle ? ` style="${chipStyle}"` : '';
-            const safeName = name.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/</g,'&lt;');
+            // HTML-escape helper for safe attribute interpolation
+            const esc = s => s.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+            const safeName = esc(name);
+            const safeMobile = esc(mobile);
             let icon;
             if (mobile) {
                 const isMobile = /Android|iPhone|iPad|iPod|webOS|BlackBerry/i.test(navigator.userAgent);
                 if (isMobile) {
-                    icon = `<a href="tel:${mobile}" class="emp-call-btn" title="Call ${mobile}" onclick="event.stopPropagation()"><span class="material-symbols-outlined" style="font-size:14px">call</span></a>`;
+                    icon = `<a href="tel:${safeMobile}" class="emp-call-btn" title="Call ${safeMobile}" onclick="event.stopPropagation()"><span class="material-symbols-outlined" style="font-size:14px">call</span></a>`;
                 } else {
-                    icon = `<span class="emp-call-btn" title="Call ${mobile}" onclick="copyNumber(event,&#39;${mobile}&#39;)"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
+                    icon = `<span class="emp-call-btn" title="Call ${safeMobile}" onclick="copyNumber(event,&#39;${safeMobile}&#39;)"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
                 }
             } else {
                 icon = `<span class="emp-call-btn emp-call-disabled" title="No mobile number" onclick="event.stopPropagation();showNoNumber(&#39;${safeName}&#39;)"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
             }
-            return `<span class="emp-chip"${styleAttr}>${name}${icon}</span>`;
+            return `<span class="emp-chip"${styleAttr}>${safeName}${icon}</span>`;
         }
 
         function fmtDuration(secStr) {

--- a/one_fm/public/html/route_manifest_template.html
+++ b/one_fm/public/html/route_manifest_template.html
@@ -931,6 +931,26 @@
             border: 1px solid var(--border);
             border-radius: 3px;
             padding: 2px 6px;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .emp-call-btn {
+            color: var(--green);
+            cursor: pointer;
+            text-decoration: none;
+            vertical-align: middle;
+            display: inline-flex;
+            align-items: center;
+            line-height: 1;
+            transition: color 0.15s;
+        }
+        .emp-call-btn:hover { color: #16a34a; }
+        .emp-call-disabled {
+            color: var(--text-dim) !important;
+            opacity: 0.35;
+            cursor: default;
         }
 
         /* ── TRIP GROUP ── */
@@ -1003,6 +1023,52 @@
             if (!isoStr) return "—";
             const d = new Date(isoStr);
             return d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", timeZone: "Asia/Kuwait" });
+        }
+
+        /** Show a toast notification (standalone — no Frappe dependency). */
+        function showToast(msg) {
+            const toast = document.createElement('div');
+            toast.textContent = msg;
+            toast.style.cssText = 'position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:8px 18px;border-radius:8px;font-size:13px;z-index:9999;opacity:0;transition:opacity 0.3s;font-family:var(--font-body)';
+            document.body.appendChild(toast);
+            requestAnimationFrame(() => toast.style.opacity = '1');
+            setTimeout(() => { toast.style.opacity = '0'; setTimeout(() => toast.remove(), 300); }, 2500);
+        }
+
+        /** Warning toast when employee has no mobile number. */
+        function showNoNumber(name) {
+            showToast('No mobile number on file for ' + name);
+        }
+
+        /** Desktop: copy number to clipboard + show toast. */
+        function copyNumber(event, mobile) {
+            event.preventDefault();
+            event.stopPropagation();
+            navigator.clipboard.writeText(mobile).then(() => {
+                showToast('Number Copied: ' + mobile);
+            }).catch(() => {
+                showToast(mobile);
+            });
+        }
+
+        /** Build an employee chip with call icon for manifest display. */
+        function empChipHtml(e, chipStyle) {
+            const name = (typeof e === 'object' && e !== null) ? (e.name || '—') : (e || '—');
+            const mobile = (typeof e === 'object' && e !== null) ? (e.mobile || '') : '';
+            const styleAttr = chipStyle ? ` style="${chipStyle}"` : '';
+            const safeName = name.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/</g,'&lt;');
+            let icon;
+            if (mobile) {
+                const isMobile = /Android|iPhone|iPad|iPod|webOS|BlackBerry/i.test(navigator.userAgent);
+                if (isMobile) {
+                    icon = `<a href="tel:${mobile}" class="emp-call-btn" title="Call ${mobile}" onclick="event.stopPropagation()"><span class="material-symbols-outlined" style="font-size:14px">call</span></a>`;
+                } else {
+                    icon = `<span class="emp-call-btn" title="Call ${mobile}" onclick="copyNumber(event,&#39;${mobile}&#39;)"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
+                }
+            } else {
+                icon = `<span class="emp-call-btn emp-call-disabled" title="No mobile number" onclick="event.stopPropagation();showNoNumber(&#39;${safeName}&#39;)"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
+            }
+            return `<span class="emp-chip"${styleAttr}>${name}${icon}</span>`;
         }
 
         function fmtDuration(secStr) {
@@ -1382,10 +1448,15 @@
 
                 // Boarding employees for DEPART (all dropoff employees board at accommodation)
                 const boardingEmployees = [];
+                const boardingNames = new Set();
                 orderedStops.forEach(item => {
                     if (item.stop.type === 'dropoff') {
                         (shipmentEmployees[item.stop.raw] ?? []).forEach(e => {
-                            if (!boardingEmployees.includes(e)) boardingEmployees.push(e);
+                            const eName = (typeof e === 'object' && e !== null) ? (e.name || '') : (e || '');
+                            if (eName && !boardingNames.has(eName)) {
+                                boardingNames.add(eName);
+                                boardingEmployees.push(e);
+                            }
                         });
                     }
                 });
@@ -1423,14 +1494,14 @@
                             <div style="font-size:10px;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px">
                                 <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">arrow_downward</span> Dropping off — ${emps.length} employee${emps.length !== 1 ? 's' : ''}
                             </div>
-                            <div class="stop-employees">${emps.map(n => `<span class="emp-chip" style="border-color:var(--accent);color:var(--accent)">${n}</span>`).join("")}</div>
+                            <div class="stop-employees">${emps.map(n => empChipHtml(n, 'border-color:var(--accent);color:var(--accent)')).join("")}</div>
                         </div>`;
                     } else if (emps.length > 0) {
                         empHtml = `<div style="margin-top:6px">
                             <div style="font-size:10px;font-weight:700;color:var(--green);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px">
                                 <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">arrow_upward</span> Picking up — ${emps.length} employee${emps.length !== 1 ? 's' : ''}
                             </div>
-                            <div class="stop-employees">${emps.map(n => `<span class="emp-chip" style="border-color:var(--green);color:var(--green)">${n}</span>`).join("")}</div>
+                            <div class="stop-employees">${emps.map(n => empChipHtml(n, 'border-color:var(--green);color:var(--green)')).join("")}</div>
                         </div>`;
                     }
 
@@ -1468,11 +1539,16 @@
 
                 // RETURN stop
                 const returningEmployees = [];
+                const returningNames = new Set();
                 orderedStops.forEach(item => {
                     if (item.stop.type === 'pickup') {
                         const stopEmps = item.stop._isVirtualReturn ? item.stop._virtualEmps : (shipmentEmployees[item.stop.raw] ?? []);
                         stopEmps.forEach(e => {
-                            if (!returningEmployees.includes(e)) returningEmployees.push(e);
+                            const eName = (typeof e === 'object' && e !== null) ? (e.name || '') : (e || '');
+                            if (eName && !returningNames.has(eName)) {
+                                returningNames.add(eName);
+                                returningEmployees.push(e);
+                            }
                         });
                     }
                 });
@@ -1562,7 +1638,7 @@
                         <div style="font-size:10px;font-weight:700;color:var(--green);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px">
                             <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">directions_bus</span> Onboarding — ${allEmps.length} employee${allEmps.length !== 1 ? 's' : ''}
                         </div>
-                        <div class="stop-employees">${allEmps.map(n => `<span class="emp-chip">${n}</span>`).join("")}</div>
+                        <div class="stop-employees">${allEmps.map(n => empChipHtml(n)).join("")}</div>
                     </div>`;
                 } else if (stopEmps.length > 0) {
                     if (stop.type === 'dropoff') {
@@ -1570,14 +1646,14 @@
                             <div style="font-size:10px;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px">
                                 <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">arrow_downward</span> Dropping off — ${stopEmps.length} employee${stopEmps.length !== 1 ? 's' : ''}
                             </div>
-                            <div class="stop-employees">${stopEmps.map(n => `<span class="emp-chip" style="border-color:var(--accent);color:var(--accent)">${n}</span>`).join("")}</div>
+                            <div class="stop-employees">${stopEmps.map(n => empChipHtml(n, 'border-color:var(--accent);color:var(--accent)')).join("")}</div>
                         </div>`;
                     } else if (stop.type === 'pickup') {
                         empHtml = `<div style="margin-top:6px">
                             <div style="font-size:10px;font-weight:700;color:var(--green);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px">
                                 <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">arrow_upward</span> Picking up — ${stopEmps.length} employee${stopEmps.length !== 1 ? 's' : ''}
                             </div>
-                            <div class="stop-employees">${stopEmps.map(n => `<span class="emp-chip" style="border-color:var(--green);color:var(--green)">${n}</span>`).join("")}</div>
+                            <div class="stop-employees">${stopEmps.map(n => empChipHtml(n, 'border-color:var(--green);color:var(--green)')).join("")}</div>
                         </div>`;
                     }
                 }


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

**Employee Contact Integration for Route Planner**

Enable GSD Admins and Camp Security to directly contact employees from the Route Planner detail panel, pool cards, and Manifest by displaying mobile numbers and providing click-to-call (mobile) or copy-to-clipboard (desktop) functionality.


## Analysis and design (optional)

Data flows from `Employee.cell_number` → backend `emp_to_obj()` helper → `{name, mobile}` objects in `shipment_cards[].employees` → frontend Vue methods (`empName()`, `empMobile()`, `handleEmployeeCall()`) and manifest `empChipHtml()`.

Platform detection branches interaction: `tel:` protocol on mobile devices, clipboard copy with toast notification on desktop. Employees without a mobile number show a grey disabled icon with a warning toast.


## Solution description

### Backend (`route_planner.py`)
- Extended `emp_name_map` query to fetch `cell_number` alongside `employee_name` (single batch query, no extra DB hit)
- Added `emp_to_obj(emp_id)` helper converting employee IDs → `{name: "...", mobile: "..."}` objects
- Updated all 4 employee array outputs (DIRECT, OSM, OLM cards + manifest) to emit objects

### Frontend — Route Planner JS (`route_planner.js`)
- Added `empName(e)` / `empMobile(e)` backward-compatible accessors (handles both objects and legacy plain strings)
- Added `handleEmployeeCall(e)` with mobile/desktop branching
- Updated pool card, trip-view, and single-view templates with phone icons and index-based Vue `:key` bindings
- Added fuzzy card matching for loaded plans: when saved `cardId` doesn't match current session, falls back to `accommodation + stop_location + direction` match — resolves employee details for loaded plans
- Applied fuzzy match in `selectedCard`, `selectedTripStops`, and `buildManifestData`

### Frontend — Manifest Template (`route_manifest_template.html`)
- Added `empChipHtml(e, chipStyle)` reusable chip builder with HTML entity-safe escaping
- Added standalone `showToast()`, `showNoNumber()`, `copyNumber()` helpers (no Frappe dependency)
- Updated all 5 employee chip renderers to use `empChipHtml()`
- Fixed `boardingEmployees` and `returningEmployees` dedup using `Set`-based name comparison (replaces `Array.includes()` which fails with object identity)


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots

<img width="310" height="369" alt="Screenshot 2026-05-14 at 4 13 53 PM" src="https://github.com/user-attachments/assets/50759d6e-3573-4c29-ac4b-abe105ebe080" />
<img width="1159" height="357" alt="Screenshot 2026-05-14 at 4 14 04 PM" src="https://github.com/user-attachments/assets/81140b9d-e412-406c-ad91-d147a24308a6" />


## Areas affected and ensured

| Area | Impact |
|------|--------|
| Route Planner pool cards | Employee chips now show call icons |
| Route Planner detail panel (single + trip view) | Employee section renders with call action |
| Route Planner manifest generation | Manifest employee chips include call buttons |
| Loaded/saved plan resolution | Fuzzy match ensures employee data loads for saved plans |
| Route Manifest standalone HTML page | Employee chips with platform-aware call interaction |


## Is there any existing behavior change of other features due to this code change?

**Yes.** Two changes affect existing behavior:

1. **Employee data format changed from strings to objects** — `card.employees` arrays now contain `{name, mobile}` objects instead of plain name strings. All template renderers and deduplication logic were updated to handle both formats for backward compatibility.

2. **Loaded plan card resolution enhanced** — `selectedCard`, `selectedTripStops`, and `buildManifestData` now perform fuzzy matching when exact `cardId` lookup fails. This improves loaded plan reliability beyond just this feature.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
No child table created.

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox