### PR TITLE
feat(ccp): add recruitment and manager roles to permissions

### DIFF
--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.json
@@ -190,37 +190,48 @@
  "owner": "Administrator",
  "permissions": [
   {
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
    "export": 1,
+   "import": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "submit": 1,
    "write": 1
   },
   {
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
    "export": 1,
+   "import": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "HR Manager",
    "share": 1,
+   "submit": 1,
    "write": 1
   },
   {
+   "cancel": 1,
    "create": 1,
+   "delete": 1,
    "email": 1,
    "export": 1,
+   "import": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "HR User",
+   "share": 1,
+   "submit": 1,
    "write": 1
   },
   {
@@ -234,6 +245,28 @@
    "role": "Recruitment Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "import": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Recruiter",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Interviewer",
+   "share": 1
   },
   {
    "email": 1,


### PR DESCRIPTION
Description
This Pull Request updates the permission rules for the Candidate Country Process (CCP) DocType schema to grant appropriate access to standard human resources, recruitment, and interviewing roles:

System Manager, HR Manager, and HR User are granted full access to the DocType, including create, write, delete, share, submit, cancel, and import/export privileges.
Recruiter is granted standard recruitment processing access (create, write, share, submit, cancel, and export) but is restricted from importing or deleting records.
Interviewer is restricted to read-only access (can read, print, email, share, and report) with no modify or submission privileges.