### PR TITLE
patch: update day off category in erf 2025 00030

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -293,6 +293,7 @@ one_fm.patches.v15_0.add_sales_invoice_contract_fields #3
 one_fm.patches.v15_0.add_sales_taxes_charges_add_or_deduct_field
 one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
+one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/update_day_off_category_erf_2025_00030.py
+++ b/one_fm/patches/v15_0/update_day_off_category_erf_2025_00030.py
@@ -1,0 +1,26 @@
+import frappe
+
+def execute():
+	"""
+	Update day_off_category from Weekly to Monthly for ERF-2025-00030 
+	and all Job Applicants linked to this ERF using SQL
+	"""
+	erf_name = "ERF-2025-00030"
+	
+	# Check if ERF exists
+	if not frappe.db.exists("ERF", erf_name):
+		return
+	
+	# Update ERF record day_off_category to Monthly
+	frappe.db.sql("""
+		UPDATE `tabERF`
+		SET day_off_category = %s
+		WHERE name = %s AND day_off_category = %s
+	""", ("Monthly", erf_name, "Weekly"))
+	
+	# Update all Job Applicants linked to this ERF
+	frappe.db.sql("""
+		UPDATE `tabJob Applicant`
+		SET day_off_category = %s
+		WHERE one_fm_erf = %s AND day_off_category = %s
+	""", ("Monthly", erf_name, "Weekly"))


### PR DESCRIPTION
This pull request introduces a new patch to update the `day_off_category` field for a specific ERF and its related Job Applicants from "Weekly" to "Monthly". The patch is registered in the patch list and implemented as a new script.

**Patch registration:**

* Added `one_fm.patches.v15_0.update_day_off_category_erf_2025_00030` to the patch list in `one_fm/patches.txt` to ensure it is executed during migrations.

**Patch implementation:**

* Created `update_day_off_category_erf_2025_00030.py` to:
  - Check if the ERF with name `"ERF-2025-00030"` exists.
  - Update its `day_off_category` from "Weekly" to "Monthly".
  - Update the `day_off_category` for all linked Job Applicants from "Weekly" to "Monthly".