### PR TITLE
patch: update job offer day of category

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -296,6 +296,7 @@ one_fm.patches.v15_0.update_penalty_and_investigation_workflow
 one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
 one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
 one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
+one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/update_job_offer_day_off_category_for_job_applicants.py
+++ b/one_fm/patches/v15_0/update_job_offer_day_off_category_for_job_applicants.py
@@ -1,0 +1,25 @@
+import frappe
+
+def execute():
+	"""
+	Update the day_off_category to 'Monthly' for Job Offers linked to specific Job Applicants.
+	Uses direct SQL update to skip validation and ORM controls.
+	"""
+	
+	job_applicants = [
+		'HR-APP-2026-01813', 'HR-APP-2026-01836', 'HR-APP-2026-01824', 'HR-APP-2026-01826',
+		'HR-APP-2026-01827', 'HR-APP-2026-01828', 'HR-APP-2026-01829', 'HR-APP-2026-01830',
+		'HR-APP-2026-01823', 'HR-APP-2026-01831', 'HR-APP-2026-01832', 'HR-APP-2026-01833',
+		'HR-APP-2026-01834', 'HR-APP-2026-01835', 'HR-APP-2026-01820', 'HR-APP-2026-01837',
+		'HR-APP-2026-01822', 'HR-APP-2026-01821', 'HR-APP-2026-01817', 'HR-APP-2026-01816',
+		'HR-APP-2026-01814'
+	]
+	
+	# Update day_off_category to 'Monthly' for Job Offers linked to the specified job applicants
+	frappe.db.sql("""
+		UPDATE `tabJob Offer`
+		SET day_off_category = %s
+		WHERE job_applicant IN ({})
+	""".format(','.join(['%s'] * len(job_applicants))), ['Monthly'] + job_applicants)
+	
+	frappe.db.commit()


### PR DESCRIPTION
This pull request adds a new patch to update the `day_off_category` field to 'Monthly' for specific job applicants' job offers. The update is implemented using a direct SQL statement for efficiency and to bypass ORM validation.

**Database migration:**

* Added a new patch file `update_job_offer_day_off_category_for_job_applicants.py` that updates the `day_off_category` to 'Monthly' in the `tabJob Offer` table for a specific list of job applicants using a direct SQL update.

**Patch registration:**

* Registered the new patch in `one_fm/patches.txt` to ensure it runs as part of the migration process.