### PR TITLE
[WI-001025][License Plate no to be displayed in Transportation Schedule ( Route Planner)]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -2184,7 +2184,7 @@ function mountRoutePlannerApp(wrapper, data) {
                     vehiclesList.push({ label: v.label, startLocation: null });
                     vMeta[v.label] = {
                         accommodation: v.accommodation, driver: v.driver,
-                        seats: v.seats, location: v.accommodation,
+                        seats: v.seats, location: v.location,
                         license_plate: v.license_plate
                     };
 

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -2184,7 +2184,8 @@ function mountRoutePlannerApp(wrapper, data) {
                     vehiclesList.push({ label: v.label, startLocation: null });
                     vMeta[v.label] = {
                         accommodation: v.accommodation, driver: v.driver,
-                        seats: v.seats, location: v.accommodation
+                        seats: v.seats, location: v.accommodation,
+                        license_plate: v.license_plate
                     };
 
                     // Sort vehicle items: trip stops by stopIndex, solo items by start time
@@ -2510,6 +2511,7 @@ function injectRPVueTemplate() {
             <!-- Vehicle label column -->
             <div class="rp-lane-label">
               <div class="rp-gv-plate">{{ vehicle.label }}</div>
+              <div v-if="vehicle.license_plate" class="rp-gv-lp">{{ vehicle.license_plate }}</div>
               <div class="rp-gv-meta">{{ vehicle.driver }} &middot; {{ vehicle.seats }} seats</div>
               <div class="rp-gv-acc">{{ vehicle.accommodation }}</div>
             </div>
@@ -3303,6 +3305,7 @@ function injectRPStyles() {
         .rp-lane-svg       { display: block; }
 
         .rp-gv-plate { font-size: 14px; font-weight: 700; color: var(--md-sys-color-on-surface); }
+        .rp-gv-lp    { font-size: 11px; font-weight: 500; color: var(--md-sys-color-outline); margin-top: 1px; }
         .rp-gv-meta  { font-size: 12px; color: var(--md-sys-color-on-surface-variant); margin-top: 1px; }
         .rp-gv-acc   { font-size: 11px; color: var(--md-sys-color-outline); margin-top: 1px; }
 
@@ -3474,6 +3477,7 @@ function injectRPStyles() {
             .rp-lane-label { width: 100px; min-width: 100px; padding: 4px 8px; }
             .rp-label-stub { min-height: 36px; }
             .rp-gv-plate { font-size: 11px; }
+            .rp-gv-lp    { font-size: 9px; }
             .rp-gv-meta  { font-size: 9px; }
             .rp-gv-acc   { display: none; } /* Hide accommodation on label */
 
@@ -3512,6 +3516,7 @@ function injectRPStyles() {
             /* Lane labels: even narrower */
             .rp-lane-label { width: 75px; min-width: 75px; padding: 3px 6px; }
             .rp-gv-plate { font-size: 10px; }
+            .rp-gv-lp    { display: none; }
             .rp-gv-meta  { display: none; }
 
             /* Zoom buttons */
@@ -3634,6 +3639,7 @@ function injectRPStyles() {
         #rp-shell.rp-dark .rp-lane-alt { background: rgba(255,255,255,0.02); }
         #rp-shell.rp-dark .rp-lane-label { border-color: var(--md-sys-color-outline-variant); }
         #rp-shell.rp-dark .rp-gv-plate { color: var(--md-sys-color-on-surface); }
+        #rp-shell.rp-dark .rp-gv-lp    { color: var(--md-sys-color-outline); }
         #rp-shell.rp-dark .rp-gv-meta { color: var(--md-sys-color-outline); }
         #rp-shell.rp-dark .rp-gv-acc { color: var(--md-sys-color-outline); }
 

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -41,7 +41,7 @@ def get_route_planner_data():
         # ── 1. Vehicles (batch queries) ──
         transport_vehicles = frappe.get_all("Vehicle",
             filters={"transport_stop_vehicle": 1},
-            fields=["name", "location", "seats", "one_fm_vehicle_type", "make", "employee"],
+            fields=["name", "license_plate", "location", "seats", "one_fm_vehicle_type", "make", "employee"],
             order_by="name asc"
         )
 
@@ -81,6 +81,7 @@ def get_route_planner_data():
             vehicles.append({
                 "id":            v.name,
                 "label":         v.name,
+                "license_plate": v.license_plate or "",
                 "driver":        driver_name,
                 "seats":         v.seats or 0,
                 "type":          v.one_fm_vehicle_type or "—",

--- a/one_fm/public/html/route_manifest_template.html
+++ b/one_fm/public/html/route_manifest_template.html
@@ -1174,6 +1174,12 @@
             return d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", timeZone: "Asia/Kuwait" });
         }
 
+        /** HTML-escape a string to prevent XSS when interpolating into innerHTML. */
+        function escHtml(s) {
+            if (!s) return "";
+            return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+        }
+
         /** Show a toast notification (standalone — no Frappe dependency). */
         function showToast(msg) {
             const toast = document.createElement('div');
@@ -1411,7 +1417,7 @@
                 const dur = m.totalDuration ? fmtDuration(m.totalDuration) : "";
                 btn.innerHTML = `
       <span class="vehicle-btn-label">${pr.label}</span>
-      ${meta.license_plate ? `<span class="vehicle-btn-meta" style="font-size:11px;color:var(--text-muted)">${meta.license_plate}</span>` : ""}
+      ${meta.license_plate ? `<span class="vehicle-btn-meta" style="font-size:11px;color:var(--text-muted)">${escHtml(meta.license_plate)}</span>` : ""}
       <span class="vehicle-btn-meta">${fmtTime(pr.route.vehicleStartTime)} → ${fmtTime(pr.route.vehicleEndTime)}</span>
       <span class="vehicle-btn-stops">
         <span>${stopCount} stops</span>
@@ -1525,7 +1531,7 @@
   <div class="vehicle-header">
     <div>
       <div class="vehicle-title">${pr.label}</div>
-      ${meta.license_plate ? `<div style="font-size:13px;color:var(--text-muted);font-weight:500;margin-top:2px">${meta.license_plate}</div>` : ""}
+      ${meta.license_plate ? `<div style="font-size:13px;color:var(--text-muted);font-weight:500;margin-top:2px">${escHtml(meta.license_plate)}</div>` : ""}
       <div class="vehicle-subtitle">${fmtTime(pr.route.vehicleStartTime)} → ${fmtTime(pr.route.vehicleEndTime)} · ${allTrips.length} trip${allTrips.length !== 1 ? 's' : ''}</div>
     </div>
       <div class="vehicle-stats">

--- a/one_fm/public/html/route_manifest_template.html
+++ b/one_fm/public/html/route_manifest_template.html
@@ -1411,6 +1411,7 @@
                 const dur = m.totalDuration ? fmtDuration(m.totalDuration) : "";
                 btn.innerHTML = `
       <span class="vehicle-btn-label">${pr.label}</span>
+      ${meta.license_plate ? `<span class="vehicle-btn-meta" style="font-size:11px;color:var(--text-muted)">${meta.license_plate}</span>` : ""}
       <span class="vehicle-btn-meta">${fmtTime(pr.route.vehicleStartTime)} → ${fmtTime(pr.route.vehicleEndTime)}</span>
       <span class="vehicle-btn-stops">
         <span>${stopCount} stops</span>
@@ -1524,6 +1525,7 @@
   <div class="vehicle-header">
     <div>
       <div class="vehicle-title">${pr.label}</div>
+      ${meta.license_plate ? `<div style="font-size:13px;color:var(--text-muted);font-weight:500;margin-top:2px">${meta.license_plate}</div>` : ""}
       <div class="vehicle-subtitle">${fmtTime(pr.route.vehicleStartTime)} → ${fmtTime(pr.route.vehicleEndTime)} · ${allTrips.length} trip${allTrips.length !== 1 ? 's' : ''}</div>
     </div>
       <div class="vehicle-stats">


### PR DESCRIPTION
Here's the filled-out PR template:

---

## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
Display the vehicle's license plate number directly below the Vehicle ID (e.g., "VHL-0001") in the Transportation Schedule (Route Planner) timeline Y-axis, the Route Manifest sidebar vehicle list, and the Route Manifest main vehicle header.


## Analysis and design (optional)
The Vehicle DocType's autoname was changed from `field:license_plate` to `VHL-.####`, making the `name` (e.g., "VHL-0001") and `license_plate` (e.g., "KW-12345") separate values. The `license_plate` field is fetched from the backend and passed through to the frontend for display.


## Solution description
**Backend (`route_planner.py`):**
- Added `license_plate` to the `frappe.get_all("Vehicle", ...)` fields list
- Included `license_plate` in the vehicle dictionary returned to the frontend API response

**Frontend — Transportation Schedule (`route_planner.js`):**
- Added a new `<div class="rp-gv-lp">` element in the Vue template Y-axis vehicle label, rendered conditionally below the Vehicle ID
- Added `.rp-gv-lp` CSS class with responsive breakpoints (9px on tablet, hidden on ≤480px mobile) and dark mode support
- Passed `license_plate` into the `vehicleMeta` object used by the Route Manifest

**Frontend — Route Manifest (`route_manifest_template.html`):**
- Added license plate below the vehicle label in the sidebar buttons
- Added license plate below the vehicle title in the main content header
- Both use conditional rendering — no empty elements if `license_plate` is falsy


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)
N/A — UI changes to the Transportation Schedule Y-axis and Route Manifest sidebar/header.


## Areas affected and ensured
- Transportation Schedule (Route Planner) page — Y-axis vehicle labels
- Route Manifest page — sidebar vehicle list and main vehicle header
- Route Planner Python API — vehicle data response


## Is there any existing behavior change of other features due to this code change?
No. The existing Vehicle ID, driver, seats, and accommodation labels remain unchanged. The license plate is an additive display element only.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No child table was created.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox

<img width="211" height="591" alt="Screenshot 2026-06-10 at 1 32 31 PM" src="https://github.com/user-attachments/assets/6cdb8c0e-1e23-4425-829f-b8acf88f5b30" />
