### PR TITLE
patch: update purchase receipt posting date

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -294,6 +294,7 @@ one_fm.patches.v15_0.add_sales_taxes_charges_add_or_deduct_field
 one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
 one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
+one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/update_purchase_receipt_prc_2026_000101_posting_date.py
+++ b/one_fm/patches/v15_0/update_purchase_receipt_prc_2026_000101_posting_date.py
@@ -1,0 +1,26 @@
+import frappe
+
+def execute():
+	"""
+	Update the posting_date of Purchase Receipt PRC-2026-000101 to 20-Apr-2026.
+	Verifies that the Purchase Receipt is created from Purchase Order POR-2025-000935 before making the change.
+	Uses direct SQL update to skip validation and ORM controls.
+	"""
+	
+	# Verify that PRC-2026-000101 has items linked to POR-2025-000935
+	po_check = frappe.db.sql("""
+		SELECT COUNT(*) FROM `tabPurchase Receipt Item`
+		WHERE parent = 'PRC-2026-000101' AND purchase_order = 'POR-2025-000935'
+	""")[0][0]
+	
+	if po_check == 0:
+		return
+	
+	# Update the posting_date to 2026-04-20 using direct SQL
+	frappe.db.sql("""
+		UPDATE `tabPurchase Receipt`
+		SET posting_date = %s
+		WHERE name = 'PRC-2026-000101'
+	""", ("2026-04-20",))
+	
+	frappe.db.commit()


### PR DESCRIPTION
This pull request introduces a new patch to update the `posting_date` for a specific Purchase Receipt in the ERP system, ensuring data consistency by verifying its linkage to a particular Purchase Order before applying the change. The patch is registered in the migration system and uses direct SQL for the update.

**Patch registration:**

* Added `one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date` to the patch list in `one_fm/patches.txt`, ensuring this update is tracked and executed during migrations.

**Data correction for Purchase Receipt:**

* Created `one_fm/patches/v15_0/update_purchase_receipt_prc_2026_000101_posting_date.py` to update the `posting_date` of Purchase Receipt `PRC-2026-000101` to `2026-04-20`, but only if it contains items linked to Purchase Order `POR-2025-000935`. The update is performed with direct SQL to bypass ORM validation, and the transaction is committed explicitly.

<img width="980" height="266" alt="Screenshot 2026-05-24 at 6 40 34 PM" src="https://github.com/user-attachments/assets/aede9c4e-4019-4ffa-aee4-b1178fc03f27" />
