### PR TITLE
fix: contracts reminder notification

### DIFF
--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -1433,10 +1433,9 @@ def send_contract_reminders(is_scheduled_event=True):
                 get_date_str(i.contract_termination_decision_period_date) if i.contract_termination_decision_period_date else None,i.name,get_date_str(i.start_date),get_date_str(i.contract_end_internal_notification_date) if i.contract_end_internal_notification_date else None,\
                 get_date_str(i.end_date),i.duration,i.client,i.contract] for i in contracts_due_internal_notification]
 
-            # Build a list of all contract contexts to render in a single grouped email
-            contracts_list = []
+            # Send a separate email for each contract to the same set of users
             for each in contracts_due_internal_notification_list:
-                contracts_list.append({
+                contract_data = {
                     "project": each[8],
                     "contract_end_internal_notif_period": get_field_with_label("Contracts", "contract_end_internal_notification", each[1]),
                     "start_date": each[4],
@@ -1448,18 +1447,18 @@ def send_contract_reminders(is_scheduled_event=True):
                     "document_id": each[3],
                     "link": frappe.utils.get_url_to_form("Contracts", each[3]),
                     "attachment": frappe.utils.get_url(each[9]) if each[9] else None
-                })
+                }
 
-            # Render all expiring contracts into a single email and send once to all recipients
-            context = {"contracts_list": contracts_list}
-            msg = frappe.render_template('one_fm/templates/emails/contracts_reminder.html', context=context)
-            sendemail(
-                recipients=[users[0]],
-                cc=users[1:] if len(users) > 1 else None,
-                subject="Contract Internal Notification Period for Expiring Contracts",
-                content=msg, is_scheduler_email=is_scheduled_event,
-                expose_recipients="header"
-            )
+                # Render email for individual contract
+                context = {"contracts_list": [contract_data]}
+                msg = frappe.render_template('one_fm/templates/emails/contracts_reminder.html', context=context)
+                sendemail(
+                    recipients=[users[0]],
+                    cc=users[1:] if len(users) > 1 else None,
+                    subject=f"Contract Internal Notification Period for Expiring Contract: {each[8]}",
+                    content=msg, is_scheduler_email=is_scheduled_event,
+                    expose_recipients="header"
+                )
     except Exception as e:
         frappe.log_error(message=str(e), title="Contract Reminder Error")
 

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -1412,12 +1412,13 @@ def get_due_contracts():
     pass
 
 @frappe.whitelist()
-def send_contract_reminders(is_scheduled_event=True):
-    """
-    Generate Reminders for Contract Termination Decision Period and Contract End Internal Notification periods.
+def send_contract_reminders(is_scheduled_event: bool = True):
+   """
+    Generate Reminders for Contract Termination Decision Period...
 
     Args:
-        is_scheduled_event -> Boolean (Default True) If method is triggered from anywhere else than the scheduled event, Pass "False" to avoid email trigger check from "ONEFM General Setting"
+        is_scheduled_event (bool): Default True. If triggered from outside
+        the scheduled event, pass False to skip email trigger check.
     """
     try:
         contracts_due_internal_notification = frappe.get_all("Contracts",{'contract_end_internal_notification_date':getdate(), 'workflow_state': 'Active'},['contract_end_internal_notification',\

--- a/one_fm/templates/emails/contracts_reminder.html
+++ b/one_fm/templates/emails/contracts_reminder.html
@@ -75,7 +75,7 @@
     </style>
     
     <div class="container">
-      <p>Please note that, today is the Contract internal notification Period for the following expiring contracts.</p>
+      <p>Please note that, today is the Contract internal notification Period for the following expiring contract.</p>
     </div>
 
   {% for contract in contracts_list %}


### PR DESCRIPTION
This pull request updates the contract reminder notification system to send separate emails for each expiring contract, rather than grouping all expiring contracts into a single email. The email template and subject line are also updated to reflect the new, per-contract notification approach.

**Notification logic changes:**

* Modified `send_contract_reminders` in `contracts.py` to send an individual email for each contract due for internal notification, instead of grouping all contracts into one email. [[1]](diffhunk://#diff-71416cff5bfcd080f483bda1d2784925039e4bf45f46262a591773443fdc13b7L1436-R1438) [[2]](diffhunk://#diff-71416cff5bfcd080f483bda1d2784925039e4bf45f46262a591773443fdc13b7L1451-R1458)

**Email content updates:**

* Updated the email subject line to include the specific contract name, making each notification more relevant and clear.
* Changed the email template message in `contracts_reminder.html` to refer to a single expiring contract instead of multiple.