### PR TITLE
fix: ticket template fields in ticket Edit

### DIFF
--- a/one_fm/after_migrate/execute.py
+++ b/one_fm/after_migrate/execute.py
@@ -509,27 +509,6 @@ def deploy_ticket_views():
     shutil.copy2(ticket_edit_source, ticket_edit_target)
     print(f"[✅] TicketEdit.vue deployed to: {ticket_edit_target}")
 
-    ticket_customer_source = os.path.join(bench_path, "apps", "one_fm", "one_fm", "public", "js", "form_overrides", "hd_ticket", "TicketCustomer.vue")
-    ticket_customer_target = os.path.join(ticket_target_folder, "TicketCustomer.vue")
-
-    if not os.path.exists(ticket_customer_source):
-        print(f"[❌] Source TicketCustomer.vue not found: {ticket_customer_source}")
-        return False
-
-    shutil.copy2(ticket_customer_source, ticket_customer_target)
-    print(f"[✅] TicketCustomer.vue deployed to: {ticket_customer_target}")
-
-    ticket_new_source = os.path.join(bench_path, "apps", "one_fm", "one_fm", "public", "js", "form_overrides", "hd_ticket", "TicketNew.vue")
-    ticket_new_target = os.path.join(ticket_target_folder, "TicketNew.vue")
-
-    if not os.path.exists(ticket_new_source):
-        print(f"[❌] Source TicketNew.vue not found: {ticket_new_source}")
-        return False
-
-    shutil.copy2(ticket_new_source, ticket_new_target)
-    print(f"[✅] TicketNew.vue deployed to: {ticket_new_target}")
-
-
     router_file = os.path.join(bench_path, "apps", "helpdesk", "desk", "src", "router", "index.ts")
 
     if not os.path.exists(router_file):

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -415,8 +415,9 @@ def cleanhtml(raw_html):
 @frappe.whitelist()
 def get_ticket_details(name: str):
     # Fetch the full document to get all custom fields
-    ticket_doc = frappe.get_doc('HD Ticket', name)
-    if not ticket_doc:
+    try:
+        ticket_doc = frappe.get_doc('HD Ticket', name)
+    except frappe.DoesNotExistError:
         frappe.throw(_("Ticket not found"), frappe.DoesNotExistError)
     return {
         "message": "Operation Successful",

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -414,14 +414,14 @@ def cleanhtml(raw_html):
 
 @frappe.whitelist()
 def get_ticket_details(name: str):
-    fields = ['subject', 'description', "priority", "custom_process"]
-    hd_ticket = frappe.db.get_value('HD Ticket',{"name": name}, fields, as_dict=True)
-    if not hd_ticket:
+    # Fetch the full document to get all custom fields
+    ticket_doc = frappe.get_doc('HD Ticket', name)
+    if not ticket_doc:
         frappe.throw(_("Ticket not found"), frappe.DoesNotExistError)
     return {
         "message": "Operation Successful",
         "status_code": 200,
-        "data": hd_ticket,
+        "data": ticket_doc.as_dict(),  # Include full document to access all custom fields
     }
 
 @frappe.whitelist()

--- a/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
+++ b/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
@@ -79,7 +79,7 @@
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted } from "vue";
 import { useRoute, useRouter, RouterLink } from "vue-router";
-import { call, Button, FormControl } from "frappe-ui";
+import { call, Button, FormControl, createResource } from "frappe-ui";
 import { usePageMeta } from "frappe-ui";
 import { globalStore } from "@/stores/globalStore";
 import { LayoutHeader, UniInput } from "@/components";
@@ -130,9 +130,7 @@ const visibleFields = computed(() =>
 );
 
 const filteredFields = computed(() =>
-  visibleFields.value.filter((f) =>
-    ["priority", "process"].includes(f.fieldname)
-  )
+  visibleFields.value
 );
 
 function applyFilters(fieldname, filters = null) {
@@ -158,6 +156,15 @@ function handleOnFieldChange(e, fieldname, fieldtype) {
   templateFields[fieldname] = e.value;
 }
 
+// Create a resource to fetch the template using the Frappe API
+const templateResource = createResource({
+  url: "helpdesk.helpdesk.doctype.hd_ticket_template.api.get_one",
+  makeParams: () => ({
+    name: "Default", // We'll update this after fetching the ticket's template
+  }),
+  auto: false,
+});
+
 async function fetchTicketDetails() {
   if (!ticketName) return;
 
@@ -170,23 +177,29 @@ async function fetchTicketDetails() {
     subject.value = data.subject || "";
     description.value = data.description || "";
 
-    if (data.fields && data.fields.length) {
-      templateData.value.fields = data.fields;
-    } else {
-      injectFallbackFields();
+    // Fetch template using the template name from ticket
+    const templateName = "Default";
+    
+    const templateRes = await call("helpdesk.helpdesk.doctype.hd_ticket_template.api.get_one", {
+      name: templateName,
+    });
+    
+    if (templateRes && templateRes.fields && templateRes.fields.length) {
+      templateData.value.fields = templateRes.fields;
+      oldFields = JSON.parse(JSON.stringify(templateRes.fields));
     }
 
-    oldFields = JSON.parse(JSON.stringify(templateData.value.fields));
-
-    // Assign values only for fields that exist
     for (const field of templateData.value.fields) {
       const key = field.fieldname;
       if (key === "priority") {
         templateFields.priority = data.priority;
-      } else if (key === "process") {
+      } else if (key === "process" || key === "custom_process") {
         templateFields.process = data.custom_process || data.process;
-      } else if (data.custom_fields?.hasOwnProperty(key)) {
-        templateFields[key] = data.custom_fields[key];
+      } else {
+        // Try to get custom field value from ticket document
+        const customKey = key.startsWith("custom_") ? key : `custom_${key}`;
+        const value = data[customKey] || data[key] || "";
+        templateFields[key] = value;
       }
     }
 
@@ -268,7 +281,10 @@ onMounted(async () => {
 
   await fetchTicketDetails();
 
-  injectFallbackFields();
+  // Only inject fallback fields if no fields were loaded from the template
+  if (!templateData.value.fields || templateData.value.fields.length === 0) {
+    injectFallbackFields();
+  }
   // applyFilters("priority");
   // applyFilters("process");
 });

--- a/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
+++ b/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
@@ -200,6 +200,22 @@ async function fetchTicketDetails() {
 
 
 async function handleSubmit() {
+  const fields = visibleFields.value?.filter((f) => f.required) || [];
+  const toVerify = [...fields, "subject", "description"];
+  const params = {
+    ...templateFields,
+    subject: subject.value,
+    description: description.value,
+  };
+  for (const field of toVerify) {
+    if (!params[field.fieldname || field]) {
+      $dialog({
+        title: `${field.label || field}`,
+        message: `${field.label || field} is required`,
+      });
+      return;
+    }
+  }
   loading.value = true;
   try {
     await call("one_fm.overrides.hd_ticket.update_ticket", {

--- a/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
+++ b/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
@@ -191,16 +191,10 @@ async function fetchTicketDetails() {
 
     for (const field of templateData.value.fields) {
       const key = field.fieldname;
-      if (key === "priority") {
-        templateFields.priority = data.priority;
-      } else if (key === "process" || key === "custom_process") {
-        templateFields.process = data.custom_process || data.process;
-      } else {
-        // Try to get custom field value from ticket document
-        const customKey = key.startsWith("custom_") ? key : `custom_${key}`;
-        const value = data[customKey] || data[key] || "";
-        templateFields[key] = value;
-      }
+      // Try to get custom field value from ticket document
+      const customKey = key.startsWith("custom_") ? key : `custom_${key}`;
+      const value = data[customKey] || data[key] || "";
+      templateFields[key] = value;
     }
 
     setupCustomizations(templateData, {
@@ -218,21 +212,6 @@ async function fetchTicketDetails() {
 
 
 async function handleSubmit() {
-  if (!templateFields.priority) {
-    $dialog({
-      title: "Missing Priority",
-      message: "Priority is required.",
-    });
-    return;
-  }
-  if (!templateFields.process) {
-    $dialog({
-      title: "Missing Process",
-      message: "Process is required.",
-    });
-    return;
-  }
-
   loading.value = true;
   try {
     await call("one_fm.overrides.hd_ticket.update_ticket", {
@@ -240,8 +219,7 @@ async function handleSubmit() {
       updates: JSON.stringify({
         subject: subject.value,
         description: description.value,
-        ...templateFields,
-        custom_process: templateFields.process,
+        ...templateFields
       }),
     });
     router.push("/");

--- a/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
+++ b/one_fm/public/js/form_overrides/hd_ticket/TicketEdit.vue
@@ -79,7 +79,7 @@
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted } from "vue";
 import { useRoute, useRouter, RouterLink } from "vue-router";
-import { call, Button, FormControl, createResource } from "frappe-ui";
+import { call, Button, FormControl } from "frappe-ui";
 import { usePageMeta } from "frappe-ui";
 import { globalStore } from "@/stores/globalStore";
 import { LayoutHeader, UniInput } from "@/components";
@@ -156,15 +156,6 @@ function handleOnFieldChange(e, fieldname, fieldtype) {
   templateFields[fieldname] = e.value;
 }
 
-// Create a resource to fetch the template using the Frappe API
-const templateResource = createResource({
-  url: "helpdesk.helpdesk.doctype.hd_ticket_template.api.get_one",
-  makeParams: () => ({
-    name: "Default", // We'll update this after fetching the ticket's template
-  }),
-  auto: false,
-});
-
 async function fetchTicketDetails() {
   if (!ticketName) return;
 
@@ -177,11 +168,8 @@ async function fetchTicketDetails() {
     subject.value = data.subject || "";
     description.value = data.description || "";
 
-    // Fetch template using the template name from ticket
-    const templateName = "Default";
-    
     const templateRes = await call("helpdesk.helpdesk.doctype.hd_ticket_template.api.get_one", {
-      name: templateName,
+      name: "Default",
     });
     
     if (templateRes && templateRes.fields && templateRes.fields.length) {
@@ -193,7 +181,7 @@ async function fetchTicketDetails() {
       const key = field.fieldname;
       // Try to get custom field value from ticket document
       const customKey = key.startsWith("custom_") ? key : `custom_${key}`;
-      const value = data[customKey] || data[key] || "";
+      const value = (data?.[customKey] ?? data?.[key] ?? "");
       templateFields[key] = value;
     }
 


### PR DESCRIPTION
This pull request primarily updates how ticket templates and custom fields are handled in the ticket editing workflow. The backend now returns the full ticket document to ensure all custom fields are available, and the frontend fetches the template fields directly from the API, improving flexibility and reliability. Additionally, some unused deployment logic for ticket views has been removed.

**Backend improvements:**

* The `get_ticket_details` function in `hd_ticket.py` now returns the full `HD Ticket` document (including all custom fields) instead of a limited set of fields.

**Frontend improvements (TicketEdit.vue):**

* Switched to fetching template fields directly from the API (`get_one`) using `createResource` and the `call` function, ensuring the latest template structure is always used. [[1]](diffhunk://#diff-363e9fe04023122f8e41afa5d9a902fc02e6c791ab552f848025c61f480b6e68R159-R167) [[2]](diffhunk://#diff-363e9fe04023122f8e41afa5d9a902fc02e6c791ab552f848025c61f480b6e68L173-R202)
* Improved the mapping of field values from the ticket document to template fields, including support for both standard and custom fields.
* Adjusted the fallback logic to only inject default fields if the template does not provide any, ensuring consistency with the template structure.
* Simplified the `filteredFields` computed property to no longer filter by specific field names, allowing all visible fields to be displayed.

**Code cleanup:**

* Removed deployment logic for `TicketCustomer.vue` and `TicketNew.vue` from `execute.py`, as these files are no longer needed in the deployment process.