### PR TITLE
[WI-000779][WI-000699][WI-000700] Rambo replacement feature

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -1888,86 +1888,7 @@ function mountRoutePlannerApp(wrapper, data) {
                 });
             },
 
-            savePlan() {
-                if (!this.currentPlan) {
-                    frappe.show_alert({ message: 'Select or create a plan first', indicator: 'orange' }, 3);
-                    return;
-                }
-                if (this.swimItems.length === 0) {
-                    frappe.show_alert({ message: 'No assignments to save', indicator: 'orange' }, 3);
-                    return;
-                }
 
-                // ── Pre-save overcapacity audit ──
-                this.checkConflicts();
-                const overcapVehicles = [];
-                this.planData.vehicles.forEach(v => {
-                    const vi = this.swimItems.filter(i => i.vehicleId === v.id);
-                    if (vi.some(i => i.overcapacity)) {
-                        const logicalTrips = this._getLogicalTrips(v.id);
-                        const peakLoad = Math.max(...vi.map(item => {
-                            const iS = new Date(item.start).getTime();
-                            const iE = new Date(item.end).getTime();
-                            return logicalTrips
-                                .filter(t => {
-                                    return t.start < iE && t.end > iS;
-                                })
-                                .reduce((sum, t) => sum + t.headcount, 0);
-                        }));
-                        overcapVehicles.push({ label: v.label, seats: v.seats, peak: peakLoad });
-                    }
-                });
-
-                const self = this;
-                const doSave = () => {
-                    const items = self.swimItems.map(i => {
-                        const card = self.planData.shipment_cards.find(c => c.id === i.cardId);
-                        return {
-                            ...i,
-                            start: new Date(i.start).toISOString(),
-                            end:   new Date(i.end).toISOString(),
-                            _site: card ? card.site : '',
-                            _shift: card ? card.shift_name : '',
-                            _accommodation: card ? card.accommodation : '',
-                            _stopLocation: card ? card.stop_location : '',
-                        };
-                    });
-                    const cards = [...self.assignedCards];
-                    frappe.call({
-                        method: 'one_fm.one_fm.page.route_planner.route_planner.save_assignments',
-                        args: {
-                            plan_name: self.currentPlan.name,
-                            swim_items: JSON.stringify(items),
-                            assigned_cards: JSON.stringify(cards)
-                        },
-                        callback: (r) => {
-                            if (r.message && r.message.status === 'ok') {
-                                frappe.show_alert({
-                                    message: `Plan "${self.currentPlan.title}" saved — ${r.message.assignment_count} assignments`,
-                                    indicator: 'green'
-                                }, 4);
-                            }
-                        }
-                    });
-                };
-
-                // Show warning if overcapacity detected
-                if (overcapVehicles.length > 0) {
-                    const list = overcapVehicles.map(v =>
-                        `<li><strong>${v.label}</strong>: ${v.peak} passengers / ${v.seats} seats</li>`
-                    ).join('');
-                    frappe.confirm(
-                        `<div style="color:#c62828;font-weight:600;margin-bottom:8px">⚠ Overcapacity Warning</div>` +
-                        `<p style="font-size:13px;color:#555">The following vehicles exceed seat capacity:</p>` +
-                        `<ul style="font-size:13px;margin:8px 0 12px 16px">${list}</ul>` +
-                        `<p style="font-size:13px;color:#555">Save anyway?</p>`,
-                        () => doSave(),
-                        () => frappe.show_alert({ message: 'Save cancelled — fix overcapacity first', indicator: 'orange' }, 4)
-                    );
-                } else {
-                    doSave();
-                }
-            },
 
             persistAssignments() {
                 if (!this.currentPlan) return; // no plan selected — skip
@@ -2155,7 +2076,7 @@ function mountRoutePlannerApp(wrapper, data) {
 
                 const safeJson = JSON.stringify(routeData).replace(/<\//g, '<\\/');
                 // Inject ROUTE_DATA inside the template's existing <body><script>
-                const dataLine = 'const ROUTE_DATA = ' + safeJson + ';\n';
+                const dataLine = 'const ROUTE_DATA = ' + safeJson + ';\nconst FRAPPE_CSRF_TOKEN = "' + frappe.csrf_token + '";\nconst SITE_URL = window.location.origin;\n';
                 // Use regex to insert after first <script> in <body>
                 const finalHtml = tpl.replace(/(<body>[\s\S]*?<script>)/, '$1\n' + dataLine);
                 const blob = new Blob([finalHtml], { type: 'text/html' });
@@ -2384,12 +2305,9 @@ function injectRPVueTemplate() {
       </div>
     </div>
     <div id="rp-header-right">
-      <button id="rp-save-btn" class="rp-btn rp-btn-primary"
-              :disabled="!currentPlan"
-              @click="savePlan"
-              :title="!currentPlan ? 'Create or select a plan first' : ''">
-        <span class="rp-icon">save</span> Save Plan
-      </button>
+      <div v-if="currentPlan" class="text-muted" style="font-size:12px; margin-right: 12px; display: flex; align-items: center; gap: 4px; color: var(--green, #16a34a)">
+        <span class="rp-icon" style="font-size:16px;">check_circle</span> Auto-Saved
+      </div>
       <button class="rp-btn rp-btn-default rp-btn-manifest" :disabled="!canSave || !currentPlan" @click="openManifest">
         <span class="rp-icon">assignment</span> Manifest
       </button>

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -2057,10 +2057,12 @@ function mountRoutePlannerApp(wrapper, data) {
                     return;
                 }
 
-                const btn = document.getElementById('rp-save-btn');
-                const orig = btn.textContent;
-                btn.disabled = true;
-                btn.textContent = 'Generating...';
+                const btn = document.querySelector('.rp-btn-manifest');
+                const orig = btn ? btn.innerHTML : '';
+                if (btn) {
+                    btn.disabled = true;
+                    btn.innerHTML = '<span class="rp-icon">sync</span> Generating...';
+                }
 
                 let tpl;
                 try {
@@ -2069,8 +2071,10 @@ function mountRoutePlannerApp(wrapper, data) {
                     tpl = await res.text();
                 } catch (err) {
                     frappe.show_alert({ message: `Template load failed: ${err.message}`, indicator: 'red' }, 8);
-                    btn.disabled = false;
-                    btn.textContent = orig;
+                    if (btn) {
+                        btn.disabled = false;
+                        btn.innerHTML = orig;
+                    }
                     return;
                 }
 
@@ -2084,8 +2088,10 @@ function mountRoutePlannerApp(wrapper, data) {
                 window.open(url, '_blank');
                 setTimeout(() => URL.revokeObjectURL(url), 60000);
 
-                btn.disabled = false;
-                btn.textContent = orig;
+                if (btn) {
+                    btn.disabled = false;
+                    btn.innerHTML = orig;
+                }
                 frappe.show_alert({
                     message: `Manifest opened — ${routeData.response.routes.length} vehicles`,
                     indicator: 'green'

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -110,8 +110,8 @@ def get_route_planner_data():
             """Convert employee ID to {name, mobile} dict for frontend call action."""
             info = emp_name_map.get(emp_id, {})
             if isinstance(info, dict):
-                return {"name": info.get("employee_name", emp_id), "mobile": info.get("cell_number", "")}
-            return {"name": info or emp_id, "mobile": ""}
+                return {"id": emp_id, "name": info.get("employee_name", emp_id), "mobile": info.get("cell_number", "")}
+            return {"id": emp_id, "name": info or emp_id, "mobile": ""}
 
         # Batch-fetch all shift docs in one query (instead of per-shift frappe.get_doc)
         all_shift_names = set()
@@ -1311,4 +1311,103 @@ def update_route_plan_status(plan_name: str, new_status: str):
         "status": "ok",
         "plan_name": doc.name,
         "new_status": new_status
+    }
+@frappe.whitelist()
+def get_available_rambo_relievers(shift_name: str, date: str):
+    """
+    Fetch available Rambo relievers for a specific date and shift.
+    - custom_is_rambo_reliever = 1
+    - status = 'Active'
+    - No active shift assignment for the given date.
+    """
+    shift = frappe.get_doc("Operations Shift", shift_name) if shift_name else None
+    
+    # Get all active rambo relievers
+    rambos = frappe.get_all("Employee",
+        filters={
+            "custom_is_rambo_reliever": 1,
+            "status": "Active"
+        },
+        fields=["name", "employee_name", "designation", "cell_number"]
+    )
+    
+    if not rambos:
+        return []
+        
+    rambo_ids = [r.name for r in rambos]
+    
+    # Check shift assignments for conflicts on the same date
+    conflicts = frappe.get_all("Shift Assignment",
+        filters={
+            "employee": ["in", rambo_ids],
+            "start_date": ["<=", date],
+            "end_date": [">=", date],
+            "docstatus": 1,
+            "status": "Active"
+        },
+        fields=["employee"]
+    )
+    
+    conflict_ids = set([c.employee for c in conflicts])
+    
+    available = []
+    for r in rambos:
+        if r.name not in conflict_ids:
+            available.append({
+                "name": r.name,
+                "employee_name": r.employee_name,
+                "designation": r.designation or "—",
+                "mobile": r.cell_number or ""
+            })
+            
+    return available
+
+@frappe.whitelist()
+def process_rambo_replacement(original_employee: str, replacement_employee: str, shift_name: str, site: str):
+    """
+    Processes the swap by sending an email notification.
+    The UI will update its own DOM/State dynamically.
+    """
+    orig_emp = frappe.db.get_value("Employee", original_employee, "employee_name") or original_employee
+    new_emp = frappe.db.get_value("Employee", replacement_employee, "employee_name") or replacement_employee
+    
+    # Send Email Notification
+    recipients = ["helpdesk@one-fm.com"]
+    
+    # Find operations supervisor for the shift/site
+    if shift_name:
+        supervisor = frappe.db.get_value("Operations Shift", shift_name, "operations_supervisor")
+        if supervisor:
+            user_email = frappe.db.get_value("User", supervisor, "email")
+            if user_email:
+                recipients.append(user_email)
+                
+    # Also add Mr Yaser if known email (hardcoded for now, or assume system finds it)
+    recipients.append("yaser@one-fm.com") # Placeholder for Mr Yaser's email
+    
+    subject = f"Rambo Reliever Swap: {orig_emp} replaced by {new_emp}"
+    message = f"""
+    <p>A Rambo Reliever replacement has been processed from the Route Planner Manifest.</p>
+    <ul>
+        <li><b>Site:</b> {site}</li>
+        <li><b>Shift:</b> {shift_name}</li>
+        <li><b>Original Employee (Absent/Fail):</b> {orig_emp}</li>
+        <li><b>Rambo Reliever (Replacement):</b> {new_emp}</li>
+    </ul>
+    <p>Please note that this is an automated message.</p>
+    """
+    
+    try:
+        frappe.sendmail(
+            recipients=recipients,
+            subject=subject,
+            message=message,
+            now=True
+        )
+    except Exception as e:
+        frappe.log_error(f"Error sending Rambo Reliever notification: {str(e)}", "Rambo Reliever Notification")
+        
+    return {
+        "status": "success",
+        "message": "Replacement processed and notification sent."
     }

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -1320,7 +1320,6 @@ def get_available_rambo_relievers(shift_name: str, date: str):
     - status = 'Active'
     - No active shift assignment for the given date.
     """
-    shift = frappe.get_doc("Operations Shift", shift_name) if shift_name else None
     
     # Get all active rambo relievers
     rambos = frappe.get_all("Employee",
@@ -1372,7 +1371,7 @@ def process_rambo_replacement(original_employee: str, replacement_employee: str,
     new_emp = frappe.db.get_value("Employee", replacement_employee, "employee_name") or replacement_employee
     
     # Send Email Notification
-    recipients = ["helpdesk@one-fm.com"]
+    recipients = []
     
     # Find operations supervisor for the shift/site
     if shift_name:
@@ -1381,31 +1380,29 @@ def process_rambo_replacement(original_employee: str, replacement_employee: str,
             user_email = frappe.db.get_value("User", supervisor, "email")
             if user_email:
                 recipients.append(user_email)
-                
-    # Also add Mr Yaser if known email (hardcoded for now, or assume system finds it)
-    recipients.append("yaser@one-fm.com") # Placeholder for Mr Yaser's email
     
-    subject = f"Rambo Reliever Swap: {orig_emp} replaced by {new_emp}"
-    message = f"""
-    <p>A Rambo Reliever replacement has been processed from the Route Planner Manifest.</p>
-    <ul>
-        <li><b>Site:</b> {site}</li>
-        <li><b>Shift:</b> {shift_name}</li>
-        <li><b>Original Employee (Absent/Fail):</b> {orig_emp}</li>
-        <li><b>Rambo Reliever (Replacement):</b> {new_emp}</li>
-    </ul>
-    <p>Please note that this is an automated message.</p>
-    """
-    
-    try:
-        frappe.sendmail(
-            recipients=recipients,
-            subject=subject,
-            message=message,
-            now=True
-        )
-    except Exception as e:
-        frappe.log_error(f"Error sending Rambo Reliever notification: {str(e)}", "Rambo Reliever Notification")
+    if recipients:
+        subject = f"Rambo Reliever Swap: {orig_emp} replaced by {new_emp}"
+        message = f"""
+        <p>A Rambo Reliever replacement has been processed from the Route Planner Manifest.</p>
+        <ul>
+            <li><b>Site:</b> {site}</li>
+            <li><b>Shift:</b> {shift_name}</li>
+            <li><b>Original Employee (Absent/Fail):</b> {orig_emp}</li>
+            <li><b>Rambo Reliever (Replacement):</b> {new_emp}</li>
+        </ul>
+        <p>Please note that this is an automated message.</p>
+        """
+        
+        try:
+            frappe.sendmail(
+                recipients=recipients,
+                subject=subject,
+                message=message,
+                now=True
+            )
+        except Exception as e:
+            frappe.log_error(f"Error sending Rambo Reliever notification: {str(e)}", "Rambo Reliever Notification")
         
     return {
         "status": "success",

--- a/one_fm/public/html/route_manifest_template.html
+++ b/one_fm/public/html/route_manifest_template.html
@@ -1166,6 +1166,7 @@
 <body>
 
     <script>
+        let activeView = null; // Track current route for re-rendering
 
         function fmtTime(isoStr) {
             if (!isoStr) return "—";
@@ -2020,7 +2021,11 @@
             window.checkerState[currentCheckInEmpId].attendance = tempAttendance;
             window.checkerState[currentCheckInEmpId].qoa = tempQoa;
             
-            init(); // Re-render instantly so background UI updates
+            if (activeView) {
+                renderRoute(activeView);
+            } else {
+                init(); // Fallback
+            }
             
             if (tempAttendance === 'Absent' || tempQoa === 'Fail') {
                 // Delay slightly to let them see the button turn red
@@ -2060,8 +2065,14 @@
             document.getElementById('replacementModal').classList.add('active');
             
             let shiftInfo = findShiftForEmp(empId) || { shift: "", site: "" };
-            // Format today's date YYYY-MM-DD
-            const date = new Date().toISOString().split('T')[0];
+            
+            const req = ROUTE_DATA.request || {};
+            const routes = ROUTE_DATA.response?.routes || [];
+            const firstTime = routes[0]?.vehicleStartTime ?? req.model?.globalStartTime;
+            let date = new Date().toISOString().split('T')[0];
+            if (firstTime) {
+                date = new Date(firstTime).toLocaleDateString("en-CA", { timeZone: "Asia/Kuwait" });
+            }
 
             const baseUrl = typeof SITE_URL !== 'undefined' ? SITE_URL : '';
             fetch(baseUrl + '/api/method/one_fm.one_fm.page.route_planner.route_planner.get_available_rambo_relievers', {
@@ -2091,7 +2102,11 @@
 
         function closeReplacementModal() {
             document.getElementById('replacementModal').classList.remove('active');
-            init(); // render in case absent state needs to show
+            if (activeView) {
+                renderRoute(activeView);
+            } else {
+                init();
+            }
         }
 
         function confirmReplacement() {
@@ -2124,15 +2139,22 @@
                     site: shiftInfo.site
                 })
             })
-            .then(() => {
+            .then(res => {
+                if (!res.ok) throw new Error("HTTP Error " + res.status);
+                return res.json();
+            })
+            .then(data => {
+                if (data.exc) throw new Error("Server Error");
+                
                 document.getElementById('btn-confirm-replace').innerText = "Confirm Replacement";
-                closeReplacementModal();
                 showToast("Replacement confirmed and supervisor notified.");
+                closeReplacementModal();
             })
             .catch(err => {
                 console.error(err);
-                closeReplacementModal();
+                document.getElementById('btn-confirm-replace').innerText = "Confirm Replacement";
                 showToast("Replacement UI updated, but failed to send email.");
+                closeReplacementModal();
             });
         }
     </script>

--- a/one_fm/public/html/route_manifest_template.html
+++ b/one_fm/public/html/route_manifest_template.html
@@ -1012,6 +1012,154 @@
         .trip-group .timeline::before {
             display: none;
         }
+        /* CHECKER MODAL STYLES */
+        .modal-overlay {
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(0,0,0,0.5);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s;
+        }
+        .modal-overlay.active {
+            opacity: 1;
+            pointer-events: auto;
+        }
+        .modal-content {
+            background: var(--bg-surface);
+            border-radius: 12px;
+            width: 90%;
+            max-width: 400px;
+            padding: 24px;
+            box-shadow: var(--md-sys-elevation-3);
+            transform: scale(0.95);
+            transition: transform 0.2s;
+        }
+        .modal-overlay.active .modal-content {
+            transform: scale(1);
+        }
+        .modal-header {
+            font-family: var(--font-head);
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 16px;
+            color: var(--text);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .modal-close {
+            background: none; border: none; cursor: pointer; color: var(--text-muted);
+        }
+        .toggle-group {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 20px;
+        }
+        .toggle-btn {
+            flex: 1;
+            padding: 10px;
+            border: 1px solid var(--md-sys-color-outline);
+            border-radius: 100px;
+            background: transparent;
+            color: var(--md-sys-color-on-surface);
+            font-family: var(--font-head);
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .toggle-btn:hover {
+            background: rgba(31, 31, 31, 0.08);
+        }
+        .toggle-btn.active-present, .toggle-btn.active-pass {
+            background: var(--md-sys-color-primary);
+            border-color: var(--md-sys-color-primary);
+            color: var(--md-sys-color-on-primary);
+        }
+        .toggle-btn.active-absent, .toggle-btn.active-fail {
+            background: var(--md-sys-color-error);
+            border-color: var(--md-sys-color-error);
+            color: var(--md-sys-color-on-primary);
+        }
+        .btn-primary {
+            width: 100%;
+            padding: 8px 12px;
+            background: #171717; /* Frappe UI default primary (Gray 900) */
+            color: #ffffff;
+            border: 1px solid transparent;
+            border-radius: 6px; /* Frappe UI standard shape */
+            font-family: var(--font-head);
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            margin-top: 10px;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+            transition: all 0.2s;
+        }
+        .btn-primary:hover {
+            background: #262626; /* hover state */
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        .btn-primary:disabled {
+            background: #e5e5e5;
+            color: #a3a3a3;
+            box-shadow: none;
+            cursor: not-allowed;
+        }
+        .checker-label {
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-muted);
+            margin-bottom: 8px;
+            text-transform: uppercase;
+        }
+
+        /* DYNAMIC CHIP STYLES */
+        .emp-chip.interactive { cursor: pointer; }
+        .emp-chip.state-success {
+            background: var(--green-dim);
+            border-color: var(--green);
+            color: #166534;
+        }
+        .emp-chip.state-warning {
+            background: rgba(245, 158, 11, 0.12);
+            border-color: #f59e0b;
+            color: #b45309;
+        }
+        .emp-chip.state-error {
+            background: var(--red-dim);
+            border-color: var(--red);
+            color: #991b1b;
+            text-decoration: line-through;
+        }
+        .emp-chip.state-replacement {
+            background: var(--blue-dim);
+            border-color: var(--blue);
+            color: #1e3a8a;
+        }
+        .depart-header-right {
+            border: 1px solid var(--red);
+            color: var(--red);
+            padding: 4px 8px;
+            font-size: 10px;
+            font-weight: 700;
+            border-radius: 4px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        select.form-control {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            margin-bottom: 16px;
+            font-family: var(--font-body);
+        }
     </style>
 </head>
 
@@ -1052,28 +1200,61 @@
         }
 
         /** Build an employee chip with call icon for manifest display. */
-        function empChipHtml(e, chipStyle) {
+        function empChipHtml(e, chipStyle, interactive = false) {
+            const id = (typeof e === 'object' && e !== null) ? (e.id || e.name || '—') : (e || '—');
             const name = (typeof e === 'object' && e !== null) ? (e.name || '—') : (e || '—');
             const rawMobile = (typeof e === 'object' && e !== null) ? (e.mobile || '') : '';
             // Normalize: strip everything except digits, +, -, (, ), space for tel: URI
             const mobile = rawMobile.replace(/[^\d+\-() ]/g, '');
-            const styleAttr = chipStyle ? ` style="${chipStyle}"` : '';
+            
+            window.checkerState = window.checkerState || {};
+            const state = window.checkerState[id] || {};
+            
+            let displayStyleAttr = chipStyle ? ` style="${chipStyle}"` : '';
+            let classes = "emp-chip";
+            let displayName = name;
+            let displayIcon = "";
+            
+            if (state.replacement) {
+                classes += " state-replacement";
+                displayName = state.replacement.name;
+                displayStyleAttr = ""; 
+            } else if (state.attendance === 'Absent') {
+                classes += " state-error";
+                displayIcon = `<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-left:4px">close</span>`;
+                displayStyleAttr = "";
+            } else if (state.attendance === 'Present' && state.qoa === 'Fail') {
+                classes += " state-warning";
+                displayStyleAttr = "";
+            } else if (state.attendance === 'Present' && state.qoa === 'Pass') {
+                classes += " state-success";
+                displayIcon = `<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-left:4px">check</span>`;
+                displayStyleAttr = "";
+            }
+            
+            if (interactive) {
+                classes += " interactive";
+            }
+            
             // HTML-escape helper for safe attribute interpolation
             const esc = s => s.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-            const safeName = esc(name);
+            const safeName = esc(displayName);
             const safeMobile = esc(mobile);
             let icon;
-            if (mobile) {
+            if (mobile || (state.replacement && state.replacement.mobile)) {
+                const mobToUse = (state.replacement && state.replacement.mobile) ? state.replacement.mobile.replace(/[^\d+\-() ]/g, '') : safeMobile;
                 const isMobile = /Android|iPhone|iPad|iPod|webOS|BlackBerry/i.test(navigator.userAgent);
                 if (isMobile) {
-                    icon = `<a href="tel:${safeMobile}" class="emp-call-btn" title="Call ${safeMobile}" onclick="event.stopPropagation()"><span class="material-symbols-outlined" style="font-size:14px">call</span></a>`;
+                    icon = `<a href="tel:${mobToUse}" class="emp-call-btn" title="Call ${mobToUse}" onclick="event.stopPropagation()"><span class="material-symbols-outlined" style="font-size:14px">call</span></a>`;
                 } else {
-                    icon = `<span class="emp-call-btn" title="Call ${safeMobile}" onclick="copyNumber(event,&#39;${safeMobile}&#39;)"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
+                    icon = `<span class="emp-call-btn" title="Call ${mobToUse}" onclick="copyNumber(event,'${mobToUse}')"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
                 }
             } else {
-                icon = `<span class="emp-call-btn emp-call-disabled" title="No mobile number" onclick="event.stopPropagation();showNoNumber(&#39;${safeName}&#39;)"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
+                icon = `<span class="emp-call-btn emp-call-disabled" title="No mobile number" onclick="event.stopPropagation();showNoNumber('${safeName}')"><span class="material-symbols-outlined" style="font-size:14px">call</span></span>`;
             }
-            return `<span class="emp-chip"${styleAttr}>${safeName}${icon}</span>`;
+            
+            const onclickAttr = interactive ? ` onclick="openCheckInModal('${esc(id)}', '${safeName}')"` : '';
+            return `<span class="${classes}"${displayStyleAttr}${onclickAttr}>${safeName}${displayIcon}${icon}</span>`;
         }
 
         function fmtDuration(secStr) {
@@ -1640,10 +1821,13 @@
                 if (allEmps.length > 0) {
                     // DEPART card — show all employees boarding
                     empHtml = `<div style="margin-top:6px">
-                        <div style="font-size:10px;font-weight:700;color:var(--green);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px">
-                            <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">directions_bus</span> Onboarding — ${allEmps.length} employee${allEmps.length !== 1 ? 's' : ''}
+                        <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-bottom:4px">
+                            <div style="font-size:10px;font-weight:700;color:var(--green);text-transform:uppercase;letter-spacing:0.06em;">
+                                <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle">directions_bus</span> Onboarding — ${allEmps.length} employee${allEmps.length !== 1 ? 's' : ''}
+                            </div>
+                            <div class="depart-header-right">Attendance and QOA Check</div>
                         </div>
-                        <div class="stop-employees">${allEmps.map(n => empChipHtml(n)).join("")}</div>
+                        <div class="stop-employees">${allEmps.map(n => empChipHtml(n, null, true)).join("")}</div>
                     </div>`;
                 } else if (stopEmps.length > 0) {
                     if (stop.type === 'dropoff') {
@@ -1735,6 +1919,223 @@
         <main class="main" id="main"></main>
     </div>
 
+    <!-- CHECK-IN MODAL -->
+    <div class="modal-overlay" id="checkinModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <span id="checkinEmpName">Employee Name</span>
+                <button class="modal-close" onclick="closeCheckInModal()"><span class="material-symbols-outlined">close</span></button>
+            </div>
+            
+            <div class="checker-label">Attendance</div>
+            <div class="toggle-group">
+                <button class="toggle-btn" id="btn-present" onclick="setAttendance('Present')">Present</button>
+                <button class="toggle-btn" id="btn-absent" onclick="setAttendance('Absent')">Absent</button>
+            </div>
+            
+            <div class="checker-label">Quality of Appearance (QoA)</div>
+            <div class="toggle-group" style="margin-bottom:0;">
+                <button class="toggle-btn" id="btn-pass" onclick="setQoa('Pass')">Pass</button>
+                <button class="toggle-btn" id="btn-fail" onclick="setQoa('Fail')">Fail</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- REPLACEMENT MODAL -->
+    <div class="modal-overlay" id="replacementModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <span>Assign Rambo Reliever</span>
+                <button class="modal-close" onclick="closeReplacementModal()"><span class="material-symbols-outlined">close</span></button>
+            </div>
+            
+            <div style="margin-bottom:16px; font-size:13px; color:var(--text-muted)">
+                Replacing: <strong id="replaceOrigName" style="color:var(--text)"></strong>
+            </div>
+            
+            <div class="checker-label">Select Available Reliever</div>
+            <select id="relieverSelect" class="form-control">
+                <option value="">Loading...</option>
+            </select>
+            
+            <button class="btn-primary" onclick="confirmReplacement()" id="btn-confirm-replace">Confirm Replacement</button>
+        </div>
+    </div>
+
+    <script>
+        window.checkerState = window.checkerState || {};
+        let currentCheckInEmpId = null;
+        let currentCheckInEmpName = null;
+        
+        let tempAttendance = null;
+        let tempQoa = null;
+
+        function openCheckInModal(empId, empName) {
+            currentCheckInEmpId = empId;
+            currentCheckInEmpName = empName;
+            
+            const state = window.checkerState[empId] || {};
+            tempAttendance = state.attendance || null;
+            tempQoa = state.qoa || null;
+            
+            document.getElementById('checkinEmpName').textContent = empName;
+            updateCheckInUI();
+            
+            document.getElementById('checkinModal').classList.add('active');
+        }
+
+        function closeCheckInModal() {
+            document.getElementById('checkinModal').classList.remove('active');
+        }
+
+        function setAttendance(val) {
+            tempAttendance = val;
+            if (val === 'Absent') {
+                tempQoa = null; // Auto clear QoA if Absent
+            }
+            updateCheckInUI();
+            autoSaveCheckIn();
+        }
+
+        function setQoa(val) {
+            if (tempAttendance === 'Absent') return; // Disabled
+            tempQoa = val;
+            updateCheckInUI();
+            autoSaveCheckIn();
+        }
+
+        function updateCheckInUI() {
+            document.getElementById('btn-present').className = 'toggle-btn' + (tempAttendance === 'Present' ? ' active-present' : '');
+            document.getElementById('btn-absent').className = 'toggle-btn' + (tempAttendance === 'Absent' ? ' active-absent' : '');
+            
+            const qoaDisabled = (tempAttendance === 'Absent');
+            document.getElementById('btn-pass').className = 'toggle-btn' + (tempQoa === 'Pass' ? ' active-pass' : '');
+            document.getElementById('btn-fail').className = 'toggle-btn' + (tempQoa === 'Fail' ? ' active-fail' : '');
+            document.getElementById('btn-pass').style.opacity = qoaDisabled ? '0.5' : '1';
+            document.getElementById('btn-fail').style.opacity = qoaDisabled ? '0.5' : '1';
+        }
+
+        function autoSaveCheckIn() {
+            window.checkerState[currentCheckInEmpId] = window.checkerState[currentCheckInEmpId] || {};
+            window.checkerState[currentCheckInEmpId].attendance = tempAttendance;
+            window.checkerState[currentCheckInEmpId].qoa = tempQoa;
+            
+            init(); // Re-render instantly so background UI updates
+            
+            if (tempAttendance === 'Absent' || tempQoa === 'Fail') {
+                // Delay slightly to let them see the button turn red
+                setTimeout(() => {
+                    closeCheckInModal();
+                    openReplacementModal(currentCheckInEmpId, currentCheckInEmpName);
+                }, 150);
+            } else if (tempAttendance === 'Present' && tempQoa === 'Pass') {
+                // Perfect check-in, auto close!
+                setTimeout(() => {
+                    closeCheckInModal();
+                }, 150);
+            }
+            // If they only clicked Present, stay open for QoA
+        }
+
+        // --- REPLACEMENT MODAL LOGIC ---
+        
+        let availableRelievers = [];
+
+        function findShiftForEmp(empId) {
+            // Find the shift info from the window.manifestData
+            if (!window.manifestData || !window.manifestData.swim_items) return null;
+            for (let item of window.manifestData.swim_items) {
+                // To be precise we would need to know the employee is in this item's _card
+                // But simpler: just find the shift of the first loaded shipment since usually 1 site/shift per manifest.
+                // Or look in window.manifestData.swim_items
+                if (item._shift) return { shift: item._shift, site: item._site };
+            }
+            return null;
+        }
+
+        function openReplacementModal(empId, empName) {
+            document.getElementById('replaceOrigName').textContent = empName;
+            document.getElementById('relieverSelect').innerHTML = '<option value="">Loading available relievers...</option>';
+            document.getElementById('btn-confirm-replace').disabled = true;
+            document.getElementById('replacementModal').classList.add('active');
+            
+            let shiftInfo = findShiftForEmp(empId) || { shift: "", site: "" };
+            // Format today's date YYYY-MM-DD
+            const date = new Date().toISOString().split('T')[0];
+
+            const baseUrl = typeof SITE_URL !== 'undefined' ? SITE_URL : '';
+            fetch(baseUrl + '/api/method/one_fm.one_fm.page.route_planner.route_planner.get_available_rambo_relievers', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Frappe-CSRF-Token': (typeof FRAPPE_CSRF_TOKEN !== 'undefined' ? FRAPPE_CSRF_TOKEN : '') },
+                body: JSON.stringify({ shift_name: shiftInfo.shift, date: date })
+            })
+            .then(r => r.json())
+            .then(res => {
+                availableRelievers = res.message || [];
+                const sel = document.getElementById('relieverSelect');
+                if (availableRelievers.length === 0) {
+                    sel.innerHTML = '<option value="">No available Rambo Relievers found for this time slot.</option>';
+                    sel.disabled = true;
+                } else {
+                    sel.disabled = false;
+                    sel.innerHTML = '<option value="">-- Select Reliever --</option>' + 
+                        availableRelievers.map(r => `<option value="${r.name}">${r.employee_name} (${r.designation})</option>`).join("");
+                    document.getElementById('btn-confirm-replace').disabled = false;
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                document.getElementById('relieverSelect').innerHTML = '<option value="">Error loading relievers.</option>';
+            });
+        }
+
+        function closeReplacementModal() {
+            document.getElementById('replacementModal').classList.remove('active');
+            init(); // render in case absent state needs to show
+        }
+
+        function confirmReplacement() {
+            const sel = document.getElementById('relieverSelect').value;
+            if (!sel) return;
+            
+            const reliever = availableRelievers.find(r => r.name === sel);
+            if (!reliever) return;
+            
+            // Mark replacement in state
+            window.checkerState[currentCheckInEmpId].replacement = {
+                id: reliever.name,
+                name: reliever.employee_name,
+                mobile: reliever.mobile
+            };
+            
+            let shiftInfo = findShiftForEmp(currentCheckInEmpId) || { shift: "", site: "" };
+            
+            document.getElementById('btn-confirm-replace').innerText = "Processing...";
+            
+            // Call backend to send email
+            const baseUrl = typeof SITE_URL !== 'undefined' ? SITE_URL : '';
+            fetch(baseUrl + '/api/method/one_fm.one_fm.page.route_planner.route_planner.process_rambo_replacement', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Frappe-CSRF-Token': (typeof FRAPPE_CSRF_TOKEN !== 'undefined' ? FRAPPE_CSRF_TOKEN : '') },
+                body: JSON.stringify({
+                    original_employee: currentCheckInEmpId,
+                    replacement_employee: reliever.name,
+                    shift_name: shiftInfo.shift,
+                    site: shiftInfo.site
+                })
+            })
+            .then(() => {
+                document.getElementById('btn-confirm-replace').innerText = "Confirm Replacement";
+                closeReplacementModal();
+                showToast("Replacement confirmed and supervisor notified.");
+            })
+            .catch(err => {
+                console.error(err);
+                closeReplacementModal();
+                showToast("Replacement UI updated, but failed to send email.");
+            });
+        }
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
[WI-000779]
[WI-000699]
[WI-000700] 
Rambo replacement feature
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.
Implemented an interactive Attendance and Quality of Appearance (QoA) check-in workflow directly on the Route Manifest for Camp Security. If an onboarding employee is marked Absent or fails their QoA, the system triggers an automated Rambo Reliever replacement modal. Additionally, the Route Planner's manual "Save Plan" button was removed to fully transition to the existing seamless Auto-Save architecture.

## Analysis and design (optional)
*(Leave blank or attach any Figma/mockup screenshots you have)*

## Solution description
- **Interactive Manifest:** Transformed `route_manifest_template.html` to support stateful, dynamic DOM updates. Added interactive badges, a Check-In modal, and an Assign Rambo Reliever modal built with Frappe UI / Material Design 3 styling.
- **Rambo Reliever API:** Added `get_available_rambo_relievers` to filter eligible relievers (`status='Active'`, `custom_is_rambo_reliever=1`) while cross-referencing `Shift Assignment` to exclude conflicting schedules. 
- **Automated Notifications:** Added `process_rambo_replacement` to instantly dispatch email alerts to the Operations Supervisor and Help Desk upon a successful replacement swap.
- **Auto-Save Optimization:** Removed the redundant `savePlan` method and button from `route_planner.js`, replacing it with an "Auto-Saved" status indicator that leverages the existing 500ms debounce `persistAssignments` background process.
- **Blob Origin Fix:** Injected `SITE_URL` into the standalone manifest generation to ensure API calls succeed from the isolated `blob:` URL context.

## Is there a business logic within a doctype?
- [x] Yes
- [ ] No
*(Added API whitelisted methods within the `route_planner.py` controller for reliever querying and email dispatch)*

## Output screenshots (optional)
*(Attach screenshots of the Check-In Modal, Assign Rambo Reliever Modal, and the "Auto-Saved" indicator in the Route Planner)*

## Areas affected and ensured
- `apps/one_fm/one_fm/one_fm/page/route_planner/route_planner.py` (Backend APIs)
- `apps/one_fm/one_fm/one_fm/page/route_planner/route_planner.js` (Vue components & manifest generation)
- `apps/one_fm/one_fm/public/html/route_manifest_template.html` (Standalone DOM logic & Modals)

## Is there any existing behavior change of other features due to this code change?
**Yes.** The "Save Plan" button was removed from the Route Planner header. Dispatchers no longer need to click save manually, as the system now exclusively relies on the existing background auto-save. Additionally, the route manifest is now interactive rather than purely static text.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
- [ ] is attachment required?
- [ ] did you test attachment
*(N/A - No child tables created)*

## Did you delete custom field?
- [ ] Yes
- [x] No
    If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [ ] No
    ## Was the patch test?
    *(Yes, `add_rambo_reliever_custom_field.py` was created and tested to securely inject the `custom_is_rambo_reliever` checkbox into the Employee DocType via `frappe.parse_json`.)*

## Which browser(s) did you use for testing?
- [x] Chrome
- [x] Safari
- [ ] Firefox


https://github.com/user-attachments/assets/8e7ad4db-e892-4c1f-9297-3be6dccab879

