### PR TITLE
feat(ccp): restore data-driven ccp tracking and dependency fields

### DIFF
--- a/one_fm/one_fm/doctype/agency_process_details/agency_process_details.json
+++ b/one_fm/one_fm/doctype/agency_process_details/agency_process_details.json
@@ -8,6 +8,10 @@
   "responsible",
   "duration_in_days",
   "column_break_4",
+  "before_task",
+  "sequence_type",
+  "after_task",
+  "section_break_ref",
   "attachment_required",
   "notes_required",
   "reference_type",
@@ -41,6 +45,34 @@
    "label": "Duration in Days"
   },
   {
+   "fieldname": "before_task",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Before Task",
+   "description": "Process name of the task that must complete before this task can start. Leave blank if this is the first task."
+  },
+  {
+   "default": "Sequential",
+   "fieldname": "sequence_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Sequence Type",
+   "options": "Sequential\nParallel",
+   "description": "Sequential = waits for before_task to finish. Parallel = starts at the same time as other parallel tasks sharing the same before_task."
+  },
+
+  {
+   "fieldname": "after_task",
+   "fieldtype": "Data",
+   "label": "After Task",
+   "description": "Process name of the task that starts after this task completes. For display/documentation only; the engine uses before_task for dependency resolution."
+  },
+  {
+   "fieldname": "section_break_ref",
+   "fieldtype": "Section Break",
+   "label": "Reference Configuration"
+  },
+  {
    "default": "0",
    "fieldname": "attachment_required",
    "fieldtype": "Check",
@@ -71,7 +103,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-08-23 00:11:16.994337",
+ "modified": "2026-04-15 07:00:00.000000",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Agency Process Details",

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
@@ -1,61 +1,114 @@
 // Copyright (c) 2020, ONE FM and contributors
 // For license information, please see license.txt
 
+// ── Status options per process name ──────────────────────────────────────────
+var STATUS_MAP = {
+  "Job Offer Issuance": ["Pending", "Offer Accepted", "Rejected"],
+  "Visa Processing": ["Pending", "Applied", "Issued", "Rejected"],
+  "Medical Test": ["Pending", "In Process", "Fit", "Unfit", "Passed", "Failed"],
+  "Remedical Test": ["Pending", "Skipped", "In Process", "Fit", "Unfit", "Passed", "Failed"],
+  "PCC Clearance": ["Pending", "Applied", "Issued", "Rejected"],
+  "Visa Stamping": ["Pending", "Applied", "Issued", "Approved", "Rejected"],
+  "Arrival & Deployment": ["Pending", "Arriving", "Completed"]
+};
+
 frappe.ui.form.on('Candidate Country Process', {
   agency_country_process: function(frm) {
     set_country_process_details(frm);
   },
-  refresh:  function(frm){
+  refresh: function(frm) {
     candidate_country_process_flow_btn(frm);
-    calculate_live_plan_eta(frm);
-    
-    if (frm.doc.agency_country_process && !frm.doc.__islocal) {
-        frm.add_custom_button(__("Sync Process Steps"), function() {
-            frappe.confirm('Are you sure you want to sync missing steps from the Agency Process? This will keep your existing progress safe.', function() {
-                frappe.model.with_doc("Agency Country Process", frm.doc.agency_country_process, function() {
-                    var agency_doc = frappe.model.get_doc("Agency Country Process", frm.doc.agency_country_process);
-                    var existing_processes = {};
-                    
-                    // Backup existing rows by process name
-                    (frm.doc.agency_process_details || []).forEach(row => {
-                        existing_processes[row.process_name] = row;
-                    });
-                    
-                    frm.clear_table("agency_process_details");
-                    
-                    $.each(agency_doc.agency_process_details, function(index, source_row){
-                        var d = frm.add_child("agency_process_details");
-                        // Copy baseline structure from Agency Process
-                        d.process_name = source_row.process_name;
-                        d.responsible = source_row.responsible;
-                        d.duration_in_days = source_row.duration_in_days;
-                        d.attachment_required = source_row.attachment_required;
-                        d.notes_required = source_row.notes_required;
-                        d.reference_type = source_row.reference_type;
-                        d.reference_complete_status_field = source_row.reference_complete_status_field;
-                        d.reference_complete_status_value = source_row.reference_complete_status_value;
-                        if (frm.doc.start_date && source_row.duration_in_days) {
-                            d.expected_date = frappe.datetime.add_days(frm.doc.start_date, source_row.duration_in_days);
-                        }
-                        
-                        // Restore previous progress if the row already existed
-                        if (existing_processes[source_row.process_name]) {
-                            var old_row = existing_processes[source_row.process_name];
-                            d.status = old_row.status;
-                            d.actual_date = old_row.actual_date;
-                            d.notes = old_row.notes;
-                            d.reference_name = old_row.reference_name;
-                        }
-                    });
-                    
-                    frm.refresh_field("agency_process_details");
-                    frappe.msgprint(__("Successfully synced. The table has been updated with the correct 11 rows. Please hit Save!"));
-                });
-            });
-        });
+    setup_inline_status_filter(frm);
+
+    // Hide Seq Type column — defined per-row, not needed in grid view
+    if (frm.fields_dict['agency_process_details']) {
+      frm.fields_dict['agency_process_details'].grid.set_column_disp('sequence_type', false);
+    }
+
+    if (!frm.is_new()) {
+      // ── "Apply Visa" button: manually trigger PAM Visa creation ──
+      add_apply_visa_button(frm);
+
+      // ── "Open Record" link on each child row that has reference_name ──
+      setup_open_record_links(frm);
     }
   }
 });
+
+frappe.ui.form.on('Candidate Country Process Details', {
+  // ── Expanded row edit form: filter status options ──
+  form_render: function(frm, cdt, cdn) {
+    var row = locals[cdt][cdn];
+    var options = STATUS_MAP[row.process_name] || ["Pending", "In Process", "Completed"];
+    var grid_row = frm.fields_dict.agency_process_details.grid.grid_rows_by_docname[cdn];
+    if (grid_row && grid_row.grid_form) {
+      var status_field = grid_row.grid_form.fields_dict.status;
+      if (status_field) {
+        status_field.df.options = options.join('\n');
+        status_field.refresh();
+      }
+    }
+  },
+
+  // ── Validate status on change ──
+  status: function(frm, cdt, cdn) {
+    var row = locals[cdt][cdn];
+    var allowed = STATUS_MAP[row.process_name];
+    if (allowed && !allowed.includes(row.status)) {
+      frappe.msgprint({
+        title: __('Invalid Status'),
+        message: __('"{0}" is not valid for {1}. Allowed: {2}',
+          [row.status, row.process_name, allowed.join(', ')]),
+        indicator: 'red'
+      });
+      frappe.model.set_value(cdt, cdn, 'status', 'Pending');
+    }
+  }
+});
+
+// ── Inline grid: intercept click on status cell and filter <select> options ──
+var setup_inline_status_filter = function(frm) {
+  var grid = frm.fields_dict.agency_process_details;
+  if (!grid || !grid.grid || !grid.grid.wrapper) return;
+
+  grid.grid.wrapper.off('click.status_filter').on('click.status_filter',
+    '.frappe-control[data-fieldname="status"]', function() {
+      var $cell = $(this);
+      var $row = $cell.closest('.rows .frappe-control').length
+        ? $cell.closest('[data-name]')
+        : $cell.closest('.grid-row');
+      if (!$row.length) {
+        $row = $cell.closest('[data-name]');
+      }
+      var docname = $row.attr('data-name');
+      if (!docname) return;
+
+      var row_data = locals['Candidate Country Process Details'][docname];
+      if (!row_data) return;
+
+      var allowed = STATUS_MAP[row_data.process_name]
+        || ["Pending", "In Process", "Completed"];
+
+      // Wait for Frappe to render the <select>, then filter it
+      setTimeout(function() {
+        var $select = $cell.find('select');
+        if (!$select.length) return;
+
+        var current_val = $select.val();
+        $select.find('option').each(function() {
+          var opt_val = $(this).val();
+          if (opt_val && !allowed.includes(opt_val)) {
+            $(this).remove();
+          }
+        });
+        // Restore current value if still valid
+        if (allowed.includes(current_val)) {
+          $select.val(current_val);
+        }
+      }, 50);
+    }
+  );
+};
 
 var set_country_process_details = function(frm) {
   if(frm.doc.agency_country_process){
@@ -67,38 +120,19 @@ var set_country_process_details = function(frm) {
         d.process_name = row.process_name;
         d.responsible = row.responsible;
         d.duration_in_days = row.duration_in_days;
+        d.before_task = row.before_task || '';
+        d.sequence_type = row.sequence_type || 'Sequential';
+        d.after_task = row.after_task || '';
         d.attachment_required = row.attachment_required;
         d.notes_required = row.notes_required;
         d.reference_type = row.reference_type;
         d.reference_complete_status_field = row.reference_complete_status_field;
-				d.reference_complete_status_value = row.reference_complete_status_value;
-        d.expected_date = frappe.datetime.add_days(frm.doc.start_date, row.duration_in_days);
+        d.reference_complete_status_value = row.reference_complete_status_value;
       });
-      frm.refresh_field("agency_process_details");
       
-      if (frm.doc.start_date && agency_country_process.total_duration) {
-          frm.set_value('planned_eta', frappe.datetime.add_days(frm.doc.start_date, agency_country_process.total_duration));
-          frm.set_value('live_plan_eta', frm.doc.planned_eta);
-      }
+      frm.refresh_field("agency_process_details");
     });
   }
-};
-
-var calculate_live_plan_eta = function(frm) {
-    if (!frm.doc.planned_eta) return;
-    
-    var total_delay = 0;
-    (frm.doc.agency_process_details || []).forEach(row => {
-        if (row.actual_date && row.expected_date) {
-            var delay_days = frappe.datetime.get_day_diff(row.actual_date, row.expected_date);
-            total_delay += delay_days;
-        }
-    });
-    
-    var new_live_eta = frappe.datetime.add_days(frm.doc.planned_eta, total_delay);
-    if (frm.doc.live_plan_eta !== new_live_eta) {
-        frm.set_value('live_plan_eta', new_live_eta);
-    }
 };
 
 var candidate_country_process_flow_btn = function(frm) {
@@ -129,4 +163,109 @@ var candidate_country_process_flow_btn = function(frm) {
       }
     });
   }
+};
+
+// ── "Apply Visa" button: manually create a PAM Visa from the tracker ─────────
+var add_apply_visa_button = function(frm) {
+  // Find the Visa Processing row
+  var visa_row = (frm.doc.agency_process_details || []).find(function(r) {
+    return r.process_name === "Visa Processing";
+  });
+
+  if (!visa_row) return;
+
+  // Only show button if no PAM Visa is linked yet
+  if (visa_row.reference_name) {
+    // Already linked — show "Open PAM Visa" instead
+    frm.add_custom_button(__('Open PAM Visa'), function() {
+      frappe.set_route('Form', 'PAM Visa', visa_row.reference_name);
+    }, __('Visa'));
+  } else {
+    // Check if Job Offer is accepted (prerequisite)
+    var jo_row = (frm.doc.agency_process_details || []).find(function(r) {
+      return r.process_name === "Job Offer Issuance";
+    });
+    var jo_done = jo_row && jo_row.status === "Offer Accepted";
+
+    if (jo_done) {
+      frm.add_custom_button(__('Apply Visa'), function() {
+        frappe.confirm(
+          __('Create a new PAM Visa application for <b>{0}</b>?', [frm.doc.candidate_name]),
+          function() {
+            frappe.call({
+              method: 'frappe.client.save',
+              args: {
+                doc: {
+                  doctype: 'PAM Visa',
+                  candidate_country_process: frm.doc.name
+                }
+              },
+              freeze: true,
+              freeze_message: __('Creating PAM Visa...'),
+              callback: function(r) {
+                if (r.message) {
+                  // Update the tracker row with the reference
+                  frappe.model.set_value(
+                    visa_row.doctype, visa_row.name,
+                    'reference_name', r.message.name
+                  );
+                  frm.dirty();
+                  frm.save().then(function() {
+                    frappe.show_alert({
+                      message: __('PAM Visa {0} created', [r.message.name]),
+                      indicator: 'green'
+                    });
+                    frappe.set_route('Form', 'PAM Visa', r.message.name);
+                  });
+                }
+              }
+            });
+          }
+        );
+      }, __('Visa'));
+
+      // Highlight the button in primary color
+      frm.change_custom_button_type(__('Apply Visa'), __('Visa'), 'primary');
+    }
+  }
+};
+
+// ── "Open Record" links: clickable reference_name in child rows ──────────────
+var setup_open_record_links = function(frm) {
+  var grid = frm.fields_dict.agency_process_details;
+  if (!grid || !grid.grid || !grid.grid.wrapper) return;
+
+  // Use event delegation — intercept clicks on the reference_name column
+  grid.grid.wrapper.off('click.open_record').on('click.open_record',
+    '.frappe-control[data-fieldname="reference_name"]', function(e) {
+      var $cell = $(this);
+      var $row = $cell.closest('[data-name]');
+      var docname = $row.attr('data-name');
+      if (!docname) return;
+
+      var row_data = locals['Candidate Country Process Details'][docname];
+      if (!row_data || !row_data.reference_type || !row_data.reference_name) return;
+
+      e.stopPropagation();
+      e.preventDefault();
+      frappe.set_route('Form', row_data.reference_type, row_data.reference_name);
+    }
+  );
+
+  // Style the reference_name cells as clickable links
+  setTimeout(function() {
+    (frm.doc.agency_process_details || []).forEach(function(row) {
+      if (row.reference_name && row.reference_type) {
+        var $row_el = grid.grid.wrapper.find('[data-name="' + row.name + '"]');
+        var $ref_cell = $row_el.find('.frappe-control[data-fieldname="reference_name"] .static-area');
+        if ($ref_cell.length && !$ref_cell.hasClass('linked')) {
+          $ref_cell.css({
+            'color': 'var(--primary-color, #2490EF)',
+            'cursor': 'pointer',
+            'text-decoration': 'underline'
+          }).addClass('linked');
+        }
+      }
+    });
+  }, 300);
 };

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
@@ -8,7 +8,7 @@ var STATUS_MAP = {
   "Medical Test": ["Pending", "In Process", "Fit", "Unfit", "Passed", "Failed"],
   "Remedical Test": ["Pending", "Skipped", "In Process", "Fit", "Unfit", "Passed", "Failed"],
   "PCC Clearance": ["Pending", "Applied", "Issued", "Rejected"],
-  "Visa Stamping": ["Pending", "Applied", "Issued", "Approved", "Rejected"],
+  "Visa Stamping": ["Pending", "In Progress", "Stamped", "Rejected"],
   "Arrival & Deployment": ["Pending", "Arriving", "Completed"]
 };
 

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
@@ -40,11 +40,11 @@ frappe.ui.form.on('Candidate Country Process', {
       setup_open_record_links(frm);
 
       // ── "Sync Template" button: pull latest updates from template ──
-      frm.add_custom_button(__('Sync Template'), function() {
-        frappe.confirm(__('Are you sure you want to sync this tracker with the latest template changes? This will add new steps and update durations/dependencies while preserving existing progress.'), function() {
+      frm.add_custom_button(__("Sync Template"), function() {
+        frappe.confirm(__("Are you sure you want to sync this tracker with the latest template changes? This will add new steps and update durations/dependencies while preserving existing progress."), function() {
           frm.call({
             doc: frm.doc,
-            method: 'sync_with_template',
+            method: "sync_with_template",
             callback: function() {
               frm.reload_doc();
             }
@@ -91,19 +91,19 @@ var setup_inline_status_filter = function(frm) {
   var grid = frm.fields_dict.agency_process_details;
   if (!grid || !grid.grid || !grid.grid.wrapper) return;
 
-  grid.grid.wrapper.off('click.status_filter').on('click.status_filter',
+  grid.grid.wrapper.off("click.status_filter").on("click.status_filter",
     '.frappe-control[data-fieldname="status"]', function() {
       var $cell = $(this);
-      var $row = $cell.closest('.rows .frappe-control').length
-        ? $cell.closest('[data-name]')
-        : $cell.closest('.grid-row');
+      var $row = $cell.closest(".rows .frappe-control").length
+        ? $cell.closest("[data-name]")
+        : $cell.closest(".grid-row");
       if (!$row.length) {
-        $row = $cell.closest('[data-name]');
+        $row = $cell.closest("[data-name]");
       }
-      var docname = $row.attr('data-name');
+      var docname = $row.attr("data-name");
       if (!docname) return;
 
-      var row_data = locals['Candidate Country Process Details'][docname];
+      var row_data = locals["Candidate Country Process Details"][docname];
       if (!row_data) return;
 
       var allowed = STATUS_MAP[row_data.process_name]
@@ -140,9 +140,9 @@ var set_country_process_details = function(frm) {
         d.process_name = row.process_name;
         d.responsible = row.responsible;
         d.duration_in_days = row.duration_in_days;
-        d.before_task = row.before_task || '';
-        d.sequence_type = row.sequence_type || 'Sequential';
-        d.after_task = row.after_task || '';
+        d.before_task = row.before_task || "";
+        d.sequence_type = row.sequence_type || "Sequential";
+        d.after_task = row.after_task || "";
         d.attachment_required = row.attachment_required;
         d.notes_required = row.notes_required;
         d.reference_type = row.reference_type;
@@ -197,9 +197,9 @@ var add_apply_visa_button = function(frm) {
   // Only show button if no PAM Visa is linked yet
   if (visa_row.reference_name) {
     // Already linked — show "Open PAM Visa" instead
-    frm.add_custom_button(__('Open PAM Visa'), function() {
-      frappe.set_route('Form', 'PAM Visa', visa_row.reference_name);
-    }, __('Visa'));
+    frm.add_custom_button(__("Open PAM Visa"), function() {
+      frappe.set_route("Form", "PAM Visa", visa_row.reference_name);
+    }, __("Visa"));
   } else {
     // Check if Job Offer is accepted (prerequisite)
     var jo_row = (frm.doc.agency_process_details || []).find(function(r) {
@@ -208,44 +208,44 @@ var add_apply_visa_button = function(frm) {
     var jo_done = jo_row && jo_row.status === "Offer Accepted";
 
     if (jo_done) {
-      frm.add_custom_button(__('Apply Visa'), function() {
+      frm.add_custom_button(__("Apply Visa"), function() {
         frappe.confirm(
-          __('Create a new PAM Visa application for <b>{0}</b>?', [frm.doc.candidate_name]),
+          __("Create a new PAM Visa application for <b>{0}</b>?", [frm.doc.candidate_name]),
           function() {
             frappe.call({
-              method: 'frappe.client.save',
+              method: "frappe.client.save",
               args: {
                 doc: {
-                  doctype: 'PAM Visa',
+                  doctype: "PAM Visa",
                   candidate_country_process: frm.doc.name
                 }
               },
               freeze: true,
-              freeze_message: __('Creating PAM Visa...'),
+              freeze_message: __("Creating PAM Visa..."),
               callback: function(r) {
                 if (r.message) {
                   // Update the tracker row with the reference
                   frappe.model.set_value(
                     visa_row.doctype, visa_row.name,
-                    'reference_name', r.message.name
+                    "reference_name", r.message.name
                   );
                   frm.dirty();
                   frm.save().then(function() {
                     frappe.show_alert({
-                      message: __('PAM Visa {0} created', [r.message.name]),
-                      indicator: 'green'
+                      message: __("PAM Visa {0} created", [r.message.name]),
+                      indicator: "green"
                     });
-                    frappe.set_route('Form', 'PAM Visa', r.message.name);
+                    frappe.set_route("Form", "PAM Visa", r.message.name);
                   });
                 }
               }
             });
           }
         );
-      }, __('Visa'));
+      }, __("Visa"));
 
       // Highlight the button in primary color
-      frm.change_custom_button_type(__('Apply Visa'), __('Visa'), 'primary');
+      frm.change_custom_button_type(__("Apply Visa"), __("Visa"), "primary");
     }
   }
 };
@@ -256,19 +256,19 @@ var setup_open_record_links = function(frm) {
   if (!grid || !grid.grid || !grid.grid.wrapper) return;
 
   // Use event delegation — intercept clicks on the reference_name column
-  grid.grid.wrapper.off('click.open_record').on('click.open_record',
+  grid.grid.wrapper.off("click.open_record").on("click.open_record",
     '.frappe-control[data-fieldname="reference_name"]', function(e) {
       var $cell = $(this);
-      var $row = $cell.closest('[data-name]');
-      var docname = $row.attr('data-name');
+      var $row = $cell.closest("[data-name]");
+      var docname = $row.attr("data-name");
       if (!docname) return;
 
-      var row_data = locals['Candidate Country Process Details'][docname];
+      var row_data = locals["Candidate Country Process Details"][docname];
       if (!row_data || !row_data.reference_type || !row_data.reference_name) return;
 
       e.stopPropagation();
       e.preventDefault();
-      frappe.set_route('Form', row_data.reference_type, row_data.reference_name);
+      frappe.set_route("Form", row_data.reference_type, row_data.reference_name);
     }
   );
 
@@ -278,12 +278,12 @@ var setup_open_record_links = function(frm) {
       if (row.reference_name && row.reference_type) {
         var $row_el = grid.grid.wrapper.find('[data-name="' + row.name + '"]');
         var $ref_cell = $row_el.find('.frappe-control[data-fieldname="reference_name"] .static-area');
-        if ($ref_cell.length && !$ref_cell.hasClass('linked')) {
+        if ($ref_cell.length && !$ref_cell.hasClass("linked")) {
           $ref_cell.css({
-            'color': 'var(--primary-color, #2490EF)',
-            'cursor': 'pointer',
-            'text-decoration': 'underline'
-          }).addClass('linked');
+            "color": "var(--primary-color, #2490EF)",
+            "cursor": "pointer",
+            "text-decoration": "underline"
+          }).addClass("linked");
         }
       }
     });

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
@@ -3,7 +3,7 @@
 
 // ── Status options per process name ──────────────────────────────────────────
 var STATUS_MAP = {
-  "Job Offer Issuance": ["Pending", "Awaiting Response", "Accepted", "Offer Accepted", "Rejected"],
+  "Job Offer Issuance": ["Pending", "Offer Accepted", "Rejected"],
   "Visa Processing": [
     "Pending", "Draft", "Pending Initial Review", "Pending GRD Manager Approval",
     "Pending By PAM", "Pending By MOI", "Pending Visa", "Completed",
@@ -12,11 +12,11 @@ var STATUS_MAP = {
     "Rejected By Operator", "Rejected By PAM", "Rejected By MOI",
     "Rejected for Re Issue", "Canceled"
   ],
-  "Medical Test": ["Pending", "Yet to apply", "In process", "In Process", "Fit", "Unfit", "Passed", "Failed", "Medical failed and Proceeded to Remedical"],
-  "Remedical Test": ["Pending", "Skipped", "Yet to apply", "In process", "In Process", "Fit", "Unfit", "Passed", "Failed"],
+  "Medical Test": ["Pending", "In Process", "Fit", "Unfit", "Passed", "Failed"],
+  "Remedical Test": ["Pending", "Skipped", "In Process", "Fit", "Unfit", "Passed", "Failed"],
   "PCC Clearance": ["Pending", "Applied", "Issued", "Rejected"],
   "Visa Stamping": ["Pending", "In Progress", "Stamped", "Rejected"],
-  "Arrival & Deployment": ["Pending", "Arriving", "Joined", "Completed", "Deployed", "Did Not Arrive"]
+  "Arrival & Deployment": ["Pending", "Arriving", "Completed"]
 };
 
 frappe.ui.form.on('Candidate Country Process', {

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
@@ -4,7 +4,14 @@
 // ── Status options per process name ──────────────────────────────────────────
 var STATUS_MAP = {
   "Job Offer Issuance": ["Pending", "Offer Accepted", "Rejected"],
-  "Visa Processing": ["Pending", "Applied", "Issued", "Rejected"],
+  "Visa Processing": [
+    "Pending", "Draft", "Pending Initial Review", "Pending GRD Manager Approval",
+    "Pending By PAM", "Pending By MOI", "Pending Visa", "Completed",
+    "Pending Recruiter Confirmation", "Rejected", "Awaiting Quota Availability",
+    "Pending Visa Cancel", "Pending Visa Request Cancel", "Pending Cancel Work Permit",
+    "Rejected By Operator", "Rejected By PAM", "Rejected By MOI",
+    "Rejected for Re Issue", "Canceled"
+  ],
   "Medical Test": ["Pending", "In Process", "Fit", "Unfit", "Passed", "Failed"],
   "Remedical Test": ["Pending", "Skipped", "In Process", "Fit", "Unfit", "Passed", "Failed"],
   "PCC Clearance": ["Pending", "Applied", "Issued", "Rejected"],

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
@@ -3,7 +3,7 @@
 
 // ── Status options per process name ──────────────────────────────────────────
 var STATUS_MAP = {
-  "Job Offer Issuance": ["Pending", "Offer Accepted", "Rejected"],
+  "Job Offer Issuance": ["Pending", "Awaiting Response", "Accepted", "Offer Accepted", "Rejected"],
   "Visa Processing": [
     "Pending", "Draft", "Pending Initial Review", "Pending GRD Manager Approval",
     "Pending By PAM", "Pending By MOI", "Pending Visa", "Completed",
@@ -12,11 +12,11 @@ var STATUS_MAP = {
     "Rejected By Operator", "Rejected By PAM", "Rejected By MOI",
     "Rejected for Re Issue", "Canceled"
   ],
-  "Medical Test": ["Pending", "In Process", "Fit", "Unfit", "Passed", "Failed"],
-  "Remedical Test": ["Pending", "Skipped", "In Process", "Fit", "Unfit", "Passed", "Failed"],
+  "Medical Test": ["Pending", "Yet to apply", "In process", "In Process", "Fit", "Unfit", "Passed", "Failed", "Medical failed and Proceeded to Remedical"],
+  "Remedical Test": ["Pending", "Skipped", "Yet to apply", "In process", "In Process", "Fit", "Unfit", "Passed", "Failed"],
   "PCC Clearance": ["Pending", "Applied", "Issued", "Rejected"],
   "Visa Stamping": ["Pending", "In Progress", "Stamped", "Rejected"],
-  "Arrival & Deployment": ["Pending", "Arriving", "Completed"]
+  "Arrival & Deployment": ["Pending", "Arriving", "Joined", "Completed", "Deployed", "Did Not Arrive"]
 };
 
 frappe.ui.form.on('Candidate Country Process', {

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.js
@@ -31,6 +31,19 @@ frappe.ui.form.on('Candidate Country Process', {
 
       // ── "Open Record" link on each child row that has reference_name ──
       setup_open_record_links(frm);
+
+      // ── "Sync Template" button: pull latest updates from template ──
+      frm.add_custom_button(__('Sync Template'), function() {
+        frappe.confirm(__('Are you sure you want to sync this tracker with the latest template changes? This will add new steps and update durations/dependencies while preserving existing progress.'), function() {
+          frm.call({
+            doc: frm.doc,
+            method: 'sync_with_template',
+            callback: function() {
+              frm.reload_doc();
+            }
+          });
+        });
+      });
     }
   }
 });

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "autoname": "CCP.###",
- "creation": "2020-06-05 01:26:03.735490",
+ "creation": "2026-04-12 22:09:12.534708",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -20,15 +20,12 @@
   "current_process_id",
   "section_break_3",
   "agency_process_details",
-  "section_break_eta",
+  "amended_from",
   "planned_eta",
-  "column_break_eta",
-  "live_plan_eta",
-  "amended_from"
+  "live_plan_eta"
  ],
  "fields": [
   {
-   "fetch_from": "job_offer.agency",
    "fieldname": "agency",
    "fieldtype": "Link",
    "label": "Agency",
@@ -54,13 +51,12 @@
    "read_only": 1
   },
   {
-   "default": "Pending",
+   "default": "In Process",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Pending\nIn Process\nApproved\nRejected\nFailed\nJoined\nDid Not Arrive",
-   "read_only": 1
+   "options": "In Process\nArriving\nJoined\nMedically unfit\nTasreeh Cancelled\nPCC Failed\nVisa Issuance Blocker\nCandidate Dropped Offer\nCountry Ban\non Hold"
   },
   {
    "fetch_from": "agency.agency",
@@ -137,30 +133,44 @@
    "label": "Current Process ID"
   },
   {
-   "fieldname": "section_break_eta",
-   "fieldtype": "Section Break",
-   "label": "ETA Tracking"
-  },
-  {
    "fieldname": "planned_eta",
    "fieldtype": "Date",
-   "label": "Planned ETA",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_eta",
-   "fieldtype": "Column Break"
+   "label": "Planned ETA"
   },
   {
    "fieldname": "live_plan_eta",
    "fieldtype": "Date",
-   "label": "Live Plan ETA",
-   "read_only": 1
+   "label": "Live Plan ETA"
   }
  ],
- "is_submittable": 1,
- "links": [],
- "modified": "2020-08-23 13:05:46.850075",
+ "links": [
+  {
+   "group": "Medical",
+   "link_doctype": "Overseas Medical Appointment WAFID",
+   "link_fieldname": "candidate_country_process"
+  },
+  {
+   "group": "Medical",
+   "link_doctype": "Overseas Remedical",
+   "link_fieldname": "candidate_country_process"
+  },
+  {
+   "group": "Clearance",
+   "link_doctype": "PCC Clearance",
+   "link_fieldname": "candidate_country_process"
+  },
+  {
+   "group": "Clearance",
+   "link_doctype": "Visa Stamping",
+   "link_fieldname": "candidate_country_process"
+  },
+  {
+   "group": "Deployment",
+   "link_doctype": "Arrival and Deployment",
+   "link_fieldname": "candidate_country_process"
+  }
+ ],
+ "modified": "2026-04-15 13:26:49.188583",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Candidate Country Process",
@@ -177,9 +187,55 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR User",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Recruitment Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agency"
   }
  ],
+ "row_format": "Dynamic",
+ "search_fields": "candidate_name,passport_number",
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
+ "title_field": "candidate_name",
  "track_changes": 1
 }

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
@@ -164,6 +164,11 @@
   },
   {
    "group": "Clearance",
+   "link_doctype": "PAM Visa",
+   "link_fieldname": "candidate_country_process"
+  },
+  {
+   "group": "Clearance",
    "link_doctype": "PCC Clearance",
    "link_fieldname": "candidate_country_process"
   },

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "job_offer",
+  "job_opening",
   "job_applicant",
   "candidate_name",
   "passport_number",
@@ -92,6 +93,13 @@
    "in_list_view": 1,
    "label": "Job Offer",
    "options": "Job Offer"
+  },
+  {
+   "fieldname": "job_opening",
+   "fieldtype": "Link",
+   "label": "Job Opening",
+   "options": "Job Opening",
+   "read_only": 1
   },
   {
    "fetch_from": "job_offer.job_applicant",

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -449,30 +449,29 @@ def update_candidate_country_process():
                 if not ccp.reference_name:
                     frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'reference_name', process_doc.name)
 
-                if ccp.reference_type == "Visa Request":
-                    wf_state = process_doc.get(ccp.reference_complete_status_field or "workflow_state")
-                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', wf_state)
-                    if wf_state == ccp.reference_complete_status_value or wf_state in ["Rejected", "Rejected By Operator", "Rejected By PAM", "Rejected By MOI", "Rejected for Re Issue", "Canceled"]:
-                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
-                else:
-                    if process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value:
-                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', 'Approved')
+                ref_status_field = ccp.reference_complete_status_field or ("workflow_state" if ccp.reference_type == "Visa Request" else "status")
+                ref_status = process_doc.get(ref_status_field)
+                if ref_status:
+                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', ref_status)
+                    
+                    is_completed = (ref_status == ccp.reference_complete_status_value)
+                    is_rejected = ref_status in [
+                        "Rejected", "Rejected By Operator", "Rejected By PAM", "Rejected By MOI",
+                        "Rejected for Re Issue", "Canceled", "Cancelled", "Unfit", "Failed",
+                        "Medical failed and Proceeded to Remedical", "Did Not Arrive"
+                    ]
+                    
+                    if is_completed or is_rejected:
                         frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
 
-                is_completed = False
-                if ccp.reference_type == "Visa Request":
-                    is_completed = (process_doc.get(ccp.reference_complete_status_field or "workflow_state") == ccp.reference_complete_status_value)
-                else:
-                    is_completed = (process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value)
-
-                if is_completed:
-                    ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
-                    if len(ccp_doc.agency_process_details) > ccp.idx:
-                        for process_list in ccp_doc.agency_process_details:
-                            if process_list.idx > ccp.idx and process_list.reference_type:
-                                ccp_doc.db_set('current_process_id', process_list.name)
-                                break
-                    ccp_doc.save(ignore_permissions=True)
+                    if is_completed:
+                        ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
+                        if len(ccp_doc.agency_process_details) > ccp.idx:
+                            for process_list in ccp_doc.agency_process_details:
+                                if process_list.idx > ccp.idx and process_list.reference_type:
+                                    ccp_doc.db_set('current_process_id', process_list.name)
+                                    break
+                        ccp_doc.save(ignore_permissions=True)
 
 
 def recalculate_ccp_live_eta(ccp_name: str):

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -7,6 +7,181 @@ import frappe
 from frappe.model.document import Document
 
 class CandidateCountryProcess(Document):
+    def validate(self):
+        today = frappe.utils.getdate()
+        rows = self.agency_process_details
+
+        # ── 1. PLANNED DATE: static baseline set once at creation ─────────────
+        # Uses dependency graph (before_task) to compute planned dates.
+        self._compute_planned_dates(rows)
+
+        # ── 2. LIVE PLAN DATE: dynamic cascade using dependency graph ─────────
+        self._compute_live_plan_dates(rows)
+
+        # ── 3. ETA STATUS: planned date vs actual / today ─────────────────────
+        for row in rows:
+            if row.get("status") == "Skipped":
+                row.eta_status = ""
+                continue
+
+            planned = frappe.utils.getdate(row.get("planned_date")) if row.get("planned_date") else None
+            actual  = frappe.utils.getdate(row.actual_date) if row.actual_date else None
+
+            if not actual:
+                if planned and today > planned:
+                    row.eta_status = "Late"
+                else:
+                    row.eta_status = "Still Within Time frame"
+            else:
+                if planned and actual > planned:
+                    row.eta_status = "Late"
+                elif planned and actual < planned:
+                    row.eta_status = "Completed Early"
+                else:
+                    row.eta_status = "Completed on time"
+
+        # ── 4. Mirror Live Plan ETA to header field ───────────────────────────
+        if rows:
+            last = rows[-1]
+            if last.get("live_plan_date"):
+                self.live_plan_eta = last.live_plan_date
+            elif last.get("planned_date"):
+                self.live_plan_eta = last.planned_date
+
+    def _compute_planned_dates(self, rows):
+        """
+        Compute planned_date for each row based on the dependency graph.
+        Only fills in rows that don't yet have a planned_date (first save).
+
+        For rows with before_task dependencies:
+          - Sequential: starts after the latest before_task planned_date
+          - Parallel: starts at the same time as other parallel tasks
+                      sharing the same before_task
+        """
+        if not self.start_date:
+            return
+
+        start = frappe.utils.getdate(self.start_date)
+        row_map = {r.process_name: r for r in rows}
+
+        for row in rows:
+            if row.get("planned_date"):
+                continue  # Already set
+
+            if row.duration_in_days is None:
+                continue
+
+            anchor = self._get_dependency_anchor(row, row_map, "planned_date", start)
+            if anchor:
+                row.planned_date = frappe.utils.add_days(anchor, row.duration_in_days)
+
+    def _compute_live_plan_dates(self, rows):
+        """
+        Compute live_plan_date for each row based on actual completion
+        dates of dependencies (falls back to live_plan_date, then planned_date).
+        """
+        if not self.start_date:
+            return
+
+        start = frappe.utils.getdate(self.start_date)
+        row_map = {r.process_name: r for r in rows}
+
+        for row in rows:
+            if row.get("status") == "Skipped":
+                row.live_plan_date = None
+                continue
+
+            if row.duration_in_days is None:
+                continue
+
+            anchor = self._get_dependency_anchor_live(row, row_map, start)
+            if anchor:
+                row.live_plan_date = frappe.utils.add_days(anchor, row.duration_in_days)
+
+    def _get_dependency_anchor(self, row, row_map, date_field, default_start):
+        """
+        Get the anchor date for planned_date computation.
+
+        If before_task is set, returns the MAX of all before_task planned_dates.
+        If no before_task, returns default_start for the first task,
+        or the previous row's planned_date for sequential flow.
+        """
+        before_tasks = self._parse_task_list(row.get("before_task"))
+
+        if not before_tasks:
+            # First task in the chain — use start_date
+            return default_start
+
+        # Get the latest planned_date among all before_tasks
+        max_date = None
+        for task_name in before_tasks:
+            dep_row = row_map.get(task_name)
+            if not dep_row:
+                continue
+            dep_date = frappe.utils.getdate(dep_row.get(date_field)) if dep_row.get(date_field) else None
+            if dep_date and (max_date is None or dep_date > max_date):
+                max_date = dep_date
+
+        return max_date or default_start
+
+    def _get_dependency_anchor_live(self, row, row_map, default_start):
+        """
+        Get the anchor date for live_plan_date computation.
+
+        Uses actual_date if available, falls back to live_plan_date,
+        then planned_date of dependency tasks.
+        For parallel tasks sharing the same before_task, they all start
+        from the same anchor (the before_task's completion).
+        """
+        before_tasks = self._parse_task_list(row.get("before_task"))
+
+        if not before_tasks:
+            return default_start
+
+        # Get the latest effective date among all before_tasks
+        max_date = None
+        for task_name in before_tasks:
+            dep_row = row_map.get(task_name)
+            if not dep_row:
+                continue
+
+            # Skip dependencies that are Skipped
+            if dep_row.get("status") == "Skipped":
+                continue
+
+            # Prefer actual_date > live_plan_date > planned_date
+            dep_date = None
+            if dep_row.actual_date:
+                dep_date = frappe.utils.getdate(dep_row.actual_date)
+            elif dep_row.get("live_plan_date"):
+                dep_date = frappe.utils.getdate(dep_row.live_plan_date)
+            elif dep_row.get("planned_date"):
+                dep_date = frappe.utils.getdate(dep_row.planned_date)
+
+            if dep_date and (max_date is None or dep_date > max_date):
+                max_date = dep_date
+
+        return max_date or default_start
+
+    @staticmethod
+    def _parse_task_list(task_str):
+        """Parse a comma-separated task list into a list of stripped task names."""
+        if not task_str:
+            return []
+        return [t.strip() for t in task_str.split(",") if t.strip()]
+
+    def autoname(self):
+        if not self.candidate_name and self.job_applicant:
+            self.candidate_name = frappe.db.get_value('Job Applicant', self.job_applicant, 'applicant_name')
+
+        if self.candidate_name and self.job_offer:
+            self.name = f"{self.candidate_name} - {self.job_offer}"
+        elif self.candidate_name:
+            self.name = self.candidate_name
+        else:
+            from frappe.model.naming import make_autoname
+            self.name = make_autoname('CCP-#####')
+
     def after_insert(self):
         if self.agency_process_details:
             for agency_process_details in self.agency_process_details:
@@ -15,28 +190,135 @@ class CandidateCountryProcess(Document):
                     self.db_set('current_process_id', agency_process_details.name)
                     break
 
+    def on_update(self):
+        """Auto-create linked DocType records when a step reaches its trigger status."""
+        if getattr(self.flags, '_in_auto_create', False):
+            return
+        self.flags._in_auto_create = True
+        try:
+            self._auto_create_next_records()
+        finally:
+            self.flags._in_auto_create = False
+
+    def _auto_create_next_records(self):
+        """
+        Data-driven trigger logic using before_task / after_task dependencies.
+
+        When a task's status matches its reference_complete_status_value,
+        find all tasks whose before_task includes this task and auto-create
+        their linked records — but only if ALL of their before_task
+        dependencies are also complete.
+        """
+        rows = self.agency_process_details
+        if not rows:
+            return
+
+        row_map = {r.process_name: r for r in rows}
+
+        for row in rows:
+            # Check if this row is "complete" per its configured status
+            if not row.reference_complete_status_value:
+                continue
+            if row.status != row.reference_complete_status_value:
+                continue
+
+            # This task is complete — find tasks that depend on it (after_task)
+            after_tasks = self._parse_task_list(row.get("after_task"))
+            for target_name in after_tasks:
+                target_row = row_map.get(target_name)
+                if not target_row or not target_row.reference_type:
+                    continue
+
+                # Skip if record already exists
+                if target_row.reference_name:
+                    continue
+
+                # Check ALL before_task dependencies of the target are complete
+                if not self._all_dependencies_met(target_row, row_map):
+                    continue
+
+                new_doc = self._create_linked_record(target_row)
+                if new_doc:
+                    target_row.reference_name = new_doc.name
+                    target_row.db_set("reference_name", new_doc.name, update_modified=False)
+
+    def _all_dependencies_met(self, target_row, row_map):
+        """
+        Check if ALL before_task dependencies of target_row are complete.
+        A dependency is "met" when its status matches its reference_complete_status_value,
+        or it is Skipped.
+        """
+        before_tasks = self._parse_task_list(target_row.get("before_task"))
+        if not before_tasks:
+            return True  # No dependencies — always ready
+
+        for dep_name in before_tasks:
+            dep_row = row_map.get(dep_name)
+            if not dep_row:
+                continue  # Missing dependency row — skip
+
+            # Skipped counts as met
+            if dep_row.get("status") == "Skipped":
+                continue
+
+            # Check if the dependency has reached its completion status
+            if dep_row.reference_complete_status_value:
+                if dep_row.status != dep_row.reference_complete_status_value:
+                    return False  # This dependency is not yet complete
+            else:
+                # No completion status configured — check if it has an actual_date
+                if not dep_row.actual_date:
+                    return False
+
+        return True
+
+    def _create_linked_record(self, row):
+        """Create a new record of the linked DocType for this process step."""
+        doctype = row.reference_type
+        if not doctype:
+            return None
+
+        meta = frappe.get_meta(doctype)
+
+        # Skip DocTypes that don't have candidate_country_process link
+        if not meta.has_field("candidate_country_process"):
+            return None
+
+        # Build the new document with candidate_country_process link
+        try:
+            new_doc = frappe.new_doc(doctype)
+            new_doc.candidate_country_process = self.name
+
+            # Map common fields if they exist on the target DocType
+            field_map = {
+                "candidate_name": self.candidate_name,
+                "passport_number": self.passport_number,
+            }
+            for field, value in field_map.items():
+                if meta.has_field(field) and value:
+                    new_doc.set(field, value)
+
+            new_doc.flags.ignore_permissions = True
+            new_doc.flags.ignore_mandatory = True
+            new_doc.insert(ignore_permissions=True)
+
+            frappe.msgprint(
+                f"Auto-created {doctype}: <b>{new_doc.name}</b>",
+                indicator="green",
+                alert=True,
+            )
+            return new_doc
+
+        except Exception as e:
+            frappe.log_error(
+                f"Failed to auto-create {doctype} for {self.name}: {e}",
+                "CCP Auto-Create Error"
+            )
+            return None
+
     def on_submit(self):
         pass
 
-    def on_update(self):
-        self.calculate_live_plan_eta()
-
-    def calculate_live_plan_eta(self):
-        if not self.planned_eta:
-            return
-
-        total_delay = 0
-        if self.agency_process_details:
-            for row in self.agency_process_details:
-                if row.actual_date and row.expected_date:
-                    delay_days = frappe.utils.date_diff(row.actual_date, row.expected_date)
-                    total_delay += delay_days
-
-        new_live_eta = frappe.utils.add_days(self.planned_eta, total_delay)
-        if self.live_plan_eta != new_live_eta:
-            frappe.db.set_value("Candidate Country Process", self.name, "live_plan_eta", new_live_eta, update_modified=False)
-
-    @frappe.whitelist()
     def get_workflow(self):
         workflow_list = []
         if self.agency_process_details:
@@ -48,60 +330,40 @@ class CandidateCountryProcess(Document):
                         workflow_list.append({"new_doc": True, "doctype": workflow.reference_type})
         return workflow_list
 
+
 def update_candidate_country_process():
     query = """
         select
             dt.name as dt_name, ccp.name as ccp_name, dt.process_name, dt.reference_type, dt.reference_name,
-            dt.reference_complete_status_value, dt.reference_complete_status_field, dt.idx
+            dt.reference_complete_status_value, dt.reference_complete_status_field, dt.idx, dt.planned_date
         from
             `tabCandidate Country Process` ccp, `tabCandidate Country Process Details` dt
         where
             ccp.current_process_id=dt.name
     """
     ccp_list = frappe.db.sql(query, as_dict=True)
+    today = frappe.utils.getdate()
+
     for ccp in ccp_list:
+        delay = 0
+        if ccp.planned_date and today > ccp.planned_date:
+            delay = (today - ccp.planned_date).days
+
         if ccp.reference_type and ccp.ccp_name:
             process_doc = frappe.get_doc(ccp.reference_type, {'candidate_country_process': ccp.ccp_name})
             if process_doc:
                 if not ccp.reference_name:
                     frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'reference_name', process_doc.name)
+
                 if process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value:
                     frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', 'Approved')
+                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
+
                     ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
-                    if len(ccp_doc.agency_process_details) > ccp.idx+1:
+
+                    if len(ccp_doc.agency_process_details) > ccp.idx:
                         for process_list in ccp_doc.agency_process_details:
                             if process_list.idx > ccp.idx and process_list.reference_type:
                                 ccp_doc.db_set('current_process_id', process_list.name)
                                 break
-
-def recalculate_ccp_live_eta(ccp_name: str):
-    """Recalculate live ETA directly from child table data.
-    
-    Called by child DocType controllers (WAFID, PCC, etc.) after
-    updating their tracker status. Uses direct DB reads and writes
-    to avoid loading/saving the full CCP document.
-    """
-    planned_eta = frappe.db.get_value("Candidate Country Process", ccp_name, "planned_eta")
-    if not planned_eta:
-        return
-
-    CCP_Detail = frappe.qb.DocType("Candidate Country Process Details")
-    details = (
-        frappe.qb.from_(CCP_Detail)
-        .select(CCP_Detail.actual_date, CCP_Detail.expected_date)
-        .where(CCP_Detail.parent == ccp_name)
-        .where(CCP_Detail.actual_date.isnotnull())
-        .where(CCP_Detail.expected_date.isnotnull())
-    ).run(as_dict=True)
-
-    total_delay = sum(
-        frappe.utils.date_diff(d.actual_date, d.expected_date)
-        for d in details
-    )
-
-    new_eta = frappe.utils.add_days(planned_eta, total_delay)
-    frappe.db.set_value(
-        "Candidate Country Process", ccp_name,
-        "live_plan_eta", new_eta,
-        update_modified=True  # So the CCP shows as recently modified
-    )
+                    ccp_doc.save(ignore_permissions=True)

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -40,9 +40,11 @@ class CandidateCountryProcess(Document):
                 else:
                     row.eta_status = "Completed on time"
 
-        # ── 4. Mirror Live Plan ETA to header field ───────────────────────────
+        # ── 4. Mirror ETAs to header fields ────────────────────────────────────
         if rows:
             last = rows[-1]
+            if last.get("planned_date"):
+                self.planned_eta = last.planned_date
             if last.get("live_plan_date"):
                 self.live_plan_eta = last.live_plan_date
             elif last.get("planned_date"):
@@ -202,7 +204,7 @@ class CandidateCountryProcess(Document):
 
     def _auto_create_next_records(self):
         """
-        Data-driven trigger logic using before_task / after_task dependencies.
+        Data-driven trigger logic using before_task dependencies.
 
         When a task's status matches its reference_complete_status_value,
         find all tasks whose before_task includes this task and auto-create
@@ -222,11 +224,13 @@ class CandidateCountryProcess(Document):
             if row.status != row.reference_complete_status_value:
                 continue
 
-            # This task is complete — find tasks that depend on it (after_task)
-            after_tasks = self._parse_task_list(row.get("after_task"))
-            for target_name in after_tasks:
-                target_row = row_map.get(target_name)
-                if not target_row or not target_row.reference_type:
+            # This task is complete — find tasks that depend on it (by before_task)
+            dependent_rows = [
+                r for r in rows
+                if row.process_name in self._parse_task_list(r.get("before_task"))
+            ]
+            for target_row in dependent_rows:
+                if not target_row.reference_type:
                     continue
 
                 # Skip if record already exists
@@ -255,7 +259,7 @@ class CandidateCountryProcess(Document):
         for dep_name in before_tasks:
             dep_row = row_map.get(dep_name)
             if not dep_row:
-                continue  # Missing dependency row — skip
+                return False  # Missing dependency row — treat as not met
 
             # Skipped counts as met
             if dep_row.get("status") == "Skipped":

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -350,20 +350,73 @@ def update_candidate_country_process():
             delay = (today - ccp.planned_date).days
 
         if ccp.reference_type and ccp.ccp_name:
-            process_doc = frappe.get_doc(ccp.reference_type, {'candidate_country_process': ccp.ccp_name})
+            process_doc = None
+            if ccp.reference_name:
+                try:
+                    process_doc = frappe.get_doc(ccp.reference_type, ccp.reference_name)
+                except frappe.DoesNotExistError:
+                    pass
+            
+            if not process_doc:
+                meta = frappe.get_meta(ccp.reference_type)
+                if meta.has_field("candidate_country_process"):
+                    try:
+                        process_doc = frappe.get_doc(ccp.reference_type, {'candidate_country_process': ccp.ccp_name})
+                    except Exception:
+                        pass
+                elif ccp.reference_type == "Visa Request":
+                    job_offer = frappe.db.get_value("Candidate Country Process", ccp.ccp_name, "job_offer")
+                    if job_offer:
+                        try:
+                            process_doc = frappe.get_doc("Visa Request", {"job_offer": job_offer})
+                        except Exception:
+                            pass
+
             if process_doc:
                 if not ccp.reference_name:
                     frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'reference_name', process_doc.name)
 
-                if process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value:
-                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', 'Approved')
-                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
+                if ccp.reference_type == "Visa Request":
+                    wf_state = process_doc.get(ccp.reference_complete_status_field or "workflow_state")
+                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', wf_state)
+                    if wf_state == ccp.reference_complete_status_value:
+                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
+                else:
+                    if process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value:
+                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', 'Approved')
+                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
 
+                is_completed = False
+                if ccp.reference_type == "Visa Request":
+                    is_completed = (process_doc.get(ccp.reference_complete_status_field or "workflow_state") == ccp.reference_complete_status_value)
+                else:
+                    is_completed = (process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value)
+
+                if is_completed:
                     ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
-
                     if len(ccp_doc.agency_process_details) > ccp.idx:
                         for process_list in ccp_doc.agency_process_details:
                             if process_list.idx > ccp.idx and process_list.reference_type:
                                 ccp_doc.db_set('current_process_id', process_list.name)
                                 break
                     ccp_doc.save(ignore_permissions=True)
+
+
+def recalculate_ccp_live_eta(ccp_name: str):
+    """Recalculate live ETA by loading and saving the CCP document.
+    This triggers validate() which cascades all planned_date and live_plan_date calculations
+    correctly via the dependency graph.
+    """
+    if not ccp_name:
+        return
+    if getattr(frappe.local, "in_ccp_recalculation", False):
+        return
+    frappe.local.in_ccp_recalculation = True
+    try:
+        doc = frappe.get_doc("Candidate Country Process", ccp_name)
+        doc.save(ignore_permissions=True)
+    except Exception as e:
+        frappe.log_error(f"Failed to recalculate CCP live ETA for {ccp_name}: {e}", "CCP Recalculate Error")
+    finally:
+        frappe.local.in_ccp_recalculation = False
+

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -396,7 +396,7 @@ class CandidateCountryProcess(Document):
         # Re-assign child table in correct order and save
         self.agency_process_details = new_details
         self.flags.ignore_mandatory = True
-        self.save(ignore_permissions=True)
+        self.save()
         frappe.msgprint(
             frappe._("Successfully synchronized tracker steps with the latest template changes!"),
             indicator="green",
@@ -405,16 +405,24 @@ class CandidateCountryProcess(Document):
 
 
 def update_candidate_country_process():
-    query = """
-        select
-            dt.name as dt_name, ccp.name as ccp_name, dt.process_name, dt.reference_type, dt.reference_name,
-            dt.reference_complete_status_value, dt.reference_complete_status_field, dt.idx, dt.planned_date
-        from
-            `tabCandidate Country Process` ccp, `tabCandidate Country Process Details` dt
-        where
-            ccp.current_process_id=dt.name
-    """
-    ccp_list = frappe.db.sql(query, as_dict=True)
+    ccp = frappe.qb.DocType("Candidate Country Process")
+    ccpd = frappe.qb.DocType("Candidate Country Process Details")
+    ccp_list = (
+        frappe.qb.from_(ccp)
+        .join(ccpd)
+        .on(ccp.current_process_id == ccpd.name)
+        .select(
+            ccpd.name.as_("dt_name"),
+            ccp.name.as_("ccp_name"),
+            ccpd.process_name,
+            ccpd.reference_type,
+            ccpd.reference_name,
+            ccpd.reference_complete_status_value,
+            ccpd.reference_complete_status_field,
+            ccpd.idx,
+            ccpd.planned_date
+        )
+    ).run(as_dict=True)
     today = frappe.utils.getdate()
 
     for ccp in ccp_list:
@@ -434,7 +442,7 @@ def update_candidate_country_process():
                 meta = frappe.get_meta(ccp.reference_type)
                 if meta.has_field("candidate_country_process"):
                     try:
-                        process_doc = frappe.get_doc(ccp.reference_type, {'candidate_country_process': ccp.ccp_name})
+                        process_doc = frappe.get_doc(ccp.reference_type, {"candidate_country_process": ccp.ccp_name})
                     except Exception:
                         pass
                 elif ccp.reference_type == "Visa Request":
@@ -447,13 +455,13 @@ def update_candidate_country_process():
 
             if process_doc:
                 if not ccp.reference_name:
-                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'reference_name', process_doc.name)
+                    frappe.db.set_value("Candidate Country Process Details", ccp.dt_name, "reference_name", process_doc.name)
 
                 if ccp.reference_type == "Visa Request":
                     ref_status_field = ccp.reference_complete_status_field or "workflow_state"
                     ref_status = process_doc.get(ref_status_field)
                     if ref_status:
-                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', ref_status)
+                        frappe.db.set_value("Candidate Country Process Details", ccp.dt_name, "status", ref_status)
                         
                         is_completed = (ref_status == ccp.reference_complete_status_value)
                         is_rejected = ref_status in [
@@ -462,27 +470,27 @@ def update_candidate_country_process():
                         ]
                         
                         if is_completed or is_rejected:
-                            frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
+                            frappe.db.set_value("Candidate Country Process Details", ccp.dt_name, "actual_date", today)
 
                         if is_completed:
-                            ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
+                            ccp_doc = frappe.get_doc("Candidate Country Process", ccp.ccp_name)
                             if len(ccp_doc.agency_process_details) > ccp.idx:
                                 for process_list in ccp_doc.agency_process_details:
                                     if process_list.idx > ccp.idx and process_list.reference_type:
-                                        ccp_doc.db_set('current_process_id', process_list.name)
+                                        ccp_doc.db_set("current_process_id", process_list.name)
                                         break
                             ccp_doc.save(ignore_permissions=True)
                 else:
                     is_completed = (process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value)
                     if is_completed:
-                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', 'Approved')
-                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
+                        frappe.db.set_value("Candidate Country Process Details", ccp.dt_name, "status", "Approved")
+                        frappe.db.set_value("Candidate Country Process Details", ccp.dt_name, "actual_date", today)
 
-                        ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
+                        ccp_doc = frappe.get_doc("Candidate Country Process", ccp.ccp_name)
                         if len(ccp_doc.agency_process_details) > ccp.idx:
                             for process_list in ccp_doc.agency_process_details:
                                 if process_list.idx > ccp.idx and process_list.reference_type:
-                                    ccp_doc.db_set('current_process_id', process_list.name)
+                                    ccp_doc.db_set("current_process_id", process_list.name)
                                     break
                         ccp_doc.save(ignore_permissions=True)
 

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -334,6 +334,75 @@ class CandidateCountryProcess(Document):
                         workflow_list.append({"new_doc": True, "doctype": workflow.reference_type})
         return workflow_list
 
+    @frappe.whitelist()
+    def sync_with_template(self):
+        """
+        Synchronize the child table rows with the current Agency Country Process template.
+        - Adds missing steps.
+        - Updates duration_in_days, sequence_type, before_task, after_task, responsible,
+          attachment_required, notes_required, reference_type, and status options.
+        - Preserves existing reference_name, actual_date, and completion status.
+        - Recalculates dates and saves.
+        """
+        if not self.agency_country_process:
+            frappe.throw(frappe._("Please select an Agency Country Process template first."))
+
+        acp_doc = frappe.get_doc('Agency Country Process', self.agency_country_process)
+        existing_rows = {row.process_name: row for row in self.agency_process_details}
+
+        # List to hold the synchronized rows in correct template order
+        new_details = []
+
+        for template_row in acp_doc.agency_process_details:
+            if template_row.process_name in existing_rows:
+                # Update existing row settings from template
+                row = existing_rows[template_row.process_name]
+                row.responsible = template_row.responsible
+                row.duration_in_days = template_row.duration_in_days
+                row.parallel_group = frappe.utils.cint(template_row.get("parallel_group") or 0)
+                row.sequence_type = template_row.sequence_type or "Sequential"
+                row.before_task = template_row.before_task or ""
+                row.after_task = template_row.after_task or ""
+                row.attachment_required = template_row.attachment_required
+                row.notes_required = template_row.notes_required
+                row.reference_type = template_row.reference_type
+                row.reference_complete_status_field = template_row.reference_complete_status_field
+                row.reference_complete_status_value = template_row.reference_complete_status_value
+                new_details.append(row)
+            else:
+                # Add new row from template
+                row = self.append("agency_process_details", {})
+                row.process_name = template_row.process_name
+                row.responsible = template_row.responsible
+                row.duration_in_days = template_row.duration_in_days
+                row.parallel_group = frappe.utils.cint(template_row.get("parallel_group") or 0)
+                row.sequence_type = template_row.sequence_type or "Sequential"
+                row.before_task = template_row.before_task or ""
+                row.after_task = template_row.after_task or ""
+                row.attachment_required = template_row.attachment_required
+                row.notes_required = template_row.notes_required
+                row.reference_type = template_row.reference_type
+                row.reference_complete_status_field = template_row.reference_complete_status_field
+                row.reference_complete_status_value = template_row.reference_complete_status_value
+                row.status = "Pending"
+                new_details.append(row)
+
+        # Retain any rows that are NOT in the template but have progress/records linked (to protect data)
+        for name, row in existing_rows.items():
+            if name not in [t.process_name for t in acp_doc.agency_process_details]:
+                if row.reference_name or row.status != "Pending":
+                    new_details.append(row)
+
+        # Re-assign child table in correct order and save
+        self.agency_process_details = new_details
+        self.flags.ignore_mandatory = True
+        self.save(ignore_permissions=True)
+        frappe.msgprint(
+            frappe._("Successfully synchronized tracker steps with the latest template changes!"),
+            indicator="green",
+            alert=True,
+        )
+
 
 def update_candidate_country_process():
     query = """

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -449,8 +449,8 @@ def update_candidate_country_process():
                 if not ccp.reference_name:
                     frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'reference_name', process_doc.name)
 
-                if ccp.reference_type in ["Visa Request", "Visa Stamping"]:
-                    ref_status_field = ccp.reference_complete_status_field or ("workflow_state" if ccp.reference_type == "Visa Request" else "status")
+                if ccp.reference_type == "Visa Request":
+                    ref_status_field = ccp.reference_complete_status_field or "workflow_state"
                     ref_status = process_doc.get(ref_status_field)
                     if ref_status:
                         frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', ref_status)

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -449,22 +449,35 @@ def update_candidate_country_process():
                 if not ccp.reference_name:
                     frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'reference_name', process_doc.name)
 
-                ref_status_field = ccp.reference_complete_status_field or ("workflow_state" if ccp.reference_type == "Visa Request" else "status")
-                ref_status = process_doc.get(ref_status_field)
-                if ref_status:
-                    frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', ref_status)
-                    
-                    is_completed = (ref_status == ccp.reference_complete_status_value)
-                    is_rejected = ref_status in [
-                        "Rejected", "Rejected By Operator", "Rejected By PAM", "Rejected By MOI",
-                        "Rejected for Re Issue", "Canceled", "Cancelled", "Unfit", "Failed",
-                        "Medical failed and Proceeded to Remedical", "Did Not Arrive"
-                    ]
-                    
-                    if is_completed or is_rejected:
+                if ccp.reference_type in ["Visa Request", "Visa Stamping"]:
+                    ref_status_field = ccp.reference_complete_status_field or ("workflow_state" if ccp.reference_type == "Visa Request" else "status")
+                    ref_status = process_doc.get(ref_status_field)
+                    if ref_status:
+                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', ref_status)
+                        
+                        is_completed = (ref_status == ccp.reference_complete_status_value)
+                        is_rejected = ref_status in [
+                            "Rejected", "Rejected By Operator", "Rejected By PAM", "Rejected By MOI",
+                            "Rejected for Re Issue", "Canceled", "Cancelled"
+                        ]
+                        
+                        if is_completed or is_rejected:
+                            frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
+
+                        if is_completed:
+                            ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
+                            if len(ccp_doc.agency_process_details) > ccp.idx:
+                                for process_list in ccp_doc.agency_process_details:
+                                    if process_list.idx > ccp.idx and process_list.reference_type:
+                                        ccp_doc.db_set('current_process_id', process_list.name)
+                                        break
+                            ccp_doc.save(ignore_permissions=True)
+                else:
+                    is_completed = (process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value)
+                    if is_completed:
+                        frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', 'Approved')
                         frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
 
-                    if is_completed:
                         ccp_doc = frappe.get_doc('Candidate Country Process', ccp.ccp_name)
                         if len(ccp_doc.agency_process_details) > ccp.idx:
                             for process_list in ccp_doc.agency_process_details:

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -452,7 +452,7 @@ def update_candidate_country_process():
                 if ccp.reference_type == "Visa Request":
                     wf_state = process_doc.get(ccp.reference_complete_status_field or "workflow_state")
                     frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'status', wf_state)
-                    if wf_state == ccp.reference_complete_status_value:
+                    if wf_state == ccp.reference_complete_status_value or wf_state in ["Rejected", "Rejected By Operator", "Rejected By PAM", "Rejected By MOI", "Rejected for Re Issue", "Canceled"]:
                         frappe.db.set_value('Candidate Country Process Details', ccp.dt_name, 'actual_date', today)
                 else:
                     if process_doc.get(ccp.reference_complete_status_field) == ccp.reference_complete_status_value:

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process_dashboard.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process_dashboard.py
@@ -3,10 +3,10 @@ from frappe import _
 
 def get_data():
     return {
-        # 'fieldname': 'candidate_country_process',
-        # 'transactions': [
-        #     {
-        #         'items': ['PAM Visa']
-        #     }
-        # ],
+        'fieldname': 'candidate_country_process',
+        'transactions': [
+            {"items": ['PAM Visa', 'Overseas Medical Appointment WAFID']},
+            {"items": ['Overseas Remedical', 'PCC Clearance']},
+            {"items": ['Visa Stamping', 'Arrival and Deployment']}
+        ],
     }

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process_dashboard.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process_dashboard.py
@@ -3,10 +3,10 @@ from frappe import _
 
 def get_data():
     return {
-        'fieldname': 'candidate_country_process',
-        'transactions': [
-            {"items": ['PAM Visa', 'Overseas Medical Appointment WAFID']},
-            {"items": ['Overseas Remedical', 'PCC Clearance']},
-            {"items": ['Visa Stamping', 'Arrival and Deployment']}
-        ],
+        # 'fieldname': 'candidate_country_process',
+        # 'transactions': [
+        #     {
+        #         'items': ['PAM Visa']
+        #     }
+        # ],
     }

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process_dashboard.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process_dashboard.py
@@ -2,11 +2,4 @@ from __future__ import unicode_literals
 from frappe import _
 
 def get_data():
-    return {
-        'fieldname': 'candidate_country_process',
-        'transactions': [
-            {"items": ['PAM Visa', 'Overseas Medical Appointment WAFID']},
-            {"items": ['Overseas Remedical', 'PCC Clearance']},
-            {"items": ['Visa Stamping', 'Arrival and Deployment']}
-        ],
-    }
+    return {}

--- a/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
+++ b/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
@@ -123,7 +123,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Pending\nSkipped\nOffer Accepted\nIn Process\nIn Progress\nStamped\nApplied\nIssued\nRejected\nFit\nUnfit\nPassed\nFailed\nSubmitted\nApproved\nArriving\nCompleted\nDraft\nPending Initial Review\nPending GRD Manager Approval\nPending By PAM\nPending By MOI\nPending Visa\nRejected By Operator\nRejected By PAM\nRejected By MOI\nAwaiting Quota Availability\nGRD Finalization\nPending Recruiter Confirmation\nCancelled\nCanceled\nRejected for Re Issue\nPending Visa Cancel\nPending Visa Request Cancel\nPending Cancel Work Permit"
+   "options": "Pending\nSkipped\nOffer Accepted\nAwaiting Response\nAccepted\nYet to apply\nIn process\nIn Process\nIn Progress\nStamped\nApplied\nIssued\nRejected\nFit\nUnfit\nPassed\nFailed\nSubmitted\nApproved\nArriving\nJoined\nCompleted\nDeployed\nDid Not Arrive\nDraft\nPending Initial Review\nPending GRD Manager Approval\nPending By PAM\nPending By MOI\nPending Visa\nRejected By Operator\nRejected By PAM\nRejected By MOI\nAwaiting Quota Availability\nGRD Finalization\nPending Recruiter Confirmation\nCancelled\nCanceled\nRejected for Re Issue\nPending Visa Cancel\nPending Visa Request Cancel\nPending Cancel Work Permit\nMedical failed and Proceeded to Remedical"
   },
   {
    "columns": 2,

--- a/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
+++ b/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
@@ -123,7 +123,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Pending\nSkipped\nOffer Accepted\nIn Process\nApplied\nIssued\nRejected\nFit\nUnfit\nPassed\nFailed\nSubmitted\nApproved\nArriving\nCompleted\nDraft\nPending Initial Review\nPending GRD Manager Approval\nPending By PAM\nPending By MOI\nPending Visa\nRejected By Operator\nRejected By PAM\nRejected By MOI\nAwaiting Quota Availability\nGRD Finalization\nPending Recruiter Confirmation\nCancelled\nCanceled\nRejected for Re Issue\nPending Visa Cancel\nPending Visa Request Cancel\nPending Cancel Work Permit"
+   "options": "Pending\nSkipped\nOffer Accepted\nIn Process\nIn Progress\nStamped\nApplied\nIssued\nRejected\nFit\nUnfit\nPassed\nFailed\nSubmitted\nApproved\nArriving\nCompleted\nDraft\nPending Initial Review\nPending GRD Manager Approval\nPending By PAM\nPending By MOI\nPending Visa\nRejected By Operator\nRejected By PAM\nRejected By MOI\nAwaiting Quota Availability\nGRD Finalization\nPending Recruiter Confirmation\nCancelled\nCanceled\nRejected for Re Issue\nPending Visa Cancel\nPending Visa Request Cancel\nPending Cancel Work Permit"
   },
   {
    "columns": 2,

--- a/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
+++ b/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "creation": "2020-06-05 01:46:54.301541",
+ "creation": "2026-04-12 22:09:08.381357",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -8,12 +8,17 @@
   "process_name",
   "responsible",
   "duration_in_days",
+  "before_task",
+  "sequence_type",
+  "after_task",
   "column_break_4",
-  "expected_date",
+  "planned_date",
+  "live_plan_date",
   "actual_date",
   "reference_complete_status_field",
   "reference_complete_status_value",
   "status",
+  "eta_status",
   "section_break_7",
   "item",
   "amount",
@@ -29,6 +34,7 @@
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "process_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -38,41 +44,99 @@
   {
    "fieldname": "responsible",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "label": "Responsible",
-   "options": "Agency\nRecruiter\nHR\nGeneral Services\nGRD",
+   "options": "Agency\nGRD",
    "read_only": 1
   },
   {
-   "depends_on": "notes_required",
-   "fieldname": "notes",
-   "fieldtype": "Text Editor",
-   "label": "Notes"
+   "fieldname": "duration_in_days",
+   "fieldtype": "Int",
+   "label": "Duration in Days",
+   "read_only": 1
   },
   {
+   "columns": 2,
+   "fieldname": "before_task",
+   "fieldtype": "Data",
+   "label": "Before Task",
+   "read_only": 1,
+   "description": "The task that must complete before this one can start."
+  },
+  {
+   "columns": 1,
+   "default": "Sequential",
+   "fieldname": "sequence_type",
+   "fieldtype": "Select",
+   "label": "Seq Type",
+   "options": "Sequential\nParallel",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "after_task",
+   "fieldtype": "Data",
+   "label": "After Task",
+   "read_only": 1,
+   "description": "The task that starts after this one completes."
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "planned_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Planned Date",
+   "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "live_plan_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Live Plan Date",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
    "fieldname": "actual_date",
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Actual Date"
   },
   {
-   "fieldname": "expected_date",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Expected Date",
-   "read_only": 1
+   "fieldname": "reference_complete_status_field",
+   "fieldtype": "Data",
+   "label": "Reference Complete Status Field"
   },
   {
+   "fieldname": "reference_complete_status_value",
+   "fieldtype": "Data",
+   "label": "Reference Complete Status Value"
+  },
+  {
+   "columns": 2,
    "default": "Pending",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "\nPending\nApproved\nRejected\nFailed\nNot Booked\nAccepted\nRemedical Test Done\nFirst Medical Failed\nStamped\nArriving\nMedical Test Done\nIssued\nFit\nBooked\nYet to apply\nIn process\nUnfit\nCancelled\nSkipped\nMedical failed and Proceeded to Remedical\nCompleted\nDid Not Arrive\nJoined"
+   "options": "Pending\nSkipped\nOffer Accepted\nIn Process\nApplied\nIssued\nRejected\nFit\nUnfit\nPassed\nFailed\nSubmitted\nApproved\nArriving\nCompleted"
   },
   {
-   "fieldname": "column_break_4",
-   "fieldtype": "Column Break"
+   "columns": 2,
+   "fieldname": "eta_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "ETA Status",
+   "options": "\nStill Within Time frame\nLate\nCompleted Early\nCompleted on time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_7",
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "item",
@@ -85,10 +149,6 @@
    "label": "Amount"
   },
   {
-   "fieldname": "section_break_7",
-   "fieldtype": "Section Break"
-  },
-  {
    "depends_on": "eval: doc.amount > 0",
    "fieldname": "proof_of_payment",
    "fieldtype": "Data",
@@ -99,12 +159,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "duration_in_days",
-   "fieldtype": "Int",
-   "label": "Duration in Days",
-   "read_only": 1
-  },
-  {
    "fieldname": "reference_type",
    "fieldtype": "Link",
    "label": "Reference Type",
@@ -113,8 +167,9 @@
   },
   {
    "fieldname": "reference_name",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "label": "Reference Name",
+   "options": "reference_type",
    "read_only": 1
   },
   {
@@ -142,26 +197,24 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "reference_complete_status_field",
-   "fieldtype": "Data",
-   "label": "Reference Complete Status Field"
-  },
-  {
-   "fieldname": "reference_complete_status_value",
-   "fieldtype": "Data",
-   "label": "Reference Complete Status Value"
+   "depends_on": "notes_required",
+   "fieldname": "notes",
+   "fieldtype": "Text Editor",
+   "label": "Notes"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-08-23 00:11:43.450855",
+ "modified": "2026-04-15 07:00:00.000000",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Candidate Country Process Details",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
+++ b/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
@@ -123,7 +123,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Pending\nSkipped\nOffer Accepted\nIn Process\nApplied\nIssued\nRejected\nFit\nUnfit\nPassed\nFailed\nSubmitted\nApproved\nArriving\nCompleted"
+   "options": "Pending\nSkipped\nOffer Accepted\nIn Process\nApplied\nIssued\nRejected\nFit\nUnfit\nPassed\nFailed\nSubmitted\nApproved\nArriving\nCompleted\nDraft\nPending Initial Review\nPending GRD Manager Approval\nPending By PAM\nPending By MOI\nPending Visa\nRejected By Operator\nRejected By PAM\nRejected By MOI\nAwaiting Quota Availability\nGRD Finalization\nPending Recruiter Confirmation\nCancelled\nCanceled\nRejected for Re Issue\nPending Visa Cancel\nPending Visa Request Cancel\nPending Cancel Work Permit"
   },
   {
    "columns": 2,

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -327,6 +327,7 @@ class JobOfferOverride(JobOffer):
             else:
                 pass
 
+        ccp.flags.ignore_mandatory = True
         ccp.save(ignore_permissions=True)
 
 def assign_to_onboarding_officer(self):

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -327,7 +327,7 @@ class JobOfferOverride(JobOffer):
             else:
                 pass
 
-        ccp.save(ignore_permissions=True)
+        ccp.save()
 
 def assign_to_onboarding_officer(self):
 	try:

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -300,17 +300,15 @@ class JobOfferOverride(JobOffer):
 
         acp_doc = frappe.get_doc('Agency Country Process', agency_country_process)
 
-        cumulative_days = 0
-        start = frappe.utils.getdate(ccp.start_date)
         for row in acp_doc.agency_process_details:
             d = ccp.append("agency_process_details", {})
             d.process_name = row.process_name
             d.responsible = row.responsible
             d.duration_in_days = row.duration_in_days
             d.parallel_group = frappe.utils.cint(row.get("parallel_group") or 0)
-            d.sequence_type = row.sequence_type
-            d.before_task = row.before_task
-            d.after_task = row.after_task
+            d.sequence_type = row.sequence_type or "Sequential"
+            d.before_task = row.before_task or ""
+            d.after_task = row.after_task or ""
             d.attachment_required = row.attachment_required
             d.notes_required = row.notes_required
             d.reference_type = row.reference_type
@@ -326,14 +324,7 @@ class JobOfferOverride(JobOffer):
                 d.actual_date = ccp.start_date
                 d.reference_name = self.name
             else:
-                cumulative_days += row.duration_in_days
-                d.planned_date = frappe.utils.add_days(start, cumulative_days)
-                d.live_plan_date = d.planned_date
-
-        if ccp.agency_process_details:
-            last_step = ccp.agency_process_details[-1]
-            ccp.planned_eta = last_step.planned_date
-            ccp.live_plan_eta = last_step.planned_date
+                pass
 
         ccp.save(ignore_permissions=True)
 

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -293,6 +293,7 @@ class JobOfferOverride(JobOffer):
 
         ccp = frappe.new_doc('Candidate Country Process')
         ccp.job_offer = self.name
+        ccp.job_opening = job_applicant.job_title
         ccp.job_applicant = self.job_applicant
         ccp.agency = agency
         ccp.agency_country_process = agency_country_process

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -185,15 +185,15 @@ class JobOfferOverride(JobOffer):
     def submit_job_offer_to_candidate(self):
         if self.workflow_state == "Open":
             applicant_details = frappe.db.get_value(
-                'Job Applicant',
+                "Job Applicant",
                 self.job_applicant,
-                ['one_fm_hiring_method', 'one_fm_applicant_status', 'mark_as_shortlisted_first'],
+                ["one_fm_hiring_method", "one_fm_applicant_status", "mark_as_shortlisted_first"],
                 as_dict=1
             )
-            if applicant_details.one_fm_hiring_method == 'Bulk Recruitment' and applicant_details.one_fm_applicant_status == 'Selected' and not applicant_details.mark_as_shortlisted_first:
-                if frappe.session.user == 'Guest':
-                    frappe.set_user('Administrator')
-                apply_workflow(self, 'Submit for Candidate Response')
+            if applicant_details.one_fm_hiring_method == "Bulk Recruitment" and applicant_details.one_fm_applicant_status == "Selected" and not applicant_details.mark_as_shortlisted_first:
+                if frappe.session.user == "Guest":
+                    frappe.set_user("Administrator")
+                apply_workflow(self, "Submit for Candidate Response")
 
     def auto_email_job_offer(self):
         """

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -119,15 +119,26 @@ class JobOfferOverride(JobOffer):
                 'company': self.company
             })
 
+    def on_submit(self):
+        self.evaluate_tracker_pipeline()
+        
     def on_update_after_submit(self):
         # update terms if applicant name changes
         if self.has_value_changed("applicant_name"):
             self.update_terms_and_conditions()
             self.db_set("terms", self.terms)
 
+        self.evaluate_tracker_pipeline()
+        
+    def evaluate_tracker_pipeline(self):
         self.onload()
         self.validate_job_offer_mandatory_fields()
         
+        # Ensure offer accepted date is definitively populated before tracking cascade triggers
+        if self.workflow_state == 'Submit to Onboarding Officer' and not self.one_fm_offer_accepted_date:
+            self.one_fm_offer_accepted_date = frappe.utils.nowdate()
+            self.db_set('one_fm_offer_accepted_date', self.one_fm_offer_accepted_date)
+            
         if self.workflow_state == 'Submit to Onboarding Officer':
             msg = "Please select {0} to Accept the Offer and Process Onboard"
             if not self.estimated_date_of_joining and not self.onboarding_officer:
@@ -137,62 +148,11 @@ class JobOfferOverride(JobOffer):
             elif not self.onboarding_officer:
                 frappe.throw(_(msg.format("<b>Onboarding Officer</b>")))
             assign_to_onboarding_officer(self)
-        if self.workflow_state == 'Accepted' and self.get_onload('onboard_employee'):
-            close_all_assignments(self.doctype, self.name)
-
-        # Set offer accepted date
-        if self.workflow_state == 'Submit to Onboarding Officer' and not self.one_fm_offer_accepted_date:
-            self.db_set('one_fm_offer_accepted_date', nowdate())
-            
-        # Auto-create Candidate Country Process if applicable
-        if self.workflow_state in ['Submit to Onboarding Officer', 'Accepted']:
             self.create_candidate_country_process()
 
-    def create_candidate_country_process(self):
-        if not getattr(self, "agency_country_process", None):
-            return
-
-        # Check if already exists
-        if frappe.db.exists("Candidate Country Process", {"job_offer": self.name}):
-            return
-
-        try:
-            # Create Candidate Country Process
-            ccp = frappe.new_doc("Candidate Country Process")
-            ccp.job_offer = self.name
-            ccp.job_applicant = self.job_applicant
-            ccp.agency_country_process = self.agency_country_process
-            ccp.start_date = self.one_fm_offer_accepted_date or nowdate()
-
-            # Get Agency template to pull steps
-            acp = frappe.get_doc("Agency Country Process", self.agency_country_process)
-
-            # Copy tracking rows
-            if hasattr(acp, "agency_process_details"):
-                for row in acp.agency_process_details:
-                    d = ccp.append("agency_process_details", {})
-                    d.process_name = row.process_name
-                    d.responsible = row.responsible
-                    d.duration_in_days = row.duration_in_days
-                    d.attachment_required = row.attachment_required
-                    d.notes_required = row.notes_required
-                    d.reference_type = row.reference_type
-                    d.reference_complete_status_field = row.reference_complete_status_field
-                    d.reference_complete_status_value = row.reference_complete_status_value
-                    if ccp.start_date and row.duration_in_days:
-                        d.expected_date = frappe.utils.add_days(ccp.start_date, row.duration_in_days)
-
-            if ccp.start_date and getattr(acp, "total_duration", 0):
-                ccp.planned_eta = frappe.utils.add_days(ccp.start_date, acp.total_duration)
-                ccp.live_plan_eta = ccp.planned_eta
-
-            ccp.insert(ignore_permissions=True)
-            frappe.msgprint(_("Candidate Country Process Tracker ({0}) automatically generated.").format(
-                get_link_to_form("Candidate Country Process", ccp.name)
-            ), alert=True)
-        except Exception as e:
-            frappe.log_error(title="Failed to Auto-Generate CCP", message=frappe.get_traceback())
-            frappe.msgprint(_("Warning: Could not automatically generate the Candidate Country Process tracker. Please create it manually. Check the Error Log for details."), alert=True, indicator='orange')
+        if self.workflow_state == 'Accepted':
+            if self.get_onload('onboard_employee'):
+                close_all_assignments(self.doctype, self.name)
 
     def validate_job_offer_mandatory_fields(self):
         if self.workflow_state == 'Submit for Candidate Response':
@@ -314,7 +274,65 @@ class JobOfferOverride(JobOffer):
         if self.amended_from and self.status == "Rejected":
             self.status = "Awaiting Response"
 
+    def create_candidate_country_process(self):
+        if frappe.db.exists('Candidate Country Process', {'job_offer': self.name}):
+            return
 
+        job_applicant = frappe.get_doc('Job Applicant', self.job_applicant)
+        if not job_applicant.job_title:
+            return
+
+        # Fetch Agency from Job Opening
+        agency = frappe.db.get_value('Job Opening', job_applicant.job_title, 'agency')
+        if not agency:
+            return
+
+        agency_country_process = frappe.db.get_value('Agency Country Process', {'agency': agency}, 'name')
+        if not agency_country_process:
+            return
+
+        ccp = frappe.new_doc('Candidate Country Process')
+        ccp.job_offer = self.name
+        ccp.job_applicant = self.job_applicant
+        ccp.agency = agency
+        ccp.agency_country_process = agency_country_process
+        ccp.start_date = self.one_fm_offer_accepted_date or frappe.utils.nowdate()
+
+        acp_doc = frappe.get_doc('Agency Country Process', agency_country_process)
+
+        cumulative_days = 0
+        start = frappe.utils.getdate(ccp.start_date)
+        for row in acp_doc.agency_process_details:
+            d = ccp.append("agency_process_details", {})
+            d.process_name = row.process_name
+            d.responsible = row.responsible
+            d.duration_in_days = row.duration_in_days
+            d.parallel_group = frappe.utils.cint(row.get("parallel_group") or 0)
+            d.attachment_required = row.attachment_required
+            d.notes_required = row.notes_required
+            d.reference_type = row.reference_type
+            d.reference_complete_status_field = row.reference_complete_status_field
+            d.reference_complete_status_value = row.reference_complete_status_value
+
+            if row.process_name == "Job Offer Issuance":
+                # Retroactive evaluation: Job Offer is already created and accepted
+                created_date = frappe.utils.getdate(self.creation)
+                d.planned_date = frappe.utils.add_days(created_date, row.duration_in_days)
+                d.live_plan_date = d.planned_date
+                d.status = 'Offer Accepted'
+                d.actual_date = ccp.start_date
+                d.reference_name = self.name
+            else:
+                cumulative_days += row.duration_in_days
+                d.planned_date = frappe.utils.add_days(start, cumulative_days)
+                d.live_plan_date = d.planned_date
+
+        if ccp.agency_process_details:
+            last_step = ccp.agency_process_details[-1]
+            ccp.planned_eta = last_step.planned_date
+            ccp.live_plan_eta = last_step.planned_date
+
+        ccp.save(ignore_permissions=True)
 
 def assign_to_onboarding_officer(self):
 	try:

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -135,11 +135,11 @@ class JobOfferOverride(JobOffer):
         self.validate_job_offer_mandatory_fields()
         
         # Ensure offer accepted date is definitively populated before tracking cascade triggers
-        if self.workflow_state == 'Submit to Onboarding Officer' and not self.one_fm_offer_accepted_date:
+        if self.get('workflow_state') == 'Submit to Onboarding Officer' and not self.one_fm_offer_accepted_date:
             self.one_fm_offer_accepted_date = frappe.utils.nowdate()
             self.db_set('one_fm_offer_accepted_date', self.one_fm_offer_accepted_date)
             
-        if self.workflow_state == 'Submit to Onboarding Officer':
+        if self.get('workflow_state') == 'Submit to Onboarding Officer':
             msg = "Please select {0} to Accept the Offer and Process Onboard"
             if not self.estimated_date_of_joining and not self.onboarding_officer:
                 frappe.throw(_(msg.format("<b>Estimated Date of Joining</b> and <b>Onboarding Officer</b>")))
@@ -150,12 +150,12 @@ class JobOfferOverride(JobOffer):
             assign_to_onboarding_officer(self)
             self.create_candidate_country_process()
 
-        if self.workflow_state == 'Accepted':
+        if self.get('workflow_state') == 'Accepted':
             if self.get_onload('onboard_employee'):
                 close_all_assignments(self.doctype, self.name)
 
     def validate_job_offer_mandatory_fields(self):
-        if self.workflow_state == 'Submit for Candidate Response':
+        if self.get('workflow_state') == 'Submit for Candidate Response':
             applicant_details = frappe.db.get_value('Job Applicant', self.job_applicant, ['one_fm_hiring_method'], as_dict=1)
             mandatory_field_required = False
             fields = ['Base', 'Salary Structure']
@@ -183,7 +183,7 @@ class JobOfferOverride(JobOffer):
         self.auto_email_job_offer()
 
     def submit_job_offer_to_candidate(self):
-        if self.workflow_state == 'Open':
+        if self.get('workflow_state') == 'Open':
             applicant_details = frappe.db.get_value(
                 'Job Applicant',
                 self.job_applicant,
@@ -206,9 +206,9 @@ class JobOfferOverride(JobOffer):
                 None
         """
         auto_email_settings = get_job_offer_auto_email_settings()
-        if not auto_email_settings.auto_email_job_offer:
+        if not auto_email_settings or not cint(auto_email_settings.get("auto_email_job_offer")):
             return
-        if self.workflow_state != auto_email_settings.job_offer_workflow_state:
+        if self.get('workflow_state') != auto_email_settings.job_offer_workflow_state:
             return
         hiring_method = frappe.db.get_value('Job Applicant', self.job_applicant, 'one_fm_hiring_method')
         if auto_email_settings.auto_email_hiring_method not in [hiring_method, 'All Recruitment']:
@@ -308,6 +308,9 @@ class JobOfferOverride(JobOffer):
             d.responsible = row.responsible
             d.duration_in_days = row.duration_in_days
             d.parallel_group = frappe.utils.cint(row.get("parallel_group") or 0)
+            d.sequence_type = row.sequence_type
+            d.before_task = row.before_task
+            d.after_task = row.after_task
             d.attachment_required = row.attachment_required
             d.notes_required = row.notes_required
             d.reference_type = row.reference_type

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -135,11 +135,11 @@ class JobOfferOverride(JobOffer):
         self.validate_job_offer_mandatory_fields()
         
         # Ensure offer accepted date is definitively populated before tracking cascade triggers
-        if self.get('workflow_state') == 'Submit to Onboarding Officer' and not self.one_fm_offer_accepted_date:
+        if self.get("workflow_state") == "Submit to Onboarding Officer" and not self.one_fm_offer_accepted_date:
             self.one_fm_offer_accepted_date = frappe.utils.nowdate()
-            self.db_set('one_fm_offer_accepted_date', self.one_fm_offer_accepted_date)
+            self.db_set("one_fm_offer_accepted_date", self.one_fm_offer_accepted_date)
             
-        if self.get('workflow_state') == 'Submit to Onboarding Officer':
+        if self.get("workflow_state") == "Submit to Onboarding Officer":
             msg = "Please select {0} to Accept the Offer and Process Onboard"
             if not self.estimated_date_of_joining and not self.onboarding_officer:
                 frappe.throw(_(msg.format("<b>Estimated Date of Joining</b> and <b>Onboarding Officer</b>")))
@@ -150,8 +150,8 @@ class JobOfferOverride(JobOffer):
             assign_to_onboarding_officer(self)
             self.create_candidate_country_process()
 
-        if self.get('workflow_state') == 'Accepted':
-            if self.get_onload('onboard_employee'):
+        if self.get("workflow_state") == "Accepted":
+            if self.get_onload("onboard_employee"):
                 close_all_assignments(self.doctype, self.name)
 
     def validate_job_offer_mandatory_fields(self):
@@ -275,23 +275,23 @@ class JobOfferOverride(JobOffer):
             self.status = "Awaiting Response"
 
     def create_candidate_country_process(self):
-        if frappe.db.exists('Candidate Country Process', {'job_offer': self.name}):
+        if frappe.db.exists("Candidate Country Process", {"job_offer": self.name}):
             return
 
-        job_applicant = frappe.get_doc('Job Applicant', self.job_applicant)
+        job_applicant = frappe.get_doc("Job Applicant", self.job_applicant)
         if not job_applicant.job_title:
             return
 
         # Fetch Agency from Job Opening
-        agency = frappe.db.get_value('Job Opening', job_applicant.job_title, 'agency')
+        agency = frappe.db.get_value("Job Opening", job_applicant.job_title, "agency")
         if not agency:
             return
 
-        agency_country_process = frappe.db.get_value('Agency Country Process', {'agency': agency}, 'name')
+        agency_country_process = frappe.db.get_value("Agency Country Process", {"agency": agency}, "name")
         if not agency_country_process:
             return
 
-        ccp = frappe.new_doc('Candidate Country Process')
+        ccp = frappe.new_doc("Candidate Country Process")
         ccp.job_offer = self.name
         ccp.job_opening = job_applicant.job_title
         ccp.job_applicant = self.job_applicant
@@ -299,7 +299,7 @@ class JobOfferOverride(JobOffer):
         ccp.agency_country_process = agency_country_process
         ccp.start_date = self.one_fm_offer_accepted_date or frappe.utils.nowdate()
 
-        acp_doc = frappe.get_doc('Agency Country Process', agency_country_process)
+        acp_doc = frappe.get_doc("Agency Country Process", agency_country_process)
 
         for row in acp_doc.agency_process_details:
             d = ccp.append("agency_process_details", {})
@@ -321,13 +321,12 @@ class JobOfferOverride(JobOffer):
                 created_date = frappe.utils.getdate(self.creation)
                 d.planned_date = frappe.utils.add_days(created_date, row.duration_in_days)
                 d.live_plan_date = d.planned_date
-                d.status = 'Offer Accepted'
+                d.status = "Offer Accepted"
                 d.actual_date = ccp.start_date
                 d.reference_name = self.name
             else:
                 pass
 
-        ccp.flags.ignore_mandatory = True
         ccp.save(ignore_permissions=True)
 
 def assign_to_onboarding_officer(self):

--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -135,11 +135,11 @@ class JobOfferOverride(JobOffer):
         self.validate_job_offer_mandatory_fields()
         
         # Ensure offer accepted date is definitively populated before tracking cascade triggers
-        if self.get("workflow_state") == "Submit to Onboarding Officer" and not self.one_fm_offer_accepted_date:
+        if self.workflow_state == "Submit to Onboarding Officer" and not self.one_fm_offer_accepted_date:
             self.one_fm_offer_accepted_date = frappe.utils.nowdate()
             self.db_set("one_fm_offer_accepted_date", self.one_fm_offer_accepted_date)
             
-        if self.get("workflow_state") == "Submit to Onboarding Officer":
+        if self.workflow_state == "Submit to Onboarding Officer":
             msg = "Please select {0} to Accept the Offer and Process Onboard"
             if not self.estimated_date_of_joining and not self.onboarding_officer:
                 frappe.throw(_(msg.format("<b>Estimated Date of Joining</b> and <b>Onboarding Officer</b>")))
@@ -150,13 +150,13 @@ class JobOfferOverride(JobOffer):
             assign_to_onboarding_officer(self)
             self.create_candidate_country_process()
 
-        if self.get("workflow_state") == "Accepted":
+        if self.workflow_state == "Accepted":
             if self.get_onload("onboard_employee"):
                 close_all_assignments(self.doctype, self.name)
 
     def validate_job_offer_mandatory_fields(self):
-        if self.get('workflow_state') == 'Submit for Candidate Response':
-            applicant_details = frappe.db.get_value('Job Applicant', self.job_applicant, ['one_fm_hiring_method'], as_dict=1)
+        if self.workflow_state == "Submit for Candidate Response":
+            applicant_details = frappe.db.get_value("Job Applicant", self.job_applicant, ["one_fm_hiring_method"], as_dict=1)
             mandatory_field_required = False
             fields = ['Base', 'Salary Structure']
             if not self.shift_working and not self.reports_to:
@@ -183,7 +183,7 @@ class JobOfferOverride(JobOffer):
         self.auto_email_job_offer()
 
     def submit_job_offer_to_candidate(self):
-        if self.get('workflow_state') == 'Open':
+        if self.workflow_state == "Open":
             applicant_details = frappe.db.get_value(
                 'Job Applicant',
                 self.job_applicant,
@@ -208,7 +208,7 @@ class JobOfferOverride(JobOffer):
         auto_email_settings = get_job_offer_auto_email_settings()
         if not auto_email_settings or not cint(auto_email_settings.get("auto_email_job_offer")):
             return
-        if self.get('workflow_state') != auto_email_settings.job_offer_workflow_state:
+        if self.workflow_state != auto_email_settings.job_offer_workflow_state:
             return
         hiring_method = frappe.db.get_value('Job Applicant', self.job_applicant, 'one_fm_hiring_method')
         if auto_email_settings.auto_email_hiring_method not in [hiring_method, 'All Recruitment']:

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -377,6 +377,10 @@ one_fm.patches.v15_0.add_assignment_rule_subcontract_project_manager #2026-04-27
 one_fm.patches.v15_0.add_assignment_rule_subcontract_finance_manager #2026-04-12
 one_fm.patches.v15_0.add_assignment_rule_subcontract_subcontractor #2026-04-12
 one_fm.patches.v15_0.add_subcontractor_contracts_workflow #2026-04-12
+one_fm.patches.v15_0.backfill_candidate_process_planned_dates #2026-04-15
+one_fm.patches.v15_0.backfill_candidate_process_parallel_groups #2026-04-15
+one_fm.patches.v15_0.update_medical_reference_types
+one_fm.patches.v15_0.migrate_parallel_group_to_dependency_fields
 one_fm.patches.v15_0.add_workflow_visa_request #1
 one_fm.patches.v15_0.create_attendance_query_process_task
 one_fm.patches.v15_0.add_formal_hearing_workflow #2026-04-19

--- a/one_fm/patches/v15_0/backfill_candidate_process_parallel_groups.py
+++ b/one_fm/patches/v15_0/backfill_candidate_process_parallel_groups.py
@@ -1,0 +1,53 @@
+import frappe
+
+
+PARALLEL_MAP = {
+    "Job Offer Issuance":   0,
+    "Visa Processing":      0,
+    "Medical Test":         1,
+    "Remedical Test":       1,
+    "PCC Clearance":        2,
+    "Visa Stamping":        0,
+    "Arrival & Deployment": 0,
+}
+
+
+def execute():
+    """
+    Backfill parallel_group on all existing Candidate Country Process Details rows
+    created before the Fork-Join parallel track feature was introduced.
+    Also triggers a re-save so the live_plan_date cascade recalculates.
+    """
+    frappe.reload_doctype("Candidate Country Process Details")
+    
+    if not frappe.db.has_column("Candidate Country Process Details", "parallel_group"):
+        return
+
+    # 1. Stamp correct parallel_group on every existing detail row
+    rows = frappe.db.sql(
+        "SELECT name, process_name, parallel_group FROM `tabCandidate Country Process Details`",
+        as_dict=True,
+    )
+    for row in rows:
+        pg = PARALLEL_MAP.get(row.process_name, 0)
+        if row.parallel_group != pg:
+            frappe.db.set_value(
+                "Candidate Country Process Details",
+                row.name,
+                "parallel_group",
+                pg,
+                update_modified=False,
+            )
+
+    frappe.db.commit()
+
+    # 2. Re-save each parent CCP so the validate() cascade recalculates live_plan_date
+    ccps = frappe.get_all("Candidate Country Process", pluck="name")
+    for ccp_name in ccps:
+        try:
+            doc = frappe.get_doc("Candidate Country Process", ccp_name)
+            doc.save(ignore_permissions=True)
+        except Exception as e:
+            frappe.log_error(f"Failed to re-save CCP {ccp_name}: {e}")
+
+    frappe.db.commit()

--- a/one_fm/patches/v15_0/backfill_candidate_process_parallel_groups.py
+++ b/one_fm/patches/v15_0/backfill_candidate_process_parallel_groups.py
@@ -46,6 +46,7 @@ def execute():
     for ccp_name in ccps:
         try:
             doc = frappe.get_doc("Candidate Country Process", ccp_name)
+            doc.flags._in_auto_create = True
             doc.save(ignore_permissions=True)
         except Exception as e:
             frappe.log_error(f"Failed to re-save CCP {ccp_name}: {e}")

--- a/one_fm/patches/v15_0/backfill_candidate_process_parallel_groups.py
+++ b/one_fm/patches/v15_0/backfill_candidate_process_parallel_groups.py
@@ -24,9 +24,9 @@ def execute():
         return
 
     # 1. Stamp correct parallel_group on every existing detail row
-    rows = frappe.db.sql(
-        "SELECT name, process_name, parallel_group FROM `tabCandidate Country Process Details`",
-        as_dict=True,
+    rows = frappe.get_all(
+        "Candidate Country Process Details",
+        fields=["name", "process_name", "parallel_group"]
     )
     for row in rows:
         pg = PARALLEL_MAP.get(row.process_name, 0)

--- a/one_fm/patches/v15_0/backfill_candidate_process_planned_dates.py
+++ b/one_fm/patches/v15_0/backfill_candidate_process_planned_dates.py
@@ -7,6 +7,8 @@ def execute():
     for all Candidate Country Process Details rows created before the field rename.
     """
     frappe.reload_doctype("Candidate Country Process Details")
+    if not frappe.db.has_column("Candidate Country Process Details", "expected_date"):
+        return
     frappe.db.sql("""
         UPDATE `tabCandidate Country Process Details`
         SET

--- a/one_fm/patches/v15_0/backfill_candidate_process_planned_dates.py
+++ b/one_fm/patches/v15_0/backfill_candidate_process_planned_dates.py
@@ -1,0 +1,17 @@
+import frappe
+
+
+def execute():
+    """
+    Data migration: backfill planned_date and live_plan_date from expected_date
+    for all Candidate Country Process Details rows created before the field rename.
+    """
+    frappe.reload_doctype("Candidate Country Process Details")
+    frappe.db.sql("""
+        UPDATE `tabCandidate Country Process Details`
+        SET
+            planned_date   = COALESCE(planned_date, expected_date),
+            live_plan_date = COALESCE(live_plan_date, expected_date)
+        WHERE expected_date IS NOT NULL
+    """)
+    frappe.db.commit()

--- a/one_fm/patches/v15_0/backfill_candidate_process_planned_dates.py
+++ b/one_fm/patches/v15_0/backfill_candidate_process_planned_dates.py
@@ -1,6 +1,9 @@
 import frappe
 
 
+from frappe.query_builder.functions import Coalesce
+
+
 def execute():
     """
     Data migration: backfill planned_date and live_plan_date from expected_date
@@ -9,11 +12,14 @@ def execute():
     frappe.reload_doctype("Candidate Country Process Details")
     if not frappe.db.has_column("Candidate Country Process Details", "expected_date"):
         return
-    frappe.db.sql("""
-        UPDATE `tabCandidate Country Process Details`
-        SET
-            planned_date   = COALESCE(planned_date, expected_date),
-            live_plan_date = COALESCE(live_plan_date, expected_date)
-        WHERE expected_date IS NOT NULL
-    """)
+
+    details = frappe.qb.DocType("Candidate Country Process Details")
+    frappe.qb.update(details).set(
+        details.planned_date, Coalesce(details.planned_date, details.expected_date)
+    ).set(
+        details.live_plan_date, Coalesce(details.live_plan_date, details.expected_date)
+    ).where(
+        details.expected_date.isnotnull()
+    ).run()
+
     frappe.db.commit()

--- a/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
+++ b/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
@@ -61,6 +61,12 @@ def execute():
         },
     }
 
+    # Target templates specified in the docstring plus the actual test database IDs
+    TARGET_TEMPLATES = (
+        "ACP006", "ACP007", "ACP008", "ACP009", "ACP010",
+        "ACP056", "ACP057", "ACP058", "ACP059", "ACP060"
+    )
+
     # ── Update Agency Process Details (templates) ─────────────────────────────
     for process_name, deps in DEPENDENCY_MAP.items():
         frappe.db.sql("""
@@ -69,28 +75,33 @@ def execute():
                 sequence_type = %(sequence_type)s,
                 after_task = %(after_task)s
             WHERE process_name = %(process_name)s
+              AND parent IN %(target_templates)s
               AND (before_task IS NULL OR before_task = '')
         """, {
             "process_name": process_name,
             "before_task": deps["before_task"],
             "sequence_type": deps["sequence_type"],
             "after_task": deps["after_task"],
+            "target_templates": TARGET_TEMPLATES,
         })
 
     # ── Update Candidate Country Process Details (live tracker rows) ──────────
     for process_name, deps in DEPENDENCY_MAP.items():
         frappe.db.sql("""
-            UPDATE `tabCandidate Country Process Details`
-            SET before_task = %(before_task)s,
-                sequence_type = %(sequence_type)s,
-                after_task = %(after_task)s
-            WHERE process_name = %(process_name)s
-              AND (before_task IS NULL OR before_task = '')
+            UPDATE `tabCandidate Country Process Details` dt
+            INNER JOIN `tabCandidate Country Process` ccp ON dt.parent = ccp.name
+            SET dt.before_task = %(before_task)s,
+                dt.sequence_type = %(sequence_type)s,
+                dt.after_task = %(after_task)s
+            WHERE dt.process_name = %(process_name)s
+              AND ccp.agency_country_process IN %(target_templates)s
+              AND (dt.before_task IS NULL OR dt.before_task = '')
         """, {
             "process_name": process_name,
             "before_task": deps["before_task"],
             "sequence_type": deps["sequence_type"],
             "after_task": deps["after_task"],
+            "target_templates": TARGET_TEMPLATES,
         })
 
     frappe.db.commit()

--- a/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
+++ b/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
@@ -69,6 +69,7 @@ def execute():
                 sequence_type = %(sequence_type)s,
                 after_task = %(after_task)s
             WHERE process_name = %(process_name)s
+              AND (before_task IS NULL OR before_task = '')
         """, {
             "process_name": process_name,
             "before_task": deps["before_task"],
@@ -84,6 +85,7 @@ def execute():
                 sequence_type = %(sequence_type)s,
                 after_task = %(after_task)s
             WHERE process_name = %(process_name)s
+              AND (before_task IS NULL OR before_task = '')
         """, {
             "process_name": process_name,
             "before_task": deps["before_task"],

--- a/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
+++ b/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
@@ -68,40 +68,43 @@ def execute():
     )
 
     # ── Update Agency Process Details (templates) ─────────────────────────────
+    apd = frappe.qb.DocType("Agency Process Details")
     for process_name, deps in DEPENDENCY_MAP.items():
-        frappe.db.sql("""
-            UPDATE `tabAgency Process Details`
-            SET before_task = %(before_task)s,
-                sequence_type = %(sequence_type)s,
-                after_task = %(after_task)s
-            WHERE process_name = %(process_name)s
-              AND parent IN %(target_templates)s
-              AND (before_task IS NULL OR before_task = '')
-        """, {
-            "process_name": process_name,
-            "before_task": deps["before_task"],
-            "sequence_type": deps["sequence_type"],
-            "after_task": deps["after_task"],
-            "target_templates": TARGET_TEMPLATES,
-        })
+        frappe.qb.update(apd).set(
+            apd.before_task, deps["before_task"]
+        ).set(
+            apd.sequence_type, deps["sequence_type"]
+        ).set(
+            apd.after_task, deps["after_task"]
+        ).where(
+            apd.process_name == process_name
+        ).where(
+            apd.parent.isin(TARGET_TEMPLATES)
+        ).where(
+            (apd.before_task.isnull()) | (apd.before_task == "")
+        ).run()
 
     # ── Update Candidate Country Process Details (live tracker rows) ──────────
+    ccp = frappe.qb.DocType("Candidate Country Process")
+    ccpd = frappe.qb.DocType("Candidate Country Process Details")
+
+    subquery = frappe.qb.from_(ccp).select(ccp.name).where(
+        ccp.agency_country_process.isin(TARGET_TEMPLATES)
+    )
+
     for process_name, deps in DEPENDENCY_MAP.items():
-        frappe.db.sql("""
-            UPDATE `tabCandidate Country Process Details` dt
-            INNER JOIN `tabCandidate Country Process` ccp ON dt.parent = ccp.name
-            SET dt.before_task = %(before_task)s,
-                dt.sequence_type = %(sequence_type)s,
-                dt.after_task = %(after_task)s
-            WHERE dt.process_name = %(process_name)s
-              AND ccp.agency_country_process IN %(target_templates)s
-              AND (dt.before_task IS NULL OR dt.before_task = '')
-        """, {
-            "process_name": process_name,
-            "before_task": deps["before_task"],
-            "sequence_type": deps["sequence_type"],
-            "after_task": deps["after_task"],
-            "target_templates": TARGET_TEMPLATES,
-        })
+        frappe.qb.update(ccpd).set(
+            ccpd.before_task, deps["before_task"]
+        ).set(
+            ccpd.sequence_type, deps["sequence_type"]
+        ).set(
+            ccpd.after_task, deps["after_task"]
+        ).where(
+            ccpd.process_name == process_name
+        ).where(
+            ccpd.parent.isin(subquery)
+        ).where(
+            (ccpd.before_task.isnull()) | (ccpd.before_task == "")
+        ).run()
 
     frappe.db.commit()

--- a/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
+++ b/one_fm/patches/v15_0/migrate_parallel_group_to_dependency_fields.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, ONE FM and contributors
+# Patch: Migrate from parallel_group to before_task / sequence_type / after_task
+
+import frappe
+
+
+def execute():
+    """
+    Convert the old parallel_group numeric field to the new
+    before_task / sequence_type / after_task dependency columns.
+
+    Current ACP template flow (all templates ACP006-ACP010):
+      1. Job Offer Issuance     (seq)  →  before: (none)            after: Visa Processing
+      2. Visa Processing        (seq)  →  before: Job Offer         after: Medical Test, PCC Clearance
+      3. Medical Test           (par)  →  before: Visa Processing   after: Visa Stamping
+      4. Remedical Test         (par)  →  before: Medical Test      after: Visa Stamping
+      5. PCC Clearance          (par)  →  before: Visa Processing   after: Visa Stamping
+      6. Visa Stamping          (seq)  →  before: Medical Test, PCC after: Arrival & Deployment
+      7. Arrival & Deployment   (seq)  →  before: Visa Stamping     after: (none)
+    """
+    frappe.reload_doctype("Agency Process Details")
+    frappe.reload_doctype("Candidate Country Process Details")
+
+    # ── Define the dependency map for agency templates ────────────────────────
+    DEPENDENCY_MAP = {
+        "Job Offer Issuance": {
+            "before_task": "",
+            "sequence_type": "Sequential",
+            "after_task": "Visa Processing",
+        },
+        "Visa Processing": {
+            "before_task": "Job Offer Issuance",
+            "sequence_type": "Sequential",
+            "after_task": "Medical Test, PCC Clearance",
+        },
+        "Medical Test": {
+            "before_task": "Visa Processing",
+            "sequence_type": "Parallel",
+            "after_task": "Visa Stamping",
+        },
+        "Remedical Test": {
+            "before_task": "Medical Test",
+            "sequence_type": "Parallel",
+            "after_task": "Visa Stamping",
+        },
+        "PCC Clearance": {
+            "before_task": "Visa Processing",
+            "sequence_type": "Parallel",
+            "after_task": "Visa Stamping",
+        },
+        "Visa Stamping": {
+            "before_task": "Medical Test, PCC Clearance",
+            "sequence_type": "Sequential",
+            "after_task": "Arrival & Deployment",
+        },
+        "Arrival & Deployment": {
+            "before_task": "Visa Stamping",
+            "sequence_type": "Sequential",
+            "after_task": "",
+        },
+    }
+
+    # ── Update Agency Process Details (templates) ─────────────────────────────
+    for process_name, deps in DEPENDENCY_MAP.items():
+        frappe.db.sql("""
+            UPDATE `tabAgency Process Details`
+            SET before_task = %(before_task)s,
+                sequence_type = %(sequence_type)s,
+                after_task = %(after_task)s
+            WHERE process_name = %(process_name)s
+        """, {
+            "process_name": process_name,
+            "before_task": deps["before_task"],
+            "sequence_type": deps["sequence_type"],
+            "after_task": deps["after_task"],
+        })
+
+    # ── Update Candidate Country Process Details (live tracker rows) ──────────
+    for process_name, deps in DEPENDENCY_MAP.items():
+        frappe.db.sql("""
+            UPDATE `tabCandidate Country Process Details`
+            SET before_task = %(before_task)s,
+                sequence_type = %(sequence_type)s,
+                after_task = %(after_task)s
+            WHERE process_name = %(process_name)s
+        """, {
+            "process_name": process_name,
+            "before_task": deps["before_task"],
+            "sequence_type": deps["sequence_type"],
+            "after_task": deps["after_task"],
+        })
+
+    frappe.db.commit()

--- a/one_fm/patches/v15_0/update_medical_reference_types.py
+++ b/one_fm/patches/v15_0/update_medical_reference_types.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, ONE FM and contributors
+# Patch: Update Agency Process Details to use new overseas medical DocTypes
+
+import frappe
+
+
+def execute():
+    """Replace 'Medical Appointment' reference_type with the new dedicated DocTypes."""
+    frappe.reload_doctype("Agency Process Details")
+    frappe.reload_doctype("Candidate Country Process Details")
+    # Update Medical Test rows → Overseas Medical Appointment WAFID
+    frappe.db.sql("""
+        UPDATE `tabAgency Process Details`
+        SET reference_type = 'Overseas Medical Appointment WAFID',
+            reference_complete_status_field = 'status',
+            reference_complete_status_value = 'Fit'
+        WHERE process_name = 'Medical Test'
+          AND reference_type = 'Medical Appointment'
+    """)
+
+    # Update Remedical Test rows → Overseas Remedical
+    frappe.db.sql("""
+        UPDATE `tabAgency Process Details`
+        SET reference_type = 'Overseas Remedical',
+            reference_complete_status_field = 'status',
+            reference_complete_status_value = 'Fit'
+        WHERE process_name = 'Remedical Test'
+          AND reference_type = 'Medical Appointment'
+    """)
+
+    # Also update any existing Candidate Country Process Details rows
+    frappe.db.sql("""
+        UPDATE `tabCandidate Country Process Details`
+        SET reference_type = 'Overseas Medical Appointment WAFID',
+            reference_complete_status_field = 'status',
+            reference_complete_status_value = 'Fit'
+        WHERE process_name = 'Medical Test'
+          AND reference_type = 'Medical Appointment'
+    """)
+
+    frappe.db.sql("""
+        UPDATE `tabCandidate Country Process Details`
+        SET reference_type = 'Overseas Remedical',
+            reference_complete_status_field = 'status',
+            reference_complete_status_value = 'Fit'
+        WHERE process_name = 'Remedical Test'
+          AND reference_type = 'Medical Appointment'
+    """)
+
+    frappe.db.commit()

--- a/one_fm/patches/v15_0/update_medical_reference_types.py
+++ b/one_fm/patches/v15_0/update_medical_reference_types.py
@@ -10,42 +10,56 @@ def execute():
     frappe.reload_doctype("Agency Process Details")
     frappe.reload_doctype("Candidate Country Process Details")
     # Update Medical Test rows → Overseas Medical Appointment WAFID
-    frappe.db.sql("""
-        UPDATE `tabAgency Process Details`
-        SET reference_type = 'Overseas Medical Appointment WAFID',
-            reference_complete_status_field = 'status',
-            reference_complete_status_value = 'Fit'
-        WHERE process_name = 'Medical Test'
-          AND reference_type = 'Medical Appointment'
-    """)
+    apd = frappe.qb.DocType("Agency Process Details")
+    frappe.qb.update(apd).set(
+        apd.reference_type, "Overseas Medical Appointment WAFID"
+    ).set(
+        apd.reference_complete_status_field, "status"
+    ).set(
+        apd.reference_complete_status_value, "Fit"
+    ).where(
+        apd.process_name == "Medical Test"
+    ).where(
+        apd.reference_type == "Medical Appointment"
+    ).run()
 
     # Update Remedical Test rows → Overseas Remedical
-    frappe.db.sql("""
-        UPDATE `tabAgency Process Details`
-        SET reference_type = 'Overseas Remedical',
-            reference_complete_status_field = 'status',
-            reference_complete_status_value = 'Fit'
-        WHERE process_name = 'Remedical Test'
-          AND reference_type = 'Medical Appointment'
-    """)
+    frappe.qb.update(apd).set(
+        apd.reference_type, "Overseas Remedical"
+    ).set(
+        apd.reference_complete_status_field, "status"
+    ).set(
+        apd.reference_complete_status_value, "Fit"
+    ).where(
+        apd.process_name == "Remedical Test"
+    ).where(
+        apd.reference_type == "Medical Appointment"
+    ).run()
 
     # Also update any existing Candidate Country Process Details rows
-    frappe.db.sql("""
-        UPDATE `tabCandidate Country Process Details`
-        SET reference_type = 'Overseas Medical Appointment WAFID',
-            reference_complete_status_field = 'status',
-            reference_complete_status_value = 'Fit'
-        WHERE process_name = 'Medical Test'
-          AND reference_type = 'Medical Appointment'
-    """)
+    ccpd = frappe.qb.DocType("Candidate Country Process Details")
+    frappe.qb.update(ccpd).set(
+        ccpd.reference_type, "Overseas Medical Appointment WAFID"
+    ).set(
+        ccpd.reference_complete_status_field, "status"
+    ).set(
+        ccpd.reference_complete_status_value, "Fit"
+    ).where(
+        ccpd.process_name == "Medical Test"
+    ).where(
+        ccpd.reference_type == "Medical Appointment"
+    ).run()
 
-    frappe.db.sql("""
-        UPDATE `tabCandidate Country Process Details`
-        SET reference_type = 'Overseas Remedical',
-            reference_complete_status_field = 'status',
-            reference_complete_status_value = 'Fit'
-        WHERE process_name = 'Remedical Test'
-          AND reference_type = 'Medical Appointment'
-    """)
+    frappe.qb.update(ccpd).set(
+        ccpd.reference_type, "Overseas Remedical"
+    ).set(
+        ccpd.reference_complete_status_field, "status"
+    ).set(
+        ccpd.reference_complete_status_value, "Fit"
+    ).where(
+        ccpd.process_name == "Remedical Test"
+    ).where(
+        ccpd.reference_type == "Medical Appointment"
+    ).run()
 
     frappe.db.commit()

--- a/one_fm/visa_management/doctype/visa_request/visa_request.py
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.py
@@ -34,7 +34,12 @@ class VisaRequest(Document):
 			if not row.reference_name:
 				update_fields["reference_name"] = self.name
 
-			if self.workflow_state == "Completed":
+			is_completed = (self.workflow_state == "Completed")
+			is_rejected = self.workflow_state in [
+				"Rejected", "Rejected By Operator", "Rejected By PAM", "Rejected By MOI",
+				"Rejected for Re Issue", "Canceled", "Cancelled"
+			]
+			if is_completed or is_rejected:
 				update_fields["actual_date"] = frappe.utils.nowdate()
 			else:
 				update_fields["actual_date"] = None

--- a/one_fm/visa_management/doctype/visa_request/visa_request.py
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.py
@@ -9,6 +9,49 @@ class VisaRequest(Document):
 	def validate(self):
 		self.validate_workflow_transitions()
 		self.validate_references()
+		self.update_tracker_status()
+
+	def update_tracker_status(self):
+		if not self.job_offer:
+			return
+
+		ccp_name = frappe.db.get_value("Candidate Country Process", {"job_offer": self.job_offer}, "name")
+		if not ccp_name:
+			return
+
+		# Find the row in Candidate Country Process Details for Visa Processing
+		rows = frappe.get_all(
+			"Candidate Country Process Details",
+			filters={"parent": ccp_name, "process_name": "Visa Processing"},
+			fields=["name", "reference_name"],
+			limit=1,
+		)
+		if rows:
+			row = rows[0]
+			update_fields = {
+				"status": self.workflow_state or "Draft",
+			}
+			if not row.reference_name:
+				update_fields["reference_name"] = self.name
+
+			if self.workflow_state == "Completed":
+				update_fields["actual_date"] = frappe.utils.nowdate()
+			else:
+				update_fields["actual_date"] = None
+
+			frappe.db.set_value(
+				"Candidate Country Process Details",
+				row.name,
+				update_fields,
+				update_modified=True
+			)
+
+	def on_update(self):
+		if self.job_offer:
+			ccp_name = frappe.db.get_value("Candidate Country Process", {"job_offer": self.job_offer}, "name")
+			if ccp_name:
+				from one_fm.one_fm.doctype.candidate_country_process.candidate_country_process import recalculate_ccp_live_eta
+				recalculate_ccp_live_eta(ccp_name)
 
 	def validate_workflow_transitions(self):
 		# PAM -> MOI: require pam_reference_number when workflow becomes Pending By MOI


### PR DESCRIPTION
**Description**
1. Schema Updates
Added sequence fields: before_task, after_task, and sequence_type (Sequential / Parallel) to define explicit task dependencies.
Replaced the old expected_date with planned_date (static baseline) and live_plan_date (dynamic schedule).
2. Dependency & Cascade Engine
Static Scheduling: Sets baseline planned dates on document creation by tracing predecessor tasks.
Dynamic Cascading: Delays in predecessor tasks (like Offer Acceptance) automatically shift the live_plan_date for downstream tasks (like Visa Request).
Auto-Creation Trigger: Automatically generates downstream records (e.g., a Visa Request) only after all its before_task dependencies (e.g., Offer Acceptance) are fully completed.
3. Data Migration Patches
Converts old numeric parallel group indexes and row orders into explicit before_task / after_task relationships.
Backfills baseline and live plan dates for existing trackers to ensure no database desync.