### PR TITLE
[WI-001012][Rambo Frontend UI to Transportation Schedule]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -3,7 +3,7 @@ frappe.pages['route-planner'].on_page_load = function (wrapper) {
     $(wrapper).html(`
         <div id="rp-loading">
             <div id="rp-loading-spinner"></div>
-            <div id="rp-loading-text">Loading Route Planner...</div>
+            <div id="rp-loading-text">Loading Transportation Schedule...</div>
             <div id="rp-loading-sub">Fetching vehicles, shifts and employee data</div>
         </div>
     `);
@@ -1816,7 +1816,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         {
                             fieldname: "is_default", label: "Is Default", fieldtype: "Check",
                             default: 0,
-                            description: "Auto-load this plan when opening Route Planner"
+                            description: "Auto-load this plan when opening Transportation Schedule"
                         },
                     ],
                     primary_action_label: __("Create"),
@@ -2276,7 +2276,7 @@ function injectRPVueTemplate() {
   <!-- ══ Header ══ -->
   <div id="rp-header">
     <div id="rp-header-left">
-      <div id="rp-title">Route Planner</div>
+      <div id="rp-title">Transportation Schedule</div>
     <div id="rp-plan-selector" style="display:flex;align-items:center;gap:8px;margin-top:4px;flex-wrap:wrap">
         <select :value="currentPlan ? currentPlan.name : ''"
                 @change="switchPlan($event.target.value)"

--- a/one_fm/one_fm/page/route_planner/route_planner.json
+++ b/one_fm/one_fm/page/route_planner/route_planner.json
@@ -4,7 +4,7 @@
     "name": "route-planner",
     "page_name": "route-planner",
     "standard": "Yes",
-    "title": "Route Planner",
+    "title": "Transportation Schedule",
     "roles": [
         {
             "role": "System Manager"

--- a/one_fm/one_fm/workspace/fleet/fleet.json
+++ b/one_fm/one_fm/workspace/fleet/fleet.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Fleet Management</span>\",\"col\":12}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Route Plan\",\"col\":3}},{\"type\":\"card\",\"data\":{\"card_name\":\"Fleet\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Transport\",\"col\":4}}]",
+ "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Fleet Management</span>\",\"col\":12}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Schedule\",\"col\":3}},{\"type\":\"card\",\"data\":{\"card_name\":\"Fleet\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Transport\",\"col\":4}}]",
  "creation": "2022-10-31 21:02:45.195181",
  "docstatus": 0,
  "doctype": "Workspace",
@@ -50,7 +50,7 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Route Plan",
+   "label": "Transportation Schedule",
    "link_count": 0,
    "link_to": "route_planner",
    "link_type": "Page",
@@ -101,7 +101,7 @@
  "shortcuts": [
   {
    "color": "Blue",
-   "label": "Route Plan",
+   "label": "Transportation Schedule",
    "link_to": "route_planner",
    "type": "Page"
   }

--- a/one_fm/operations/doctype/route_plan/route_plan.json
+++ b/one_fm/operations/doctype/route_plan/route_plan.json
@@ -62,7 +62,7 @@
       "fieldtype": "Check",
       "label": "Is Default",
       "default": "0",
-      "description": "If checked, this plan auto-loads when the Route Planner page opens"
+      "description": "If checked, this plan auto-loads when the Transportation Schedule page opens"
     },
     {
       "fieldname": "section_break_assignments",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [x] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
Rename the frontend UI from "Route Planner" to "Transportation Schedule" across all user-facing labels — page title, header, loading text, workspace shortcuts/links, and DocType field descriptions — so the terminology accurately reflects its function as a time-based scheduling dashboard.


## Analysis and design (optional)
No design changes. This is a text-only rename affecting UI labels. Internal code identifiers (file names, API paths, CSS IDs, variable names) are intentionally preserved to avoid breaking changes.


## Solution description

**4 files modified:**

| File | Change |
|---|---|
| `one_fm/one_fm/page/route_planner/route_planner.json` | Page `title` changed from "Route Planner" → "Transportation Schedule". This drives the Awesome Bar / global search result label. |
| `one_fm/one_fm/page/route_planner/route_planner.js` | 3 user-facing strings updated: loading spinner text (line 6), "Save Plan" dialog `is_default` field description (line 1819), and the main header title `#rp-title` (line 2279). |
| `one_fm/operations/doctype/route_plan/route_plan.json` | `is_default` field description updated to reference "Transportation Schedule" instead of "Route Planner". |
| `one_fm/one_fm/workspace/fleet/fleet.json` | Workspace shortcut label, card link label, and content JSON shortcut name all updated from "Route Plan" → "Transportation Schedule". |


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)
N/A — text-only rename. After clearing cache:
- Header displays **"Transportation Schedule"**
- Awesome Bar search for "Transportation Schedule" returns the correct navigation link
- Fleet workspace shortcut and Transport card link both show **"Transportation Schedule"**


## Areas affected and ensured
- Page header title (top-left corner)
- Loading spinner text
- Frappe Awesome Bar / global search results
- Fleet workspace — shortcut tile and Transport card link
- Route Plan DocType — `is_default` field help text
- "Save Plan" dialog — `is_default` checkbox description


## Is there any existing behavior change of other features due to this code change?
**No.** All changes are cosmetic label renames. The page URL (`/app/route-planner`), API endpoints, file paths, and all internal logic remain unchanged.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

_(No data migration needed — changes are in JSON fixture files and client-side JS labels that sync on `bench migrate` / cache clear.)_


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox

<img width="1160" height="689" alt="Screenshot 2026-06-09 at 2 31 51 AM" src="https://github.com/user-attachments/assets/8afe7d53-bcde-446a-99b9-f92d1cb5676a" />

