### PR TITLE
[WI-000980][Overtime Request Update]

### DIFF
--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.js
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.js
@@ -3,10 +3,7 @@
 
 frappe.ui.form.on("Overtime Request", {
 	setup: function(frm) {
-		// Story 1: Default requested_by to the current logged-in user
-		if (frm.is_new()) {
-			frm.set_value("requested_by", frappe.session.user);
-		}
+		// requested_by is auto-set via default:"__user" in DocType JSON
 	},
 
 	refresh: function(frm) {

--- a/one_fm/one_fm/doctype/overtime_request/overtime_request.json
+++ b/one_fm/one_fm/doctype/overtime_request/overtime_request.json
@@ -96,10 +96,13 @@
    "options": "Department"
   },
   {
+   "default": "__user",
    "fieldname": "requested_by",
    "fieldtype": "Link",
    "label": "Requested By",
-   "options": "User"
+   "options": "User",
+   "read_only": 1,
+   "set_only_once": 1
   },
   {
    "fetch_from": "employee.reports_to",

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -200,7 +200,6 @@ class MOM(Document):
 				changed = True
 				
 			if changed:
-			if changed:
 				task.flags.ignore_links = True
 				task.flags.ignore_workflow = True
 				task.save(ignore_permissions=True)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
**Overtime Request — Auto-populate "Requested By" as read-only.**

As a Line Manager, I want to see the Requestor Name in read-only, so that it is easier to take an approval decision. The `Requested By` field shall be automatically fetched with the logged-in user and be read-only upon opening a new record.


## Analysis and design (optional)
The `requested_by` field (Link → User) already had server-side (`before_insert`) and client-side (`setup`) logic to default to `frappe.session.user`. However:
1. The field was **not marked read-only** in the DocType JSON, allowing manual edits.
2. The JS `frm.set_value()` in `setup` was interfering with Frappe's Link field display rendering after the employee fetch, causing the wrong display name to appear.
3. No `set_only_once` protection existed, so the value could be overwritten during workflow transitions.


## Solution description

### `overtime_request.json`
- Added `"default": "__user"` — Frappe's native mechanism to auto-populate with the logged-in user, more reliable than JS-only defaults.
- Added `"read_only": 1` — prevents manual edits to the field.
- Added `"set_only_once": 1` — locks the value after initial creation, preventing overwrites during workflow transitions.

### `overtime_request.js`
- Removed the redundant `frm.set_value("requested_by", frappe.session.user)` from `setup` — the `default: "__user"` in the DocType JSON now handles this natively and avoids Link title rendering conflicts.

### `mom.py` (pre-existing bug fix)
- Removed a duplicate `if changed:` line (line 202) that caused an `IndentationError` blocking `bench migrate`.


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No

The `before_insert` method in `overtime_request.py` already sets `requested_by = frappe.session.user` as a fallback. No changes were needed to this logic.


## Output screenshots (optional)
After the change, the `Requested By` field:
- Auto-populates with the logged-in user on new forms
- Is greyed out / non-editable
- Retains the original requester's identity after save and through workflow transitions


## Areas affected and ensured
- Overtime Request form — `Requested By` field display and editability
- No impact on workflow notifications (they read `requested_by` but don't write to it)
- No impact on assignment rules


## Is there any existing behavior change of other features due to this code change?
No. The `requested_by` value was already being set to `frappe.session.user` via `before_insert`. This change only ensures the field is read-only, uses a native default, and is locked after creation.


## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
No.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

No data migration needed — the `default: "__user"` only applies to new records. Existing records already have `requested_by` set via `before_insert`.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
<img width="1340" height="630" alt="Screenshot 2026-06-09 at 12 15 00 AM" src="https://github.com/user-attachments/assets/627d9ea1-94fd-47c5-87ad-0ae4f7947247" />
<img width="1418" height="701" alt="Screenshot 2026-06-09 at 12 15 15 AM" src="https://github.com/user-attachments/assets/7af34062-5595-48c0-90a7-52d12ffeb389" />
