### PR TITLE
fix: show operational impact section and enforce required fields in p…

### DIFF
--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
@@ -257,11 +257,11 @@ frappe.ui.form.on("Employee Resignation", {
 				frm.set_value('shift_working', is_shift_worker);
 			}
 
-			let show_ops_impact = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
-			frm.toggle_display("operational_impact_section", show_ops_impact);
-
 			let is_draft = frm.doc.__islocal || frm.doc.workflow_state === 'Draft';
 			let is_restricted_stage = is_draft || frm.doc.workflow_state === 'Pending Relieving Date Correction';
+
+			let show_ops_impact = !is_restricted_stage;
+			frm.toggle_display("operational_impact_section", show_ops_impact);
 
 			if (is_restricted_stage) {
 				frm.set_df_property('operations_manager', 'hidden', 1);
@@ -273,10 +273,9 @@ frappe.ui.form.on("Employee Resignation", {
 				frm.set_df_property('operations_manager', 'read_only', !is_shift_worker ? 1 : 0);
 				frm.set_df_property('offboarding_officer', 'hidden', 0);
 
-				// Mandatory for Operations Manager and onwards, OR for Corporate (non-shift) in Pending Supervisor (since they skip OM)
-				let is_mandatory = ["Pending Operations Manager", "Approved"].includes(frm.doc.workflow_state) || (frm.doc.workflow_state === "Pending Supervisor" && !is_shift_worker);
-				frm.set_df_property('operations_manager', 'reqd', (is_mandatory && is_shift_worker) ? 1 : 0);
-				frm.set_df_property('offboarding_officer', 'reqd', is_mandatory ? 1 : 0);
+				// Mandatory for all non-restricted stages (Pending Supervisor, Pending Operations Manager, Approved)
+				frm.set_df_property('operations_manager', 'reqd', is_shift_worker ? 1 : 0);
+				frm.set_df_property('offboarding_officer', 'reqd', 1);
 			}
 		});
 	}


### PR DESCRIPTION
Description
Resolves a validation error where the supervisor cannot transition a shift-worker's resignation from Pending Supervisor to Pending Operations Manager due to missing fields.
Root Cause
The operational_impact_section (which holds supervisor, replacement, and routing fields) was hidden from supervisors in the Pending Supervisor stage if the employee was a shift worker. Because these fields were hidden, supervisors could not select the Operations Manager or Offboarding Officer, causing the server-side validator to reject the document upon submission.
Changes
Updated the client-side script (employee_resignation.js) to keep the operational_impact_section visible in all active, non-restricted stages (Pending Supervisor, Pending Operations Manager, and Approved).
Dynamically marked Operations Manager (for shift-workers) and Offboarding Officer (for all) as mandatory (reqd) in the UI during these active stages so they must be filled by the supervisor prior to saving or submitting.