### PR TITLE
fix: Stabilize Job Offer Auto-Generation & CCP Workflow

### DIFF
--- a/one_fm/custom/custom_field/job_offer.py
+++ b/one_fm/custom/custom_field/job_offer.py
@@ -253,7 +253,8 @@ def get_job_offer_custom_fields():
                 "fieldtype": "Link",
                 "insert_after": "applicant_name",
                 "label": "Agency Country Process",
-                "options": "Agency Country Process"
+                "options": "Agency Country Process",
+                "allow_on_submit": 1
             },
             {
                 "fieldname": "agency",
@@ -262,7 +263,8 @@ def get_job_offer_custom_fields():
                 "label": "Agency",
                 "options": "Agency",
                 "fetch_from": "job_applicant.one_fm_agency",
-                "fetch_if_empty": 1
+                "fetch_if_empty": 1,
+                "allow_on_submit": 1
             },
             {
                 "fieldname": "one_fm_erf",

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -142,8 +142,7 @@ class JobOfferOverride(JobOffer):
 
         # Set offer accepted date
         if self.workflow_state == 'Submit to Onboarding Officer' and not self.one_fm_offer_accepted_date:
-            self.one_fm_offer_accepted_date = nowdate()
-            self.save(ignore_permissions=True)
+            self.db_set('one_fm_offer_accepted_date', nowdate())
             
         # Auto-create Candidate Country Process if applicable
         if self.workflow_state in ['Submit to Onboarding Officer', 'Accepted']:
@@ -193,7 +192,7 @@ class JobOfferOverride(JobOffer):
             ), alert=True)
         except Exception as e:
             frappe.log_error(title="Failed to Auto-Generate CCP", message=frappe.get_traceback())
-            frappe.msgprint(_("Warning: Could not automatically generate the Candidate Country Process tracker. Please create it manually. ({0})").format(str(e)), alert=True, indicator='orange')
+            frappe.msgprint(_("Warning: Could not automatically generate the Candidate Country Process tracker. Please create it manually. Check the Error Log for details."), alert=True, indicator='orange')
 
     def validate_job_offer_mandatory_fields(self):
         if self.workflow_state == 'Submit for Candidate Response':


### PR DESCRIPTION

<img width="4095" height="288" alt="image" src="https://github.com/user-attachments/assets/ecc509da-6709-442d-8d59-d7c857154e34" />

**Description**
What this PR does: This hotfix stabilizes the "Select Candidate" bulk recruitment flow by ensuring the Agency Country Process tracker generates safely and reliably.

**Changes included:**
Resolved UI Disappearance Bug: Added allow_on_submit to the Agency and Agency Country Process custom fields. Previously, because Bulk Recruitment auto-submits Job Offers instantly, Frappe would hide these fields if they were blank, locking out the recruiter. They remain visible and editable now.
Safer Database Writes: Refactored the Offer Accepted Date stamping logic in job_offer.py from .save(ignore_permissions=True) to .db_set(). This adheres to Frappe best practices inside on_update_after_submit hooks, avoiding heavy recursive re-validations.
Frontend Security: Sanitized the exception warning thrown during CCP generation. Raw Python tracebacks (str(e)) are no longer exposed to the UI, and are instead safely routed exclusively to the Frappe Error Log.