### PR TITLE
fix: Fix unescaped backslash in pyproject.toml exclude pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ files = [
     "one_fm/utils/__init__.py",
     "one_fm/permissions.py",
 ]
-exclude = "^one_fm/patches|/test_.*\.py$"
+exclude = '^one_fm/patches|/test_.*\.py$'
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
The `exclude` key in `[tool.mypy]` section of `pyproject.toml` used a double-quoted string containing `\.` which is an invalid escape sequence in TOML. This caused a `TOMLDecodeError: Unescaped '\' in a string (at line 93, column 38)` error, breaking `bench setup requirements`.

## Analysis and design (optional)
N/A

## Solution description
Changed the double-quoted string to a single-quoted (literal) string for the `exclude` regex pattern in `[tool.mypy]`. Single-quoted strings in TOML do not process backslash escapes, making them the correct choice for regex patterns.

**Before:**
`exclude = "^one_fm/patches|/test_.*\.py$"`

**After:**
`exclude = '^one_fm/patches|/test_.*\.py$'`

## Is there a business logic within a doctype?
- [x] No

## Output screenshots (optional)
N/A

## Areas affected and ensured
- `pyproject.toml` — mypy configuration only. No functional code changed.

## Is there any existing behavior change of other features due to this code change?
No. This only fixes the TOML parsing error; mypy behavior remains identical.

## Did you test with the following dataset?
- [x] Existing Data