### PR TITLE
[WI-000952][Contract Compliance Checker Action ]

### DIFF
--- a/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.js
+++ b/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.js
@@ -9,11 +9,9 @@ frappe.ui.form.on("Contract Compliance Checker", {
 		frm.trigger("render_take_action_buttons");
 	},
 	render_take_action_buttons: function(frm) {
-		frappe.after_ajax(function() {
-			setTimeout(function() {
-				_inject_take_action_buttons(frm);
-			}, 500);
-		});
+		setTimeout(function() {
+			_inject_take_action_buttons(frm);
+		}, 0);
 	}
 });
 
@@ -70,7 +68,7 @@ function _inject_take_action_buttons(frm) {
 		if (!row_doc || !row_doc.comment) return;
 
 		let $btn = $(
-			'<button class="btn btn-xs btn-primary take-action-btn">'
+			'<button type="button" class="btn btn-xs btn-primary take-action-btn">'
 			+ __("Take Action") + "</button>"
 		);
 

--- a/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.js
+++ b/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.js
@@ -1,8 +1,131 @@
 // Copyright (c) 2025, ONE FM and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Contract Compliance Checker", {
-// 	refresh(frm) {
+frappe.ui.form.on("Contract Compliance Checker", {
+	onload: function(frm) {
+		frm.trigger("render_take_action_buttons");
+	},
+	refresh: function(frm) {
+		frm.trigger("render_take_action_buttons");
+	},
+	render_take_action_buttons: function(frm) {
+		frappe.after_ajax(function() {
+			setTimeout(function() {
+				_inject_take_action_buttons(frm);
+			}, 500);
+		});
+	}
+});
 
-// 	},
-// });
+function _handle_take_action(frm, idx) {
+	let row = (frm.doc.items || [])[idx - 1];
+
+	if (!row || !row.comment) {
+		frappe.msgprint(__("No compliance issue found for this row."));
+		return;
+	}
+
+	frappe.call({
+		method: "one_fm.operations.doctype.contract_compliance_checker.contract_compliance_checker.get_take_action_data",
+		args: {
+			project: frm.doc.project,
+			item: row.item,
+			comment: row.comment,
+			from_date: row.from_date,
+			to_date: row.to_date
+		},
+		callback: function(r) {
+			if (r.message && r.message.path) {
+				let url = new URL(r.message.path, window.location.origin);
+				let params = r.message.params || {};
+				Object.entries(params).forEach(function([key, value]) {
+					if (value) url.searchParams.set(key, value);
+				});
+				window.open(url.toString(), "_blank");
+			} else {
+				frappe.msgprint(__("Unable to determine the appropriate action for this item."));
+			}
+		}
+	});
+}
+
+function _inject_take_action_buttons(frm) {
+	let $grid_wrapper = frm.fields_dict.items.grid.wrapper;
+
+	$grid_wrapper.find('[data-fieldname="take_action"]').each(function() {
+		let $cell = $(this);
+		let $static = $cell.find(".static-area");
+
+		if (!$static.length) {
+			$static = $cell;
+		}
+
+		// Skip if button already injected
+		if ($static.find(".take-action-btn").length) return;
+
+		let $row = $cell.closest("[data-idx]");
+		let idx = parseInt($row.attr("data-idx"));
+		let row_doc = (frm.doc.items || [])[idx - 1];
+
+		if (!row_doc || !row_doc.comment) return;
+
+		let $btn = $(
+			'<button class="btn btn-xs btn-primary take-action-btn">'
+			+ __("Take Action") + "</button>"
+		);
+
+		// Bind click directly on the button to prevent grid row activation
+		$btn.on("click", function(e) {
+			e.stopPropagation();
+			e.stopImmediatePropagation();
+			e.preventDefault();
+			_handle_take_action(frm, idx);
+			return false;
+		});
+
+		$static.html("").append($btn);
+
+		// Prevent clicks on the cell from activating the grid row
+		$cell.on("click", function(e) {
+			if ($(e.target).closest(".take-action-btn").length) {
+				e.stopPropagation();
+				e.stopImmediatePropagation();
+			}
+		});
+	});
+}
+
+// Fallback: handles button click when a row is opened in edit/form view
+frappe.ui.form.on("Contract Compliance Checker Item", {
+	take_action: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+
+		if (!row.comment) {
+			frappe.msgprint(__("No compliance issue found for this row."));
+			return;
+		}
+
+		frappe.call({
+			method: "one_fm.operations.doctype.contract_compliance_checker.contract_compliance_checker.get_take_action_data",
+			args: {
+				project: frm.doc.project,
+				item: row.item,
+				comment: row.comment,
+				from_date: row.from_date,
+				to_date: row.to_date
+			},
+			callback: function(r) {
+				if (r.message && r.message.path) {
+					let url = new URL(r.message.path, window.location.origin);
+					let params = r.message.params || {};
+					Object.entries(params).forEach(function([key, value]) {
+						if (value) url.searchParams.set(key, value);
+					});
+					window.open(url.toString(), "_blank");
+				} else {
+					frappe.msgprint(__("Unable to determine the appropriate action for this item."));
+				}
+			}
+		});
+	}
+});

--- a/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.py
+++ b/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.py
@@ -569,7 +569,7 @@ def _determine_issue_type(comment: str) -> str:
 	comment_lower = comment.lower()
 	if "no operations roles created" in comment_lower:
 		return "operations_role"
-	if "operations post created" in comment_lower:
+	if "operations posts created" in comment_lower or "operations post created" in comment_lower:
 		return "operations_post"
 	if "employee schedules" in comment_lower:
 		return "employee_schedule"
@@ -608,15 +608,17 @@ def get_take_action_data(
 			},
 		}
 
-	# Look up active Operations Roles for this project + sale item
-	operations_roles = frappe.get_list(
+	# Look up the first active Operations Role deterministically
+	role = frappe.db.get_value(
 		"Operations Role",
 		filters={"project": project, "sale_item": item, "status": "Active"},
-		fields=["name", "shift", "site"],
+		fieldname=["name", "shift", "site"],
+		order_by="name asc",
+		as_dict=True,
 	)
 
 	# Fallback to Operations Role list if no roles found
-	if not operations_roles:
+	if not role:
 		return {
 			"path": "/app/operations-role",
 			"params": {
@@ -624,8 +626,6 @@ def get_take_action_data(
 				"sale_item": item,
 			},
 		}
-
-	role = operations_roles[0]
 
 	# Operations Post issue: redirect to Operations Post list view
 	if issue_type == "operations_post":
@@ -639,9 +639,15 @@ def get_take_action_data(
 		}
 
 	# Derive year and month from from_date for the Roster calendar
-	date_obj = getdate(from_date)
-	year = str(date_obj.year)
-	month = str(date_obj.month)
+	try:
+		date_obj = getdate(from_date)
+		year = str(date_obj.year)
+		month = str(date_obj.month)
+	except Exception:
+		from frappe.utils import today
+		date_obj = getdate(today())
+		year = str(date_obj.year)
+		month = str(date_obj.month)
 
 	# Employee Schedule issue: redirect to Roster Staff View
 	if issue_type == "employee_schedule":

--- a/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.py
+++ b/one_fm/operations/doctype/contract_compliance_checker/contract_compliance_checker.py
@@ -558,3 +558,121 @@ def generate_contract_compliance_checker():
 	except Exception as e:
 		frappe.log_error(title="Contract Compliance Checker Generation Failed", message=frappe.get_traceback())
 		pass
+
+
+def _determine_issue_type(comment: str) -> str:
+	"""Determine the compliance issue type from the comment text.
+
+	Returns one of: operations_role, operations_post, employee_schedule, post_schedule, or empty string.
+	Priority order ensures the most fundamental issue is identified first.
+	"""
+	comment_lower = comment.lower()
+	if "no operations roles created" in comment_lower:
+		return "operations_role"
+	if "operations post created" in comment_lower:
+		return "operations_post"
+	if "employee schedules" in comment_lower:
+		return "employee_schedule"
+	if "post schedules" in comment_lower or "post schedule" in comment_lower:
+		return "post_schedule"
+	return ""
+
+
+@frappe.whitelist()
+def get_take_action_data(
+	project: str,
+	item: str,
+	comment: str,
+	from_date: str,
+	to_date: str,
+) -> dict:
+	"""Return redirect path and filter params for the Take Action button.
+
+	Determines the issue type from the comment, resolves the operations context
+	(role, shift, site) from the database, and returns the appropriate URL data.
+	"""
+	if not comment:
+		return {}
+
+	issue_type = _determine_issue_type(comment)
+	if not issue_type:
+		return {}
+
+	# Operations Role issue: redirect to Operations Role list view
+	if issue_type == "operations_role":
+		return {
+			"path": "/app/operations-role",
+			"params": {
+				"project": project,
+				"sale_item": item,
+			},
+		}
+
+	# Look up active Operations Roles for this project + sale item
+	operations_roles = frappe.get_list(
+		"Operations Role",
+		filters={"project": project, "sale_item": item, "status": "Active"},
+		fields=["name", "shift", "site"],
+	)
+
+	# Fallback to Operations Role list if no roles found
+	if not operations_roles:
+		return {
+			"path": "/app/operations-role",
+			"params": {
+				"project": project,
+				"sale_item": item,
+			},
+		}
+
+	role = operations_roles[0]
+
+	# Operations Post issue: redirect to Operations Post list view
+	if issue_type == "operations_post":
+		return {
+			"path": "/app/operations-post",
+			"params": {
+				"project": project,
+				"site_shift": role.shift,
+				"post_template": role.name,
+			},
+		}
+
+	# Derive year and month from from_date for the Roster calendar
+	date_obj = getdate(from_date)
+	year = str(date_obj.year)
+	month = str(date_obj.month)
+
+	# Employee Schedule issue: redirect to Roster Staff View
+	if issue_type == "employee_schedule":
+		return {
+			"path": "/app/roster",
+			"params": {
+				"main_view": "roster",
+				"sub_view": "roster",
+				"project": project,
+				"site": role.site,
+				"shift": role.shift,
+				"operations_role": role.name,
+				"year": year,
+				"month": month,
+			},
+		}
+
+	# Post Schedule issue: redirect to Roster Post View
+	if issue_type == "post_schedule":
+		return {
+			"path": "/app/roster",
+			"params": {
+				"main_view": "roster",
+				"sub_view": "post",
+				"project": project,
+				"site": role.site,
+				"shift": role.shift,
+				"operations_role": role.name,
+				"year": year,
+				"month": month,
+			},
+		}
+
+	return {}

--- a/one_fm/operations/doctype/contract_compliance_checker_item/contract_compliance_checker_item.json
+++ b/one_fm/operations/doctype/contract_compliance_checker_item/contract_compliance_checker_item.json
@@ -10,6 +10,7 @@
   "column_break_yocn",
   "from_date",
   "to_date",
+  "take_action",
   "section_break_fwjq",
   "comment"
  ],
@@ -40,6 +41,13 @@
    "in_list_view": 1,
    "label": "From Date",
    "read_only": 1
+  },
+  {
+   "bold": 1,
+   "fieldname": "take_action",
+   "fieldtype": "Button",
+   "in_list_view": 1,
+   "label": "Take Action"
   },
   {
    "fieldname": "section_break_fwjq",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
Added a "Take Action" button to each row of the Contract Compliance Checker Item child table that dynamically redirects the user to the appropriate module with pre-applied filters based on the compliance issue type detected in the comment field.

- **Employee Schedule** issues → Roster Staff View (with project, site, shift, role, month/year filters)
- **Post Schedule** issues → Roster Post View (with project, site, shift, role, month/year filters)
- **Operations Role** issues → Operations Role List View (with project, sale item filters)
- **Operations Post** issues → Operations Post List View (with project, shift, role filters)


## Analysis and design (optional)
The comment field in each child row is generated server-side by the `GenerateContractComplianceChecker` class and contains specific keywords indicating the issue type. A server-side whitelisted method parses the comment to determine the issue type, resolves the Operations Role/Shift/Site context from the database, and returns the redirect URL data. The client script constructs the URL and opens it in a new tab.


## Solution description

**3 files modified:**

1. **`contract_compliance_checker_item.json`** — Added `take_action` Button field to `field_order` and `fields` with `in_list_view: 1` and `bold: 1` so it appears in every grid row.

2. **`contract_compliance_checker.py`** — Added:
   - `_determine_issue_type(comment)` — helper that parses the comment text using keyword matching to classify the issue as `operations_role`, `operations_post`, `employee_schedule`, or `post_schedule`.
   - `get_take_action_data(project, item, comment, from_date, to_date)` — whitelisted method that determines the issue type, looks up active Operations Roles by `project + sale_item` to resolve shift/site, and returns the target URL path and filter params.

3. **`contract_compliance_checker.js`** — Added:
   - Parent form `refresh`/`onload` handlers that inject styled buttons into every grid row's Take Action cell via DOM manipulation (since Frappe editable grids only render native Button fields on the active row).
   - Direct click handlers with `stopImmediatePropagation()` to prevent Frappe's grid row activation from consuming the first click.
   - Fallback `take_action` handler on the child table for when a row is opened in form/edit view.


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No

Server-side logic to parse compliance comments and resolve Operations Role/Shift/Site from the database to construct redirect URLs.


## Output screenshots (optional)
N/A — Take Action buttons appear on all child table rows and open the correct filtered view in a new tab on click.


## Areas affected and ensured
- Contract Compliance Checker form view (child table grid rendering)
- Contract Compliance Checker Item DocType (new field added)
- No changes to Roster page, Operations Role, or Operations Post


## Is there any existing behavior change of other features due to this code change?
No. The changes are additive — a new button field and its handler. No existing functionality is modified.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No new child table created. An existing child table (`Contract Compliance Checker Item`) was modified to add one Button field.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

The `take_action` field is added via the DocType JSON and applied by `bench migrate`. No data migration patch is needed.

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox


https://github.com/user-attachments/assets/e603e419-c168-4c59-9ae9-7e37c5f2b51c

<img width="1072" height="212" alt="Screenshot 2026-06-10 at 1 37 49 AM" src="https://github.com/user-attachments/assets/f4e1779d-d239-4149-afd3-252a33cd94ff" />