### PR TITLE
[WI-001010][Timeline Drag and Drop Precision]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -85,7 +85,6 @@ function mountRoutePlannerApp(wrapper, data) {
 
                 // ── Drag tooltip (5-min snap) ──
                 dragTooltip: null,          // { x, y, timeLabel } — floating HH:MM tooltip during block drag
-                dragSnappedTime: null,      // Date — current 5-min-snapped start time during drag
 
                 // ── Plan management ──
                 currentPlan: null,        // { name, title, status, effective_from, effective_until }
@@ -1205,7 +1204,6 @@ function mountRoutePlannerApp(wrapper, data) {
                         y: me.clientY,
                         timeLabel: this.fmtTime(snappedStart)
                     };
-                    this.dragSnappedTime = snappedStart;
 
                     // Vertical: detect target lane
                     const el = document.elementFromPoint(me.clientX, me.clientY);
@@ -1231,7 +1229,6 @@ function mountRoutePlannerApp(wrapper, data) {
                     document.removeEventListener('mouseup', onUp);
                     clearHighlight();
                     this.dragTooltip = null;
-                    this.dragSnappedTime = null;
                     setTimeout(() => { this.isDraggingBlock = false; }, 60);
                     if (moved) {
                         // If dropped on a different lane, validate seat capacity first
@@ -1309,7 +1306,6 @@ function mountRoutePlannerApp(wrapper, data) {
                         y: t.clientY,
                         timeLabel: this.fmtTime(snappedStart)
                     };
-                    this.dragSnappedTime = snappedStart;
                 };
 
                 const onTouchEnd = () => {
@@ -1317,7 +1313,6 @@ function mountRoutePlannerApp(wrapper, data) {
                     document.removeEventListener('touchend', onTouchEnd);
                     document.removeEventListener('touchcancel', onTouchCancel);
                     this.dragTooltip = null;
-                    this.dragSnappedTime = null;
                     setTimeout(() => { this.isDraggingBlock = false; }, 60);
                     if (moved) {
                         this.checkConflicts();
@@ -1334,7 +1329,6 @@ function mountRoutePlannerApp(wrapper, data) {
                     item.start = new Date(origStart);
                     item.end = new Date(origEnd);
                     this.dragTooltip = null;
-                    this.dragSnappedTime = null;
                     setTimeout(() => { this.isDraggingBlock = false; }, 60);
                 };
 

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -83,6 +83,10 @@ function mountRoutePlannerApp(wrapper, data) {
                 stopDragSourceIndex: null,  // drag-reorder: source stop index
                 stopDragOverIndex: null,    // drag-reorder: hovered stop index
 
+                // ── Drag tooltip (5-min snap) ──
+                dragTooltip: null,          // { x, y, timeLabel } — floating HH:MM tooltip during block drag
+                dragSnappedTime: null,      // Date — current 5-min-snapped start time during drag
+
                 // ── Plan management ──
                 currentPlan: null,        // { name, title, status, effective_from, effective_until }
                 planList: [],           // all available plans
@@ -440,6 +444,13 @@ function mountRoutePlannerApp(wrapper, data) {
                 return new Date(t).toLocaleTimeString('en-GB', {
                     hour: '2-digit', minute: '2-digit', timeZone: 'Asia/Kuwait'
                 });
+            },
+
+            /** Round a Date to the nearest 5-minute boundary. */
+            snapTo5Min(d) {
+                const ms = new Date(d).getTime();
+                const FIVE_MIN = 5 * 60 * 1000;
+                return new Date(Math.round(ms / FIVE_MIN) * FIVE_MIN);
             },
 
             fmtISO(iso) {
@@ -1180,10 +1191,21 @@ function mountRoutePlannerApp(wrapper, data) {
                     if (!moved) return;
                     this.isDraggingBlock = true;
 
-                    // Horizontal: shift time
+                    // Horizontal: shift time (snapped to 5-min intervals)
                     const deltaMs = (dx / this.svgWidth) * this.windowDurationMs;
-                    item.start = new Date(origStart + deltaMs);
-                    item.end = new Date(origEnd + deltaMs);
+                    const rawStart = new Date(origStart + deltaMs);
+                    const snappedStart = this.snapTo5Min(rawStart);
+                    const snapDelta = snappedStart.getTime() - origStart;
+                    item.start = snappedStart;
+                    item.end = new Date(origEnd + snapDelta);
+
+                    // Update floating tooltip
+                    this.dragTooltip = {
+                        x: me.clientX,
+                        y: me.clientY,
+                        timeLabel: this.fmtTime(snappedStart)
+                    };
+                    this.dragSnappedTime = snappedStart;
 
                     // Vertical: detect target lane
                     const el = document.elementFromPoint(me.clientX, me.clientY);
@@ -1208,6 +1230,8 @@ function mountRoutePlannerApp(wrapper, data) {
                     document.removeEventListener('mousemove', onMove);
                     document.removeEventListener('mouseup', onUp);
                     clearHighlight();
+                    this.dragTooltip = null;
+                    this.dragSnappedTime = null;
                     setTimeout(() => { this.isDraggingBlock = false; }, 60);
                     if (moved) {
                         // If dropped on a different lane, validate seat capacity first
@@ -1273,14 +1297,27 @@ function mountRoutePlannerApp(wrapper, data) {
                     if (!moved) return;
                     this.isDraggingBlock = true;
                     const deltaMs = (dx / this.svgWidth) * this.windowDurationMs;
-                    item.start = new Date(origStart + deltaMs);
-                    item.end = new Date(origEnd + deltaMs);
+                    const rawStart = new Date(origStart + deltaMs);
+                    const snappedStart = this.snapTo5Min(rawStart);
+                    const snapDelta = snappedStart.getTime() - origStart;
+                    item.start = snappedStart;
+                    item.end = new Date(origEnd + snapDelta);
+
+                    // Update floating tooltip
+                    this.dragTooltip = {
+                        x: t.clientX,
+                        y: t.clientY,
+                        timeLabel: this.fmtTime(snappedStart)
+                    };
+                    this.dragSnappedTime = snappedStart;
                 };
 
                 const onTouchEnd = () => {
                     document.removeEventListener('touchmove', onTouchMove);
                     document.removeEventListener('touchend', onTouchEnd);
                     document.removeEventListener('touchcancel', onTouchCancel);
+                    this.dragTooltip = null;
+                    this.dragSnappedTime = null;
                     setTimeout(() => { this.isDraggingBlock = false; }, 60);
                     if (moved) {
                         this.checkConflicts();
@@ -1296,6 +1333,8 @@ function mountRoutePlannerApp(wrapper, data) {
                     // Revert position on cancel
                     item.start = new Date(origStart);
                     item.end = new Date(origEnd);
+                    this.dragTooltip = null;
+                    this.dragSnappedTime = null;
                     setTimeout(() => { this.isDraggingBlock = false; }, 60);
                 };
 
@@ -2265,6 +2304,16 @@ function injectRPVueTemplate() {
     s.id = 'rp-vue-template';
     s.textContent = `
 <div id="rp-shell">
+
+  <!-- ── Drag time tooltip (5-min snap) ── -->
+  <div v-if="dragTooltip"
+       class="rp-drag-tooltip"
+       :style="{
+           left: dragTooltip.x + 'px',
+           top: (dragTooltip.y - 44) + 'px'
+       }">
+    {{ dragTooltip.timeLabel }}
+  </div>
 
   <!-- ══ Header ══ -->
   <div id="rp-header">
@@ -3256,6 +3305,30 @@ function injectRPStyles() {
         .rp-block-grab     { cursor: grab; }
         .rp-block-grabbing { cursor: grabbing; }
         .rp-empty-state    { padding: 48px; text-align: center; font-size: 14px; color: var(--md-sys-color-outline); }
+
+        /* ── Drag time tooltip (5-min snap) ── */
+        .rp-drag-tooltip {
+            position: fixed;
+            z-index: 9999;
+            pointer-events: none;
+            background: rgba(0, 0, 0, 0.85);
+            color: #fff;
+            font-family: 'Google Sans', Roboto, monospace;
+            font-size: 14px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            padding: 6px 14px;
+            border-radius: 8px;
+            white-space: nowrap;
+            transform: translateX(-50%);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            backdrop-filter: blur(4px);
+            animation: rp-tooltip-in 0.1s ease-out;
+        }
+        @keyframes rp-tooltip-in {
+            from { opacity: 0; transform: translateX(-50%) translateY(4px); }
+            to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+        }
 
         /* ── Detail Panel ── */
         #rp-detail-panel {


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

**Timeline Drag-and-Drop 5-Minute Precision** — Adds strict 5-minute snapping to the Route Planner Gantt chart when dragging trip blocks. A floating `HH:MM` tooltip follows the cursor during drag, dynamically updating to show the snapped time (e.g., 06:00, 06:05, 06:10). Blocks now visually jump between 5-minute intervals instead of moving pixel-by-pixel, and the saved `start_time`/`end_time` are guaranteed to land on 5-minute boundaries.


## Analysis and design (optional)

The implementation adds a `snapTo5Min()` utility that rounds any Date to the nearest 5-minute boundary using `Math.round(ms / 300000) * 300000`. Both the desktop (`onBlockMouseDown`) and mobile (`onBlockTouchStart`) drag handlers apply this snap before setting `item.start`/`item.end`. A reactive `dragTooltip` state drives a `position: fixed` tooltip `<div>` in the Vue template. No backend changes were needed — the existing `save_assignments` endpoint persists ISO strings, which now arrive pre-snapped.


## Solution description

**Single file changed:** `one_fm/one_fm/page/route_planner/route_planner.js`

1. **`data()`** — Added `dragTooltip` (object: `{x, y, timeLabel}`) and `dragSnappedTime` (Date) reactive properties
2. **`snapTo5Min(d)`** — New method that rounds a Date to the nearest 5-minute boundary
3. **`onBlockMouseDown`** (desktop drag) — Replaced raw `deltaMs` application with snapped calculation; populates `dragTooltip` on every `mousemove`; clears tooltip on `mouseup`
4. **`onBlockTouchStart`** (mobile drag) — Same snapping + tooltip logic for `touchmove`; clears on `touchend`/`touchcancel`
5. **Vue template** — Added `<div v-if="dragTooltip" class="rp-drag-tooltip">` positioned at cursor with `HH:MM` label
6. **CSS** — `.rp-drag-tooltip` with `position:fixed`, dark translucent background, `backdrop-filter:blur`, fade-in animation


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

During drag, a dark tooltip appears above the cursor showing the snapped time (e.g., `06:15`). The block jumps between 5-minute grid positions instead of free-pixel movement.


## Areas affected and ensured

- Route Planner page — timeline block drag (desktop mouse + mobile touch)
- Block repositioning (horizontal time axis)
- Cross-lane drag (vertical vehicle reassignment) — snapping applies to horizontal axis
- Auto-save persistence — times now always at 5-minute boundaries


## Is there any existing behavior change of other features due to this code change?

**Yes** — Block dragging now snaps to 5-minute intervals instead of allowing free pixel-by-pixel positioning. This is intentional and the core purpose of the feature. All other Route Planner functionality (card assignment, trip chaining, stop reorder, zoom/pan, conflict detection, save/load) is unaffected.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No child table was created.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
![Uploading Screenshot 2026-06-08 at 5.31.20 PM.png…]()
