### PR TITLE
feat: enable allow_import for Project Manpower Request

### DIFF
--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "allow_rename": 1,
  "autoname": "naming_series:",
  "creation": "2026-04-12 18:29:41.891162",


### PR DESCRIPTION
Enables the allow_import property on Project Manpower Request DocType so it can be imported via the Data Import tool.