### PR TITLE
feat(workflow): Use shift_working instead of hardcoded Project Allocation for dynamic transitions

### DIFF
--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
@@ -3,44 +3,16 @@
 
 frappe.ui.form.on("Employee Resignation", {
 	onload: function(frm) {
-		let show_header = !frm.doc.__islocal && frm.doc.workflow_state && (!["Draft", ""].includes(frm.doc.workflow_state));
-		let is_corporate = frm.doc.project_allocation === "ONE FM - Head Office";
-		let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && is_corporate);
-		frm.toggle_display("operational_impact_section", show_ops_impact);
+		frm.trigger('update_ops_manager_mandatory');
 	},
 
 	refresh: function (frm) {
-		let show_header = !frm.doc.__islocal && frm.doc.workflow_state && (!["Draft", ""].includes(frm.doc.workflow_state));
-		let is_corporate = frm.doc.project_allocation === "ONE FM - Head Office";
-		let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && is_corporate);
-		frm.toggle_display("operational_impact_section", show_ops_impact);
+		frm.trigger('update_ops_manager_mandatory');
 
 		let is_draft = frm.doc.__islocal || frm.doc.workflow_state === 'Draft';
-		
 		let is_editable = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
 		frm.set_df_property('resignation_initiation_date', 'read_only', is_editable ? 0 : 1);
 		frm.set_df_property('relieving_date', 'read_only', is_editable ? 0 : 1);
-
-
-
-		// Hide Operational Impact for Employee Draft and Correction stages
-		let is_restricted_stage = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
-		
-		if (is_restricted_stage) {
-			frm.set_df_property('operations_manager', 'hidden', 1);
-			frm.set_df_property('offboarding_officer', 'hidden', 1);
-			frm.set_df_property('operations_manager', 'reqd', 0);
-			frm.set_df_property('offboarding_officer', 'reqd', 0);
-		} else {
-			let is_corporate = frm.doc.project_allocation === "ONE FM - Head Office";
-			frm.set_df_property('operations_manager', 'hidden', 0); // Keep visible to prevent column collapse
-			frm.set_df_property('operations_manager', 'read_only', is_corporate ? 1 : 0);
-			frm.set_df_property('offboarding_officer', 'hidden', 0);
-			// Mandatory for Operations Manager and onwards, OR for Corporate in Pending Supervisor (since they skip OM)
-			let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && is_corporate);
-			frm.set_df_property('operations_manager', 'reqd', (is_mandatory && !is_corporate) ? 1 : 0);
-			frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
-		}
 
 		// Filter Offboarding Officer to only show users with the 'Offboarding Officer' role
 		frm.set_query('offboarding_officer', () => {
@@ -155,17 +127,6 @@ frappe.ui.form.on("Employee Resignation", {
 	},
 	
 	validate: function(frm) {
-	    if (["Draft", "Pending Relieving Date Correction"].includes(frm.doc.workflow_state) || frm.doc.__islocal) {
-			frm.set_df_property('operations_manager', 'reqd', 0);
-			frm.set_df_property('offboarding_officer', 'reqd', 0);
-		} else {
-			// Enforce mandatory strictly during OM assessment and beyond
-			let is_corporate = frm.doc.project_allocation === "ONE FM - Head Office";
-			let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && is_corporate);
-			frm.set_df_property('operations_manager', 'reqd', (is_mandatory && !is_corporate) ? 1 : 0);
-			frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
-		}
-
 	    if (!frm.doc.employees || frm.doc.employees.length === 0) {
 	        frappe.msgprint({
 	            title: __('Missing Information'),
@@ -276,6 +237,41 @@ frappe.ui.form.on("Employee Resignation", {
 
 	replacement_required: function(frm) {
 		// Field trigger handled in server-side logic
+	},
+
+	update_ops_manager_mandatory: function(frm) {
+		let first_emp = frm.doc.employees && frm.doc.employees[0] ? frm.doc.employees[0].employee : null;
+		if (!first_emp) {
+			frm.toggle_display("operational_impact_section", false);
+			frm.set_df_property('operations_manager', 'reqd', 0);
+			frm.set_df_property('offboarding_officer', 'reqd', 0);
+			return;
+		}
+
+		frappe.db.get_value("Employee", first_emp, "shift_working").then(r => {
+			let is_shift_worker = r.message ? r.message.shift_working : 0;
+			let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
+			frm.toggle_display("operational_impact_section", show_ops_impact);
+
+			let is_draft = frm.doc.__islocal || frm.doc.workflow_state === 'Draft';
+			let is_restricted_stage = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
+
+			if (is_restricted_stage) {
+				frm.set_df_property('operations_manager', 'hidden', 1);
+				frm.set_df_property('offboarding_officer', 'hidden', 1);
+				frm.set_df_property('operations_manager', 'reqd', 0);
+				frm.set_df_property('offboarding_officer', 'reqd', 0);
+			} else {
+				frm.set_df_property('operations_manager', 'hidden', 0);
+				frm.set_df_property('operations_manager', 'read_only', !is_shift_worker ? 1 : 0);
+				frm.set_df_property('offboarding_officer', 'hidden', 0);
+
+				// Mandatory for Operations Manager and onwards, OR for Corporate (non-shift) in Pending Supervisor (since they skip OM)
+				let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
+				frm.set_df_property('operations_manager', 'reqd', (is_mandatory && is_shift_worker) ? 1 : 0);
+				frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
+			}
+		});
 	}
 });
 
@@ -334,6 +330,8 @@ frappe.ui.form.on('Employee Resignation Item', {
                         if (d.site_supervisor_id && !supervisor_found) {
                             frm.set_value('supervisor', d.site_supervisor_id);
                         }
+                        
+                        frm.trigger('update_ops_manager_mandatory');
                         
                         // Validate live Project AND Designation mismatch
                         let errors = [];

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
@@ -309,7 +309,7 @@ def get_employee_resignation_details(employee):
 		return {}
 
 	emp_data = frappe.db.get_value("Employee", employee, 
-		["project", "department", "designation", "site", "employment_type", "shift", "custom_operations_role_allocation", "employee_name", "reports_to"], 
+		["project", "department", "designation", "site", "employment_type", "shift", "custom_operations_role_allocation", "employee_name", "reports_to", "shift_working"], 
 		as_dict=True)
 
 	if not emp_data:

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
@@ -27,7 +27,13 @@ class EmployeeResignation(Document):
 		state = self.get("workflow_state")
 		if state and state not in ("Draft", "Pending Relieving Date Correction"):
 			if state in ("Pending Operations Manager", "Approved"):
-				if not self.operations_manager and self.get("project_allocation") != "ONE FM - Head Office":
+				is_shift_worker = False
+				if self.get("employees"):
+					first_emp = self.employees[0].employee
+					if first_emp:
+						is_shift_worker = frappe.db.get_value("Employee", first_emp, "shift_working")
+
+				if not self.operations_manager and is_shift_worker:
 					frappe.throw(_("Please specify the <b>Operations Manager</b> before saving or submitting."))
 				if not self.offboarding_officer:
 					frappe.throw(_("Please specify the <b>Offboarding Officer</b> before saving or submitting."))

--- a/one_fm/one_fm/doctype/employee_resignation_withdrawal/employee_resignation_withdrawal.js
+++ b/one_fm/one_fm/doctype/employee_resignation_withdrawal/employee_resignation_withdrawal.js
@@ -114,20 +114,23 @@ frappe.ui.form.on("Employee Resignation Withdrawal", {
 			}
 		}
 
-		if (frm.doc.employee_resignation) {
-			frappe.db.get_value('Employee Resignation', frm.doc.employee_resignation, ['project_allocation', 'site_allocation', 'department'])
+		if (frm.doc.employees && frm.doc.employees.length > 0 && frm.doc.employees[0].employee) {
+			frappe.db.get_value('Employee', frm.doc.employees[0].employee, 'shift_working')
 			.then(r => {
-				if (r && r.message) {
-					let project = r.message.project_allocation || "";
-					let site = r.message.site_allocation || "";
-					let dept = r.message.department || "";
-					let is_corporate = (project.includes("Head Office") || site.includes("Head Office") || dept.includes("Head Office"));
-					
-					// Set dynamic property for Frappe's native Depends On engine
-					frm.doc.is_corporate = is_corporate ? 1 : 0;
-					
-					// Force native re-evaluation
-                    frm.refresh_fields();
+				let is_shift_worker = r.message ? r.message.shift_working : 0;
+				frm.doc.is_corporate = is_shift_worker ? 0 : 1;
+				frm.refresh_fields();
+			});
+		} else if (frm.doc.employee_resignation) {
+			frappe.db.get_doc("Employee Resignation", frm.doc.employee_resignation).then(parent_doc => {
+				let parent_emp = parent_doc.employees && parent_doc.employees[0] ? parent_doc.employees[0].employee : null;
+				if (parent_emp) {
+					frappe.db.get_value('Employee', parent_emp, 'shift_working')
+					.then(r => {
+						let is_shift_worker = r.message ? r.message.shift_working : 0;
+						frm.doc.is_corporate = is_shift_worker ? 0 : 1;
+						frm.refresh_fields();
+					});
 				}
 			});
 		}

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -382,7 +382,7 @@ one_fm.patches.v15_0.create_attendance_query_process_task
 one_fm.patches.v15_0.add_formal_hearing_workflow #2026-04-19
 one_fm.patches.v15_0.add_formal_hearing_process_tasks_and_assignment_rules
 one_fm.patches.v15_0.add_absence_case_hr_officer_process_task_and_assignment_rule #2026-04-16
-one_fm.patches.v15_0.update_resignation_workflow_and_schema #2026-05-20-v2
+one_fm.patches.v15_0.update_resignation_workflow_and_schema #2026-05-21-v4
 one_fm.patches.v15_0.remove_pathfinder_log_type_field #2026-04-19
 one_fm.patches.v15_0.add_assignment_rule_recruiter_visa_request
 one_fm.patches.v15_0.add_assignment_rule_groperator_visa_request

--- a/one_fm/patches/v15_0/update_resignation_workflow_and_schema.py
+++ b/one_fm/patches/v15_0/update_resignation_workflow_and_schema.py
@@ -47,7 +47,8 @@ def execute():
 			
 		transitions_data = [
 			{"state": "Draft", "action": "Submit for Review", "next_state": "Pending Supervisor", "allowed": "Employee"},
-			{"state": "Pending Supervisor", "action": "Submit for Approval", "next_state": "Pending Operations Manager", "allowed": "Employee", "allowed_user_field": "supervisor"},
+			{"state": "Pending Supervisor", "action": "Submit for Approval", "next_state": "Pending Operations Manager", "allowed": "Employee", "allowed_user_field": "supervisor", "condition": "frappe.db.get_value('Employee', doc.employees[0].employee, 'shift_working') == 1"},
+			{"state": "Pending Supervisor", "action": "Approve", "next_state": "Approved", "allowed": "Employee", "allowed_user_field": "supervisor", "condition": "frappe.db.get_value('Employee', doc.employees[0].employee, 'shift_working') == 0"},
 			{"state": "Pending Supervisor", "action": "Request Relieving Date Change", "next_state": "Pending Relieving Date Correction", "allowed": "Employee", "allowed_user_field": "supervisor"},
 			{"state": "Pending Relieving Date Correction", "action": "Resubmit Date", "next_state": "Pending Supervisor", "allowed": "Employee"},
 			{"state": "Pending Operations Manager", "action": "Approve", "next_state": "Approved", "allowed": "Operations Manager"}


### PR DESCRIPTION
**Description**
This change replaces the hardcoded, project-level check ("ONE FM - Head Office") with a dynamic classification based on the employee's shift_working profile field to determine the correct approval path.
Routing Paths
Corporate / White-Collar (Not Shift-Working):
Path: Draft ➔ Line Manager (Supervisor) ➔ Approved (triggers PMR if needed).
Change: Completely skips the irrelevant "Pending Operations Manager" validation and state.
Field / Blue-Collar (Shift-Working):
Path: Draft ➔ Site/Shift Supervisor ➔ Pending Operations Manager ➔ Approved (triggers PMR if needed).
Change: Standard multi-layered approval remains active as required.
Technical Implementation
employee_resignation.py: Updated the Python validation block to fetch the primary employee's shift_working status from the database rather than matching string project allocation.
update_resignation_workflow_and_schema.py: Added dynamic SQL-based condition checks (frappe.db.get_value) directly inside the Workflow Engine transition conditions.
patches.txt: Bumped patch to v4 to force database rebuild.