### PR TITLE
feat: send message to process from hd ticket update

### DIFF
--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -9,6 +9,7 @@ from one_fm.processor import sendemail
 from one_fm.api.doc_events import get_employee_user_id
 from one_fm.utils import response
 from frappe.utils.password import get_decrypted_password
+from one_bpmn.api import send_message
 
 class HDTicketOverride(HDTicket):
     def before_insert(self):
@@ -445,6 +446,12 @@ def update_ticket(name: str, updates: str):
     doc.save(ignore_permissions=True)
     frappe.db.commit()
     doc.notify_ticket_raiser_of_receipt()
+
+    send_message(
+        message_name="hd_ticket_update",
+        context_doctype="HD Ticket",
+        context_docname=name
+    )
 
     return {
         "message": "Operation Successful",

--- a/one_fm/overrides/hd_ticket.py
+++ b/one_fm/overrides/hd_ticket.py
@@ -9,7 +9,10 @@ from one_fm.processor import sendemail
 from one_fm.api.doc_events import get_employee_user_id
 from one_fm.utils import response
 from frappe.utils.password import get_decrypted_password
-from one_bpmn.api import send_message
+try:
+    from one_bpmn.api import send_message as send_processa_message
+except ImportError:
+    send_processa_message = None
 
 class HDTicketOverride(HDTicket):
     def before_insert(self):
@@ -447,11 +450,15 @@ def update_ticket(name: str, updates: str):
     frappe.db.commit()
     doc.notify_ticket_raiser_of_receipt()
 
-    send_message(
-        message_name="hd_ticket_update",
-        context_doctype="HD Ticket",
-        context_docname=name
-    )
+    if send_processa_message:
+        try:
+            send_processa_message(
+                message_name="hd_ticket_update",
+                context_doctype="HD Ticket",
+                context_docname=name
+            )
+        except Exception as e:
+            frappe.log_error(message=frappe.get_traceback(), title="Processa Message Error (HD Ticket Update)")
 
     return {
         "message": "Operation Successful",


### PR DESCRIPTION
This pull request adds integration with the `one_bpmn` process automation system to the HD Ticket update workflow. Now, when a ticket is updated, a message is sent to `one_bpmn` (if available), with error handling to ensure the main workflow is not disrupted if the integration fails.

**Integration with process automation:**

* Imported `send_message` from `one_bpmn.api` as `send_processa_message`, with a fallback to `None` if the module is not available.
* Updated the `update_ticket` function to send a `hd_ticket_update` message to `one_bpmn` after a ticket is updated, with exception handling and error logging to prevent failures in the integration from affecting the main update process.