### PR TITLE
chore: update patches - use query builder

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -295,8 +295,8 @@ one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
 one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
 one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
-one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
-one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants
+one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date #1
+one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants #1
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -295,8 +295,8 @@ one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
 one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
 one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
-one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date #1
-one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants #1
+one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
+one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/update_job_offer_day_off_category_for_job_applicants.py
+++ b/one_fm/patches/v15_0/update_job_offer_day_off_category_for_job_applicants.py
@@ -3,7 +3,7 @@ import frappe
 def execute():
 	"""
 	Update the day_off_category to 'Monthly' for Job Offers linked to specific Job Applicants.
-	Uses direct SQL update to skip validation and ORM controls.
+	Uses Query Builder to update records. Checks if data exists first.
 	"""
 	
 	job_applicants = [
@@ -15,11 +15,23 @@ def execute():
 		'HR-APP-2026-01814'
 	]
 	
-	# Update day_off_category to 'Monthly' for Job Offers linked to the specified job applicants
-	frappe.db.sql("""
-		UPDATE `tabJob Offer`
-		SET day_off_category = %s
-		WHERE job_applicant IN ({})
-	""".format(','.join(['%s'] * len(job_applicants))), ['Monthly'] + job_applicants)
+	# Check if Job Offers exist for the specified job applicants
+	JobOffer = frappe.qb.DocType("Job Offer")
+	job_offers = (
+		frappe.qb.from_(JobOffer)
+		.select(JobOffer.name)
+		.where(JobOffer.job_applicant.isin(job_applicants))
+		.limit(1)
+	).run()
+
+	if not job_offers:
+		return
+
+	# Update day_off_category to 'Monthly' for all matching Job Offers
+	(
+		frappe.qb.update(JobOffer)
+		.set(JobOffer.day_off_category, "Monthly")
+		.where(JobOffer.job_applicant.isin(job_applicants))
+	).run()
 	
 	frappe.db.commit()

--- a/one_fm/patches/v15_0/update_job_offer_day_off_category_for_job_applicants.py
+++ b/one_fm/patches/v15_0/update_job_offer_day_off_category_for_job_applicants.py
@@ -21,7 +21,6 @@ def execute():
 		frappe.qb.from_(JobOffer)
 		.select(JobOffer.name)
 		.where(JobOffer.job_applicant.isin(job_applicants))
-		.limit(1)
 	).run()
 
 	if not job_offers:

--- a/one_fm/patches/v15_0/update_purchase_receipt_prc_2026_000101_posting_date.py
+++ b/one_fm/patches/v15_0/update_purchase_receipt_prc_2026_000101_posting_date.py
@@ -1,26 +1,32 @@
 import frappe
+from frappe.model.document import Document
 
 def execute():
 	"""
 	Update the posting_date of Purchase Receipt PRC-2026-000101 to 20-Apr-2026.
 	Verifies that the Purchase Receipt is created from Purchase Order POR-2025-000935 before making the change.
-	Uses direct SQL update to skip validation and ORM controls.
+	Uses Query Builder for updates.
 	"""
 	
 	# Verify that PRC-2026-000101 has items linked to POR-2025-000935
-	po_check = frappe.db.sql("""
-		SELECT COUNT(*) FROM `tabPurchase Receipt Item`
-		WHERE parent = 'PRC-2026-000101' AND purchase_order = 'POR-2025-000935'
-	""")[0][0]
+	PurchaseReceiptItem = frappe.qb.DocType("Purchase Receipt Item")
+	pr_items = (
+		frappe.qb.from_(PurchaseReceiptItem)
+		.select(PurchaseReceiptItem.name)
+		.where(PurchaseReceiptItem.parent == "PRC-2026-000101")
+		.where(PurchaseReceiptItem.purchase_order == "POR-2025-000935")
+		.limit(1)
+	).run()
 	
-	if po_check == 0:
+	if not pr_items:
 		return
 	
-	# Update the posting_date to 2026-04-20 using direct SQL
-	frappe.db.sql("""
-		UPDATE `tabPurchase Receipt`
-		SET posting_date = %s
-		WHERE name = 'PRC-2026-000101'
-	""", ("2026-04-20",))
+	# Update the posting_date to 2026-04-20 using Query Builder
+	PurchaseReceipt = frappe.qb.DocType("Purchase Receipt")
+	(
+		frappe.qb.update(PurchaseReceipt)
+		.set(PurchaseReceipt.posting_date, "2026-04-20")
+		.where(PurchaseReceipt.name == "PRC-2026-000101")
+	).run()
 	
 	frappe.db.commit()


### PR DESCRIPTION
This pull request refactors two patch scripts to use Frappe's Query Builder instead of direct SQL statements, improving code readability and maintainability. It also updates the patch registration in `patches.txt` to include references for tracking.

**Refactoring to Query Builder:**

* Refactored `update_job_offer_day_off_category_for_job_applicants.py` to use Query Builder for checking and updating `Job Offer` records, instead of raw SQL. The script now verifies if relevant job offers exist before updating, making the operation safer and more efficient. [[1]](diffhunk://#diff-6ca5a2e336cdf6e0cd72e3e788ef99a694292002dbc8fb853741578e63a63808L6-R6) [[2]](diffhunk://#diff-6ca5a2e336cdf6e0cd72e3e788ef99a694292002dbc8fb853741578e63a63808L18-R35)
* Refactored `update_purchase_receipt_prc_2026_000101_posting_date.py` to use Query Builder for both checking and updating records. The script now checks for linked purchase orders using Query Builder and only updates the posting date if the condition is met.

**Patch registration updates:**

* Updated `one_fm/patches.txt` to add tracking comments (`#1`) for the two modified patches, aiding traceability.

<img width="998" height="404" alt="Screenshot 2026-05-25 at 2 10 45 PM" src="https://github.com/user-attachments/assets/5b3aa5d0-4091-4b5c-896b-931f09d72daa" />
