### PR TITLE
fix(interview-console): fix Workflow permission error for standard users

### DIFF
--- a/one_fm/one_fm/page/interview_console/interview_console.py
+++ b/one_fm/one_fm/page/interview_console/interview_console.py
@@ -198,7 +198,7 @@ def _save_applicant_photo(applicant: str, photo_data: str):
 
 def _update_applicant_status(applicant: str, status: str, height: str | None):
     doc = frappe.get_doc("Job Applicant", applicant)
-    has_workflow = frappe.get_list("Workflow", filters={"document_type": "Job Applicant", "is_active": 1}, limit=1)
+    has_workflow = frappe.db.get_value("Workflow", {"document_type": "Job Applicant", "is_active": 1})
 
     if status == "Shortlisted":
         doc.one_fm_applicant_status = "Shortlisted"


### PR DESCRIPTION
This PR fixes a PermissionError where users without System Manager role were unable to save interview data in the Interview Console due to Workflow doctype access restrictions. The fix replaces frappe.get_list with frappe.db.get_value to bypass permission enforcement for Workflow configuration reads.