### PR TITLE
Merge version-15 into test-production

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -294,6 +294,7 @@ one_fm.patches.v15_0.add_sales_taxes_charges_add_or_deduct_field
 one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
 one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
+one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/update_purchase_receipt_prc_2026_000101_posting_date.py
+++ b/one_fm/patches/v15_0/update_purchase_receipt_prc_2026_000101_posting_date.py
@@ -1,0 +1,26 @@
+import frappe
+
+def execute():
+	"""
+	Update the posting_date of Purchase Receipt PRC-2026-000101 to 20-Apr-2026.
+	Verifies that the Purchase Receipt is created from Purchase Order POR-2025-000935 before making the change.
+	Uses direct SQL update to skip validation and ORM controls.
+	"""
+	
+	# Verify that PRC-2026-000101 has items linked to POR-2025-000935
+	po_check = frappe.db.sql("""
+		SELECT COUNT(*) FROM `tabPurchase Receipt Item`
+		WHERE parent = 'PRC-2026-000101' AND purchase_order = 'POR-2025-000935'
+	""")[0][0]
+	
+	if po_check == 0:
+		return
+	
+	# Update the posting_date to 2026-04-20 using direct SQL
+	frappe.db.sql("""
+		UPDATE `tabPurchase Receipt`
+		SET posting_date = %s
+		WHERE name = 'PRC-2026-000101'
+	""", ("2026-04-20",))
+	
+	frappe.db.commit()


### PR DESCRIPTION
## Summary

Merges latest changes from `version-15` into `test-production`.

### Conflict Resolution

The only conflict was in `one_fm/patches.txt` (pre_model_sync section). Both patches were kept:
- `add_rambo_reliever_custom_field #2026-05-14` (from test-production)
- `update_purchase_receipt_prc_2026_000101_posting_date` (from version-15)