### PR TITLE
Fix/resignation stabilization v2

### DIFF
--- a/one_fm/api/mobile_utils.py
+++ b/one_fm/api/mobile_utils.py
@@ -49,8 +49,15 @@ def _get_raw_body_params():
 
     result = {}
     try:
-        if hasattr(frappe, 'request'):
-            body = frappe.request.get_data(as_text=True)
+        request = None
+        try:
+            if frappe.request:
+                request = frappe.request
+        except RuntimeError:
+            pass
+
+        if request:
+            body = request.get_data(as_text=True)
             if body:
                 # Try JSON first
                 try:
@@ -113,8 +120,15 @@ def get_param(key, explicit_value=None, default=None):
         return form_val
 
     # 3. request.args (GET query string under token auth)
-    if hasattr(frappe, 'request') and hasattr(frappe.request, 'args'):
-        args_val = frappe.request.args.get(key)
+    request = None
+    try:
+        if frappe.request:
+            request = frappe.request
+    except RuntimeError:
+        pass
+
+    if request and hasattr(request, 'args'):
+        args_val = request.args.get(key)
         if args_val is not None:
             return args_val
 

--- a/one_fm/api/v1/resignation.py
+++ b/one_fm/api/v1/resignation.py
@@ -84,9 +84,11 @@ def create_resignation(
 ):
     try:
         p = get_all_params(
-            "resignation_initiation_date", "relieving_date", "attachment",
             employee_id=employee_id,
             supervisor=supervisor,
+            resignation_initiation_date=resignation_initiation_date,
+            relieving_date=relieving_date,
+            attachment=attachment,
         )
         input_id   = p["employee_id"]
         supervisor = p["supervisor"]

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
@@ -250,11 +250,11 @@ frappe.ui.form.on("Employee Resignation", {
 
 		frappe.db.get_value('Employee', first_emp, 'shift_working')
 		.then(r => {
-			let is_shift_worker = r.message ? r.message.shift_working : 0;
+			let is_shift_worker = r.message ? cint(r.message.shift_working) : 0;
 			
 			// Dynamically sync frm.doc.shift_working in-memory to prevent desync
-			if (frm.doc.shift_working !== is_shift_worker) {
-				frm.doc.shift_working = is_shift_worker;
+			if (cint(frm.doc.shift_working) !== is_shift_worker) {
+				frm.set_value('shift_working', is_shift_worker);
 			}
 
 			let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
@@ -322,7 +322,7 @@ frappe.ui.form.on('Employee Resignation Item', {
                         if (!frm.doc.shift_allocation) frm.set_value('shift_allocation', d.shift);
                         if (!frm.doc.operations_role_allocation) frm.set_value('operations_role_allocation', d.custom_operations_role_allocation);
                         
-                        frm.set_value('shift_working', d.shift_working || 0);
+                        frm.set_value('shift_working', cint(d.shift_working) || 0);
                         
                         // Automatically fetch Supervisor (Priority: Line Manager -> Site Supervisor)
                         let supervisor_found = false;

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
@@ -248,28 +248,37 @@ frappe.ui.form.on("Employee Resignation", {
 			return;
 		}
 
-		let is_shift_worker = frm.doc.shift_working || 0;
-		let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
-		frm.toggle_display("operational_impact_section", show_ops_impact);
+		frappe.db.get_value('Employee', first_emp, 'shift_working')
+		.then(r => {
+			let is_shift_worker = r.message ? r.message.shift_working : 0;
+			
+			// Dynamically sync frm.doc.shift_working in-memory to prevent desync
+			if (frm.doc.shift_working !== is_shift_worker) {
+				frm.doc.shift_working = is_shift_worker;
+			}
 
-		let is_draft = frm.doc.__islocal || frm.doc.workflow_state === 'Draft';
-		let is_restricted_stage = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
+			let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
+			frm.toggle_display("operational_impact_section", show_ops_impact);
 
-		if (is_restricted_stage) {
-			frm.set_df_property('operations_manager', 'hidden', 1);
-			frm.set_df_property('offboarding_officer', 'hidden', 1);
-			frm.set_df_property('operations_manager', 'reqd', 0);
-			frm.set_df_property('offboarding_officer', 'reqd', 0);
-		} else {
-			frm.set_df_property('operations_manager', 'hidden', 0);
-			frm.set_df_property('operations_manager', 'read_only', !is_shift_worker ? 1 : 0);
-			frm.set_df_property('offboarding_officer', 'hidden', 0);
+			let is_draft = frm.doc.__islocal || frm.doc.workflow_state === 'Draft';
+			let is_restricted_stage = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
 
-			// Mandatory for Operations Manager and onwards, OR for Corporate (non-shift) in Pending Supervisor (since they skip OM)
-			let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
-			frm.set_df_property('operations_manager', 'reqd', (is_mandatory && is_shift_worker) ? 1 : 0);
-			frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
-		}
+			if (is_restricted_stage) {
+				frm.set_df_property('operations_manager', 'hidden', 1);
+				frm.set_df_property('offboarding_officer', 'hidden', 1);
+				frm.set_df_property('operations_manager', 'reqd', 0);
+				frm.set_df_property('offboarding_officer', 'reqd', 0);
+			} else {
+				frm.set_df_property('operations_manager', 'hidden', 0);
+				frm.set_df_property('operations_manager', 'read_only', !is_shift_worker ? 1 : 0);
+				frm.set_df_property('offboarding_officer', 'hidden', 0);
+
+				// Mandatory for Operations Manager and onwards, OR for Corporate (non-shift) in Pending Supervisor (since they skip OM)
+				let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
+				frm.set_df_property('operations_manager', 'reqd', (is_mandatory && is_shift_worker) ? 1 : 0);
+				frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
+			}
+		});
 	}
 });
 

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
@@ -248,30 +248,28 @@ frappe.ui.form.on("Employee Resignation", {
 			return;
 		}
 
-		frappe.db.get_value("Employee", first_emp, "shift_working").then(r => {
-			let is_shift_worker = r.message ? r.message.shift_working : 0;
-			let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
-			frm.toggle_display("operational_impact_section", show_ops_impact);
+		let is_shift_worker = frm.doc.shift_working || 0;
+		let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
+		frm.toggle_display("operational_impact_section", show_ops_impact);
 
-			let is_draft = frm.doc.__islocal || frm.doc.workflow_state === 'Draft';
-			let is_restricted_stage = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
+		let is_draft = frm.doc.__islocal || frm.doc.workflow_state === 'Draft';
+		let is_restricted_stage = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
 
-			if (is_restricted_stage) {
-				frm.set_df_property('operations_manager', 'hidden', 1);
-				frm.set_df_property('offboarding_officer', 'hidden', 1);
-				frm.set_df_property('operations_manager', 'reqd', 0);
-				frm.set_df_property('offboarding_officer', 'reqd', 0);
-			} else {
-				frm.set_df_property('operations_manager', 'hidden', 0);
-				frm.set_df_property('operations_manager', 'read_only', !is_shift_worker ? 1 : 0);
-				frm.set_df_property('offboarding_officer', 'hidden', 0);
+		if (is_restricted_stage) {
+			frm.set_df_property('operations_manager', 'hidden', 1);
+			frm.set_df_property('offboarding_officer', 'hidden', 1);
+			frm.set_df_property('operations_manager', 'reqd', 0);
+			frm.set_df_property('offboarding_officer', 'reqd', 0);
+		} else {
+			frm.set_df_property('operations_manager', 'hidden', 0);
+			frm.set_df_property('operations_manager', 'read_only', !is_shift_worker ? 1 : 0);
+			frm.set_df_property('offboarding_officer', 'hidden', 0);
 
-				// Mandatory for Operations Manager and onwards, OR for Corporate (non-shift) in Pending Supervisor (since they skip OM)
-				let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
-				frm.set_df_property('operations_manager', 'reqd', (is_mandatory && is_shift_worker) ? 1 : 0);
-				frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
-			}
-		});
+			// Mandatory for Operations Manager and onwards, OR for Corporate (non-shift) in Pending Supervisor (since they skip OM)
+			let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
+			frm.set_df_property('operations_manager', 'reqd', (is_mandatory && is_shift_worker) ? 1 : 0);
+			frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
+		}
 	}
 });
 
@@ -314,6 +312,8 @@ frappe.ui.form.on('Employee Resignation Item', {
                         if (!frm.doc.employment_type) frm.set_value('employment_type', d.employment_type);
                         if (!frm.doc.shift_allocation) frm.set_value('shift_allocation', d.shift);
                         if (!frm.doc.operations_role_allocation) frm.set_value('operations_role_allocation', d.custom_operations_role_allocation);
+                        
+                        frm.set_value('shift_working', d.shift_working || 0);
                         
                         // Automatically fetch Supervisor (Priority: Line Manager -> Site Supervisor)
                         let supervisor_found = false;

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
@@ -200,6 +200,14 @@
             "ignore_user_permissions": 1
         },
         {
+            "default": "0",
+            "fieldname": "shift_working",
+            "fieldtype": "Check",
+            "label": "Shift Working",
+            "read_only": 1,
+            "hidden": 1
+        },
+        {
             "depends_on": "eval: !doc.__islocal",
             "fieldname": "operational_impact_section",
             "fieldtype": "Section Break",

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
@@ -27,13 +27,7 @@ class EmployeeResignation(Document):
 		state = self.get("workflow_state")
 		if state and state not in ("Draft", "Pending Relieving Date Correction"):
 			if state in ("Pending Operations Manager", "Approved"):
-				is_shift_worker = False
-				if self.get("employees"):
-					first_emp = self.employees[0].employee
-					if first_emp:
-						is_shift_worker = frappe.db.get_value("Employee", first_emp, "shift_working")
-
-				if not self.operations_manager and is_shift_worker:
+				if not self.operations_manager and self.shift_working:
 					frappe.throw(_("Please specify the <b>Operations Manager</b> before saving or submitting."))
 				if not self.offboarding_officer:
 					frappe.throw(_("Please specify the <b>Offboarding Officer</b> before saving or submitting."))
@@ -186,13 +180,14 @@ class EmployeeResignation(Document):
 		if self.get("employees"):
 			first_emp = self.employees[0].employee
 			if first_emp:
-				emp = frappe.db.get_value("Employee", first_emp, ["site", "project", "department", "shift", "custom_operations_role_allocation"], as_dict=True)
+				emp = frappe.db.get_value("Employee", first_emp, ["site", "project", "department", "shift", "custom_operations_role_allocation", "shift_working"], as_dict=True)
 				if emp:
 					self.site_allocation = emp.site
 					self.project_allocation = emp.project
 					self.department = emp.department
 					self.shift_allocation = emp.shift
 					self.operations_role_allocation = emp.custom_operations_role_allocation
+					self.shift_working = emp.shift_working or 0
 
 
 	def set_supervisor(self):

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
@@ -8,6 +8,7 @@ from frappe.model.document import Document
 
 class EmployeeResignation(Document):
 	def validate(self):
+		self.set_allocations()
 		self.set_supervisor()
 		self.validate_employee_permissions()
 		self.validate_employees()

--- a/one_fm/one_fm/doctype/employee_resignation/test_employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/test_employee_resignation.py
@@ -32,7 +32,10 @@ class TestEmployeeResignation(FrappeTestCase):
 			})
 			return emp_name
 
-		company = frappe.db.get_single_value("Global Defaults", "default_company") or "ONE FM"
+		company = frappe.db.get_single_value("Global Defaults", "default_company")
+		if not company or not frappe.db.exists("Company", company):
+			companies = frappe.get_all("Company", limit=1)
+			company = companies[0].name if companies else "ONE FM"
 		emp = frappe.get_doc({
 			"doctype": "Employee",
 			"employee": emp_name,
@@ -159,47 +162,133 @@ class TestEmployeeResignation(FrappeTestCase):
 
 	def test_shift_worker_requires_operations_manager(self):
 		"""Test that shift workers must specify an operations manager in managerial stages."""
-		emp_name = self._make_employee("SHIFT-VAL")
-		frappe.db.set_value("Employee", emp_name, "shift_working", 1)
+		emp_name = "TEST-SHIFT-VAL-EMP"
 		
-		doc = self._make_resignation(emp_name)
-		doc.resignation_initiation_date = "2026-10-10"
-		doc.relieving_date = "2026-10-15"
-		
-		doc.append("employees", {
-			"employee": emp_name,
-			"resignation_letter": "/files/test_letter.pdf"
-		})
-		
-		doc.workflow_state = "Pending Operations Manager"
-		doc.offboarding_officer = "test-rsgn-manager@example.com"
-		
-		# 1. Validation must fail because operations_manager is empty and shift_working = 1
-		with self.assertRaises(frappe.ValidationError) as context:
+		original_get_value = frappe.db.get_value
+		def mock_get_value(doctype, filters=None, fieldname=None, *args, **kwargs):
+			if doctype == "Employee" and filters == emp_name:
+				if fieldname == ["site", "project", "department", "shift", "custom_operations_role_allocation", "shift_working"]:
+					return frappe._dict({
+						"site": "Test Site",
+						"project": "Test Project",
+						"department": "Test Dept",
+						"shift": "Test Shift",
+						"custom_operations_role_allocation": "Test Role",
+						"shift_working": 1
+					})
+				if fieldname == ["project", "designation", "employee_name"]:
+					return frappe._dict({
+						"project": "Test Project",
+						"designation": "Test Designation",
+						"employee_name": "Test Employee"
+					})
+				if fieldname == ["user_id", "reports_to", "shift", "site", "shift_working", "employee_name"]:
+					return frappe._dict({
+						"user_id": "test-rsgn-manager@example.com",
+						"reports_to": "Supervisor-Name",
+						"shift": "Test Shift",
+						"site": "Test Site",
+						"shift_working": 1,
+						"employee_name": "Test Employee"
+					})
+			return original_get_value(doctype, filters, fieldname, *args, **kwargs)
+			
+		original_exists = frappe.db.exists
+		def mock_exists(dt, name=None, *args, **kwargs):
+			if dt == "Employee":
+				if isinstance(name, dict) and name.get("name") in (emp_name, "TEST-SHIFT-VAL-EMP", "TEST-CORP-VAL-EMP"):
+					return True
+				if name in (emp_name, "TEST-SHIFT-VAL-EMP", "TEST-CORP-VAL-EMP"):
+					return True
+			return original_exists(dt, name, *args, **kwargs)
+
+		frappe.db.get_value = mock_get_value
+		frappe.db.exists = mock_exists
+		try:
+			doc = self._make_resignation(emp_name)
+			doc.resignation_initiation_date = "2026-10-10"
+			doc.relieving_date = "2026-10-15"
+			
+			doc.append("employees", {
+				"employee": emp_name,
+				"resignation_letter": "/files/test_letter.pdf"
+			})
+			
+			doc.workflow_state = "Pending Operations Manager"
+			doc.offboarding_officer = "test-rsgn-manager@example.com"
+			
+			# 1. Validation must fail because operations_manager is empty and shift_working = 1
+			with self.assertRaises(frappe.ValidationError) as context:
+				doc.validate()
+			self.assertIn("Please specify the Operations Manager", str(context.exception))
+			
+			# 2. Validation must pass when operations_manager is provided
+			doc.operations_manager = "test-rsgn-manager@example.com"
 			doc.validate()
-		self.assertIn("Please specify the Operations Manager", str(context.exception))
-		
-		# 2. Validation must pass when operations_manager is provided
-		doc.operations_manager = "test-rsgn-manager@example.com"
-		doc.validate()
+		finally:
+			frappe.db.get_value = original_get_value
+			frappe.db.exists = original_exists
 
 	def test_corporate_worker_does_not_require_operations_manager(self):
 		"""Test that corporate workers do not require an operations manager."""
-		emp_name = self._make_employee("CORP-VAL")
-		frappe.db.set_value("Employee", emp_name, "shift_working", 0)
+		emp_name = "TEST-CORP-VAL-EMP"
 		
-		doc = self._make_resignation(emp_name)
-		doc.resignation_initiation_date = "2026-10-10"
-		doc.relieving_date = "2026-10-15"
-		
-		doc.append("employees", {
-			"employee": emp_name,
-			"resignation_letter": "/files/test_letter.pdf"
-		})
-		
-		doc.workflow_state = "Pending Operations Manager"
-		doc.offboarding_officer = "test-rsgn-manager@example.com"
-		doc.operations_manager = ""
-		
-		# Validation must pass successfully since shift_working = 0
-		doc.validate()
+		original_get_value = frappe.db.get_value
+		def mock_get_value(doctype, filters=None, fieldname=None, *args, **kwargs):
+			if doctype == "Employee" and filters == emp_name:
+				if fieldname == ["site", "project", "department", "shift", "custom_operations_role_allocation", "shift_working"]:
+					return frappe._dict({
+						"site": "Test Site",
+						"project": "Test Project",
+						"department": "Test Dept",
+						"shift": "Test Shift",
+						"custom_operations_role_allocation": "Test Role",
+						"shift_working": 0
+					})
+				if fieldname == ["project", "designation", "employee_name"]:
+					return frappe._dict({
+						"project": "Test Project",
+						"designation": "Test Designation",
+						"employee_name": "Test Employee"
+					})
+				if fieldname == ["user_id", "reports_to", "shift", "site", "shift_working", "employee_name"]:
+					return frappe._dict({
+						"user_id": "test-rsgn-manager@example.com",
+						"reports_to": "Supervisor-Name",
+						"shift": "Test Shift",
+						"site": "Test Site",
+						"shift_working": 0,
+						"employee_name": "Test Employee"
+					})
+			return original_get_value(doctype, filters, fieldname, *args, **kwargs)
+			
+		original_exists = frappe.db.exists
+		def mock_exists(dt, name=None, *args, **kwargs):
+			if dt == "Employee":
+				if isinstance(name, dict) and name.get("name") in (emp_name, "TEST-SHIFT-VAL-EMP", "TEST-CORP-VAL-EMP"):
+					return True
+				if name in (emp_name, "TEST-SHIFT-VAL-EMP", "TEST-CORP-VAL-EMP"):
+					return True
+			return original_exists(dt, name, *args, **kwargs)
+
+		frappe.db.get_value = mock_get_value
+		frappe.db.exists = mock_exists
+		try:
+			doc = self._make_resignation(emp_name)
+			doc.resignation_initiation_date = "2026-10-10"
+			doc.relieving_date = "2026-10-15"
+			
+			doc.append("employees", {
+				"employee": emp_name,
+				"resignation_letter": "/files/test_letter.pdf"
+			})
+			
+			doc.workflow_state = "Pending Operations Manager"
+			doc.offboarding_officer = "test-rsgn-manager@example.com"
+			doc.operations_manager = ""
+			
+			# Validation must pass successfully since shift_working = 0
+			doc.validate()
+		finally:
+			frappe.db.get_value = original_get_value
+			frappe.db.exists = original_exists

--- a/one_fm/one_fm/doctype/employee_resignation/test_employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/test_employee_resignation.py
@@ -156,3 +156,50 @@ class TestEmployeeResignation(FrappeTestCase):
 			doc.validate_dates()
 		
 		self.assertTrue("Relieving Date cannot be before Resignation Initiation Date" in str(context.exception))
+
+	def test_shift_worker_requires_operations_manager(self):
+		"""Test that shift workers must specify an operations manager in managerial stages."""
+		emp_name = self._make_employee("SHIFT-VAL")
+		frappe.db.set_value("Employee", emp_name, "shift_working", 1)
+		
+		doc = self._make_resignation(emp_name)
+		doc.resignation_initiation_date = "2026-10-10"
+		doc.relieving_date = "2026-10-15"
+		
+		doc.append("employees", {
+			"employee": emp_name,
+			"resignation_letter": "/files/test_letter.pdf"
+		})
+		
+		doc.workflow_state = "Pending Operations Manager"
+		doc.offboarding_officer = "test-rsgn-manager@example.com"
+		
+		# 1. Validation must fail because operations_manager is empty and shift_working = 1
+		with self.assertRaises(frappe.ValidationError) as context:
+			doc.validate()
+		self.assertIn("Please specify the Operations Manager", str(context.exception))
+		
+		# 2. Validation must pass when operations_manager is provided
+		doc.operations_manager = "test-rsgn-manager@example.com"
+		doc.validate()
+
+	def test_corporate_worker_does_not_require_operations_manager(self):
+		"""Test that corporate workers do not require an operations manager."""
+		emp_name = self._make_employee("CORP-VAL")
+		frappe.db.set_value("Employee", emp_name, "shift_working", 0)
+		
+		doc = self._make_resignation(emp_name)
+		doc.resignation_initiation_date = "2026-10-10"
+		doc.relieving_date = "2026-10-15"
+		
+		doc.append("employees", {
+			"employee": emp_name,
+			"resignation_letter": "/files/test_letter.pdf"
+		})
+		
+		doc.workflow_state = "Pending Operations Manager"
+		doc.offboarding_officer = "test-rsgn-manager@example.com"
+		doc.operations_manager = ""
+		
+		# Validation must pass successfully since shift_working = 0
+		doc.validate()

--- a/one_fm/one_fm/doctype/employee_resignation_withdrawal/employee_resignation_withdrawal.js
+++ b/one_fm/one_fm/doctype/employee_resignation_withdrawal/employee_resignation_withdrawal.js
@@ -117,8 +117,8 @@ frappe.ui.form.on("Employee Resignation Withdrawal", {
 		if (frm.doc.employee_resignation) {
 			frappe.db.get_value('Employee Resignation', frm.doc.employee_resignation, 'shift_working')
 			.then(r => {
-				let is_shift_worker = r.message ? r.message.shift_working : 0;
-				frm.doc.is_corporate = is_shift_worker ? 0 : 1;
+				let is_shift_worker = r.message ? cint(r.message.shift_working) : 0;
+				frm.set_value('is_corporate', is_shift_worker ? 0 : 1);
 				frm.refresh_fields();
 			});
 		}

--- a/one_fm/one_fm/doctype/employee_resignation_withdrawal/employee_resignation_withdrawal.js
+++ b/one_fm/one_fm/doctype/employee_resignation_withdrawal/employee_resignation_withdrawal.js
@@ -114,24 +114,12 @@ frappe.ui.form.on("Employee Resignation Withdrawal", {
 			}
 		}
 
-		if (frm.doc.employees && frm.doc.employees.length > 0 && frm.doc.employees[0].employee) {
-			frappe.db.get_value('Employee', frm.doc.employees[0].employee, 'shift_working')
+		if (frm.doc.employee_resignation) {
+			frappe.db.get_value('Employee Resignation', frm.doc.employee_resignation, 'shift_working')
 			.then(r => {
 				let is_shift_worker = r.message ? r.message.shift_working : 0;
 				frm.doc.is_corporate = is_shift_worker ? 0 : 1;
 				frm.refresh_fields();
-			});
-		} else if (frm.doc.employee_resignation) {
-			frappe.db.get_doc("Employee Resignation", frm.doc.employee_resignation).then(parent_doc => {
-				let parent_emp = parent_doc.employees && parent_doc.employees[0] ? parent_doc.employees[0].employee : null;
-				if (parent_emp) {
-					frappe.db.get_value('Employee', parent_emp, 'shift_working')
-					.then(r => {
-						let is_shift_worker = r.message ? r.message.shift_working : 0;
-						frm.doc.is_corporate = is_shift_worker ? 0 : 1;
-						frm.refresh_fields();
-					});
-				}
 			});
 		}
 	},

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -383,6 +383,7 @@ one_fm.patches.v15_0.add_formal_hearing_workflow #2026-04-19
 one_fm.patches.v15_0.add_formal_hearing_process_tasks_and_assignment_rules
 one_fm.patches.v15_0.add_absence_case_hr_officer_process_task_and_assignment_rule #2026-04-16
 one_fm.patches.v15_0.update_resignation_workflow_and_schema #2026-05-21-v4
+one_fm.patches.v15_0.update_resignation_workflow_and_schema_v2 #2026-05-21-v5
 one_fm.patches.v15_0.remove_pathfinder_log_type_field #2026-04-19
 one_fm.patches.v15_0.add_assignment_rule_recruiter_visa_request
 one_fm.patches.v15_0.add_assignment_rule_groperator_visa_request

--- a/one_fm/patches/v15_0/update_resignation_workflow_and_schema_v2.py
+++ b/one_fm/patches/v15_0/update_resignation_workflow_and_schema_v2.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 def execute():
 	# 1. Sync Employee Resignation schema to ensure shift_working field exists in DB
@@ -7,17 +6,24 @@ def execute():
 	frappe.clear_cache(doctype="Employee Resignation")
 	frappe.db.updatedb("Employee Resignation")
 
-
-
-
-
 	# 2. Backfill shift_working field for all existing Employee Resignation documents
-	resignations = frappe.get_all("Employee Resignation", fields=["name"])
-	for r in resignations:
-		doc = frappe.get_doc("Employee Resignation", r.name)
-		if doc.employees and doc.employees[0].employee:
-			shift_working = frappe.db.get_value("Employee", doc.employees[0].employee, "shift_working") or 0
-			frappe.db.set_value("Employee Resignation", doc.name, "shift_working", shift_working, update_modified=False)
+	items = frappe.get_all(
+		"Employee Resignation Item",
+		filters={"parenttype": "Employee Resignation", "idx": 1},
+		fields=["parent", "employee"]
+	)
+	if items:
+		emp_names = list(set(item.employee for item in items if item.employee))
+		emp_shift_map = {}
+		if emp_names:
+			emp_shift_map = {
+				emp.name: (emp.shift_working or 0)
+				for emp in frappe.get_all("Employee", filters={"name": ["in", emp_names]}, fields=["name", "shift_working"])
+			}
+		for item in items:
+			if item.employee:
+				shift_working = emp_shift_map.get(item.employee, 0)
+				frappe.db.set_value("Employee Resignation", item.parent, "shift_working", shift_working, update_modified=False)
 
 	# 3. Rebuild Workflow with simplified shift_working condition
 	workflow_name = "Employee Resignation"

--- a/one_fm/patches/v15_0/update_resignation_workflow_and_schema_v2.py
+++ b/one_fm/patches/v15_0/update_resignation_workflow_and_schema_v2.py
@@ -1,0 +1,54 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+	# 1. Sync Employee Resignation schema to ensure shift_working field exists in DB
+	frappe.reload_doc("one_fm", "doctype", "employee_resignation", force=True)
+	frappe.clear_cache(doctype="Employee Resignation")
+	frappe.db.updatedb("Employee Resignation")
+
+
+
+
+
+	# 2. Backfill shift_working field for all existing Employee Resignation documents
+	resignations = frappe.get_all("Employee Resignation", fields=["name"])
+	for r in resignations:
+		doc = frappe.get_doc("Employee Resignation", r.name)
+		if doc.employees and doc.employees[0].employee:
+			shift_working = frappe.db.get_value("Employee", doc.employees[0].employee, "shift_working") or 0
+			frappe.db.set_value("Employee Resignation", doc.name, "shift_working", shift_working, update_modified=False)
+
+	# 3. Rebuild Workflow with simplified shift_working condition
+	workflow_name = "Employee Resignation"
+	if frappe.db.exists("Workflow", workflow_name):
+		wf = frappe.get_doc("Workflow", workflow_name)
+		# Rebuild states
+		wf.set("states", [])
+		wf.set("transitions", [])
+		
+		states_data = [
+			{"state": "Draft", "doc_status": 0, "update_field": "status", "update_value": "Pending", "allow_edit": "Employee", "style": "Primary"},
+			{"state": "Pending Supervisor", "doc_status": 0, "update_field": "status", "update_value": "Pending", "allow_edit": "Employee", "style": "Warning"},
+			{"state": "Pending Relieving Date Correction", "doc_status": 0, "update_field": "status", "update_value": "Pending", "allow_edit": "Employee", "style": "Danger"},
+			{"state": "Pending Operations Manager", "doc_status": 0, "update_field": "status", "update_value": "Pending", "allow_edit": "Operations Manager", "style": "Warning"},
+			{"state": "Approved", "doc_status": 1, "update_field": "status", "update_value": "Approved", "allow_edit": "Offboarding Officer", "style": "Success"},
+			{"state": "Withdrawn", "doc_status": 1, "update_field": "status", "update_value": "Withdrawn", "allow_edit": "System Manager", "style": "Inverse"}
+		]
+		for s in states_data:
+			wf.append("states", s)
+			
+		transitions_data = [
+			{"state": "Draft", "action": "Submit for Review", "next_state": "Pending Supervisor", "allowed": "Employee"},
+			{"state": "Pending Supervisor", "action": "Submit for Approval", "next_state": "Pending Operations Manager", "allowed": "Employee", "allowed_user_field": "supervisor", "condition": "doc.shift_working == 1"},
+			{"state": "Pending Supervisor", "action": "Approve", "next_state": "Approved", "allowed": "Employee", "allowed_user_field": "supervisor", "condition": "doc.shift_working == 0"},
+			{"state": "Pending Supervisor", "action": "Request Relieving Date Change", "next_state": "Pending Relieving Date Correction", "allowed": "Employee", "allowed_user_field": "supervisor"},
+			{"state": "Pending Relieving Date Correction", "action": "Resubmit Date", "next_state": "Pending Supervisor", "allowed": "Employee"},
+			{"state": "Pending Operations Manager", "action": "Approve", "next_state": "Approved", "allowed": "Operations Manager"}
+		]
+		for t in transitions_data:
+			wf.append("transitions", t)
+			
+		wf.save(ignore_permissions=True)
+
+	frappe.clear_cache(doctype="Employee Resignation")


### PR DESCRIPTION
#Description
<img width="1143" height="205" alt="image" src="https://github.com/user-attachments/assets/7c77e5f3-220b-4a1d-bdbc-6de0c728ac66" />

Key Changes:
Client-Side Form State Stabilization:

Updated employee_resignation.js (update_ops_manager_mandatory) to dynamically fetch the employee's shift_working status from the database via an asynchronous check on load, refresh, and row selection.
Resolves a critical UI bug where the operations_manager field was hidden/read-only on the form when shift_working was out of sync, preventing supervisors from specifying the required manager.
Schema & Backend Validations:

Added the shift_working metadata field to the Employee Resignation schema.
Enforced conditional validation where operations_manager is strictly mandatory for shift/operations workers (shift_working == 1) but skipped for corporate/non-shift employees.
Included a dynamic migration patch to backfill the shift_working property for existing documents.