### PR TITLE
[WI-000975][Blocking Employee Check-in]

### DIFF
--- a/one_fm/api/v1/face_recognition.py
+++ b/one_fm/api/v1/face_recognition.py
@@ -255,10 +255,16 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
         if not isinstance(employee_id, str):
             return response("Bad Request", 400, None, "Invalid Employee ID format. Please enter a valid value.")
 
-        employee = frappe.db.get_value("Employee", {"employee_id": employee_id}, ["name", "holiday_list", "employee_name", "shift_working"], as_dict=1)
+        employee = frappe.db.get_value("Employee", {"employee_id": employee_id}, ["name", "holiday_list", "employee_name", "shift_working", "status"], as_dict=1)
         if not employee:
             return response("Resource Not Found", 404, None,
                             "No employee record found with {employee_id}".format(employee_id=employee_id))
+
+        # Block employees who have not returned from leave
+        if employee.status == "Not Returned From Leave":
+            return response("Access Denied", 403, None,
+                            "Access Denied: Please contact your Site Supervisor to complete "
+                            "your Duty Resumption process before logging checkin.")
         
         today = getdate()
         

--- a/one_fm/one_fm/doctype/bonus_request_items/bonus_request_items.json
+++ b/one_fm/one_fm/doctype/bonus_request_items/bonus_request_items.json
@@ -134,6 +134,7 @@
    "default": "0",
    "fieldname": "approve",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Approve"
   },
   {
@@ -144,6 +145,7 @@
    "default": "0",
    "fieldname": "reject",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Reject"
   }
  ],

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -29,7 +29,7 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 
 	def validate_not_returned_from_leave(self):
 		"""Block checkin for employees with 'Not Returned From Leave' status."""
-		employee_status = frappe.db.get_value("Employee", self.employee, "status")
+		employee_status = frappe.get_cached_value("Employee", self.employee, "status")
 		if employee_status == "Not Returned From Leave":
 			frappe.throw(
 				_("Access Denied: Please contact your Site Supervisor to complete "
@@ -38,8 +38,8 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 			)
 
 	def validate(self):
+		self.validate_not_returned_from_leave()
 		try:
-			self.validate_not_returned_from_leave()
 			validate_active_employee(self.employee)
 			self.validate_duplicate_log()
 			if frappe.db.get_single_value("HR and Payroll Additional Settings",

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -27,8 +27,19 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 	def fetch_shift(self):
 		pass
 
+	def validate_not_returned_from_leave(self):
+		"""Block checkin for employees with 'Not Returned From Leave' status."""
+		employee_status = frappe.db.get_value("Employee", self.employee, "status")
+		if employee_status == "Not Returned From Leave":
+			frappe.throw(
+				_("Access Denied: Please contact your Site Supervisor to complete "
+				  "your Duty Resumption process before logging checkin."),
+				title=_("Checkin Blocked")
+			)
+
 	def validate(self):
 		try:
+			self.validate_not_returned_from_leave()
 			validate_active_employee(self.employee)
 			self.validate_duplicate_log()
 			if frappe.db.get_single_value("HR and Payroll Additional Settings",

--- a/one_fm/tests/test_block_checkin_not_returned_from_leave.py
+++ b/one_fm/tests/test_block_checkin_not_returned_from_leave.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, ONE-F-M and Contributors
+# See license.txt
+import frappe
+import unittest
+from frappe.utils import today, add_days, now_datetime
+
+
+class TestBlockCheckinNotReturnedFromLeave(unittest.TestCase):
+	"""Tests for blocking Employee Checkin when employee status is 'Not Returned From Leave'."""
+
+	def setUp(self):
+		frappe.flags.in_test = 1
+		frappe.set_user("Administrator")
+		frappe.flags.in_import = True
+		frappe.flags.ignore_permissions = True
+
+		self.company = frappe.db.get_value("Company", {"is_group": 0}, "name") or "Test Company"
+		self.employee = self._create_test_employee("Active")
+		frappe.db.commit()
+
+	def tearDown(self):
+		# Clean up test checkins
+		frappe.db.sql(
+			"DELETE FROM `tabEmployee Checkin` WHERE employee = %s",
+			self.employee.name,
+		)
+		frappe.delete_doc("Employee", self.employee.name, force=1, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _create_test_employee(self, status):
+		"""Create a minimal test employee with the given status."""
+		employee = frappe.get_doc({
+			"doctype": "Employee",
+			"first_name": "Checkin Block Test",
+			"employee_name": "Checkin Block Test",
+			"one_fm_first_name_in_arabic": "اختبار",
+			"one_fm_last_name_in_arabic": "حظر",
+			"status": status,
+			"date_of_birth": "1990-01-01",
+			"date_of_joining": add_days(today(), -365),
+			"gender": "Male",
+			"company": self.company,
+			"one_fm_basic_salary": 100,
+			"day_off_category": "Weekly",
+			"number_of_days_off": 1,
+			"create_user_permission": 0,
+		}).insert(ignore_permissions=True)
+		return employee
+
+	def test_checkin_blocked_for_not_returned_from_leave(self):
+		"""Employee with status 'Not Returned From Leave' must NOT be able to check in."""
+		# Set employee status to "Not Returned From Leave"
+		frappe.db.set_value("Employee", self.employee.name, "status", "Not Returned From Leave")
+		frappe.db.commit()
+		frappe.clear_cache(doctype="Employee")
+
+		checkin = frappe.new_doc("Employee Checkin")
+		checkin.employee = self.employee.name
+		checkin.log_type = "IN"
+		checkin.time = now_datetime()
+
+		self.assertRaises(frappe.ValidationError, checkin.insert)
+
+	def test_checkin_allowed_for_active_employee(self):
+		"""Employee with status 'Active' should be able to check in."""
+		checkin = frappe.new_doc("Employee Checkin")
+		checkin.employee = self.employee.name
+		checkin.log_type = "IN"
+		checkin.time = now_datetime()
+
+		# Should not raise — insert succeeds
+		try:
+			checkin.insert(ignore_permissions=True)
+		except frappe.ValidationError as e:
+			if "Not Returned From Leave" in str(e) or "Access Denied" in str(e):
+				self.fail("Active employee was incorrectly blocked from checking in.")
+
+	def test_checkin_allowed_after_status_restored(self):
+		"""After status changes back to 'Active', checkin should succeed."""
+		# Block first
+		frappe.db.set_value("Employee", self.employee.name, "status", "Not Returned From Leave")
+		frappe.db.commit()
+		frappe.clear_cache(doctype="Employee")
+
+		checkin = frappe.new_doc("Employee Checkin")
+		checkin.employee = self.employee.name
+		checkin.log_type = "IN"
+		checkin.time = now_datetime()
+
+		self.assertRaises(frappe.ValidationError, checkin.insert)
+
+		# Restore status
+		frappe.db.set_value("Employee", self.employee.name, "status", "Active")
+		frappe.db.commit()
+		frappe.clear_cache(doctype="Employee")
+
+		# Should succeed now
+		checkin2 = frappe.new_doc("Employee Checkin")
+		checkin2.employee = self.employee.name
+		checkin2.log_type = "IN"
+		checkin2.time = now_datetime()
+
+		try:
+			checkin2.insert(ignore_permissions=True)
+		except frappe.ValidationError as e:
+			if "Not Returned From Leave" in str(e) or "Access Denied" in str(e):
+				self.fail("Employee was still blocked after status was restored to Active.")
+
+	def test_blocked_checkin_error_message(self):
+		"""Verify the exact error message text for blocked checkin."""
+		frappe.db.set_value("Employee", self.employee.name, "status", "Not Returned From Leave")
+		frappe.db.commit()
+		frappe.clear_cache(doctype="Employee")
+
+		checkin = frappe.new_doc("Employee Checkin")
+		checkin.employee = self.employee.name
+		checkin.log_type = "IN"
+		checkin.time = now_datetime()
+
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			checkin.insert()
+
+		self.assertIn("Duty Resumption", str(ctx.exception))
+		self.assertIn("Access Denied", str(ctx.exception))


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Block Employee Checkin for any employee whose status is "Not Returned From Leave". When such an employee attempts to check in via the mobile app, the system intercepts the request and displays: *"Access Denied: Please contact your Site Supervisor to complete your Duty Resumption process before logging checkin."* Once HR updates the employee's status to "Active" after completing the Duty Resumption process, checkin works normally.


## Analysis and design

Two-layer defense approach:

1. **Layer 1 (Primary — Mobile UX):** Status check added in `get_site_location()` API. This blocks the employee *before* the checkin button appears, returning a 403 with the custom message. Follows the same `return response(...)` pattern used by existing checks (day-off, holiday, on-leave, replaced).

2. **Layer 2 (Safety Net — Desk/API):** `validate_not_returned_from_leave()` added to `EmployeeCheckinOverride.validate()`. This catches any checkin attempts that bypass the mobile API (desk UI, direct REST API, background jobs).


## Solution description

### File 1: `one_fm/api/v1/face_recognition.py`
- Added `"status"` to the employee field fetch in `get_site_location()` (line 258)
- Added a status check immediately after the employee existence check — if `employee.status == "Not Returned From Leave"`, returns a 403 response with the denial message (lines 263–267)

### File 2: `one_fm/overrides/employee_checkin.py`
- Added new method `validate_not_returned_from_leave()` to `EmployeeCheckinOverride` class (lines 30–38)
- Called it as the first validation in `validate()` (line 42), before `validate_active_employee()`


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No

Employee Checkin — validation logic in the override controller blocks document creation when the linked Employee has status "Not Returned From Leave".


## Areas affected and ensured

- **Employee Checkin** — new validation prevents creation for blocked employees
- **Mobile App Checkin Flow** — `get_site_location` API returns 403 early, preventing the checkin button from appearing
- **Employee status lifecycle** — relies on the existing "Not Returned From Leave" → "Active" status transition via the Duty Resumption process


## Is there any existing behavior change of other features due to this code change?

**No.** The `get_site_location()` field fetch adds `"status"` but does not remove or alter any existing fields. The new status check runs before all existing checks and only triggers for the specific "Not Returned From Leave" value. All other employee statuses (Active, Vacation, etc.) pass through unchanged.


## Did you test with the following dataset?
- [ ] Existing Data
- [ ] New Data


## Was child table created?
No child table created.

- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

No data migration needed — the "Not Returned From Leave" status already exists in the system.


## Which browser(s) did you use for testing?
- [x ] Chrome
- [ x] Safari
- [ x] Firefox


https://github.com/user-attachments/assets/0efef1e7-7e65-4c5c-987a-d6abdd8d7c9c

