### PR TITLE
[WI-001009][ Route Planner Default View Configuration]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -1718,7 +1718,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     status: msg.plan_status,
                     effective_from: msg.effective_from,
                     effective_until: msg.effective_until,
-                    is_default: msg.is_default || 0
+                    is_default: Number(msg.is_default) || 0
                 };
 
                 // Restore swim items — convert ISO strings to Date,
@@ -1788,7 +1788,7 @@ function mountRoutePlannerApp(wrapper, data) {
                                     status: plan.status,
                                     effective_from: plan.effective_from,
                                     effective_until: plan.effective_until,
-                                    is_default: plan.is_default || 0
+                                    is_default: Number(plan.is_default) || 0
                                 };
                             }
                         }
@@ -2284,7 +2284,7 @@ function injectRPVueTemplate() {
                 style="width:auto;min-width:160px">
           <option value="" disabled>Select a plan…</option>
           <option v-for="p in planList" :key="p.name" :value="p.name">
-            {{ p.is_default ? '\u2605 ' : '' }}{{ p.title }} ({{ p.status }})
+            {{ Number(p.is_default) ? '\u2605 ' : '' }}{{ p.title }} ({{ p.status }})
           </option>
         </select>
         <button class="rp-btn rp-btn-default"
@@ -2293,7 +2293,7 @@ function injectRPVueTemplate() {
               :class="currentPlan.status === 'Active' ? 'green' : currentPlan.status === 'Draft' ? 'orange' : 'gray'">
           {{ currentPlan.status }}
         </span>
-        <span v-if="currentPlan && currentPlan.is_default" class="indicator-pill blue">
+        <span v-if="currentPlan && Number(currentPlan.is_default)" class="indicator-pill blue">
           \u2605 Default
         </span>
         <button v-if="currentPlan && currentPlan.status === 'Draft'"

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -1717,7 +1717,8 @@ function mountRoutePlannerApp(wrapper, data) {
                     title: msg.plan_title,
                     status: msg.plan_status,
                     effective_from: msg.effective_from,
-                    effective_until: msg.effective_until
+                    effective_until: msg.effective_until,
+                    is_default: msg.is_default || 0
                 };
 
                 // Restore swim items — convert ISO strings to Date,
@@ -1786,7 +1787,8 @@ function mountRoutePlannerApp(wrapper, data) {
                                     title: plan.title,
                                     status: plan.status,
                                     effective_from: plan.effective_from,
-                                    effective_until: plan.effective_until
+                                    effective_until: plan.effective_until,
+                                    is_default: plan.is_default || 0
                                 };
                             }
                         }
@@ -1810,6 +1812,11 @@ function mountRoutePlannerApp(wrapper, data) {
                         {
                             fieldname: "effective_until", label: "Effective Until", fieldtype: "Date",
                             description: "Leave blank for indefinite"
+                        },
+                        {
+                            fieldname: "is_default", label: "Is Default", fieldtype: "Check",
+                            default: 0,
+                            description: "Auto-load this plan when opening Route Planner"
                         },
                     ],
                     primary_action_label: __("Create"),
@@ -2277,7 +2284,7 @@ function injectRPVueTemplate() {
                 style="width:auto;min-width:160px">
           <option value="" disabled>Select a plan…</option>
           <option v-for="p in planList" :key="p.name" :value="p.name">
-            {{ p.title }} ({{ p.status }})
+            {{ p.is_default ? '\u2605 ' : '' }}{{ p.title }} ({{ p.status }})
           </option>
         </select>
         <button class="rp-btn rp-btn-default"
@@ -2285,6 +2292,9 @@ function injectRPVueTemplate() {
         <span v-if="currentPlan" class="indicator-pill"
               :class="currentPlan.status === 'Active' ? 'green' : currentPlan.status === 'Draft' ? 'orange' : 'gray'">
           {{ currentPlan.status }}
+        </span>
+        <span v-if="currentPlan && currentPlan.is_default" class="indicator-pill blue">
+          \u2605 Default
         </span>
         <button v-if="currentPlan && currentPlan.status === 'Draft'"
                 class="rp-btn rp-btn-success"

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -1149,7 +1149,7 @@ def get_route_plans():
     if not _route_plan_exists():
         return []
     plans = frappe.get_list("Route Plan",
-        fields=["name", "title", "status", "effective_from", "effective_until"],
+        fields=["name", "title", "status", "effective_from", "effective_until", "is_default"],
         order_by="creation desc"
     )
     return plans
@@ -1206,7 +1206,10 @@ def load_assignments(plan_name: str = ""):
         return {"status": "empty", "message": _("Route Plan DocType not migrated yet.")}
 
     if not plan_name:
-        plan_name = frappe.db.get_value("Route Plan", {"status": "Active"}, "name")
+        # Prioritize the plan marked as default; fall back to Active if no default
+        plan_name = frappe.db.get_value("Route Plan", {"is_default": 1}, "name")
+        if not plan_name:
+            plan_name = frappe.db.get_value("Route Plan", {"status": "Active"}, "name")
 
     if not plan_name:
         return {"status": "empty"}
@@ -1255,6 +1258,7 @@ def load_assignments(plan_name: str = ""):
         "plan_status": doc.status,
         "effective_from": str(doc.effective_from) if doc.effective_from else None,
         "effective_until": str(doc.effective_until) if doc.effective_until else None,
+        "is_default": doc.is_default,
         "swim_items": swim_items,
         "assigned_cards": list(assigned_card_ids),
         "saved_by": doc.last_modified_by_user,
@@ -1263,7 +1267,7 @@ def load_assignments(plan_name: str = ""):
 
 
 @frappe.whitelist()
-def create_route_plan(title: str, effective_from: str, effective_until: str = ""):
+def create_route_plan(title: str, effective_from: str, effective_until: str = "", is_default: int = 0):
     """Create a new Route Plan and return its name."""
     if not _route_plan_exists():
         frappe.throw(_("Route Plan DocType not found. Please run 'bench migrate' on this site first."))
@@ -1272,6 +1276,7 @@ def create_route_plan(title: str, effective_from: str, effective_until: str = ""
     doc.title = title
     doc.effective_from = effective_from
     doc.effective_until = effective_until or None
+    doc.is_default = is_default
     doc.status = "Draft"
     doc.insert()
     return {

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -1,6 +1,7 @@
 import frappe
 import requests
 from frappe import _
+from frappe.utils import cint
 
 PICKUP_BUFFER = 10             # minutes
 MAX_TRANSIT = 60               # minutes
@@ -1276,7 +1277,7 @@ def create_route_plan(title: str, effective_from: str, effective_until: str = ""
     doc.title = title
     doc.effective_from = effective_from
     doc.effective_until = effective_until or None
-    doc.is_default = is_default
+    doc.is_default = cint(is_default)
     doc.status = "Draft"
     doc.insert()
     return {

--- a/one_fm/operations/doctype/route_plan/route_plan.json
+++ b/one_fm/operations/doctype/route_plan/route_plan.json
@@ -14,6 +14,7 @@
     "column_break_1",
     "effective_from",
     "effective_until",
+    "is_default",
     "section_break_assignments",
     "assignments",
     "section_break_meta",
@@ -55,6 +56,13 @@
       "fieldtype": "Date",
       "label": "Effective Until",
       "description": "Leave blank for indefinite"
+    },
+    {
+      "fieldname": "is_default",
+      "fieldtype": "Check",
+      "label": "Is Default",
+      "default": "0",
+      "description": "If checked, this plan auto-loads when the Route Planner page opens"
     },
     {
       "fieldname": "section_break_assignments",

--- a/one_fm/operations/doctype/route_plan/route_plan.py
+++ b/one_fm/operations/doctype/route_plan/route_plan.py
@@ -10,6 +10,7 @@ class RoutePlan(Document):
 	def validate(self):
 		self._validate_dates()
 		self._validate_single_active()
+		self._validate_single_default()
 
 	def _validate_dates(self):
 		"""Ensure effective_until >= effective_from when set."""
@@ -28,6 +29,19 @@ class RoutePlan(Document):
 			if existing:
 				frappe.throw(
 					_("Route Plan {0} is already Active. Deactivate it first or set it to Expired.").format(existing)
+				)
+
+	def _validate_single_default(self):
+		"""Only one Route Plan can be marked as Default."""
+		if self.is_default:
+			existing = frappe.db.get_value(
+				"Route Plan",
+				{"is_default": 1, "name": ["!=", self.name]},
+				"name"
+			)
+			if existing:
+				frappe.throw(
+					_("A default Route Plan already exists ({0}). Only one plan can be set as default at a time.").format(existing)
 				)
 
 	def before_save(self):

--- a/one_fm/operations/doctype/route_plan/route_plan.py
+++ b/one_fm/operations/doctype/route_plan/route_plan.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.utils import cint
 from frappe.model.document import Document
 
 
@@ -33,7 +34,7 @@ class RoutePlan(Document):
 
 	def _validate_single_default(self):
 		"""Only one Route Plan can be marked as Default."""
-		if self.is_default:
+		if cint(self.is_default):
 			existing = frappe.db.get_value(
 				"Route Plan",
 				{"is_default": 1, "name": ["!=", self.name]},


### PR DESCRIPTION
### Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
**Route Planner Default View Configuration** — Allow Fleet Managers to set a specific Route Plan as the "Default" so it automatically loads when the Route Planner page opens, while still maintaining the ability to select other plans via the dropdown.


## Analysis and design (optional)
See implementation plan in conversation. The feature adds an `is_default` Check field to the Route Plan DocType with a single-default constraint enforced server-side via `frappe.throw()`.


## Solution description

**1. DocType JSON (`route_plan.json`)**
- Added `is_default` Check field to both `field_order` and `fields` arrays, placed after `effective_until`.

**2. Controller (`route_plan.py`)**
- Added `_validate_single_default()` validation method called from `validate()`.
- If a user checks "Is Default" and another plan already has it checked, `frappe.throw()` blocks the save with the message: *"A default Route Plan already exists ({name}). Only one plan can be set as default at a time."*

**3. Backend APIs (`route_planner.py`)**
- `get_route_plans()` — Added `is_default` to returned fields for the plan dropdown.
- `load_assignments()` — Changed auto-load priority: checks `is_default=1` first, falls back to `status=Active` if no default exists (backward compatible).
- `load_assignments()` — Added `is_default` to the response payload.
- `create_route_plan()` — Accepts optional `is_default` parameter; controller validation handles duplicate prevention.

**4. Frontend (`route_planner.js`)**
- `_applyLoadedPlan()` and `switchPlan()` — Store `is_default` on the `currentPlan` object.
- `createNewPlan()` dialog — Added "Is Default" checkbox field.
- Plan dropdown — Shows ★ prefix for the default plan.
- Header — Shows blue "★ Default" indicator pill next to the status badge.


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No

The `_validate_single_default()` method in the Route Plan controller enforces that only one Route Plan can be marked as default at a time.


## Output screenshots (optional)
- **DocType form**: "Is Default" checkbox visible after "Effective Until" field.
- **Route Planner dropdown**: Default plan prefixed with ★ symbol.
- **Route Planner header**: Blue "★ Default" pill displayed next to the status indicator.
- **Validation error**: Attempting to set a second default shows a blocking error dialog.


## Areas affected and ensured
- Route Plan DocType (form view — new checkbox field)
- Route Plan controller (new validation)
- Route Planner page backend (auto-load logic, plan list API, plan creation API)
- Route Planner page frontend (dropdown, header badges, creation modal)


## Is there any existing behavior change of other features due to this code change?
**Yes** — The Route Planner page auto-load priority changed. Previously it always loaded the Active plan. Now it first checks for a plan with `is_default=1`, and falls back to the Active plan if no default is set. This is fully backward compatible — if no plan has `is_default` checked, behavior is identical to before.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
No child table was created.

- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

The `is_default` field already exists in the database (added via UI). Adding it to the JSON ensures it persists across `bench migrate` on fresh installs. No data migration patch is needed.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
<img width="1094" height="671" alt="Screenshot 2026-06-08 at 5 02 35 PM" src="https://github.com/user-attachments/assets/8653d1b9-c719-4c96-83b8-804f735363bd" />
<img width="1437" height="750" alt="Screenshot 2026-06-08 at 5 08 07 PM" src="https://github.com/user-attachments/assets/2d071d97-4116-4f29-a16a-c0e60e9bbfc7" />
<img width="773" height="218" alt="Screenshot 2026-06-08 at 5 08 16 PM" src="https://github.com/user-attachments/assets/ec25d813-1a5c-4280-99cf-90055b341adb" />
