### PR TITLE
feat: send message to process from hd ticket update

### DIFF
--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -9,6 +9,7 @@ from one_fm.processor import sendemail
 from one_fm.api.doc_events import get_employee_user_id
 from one_fm.utils import response
 from frappe.utils.password import get_decrypted_password
+from one_bpmn.api import send_message
 
 class HDTicketOverride(HDTicket):
     def before_insert(self):
@@ -445,6 +446,12 @@ def update_ticket(name: str, updates: str):
     doc.save(ignore_permissions=True)
     frappe.db.commit()
     doc.notify_ticket_raiser_of_receipt()
+
+    send_message(
+        message_name="hd_ticket_update",
+        context_doctype="HD Ticket",
+        context_docname=name
+    )
 
     return {
         "message": "Operation Successful",

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -9,7 +9,10 @@ from one_fm.processor import sendemail
 from one_fm.api.doc_events import get_employee_user_id
 from one_fm.utils import response
 from frappe.utils.password import get_decrypted_password
-from one_bpmn.api import send_message
+try:
+    from one_bpmn.api import send_message as send_processa_message
+except ImportError:
+    send_processa_message = None
 
 class HDTicketOverride(HDTicket):
     def before_insert(self):
@@ -447,11 +450,15 @@ def update_ticket(name: str, updates: str):
     frappe.db.commit()
     doc.notify_ticket_raiser_of_receipt()
 
-    send_message(
-        message_name="hd_ticket_update",
-        context_doctype="HD Ticket",
-        context_docname=name
-    )
+    if send_processa_message:
+        try:
+            send_processa_message(
+                message_name="hd_ticket_update",
+                context_doctype="HD Ticket",
+                context_docname=name
+            )
+        except Exception as e:
+            frappe.log_error(message=frappe.get_traceback(), title="Processa Message Error (HD Ticket Update)")
 
     return {
         "message": "Operation Successful",


### PR DESCRIPTION
This pull request introduces an integration between the HD Ticket system and the BPMN messaging system. The main change is the addition of a call to `send_message` after a ticket is updated, which enables external systems or workflows to be notified of ticket updates.

**Integration with BPMN messaging:**

* Added an import for `send_message` from `one_bpmn.api` in `one_fm/overrides/hd_ticket.py`.
* Invoked `send_message` with the message name `"hd_ticket_update"` after updating a ticket in the `update_ticket` function, allowing external processes to react to ticket updates.