### PR TITLE
[WI-001011][Yaser] Vehicle's naming series update]

### DIFF
--- a/one_fm/custom/property_setter/vehicle.py
+++ b/one_fm/custom/property_setter/vehicle.py
@@ -3,6 +3,13 @@ def get_vehicle_properties():
         {
             "doc_type": "Vehicle",
             "doctype_or_field": "DocType",
+            "property": "autoname",
+            "property_type": "Data",
+            "value": "VHL-.####"
+        },
+        {
+            "doc_type": "Vehicle",
+            "doctype_or_field": "DocType",
             "property": "image_field",
             "property_type": "Data",
             "value": "image"

--- a/one_fm/fleet_management/utils.py
+++ b/one_fm/fleet_management/utils.py
@@ -1,5 +1,2 @@
 # -*- coding: utf-8 -*-
 # encoding: utf-8
-from __future__ import unicode_literals
-import frappe
-from frappe import _

--- a/one_fm/fleet_management/utils.py
+++ b/one_fm/fleet_management/utils.py
@@ -3,14 +3,3 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-import frappe
-
-@frappe.whitelist(allow_guest=True)
-def vehicle_naming_series(doc, method):
-    name = 'VHL-'
-    count = frappe.db.count('Vehicle')
-    if not count or count <= 0:
-        count = 1
-    else:
-        count += 1
-    doc.name = name+str(int(count)).zfill(4)

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -296,7 +296,6 @@ doc_events = {
 		"validate": "one_fm.utils.validate_warehouse"
 	},
 	"Vehicle": {
-		"autoname": "one_fm.fleet_management.utils.vehicle_naming_series",
 		"after_insert": "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.after_insert_vehicle"
 	},
 	"Item Group": {

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -294,6 +294,7 @@ one_fm.patches.v15_0.add_sales_taxes_charges_add_or_deduct_field
 one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
 one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
+one_fm.patches.v15_0.update_vehicle_naming_series
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/update_vehicle_naming_series.py
+++ b/one_fm/patches/v15_0/update_vehicle_naming_series.py
@@ -14,26 +14,21 @@ def execute():
 		validate_fields_for_doctype=False,
 	)
 
-	# Step 2: Sync the naming series counter so it continues from the highest existing name
-	max_name = frappe.db.sql("""
-		SELECT name FROM `tabVehicle`
-		WHERE name LIKE 'VHL-%%'
-		ORDER BY LENGTH(name) DESC, name DESC
-		LIMIT 1
+	# Step 2: Sync the naming series counter so it continues from the highest existing name.
+	# Filter to names with purely numeric suffixes to avoid irregular names (e.g. VHL-TEST)
+	# resetting the counter and causing collisions.
+	max_counter = frappe.db.sql("""
+		SELECT MAX(CAST(SUBSTRING(name, 5) AS UNSIGNED))
+		FROM `tabVehicle`
+		WHERE name REGEXP '^VHL-[0-9]+$'
 	""")
 
-	if max_name:
-		# Extract the numeric part (e.g., "VHL-0042" → 42)
-		current = max_name[0][0]
-		try:
-			num = int(current.split("-", 1)[1])
-		except (IndexError, ValueError):
-			num = 0
+	num = max_counter[0][0] if max_counter and max_counter[0][0] else 0
 
-		# Update or insert the Series record so getseries() continues from here
-		if frappe.db.exists("Series", "VHL-"):
-			frappe.db.sql("UPDATE `tabSeries` SET current = %s WHERE name = %s", (num, "VHL-"))
-		else:
-			frappe.db.sql("INSERT INTO `tabSeries` (name, current) VALUES (%s, %s)", ("VHL-", num))
+	# Update or insert the Series record so getseries() continues from here
+	if frappe.db.exists("Series", "VHL-"):
+		frappe.db.sql("UPDATE `tabSeries` SET current = %s WHERE name = %s", (num, "VHL-"))
+	else:
+		frappe.db.sql("INSERT INTO `tabSeries` (name, current) VALUES (%s, %s)", ("VHL-", num))
 
 	frappe.db.commit()

--- a/one_fm/patches/v15_0/update_vehicle_naming_series.py
+++ b/one_fm/patches/v15_0/update_vehicle_naming_series.py
@@ -1,0 +1,39 @@
+import frappe
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+
+def execute():
+	# Step 1: Apply the autoname property setter
+	make_property_setter(
+		doctype="Vehicle",
+		fieldname=None,
+		property="autoname",
+		value="VHL-.####",
+		property_type="Data",
+		for_doctype=True,
+		validate_fields_for_doctype=False,
+	)
+
+	# Step 2: Sync the naming series counter so it continues from the highest existing name
+	max_name = frappe.db.sql("""
+		SELECT name FROM `tabVehicle`
+		WHERE name LIKE 'VHL-%%'
+		ORDER BY LENGTH(name) DESC, name DESC
+		LIMIT 1
+	""")
+
+	if max_name:
+		# Extract the numeric part (e.g., "VHL-0042" → 42)
+		current = max_name[0][0]
+		try:
+			num = int(current.split("-", 1)[1])
+		except (IndexError, ValueError):
+			num = 0
+
+		# Update or insert the Series record so getseries() continues from here
+		if frappe.db.exists("Series", "VHL-"):
+			frappe.db.sql("UPDATE `tabSeries` SET current = %s WHERE name = %s", (num, "VHL-"))
+		else:
+			frappe.db.sql("INSERT INTO `tabSeries` (name, current) VALUES (%s, %s)", ("VHL-", num))
+
+	frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Update the Vehicle DocType's naming series from a custom `autoname` doc_event hook (`vehicle_naming_series` function using `frappe.db.count()`) to Frappe's built-in `autoname` Property Setter (`VHL-.####`). This uses Frappe's atomic `getseries()` counter, preventing potential name collisions and duplicate names. The `license_plate` field value remains untouched during save.


## Analysis and design (optional)

The previous naming approach used `frappe.db.count('Vehicle')` which is not atomic — concurrent inserts could produce duplicate names, and deleted records could cause name reuse. The Property Setter approach delegates naming to Frappe's built-in series counter which is atomic and never recycles names.


## Solution description

1. **Removed** the `autoname` hook from the Vehicle `doc_events` in `hooks.py`
2. **Added** a DocType-level `autoname` Property Setter (`VHL-.####`) to `custom/property_setter/vehicle.py` for fresh installs
3. **Created** a migration patch (`update_vehicle_naming_series.py`) that applies the Property Setter and syncs the `tabSeries` counter to the highest existing Vehicle number (VHL-0024 → counter = 24)
4. **Removed** the now-unused `vehicle_naming_series` function from `fleet_management/utils.py`


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

After creating a new Vehicle, the name is auto-generated as `VHL-0025` (continuing from existing `VHL-0024`). The `license_plate` field retains the user-entered value without modification.


## Areas affected and ensured

- Vehicle DocType naming series
- `hooks.py` — Vehicle doc_events (only `autoname` removed; `after_insert` for leasing contract preserved)
- `fleet_management/utils.py` — dead code removal
- `custom/property_setter/vehicle.py` — new property setter entry added


## Is there any existing behavior change of other features due to this code change?

No. The naming format remains `VHL-XXXX` (4-digit zero-padded). Existing Vehicle records are unaffected. The `after_insert` hook for Vehicle Leasing Contract integration is preserved.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
No child table was created.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [x] Yes
- [ ] No

### Was the patch tested?
Yes. The patch (`update_vehicle_naming_series`) ran successfully during `bench migrate`. Verified the `tabSeries` counter is set to 24, matching the highest existing Vehicle name (`VHL-0024`). New Vehicle created successfully with name `VHL-0025`.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
<img width="1414" height="775" alt="Screenshot 2026-06-08 at 2 43 20 PM" src="https://github.com/user-attachments/assets/9de89964-0cee-4f31-89c2-9e0ab831c526" />
<img width="1136" height="328" alt="Screenshot 2026-06-08 at 2 43 25 PM" src="https://github.com/user-attachments/assets/edb167b8-a904-4641-988e-719d023ab76d" />
