### PR TITLE
fix: helpdesk update fix

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -270,6 +270,7 @@ one_fm.patches.v15_0.add_day_off_preference #2
 one_fm.patches.v15_0.update_job_offer_for_ERF_2026_00004
 one_fm.patches.v15_0.add_index_to_leave_application_in_attendance
 one_fm.patches.v15_0.update_attendance_request_assignment_rule
+one_fm.patches.v15_0.remove_hd_property_setter_from_non_existing_doc #2
 
 
 [post_model_sync]

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -270,7 +270,7 @@ one_fm.patches.v15_0.add_day_off_preference #2
 one_fm.patches.v15_0.update_job_offer_for_ERF_2026_00004
 one_fm.patches.v15_0.add_index_to_leave_application_in_attendance
 one_fm.patches.v15_0.update_attendance_request_assignment_rule
-one_fm.patches.v15_0.remove_hd_property_setter_from_non_existing_doc #2
+one_fm.patches.v15_0.remove_hd_property_setter_from_non_existing_doc #3
 
 
 [post_model_sync]

--- a/one_fm/patches/v15_0/remove_hd_property_setter_from_non_existing_doc.py
+++ b/one_fm/patches/v15_0/remove_hd_property_setter_from_non_existing_doc.py
@@ -1,0 +1,39 @@
+import frappe
+
+def execute():
+    '''
+        Remove property setter for non-existing DocType "HD SLA" and 
+        "HD Pause SLA" which were used previously to set the default value for the link field 
+        to "HD Service Level Agreement Fulfilled On Status" 
+        and "HD Pause Service Level Agreement On Status" respectively.
+    '''
+    frappe.db.sql("DELETE FROM `tabProperty Setter` WHERE doc_type IN ('HD Service Level Agreement Fulfilled On Status', 'HD Pause Service Level Agreement On Status')")
+    
+    statuses = [
+        {
+            "label_agent": "Draft",
+            "color": "Gray",
+            "enabled": 1,
+            "category": "Paused",
+            "order": 1,
+        },
+        {
+            "label_agent": "On Hold",
+            "color": "Orange",
+            "enabled": 1,
+            "category": "Paused",
+            "different_view": 1,
+            "label_customer": "On Hold",
+            "order": 2,
+        },
+        {
+            "label_agent": "Pending Deployment",
+            "color": "Orange",
+            "enabled": 1,
+            "category": "Paused",
+            "order": 3,
+        }
+    ]
+    for status in statuses:
+        if not frappe.db.exists("HD Ticket Status", status["label_agent"]):
+            frappe.get_doc({"doctype": "HD Ticket Status", **status}).insert()

--- a/one_fm/patches/v15_0/remove_hd_property_setter_from_non_existing_doc.py
+++ b/one_fm/patches/v15_0/remove_hd_property_setter_from_non_existing_doc.py
@@ -6,8 +6,29 @@ def execute():
         "HD Pause SLA" which were used previously to set the default value for the link field 
         to "HD Service Level Agreement Fulfilled On Status" 
         and "HD Pause Service Level Agreement On Status" respectively.
+        Also, remove the property setter for "options" of "status" field in "HD Ticket" doctype 
+        which was set to "Open, Closed, Replied, On Hold, Pending Deployment" as we are now 
+        fetching the options dynamically from the "HD Ticket Status" doctype.
+        Also, add default values for the new "HD Ticket Status" doctype.
     '''
-    frappe.db.sql("DELETE FROM `tabProperty Setter` WHERE doc_type IN ('HD Service Level Agreement Fulfilled On Status', 'HD Pause Service Level Agreement On Status')")
+    frappe.db.sql(
+        """
+            DELETE FROM 
+                `tabProperty Setter` 
+            WHERE
+                doc_type IN (
+                    'HD Service Level Agreement Fulfilled On Status',
+                    'HD Pause Service Level Agreement On Status'
+                )    
+        """)
+
+    frappe.db.sql(
+        """
+            DELETE FROM 
+                `tabProperty Setter` 
+            WHERE
+                name = 'HD Ticket-status-options'
+        """)
     
     statuses = [
         {


### PR DESCRIPTION
This pull request introduces a new patch to clean up obsolete property setters and improve the management of ticket statuses in the Help Desk module. The main focus is on removing configuration related to non-existing doctypes and ensuring that ticket status options are managed dynamically.

**Property Setter Cleanup:**

* Added a new patch script `remove_hd_property_setter_from_non_existing_doc.py` to remove property setters for the non-existing doctypes `HD Service Level Agreement Fulfilled On Status` and `HD Pause Service Level Agreement On Status`, as well as the static `options` property setter for the `status` field in the `HD Ticket` doctype.

**Dynamic Status Management:**

* The patch ensures that the options for the `status` field in `HD Ticket` are now fetched dynamically from the `HD Ticket Status` doctype, rather than being hardcoded.
* Default values for the new `HD Ticket Status` doctype are added if they do not already exist, ensuring that essential statuses like "Draft", "On Hold", and "Pending Deployment" are present.

**Patch Registration:**

* Registered the new patch in `one_fm/patches.txt` so it will be executed during the next migration.