### PR TITLE
[WI-001026][Auto-Generate Sequential Trip Name]

### DIFF
--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -1033,7 +1033,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         },
                         {
                             fieldtype: 'Data', fieldname: 'trip_name',
-                            label: 'Trip Name',
+                            label: 'Trip Name', reqd: 1,
                             description: 'Auto-generated sequential trip name.',
                             default: self.generateTripName(vehicleId),
                             read_only: 1
@@ -1729,20 +1729,23 @@ function mountRoutePlannerApp(wrapper, data) {
                 const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
                 if (!vehicle) return '';
 
-                // Extract integer from VHL-#### pattern
+                // Extract integer from VHL-#### pattern; fallback to 1-based vehicle index
                 const match = vehicleId.match(/VHL-(\d+)/i);
-                const vehicleNumber = match ? parseInt(match[1], 10) : 0;
-                if (!vehicleNumber) return '';
+                let vehicleNumber = match ? parseInt(match[1], 10) : 0;
+                if (!vehicleNumber) {
+                    // Fallback: use 1-based position in vehicles list
+                    const idx = this.planData.vehicles.findIndex(v => v.id === vehicleId);
+                    vehicleNumber = idx >= 0 ? idx + 1 : 1;
+                }
 
                 // Count existing unique trips on this vehicle
                 const existingTripIds = new Set();
                 this.swimItems.forEach(item => {
                     if (item.vehicleId !== vehicleId) return;
-                    // Each unique tripId = 1 trip. Items without tripId = standalone trip each.
                     if (item.tripId) {
                         existingTripIds.add(item.tripId);
                     } else {
-                        existingTripIds.add(item.id); // each solo item is its own trip
+                        existingTripIds.add(item.id);
                     }
                 });
                 const nextSeq = existingTripIds.size + 1;

--- a/one_fm/one_fm/page/route_planner/route_planner.js
+++ b/one_fm/one_fm/page/route_planner/route_planner.js
@@ -812,8 +812,9 @@ function mountRoutePlannerApp(wrapper, data) {
                         {
                             fieldtype: 'Data', fieldname: 'trip_name',
                             label: 'Trip Name', reqd: 1,
-                            description: 'Name this trip (e.g. "Morning Run 2", "Evening Pickup B")',
-                            placeholder: 'e.g. Morning Run 2'
+                            description: 'Auto-generated sequential trip name.',
+                            default: self.generateTripName(vehicleId),
+                            read_only: 1
                         },
                         { fieldtype: 'Section Break' },
                         {
@@ -1033,8 +1034,9 @@ function mountRoutePlannerApp(wrapper, data) {
                         {
                             fieldtype: 'Data', fieldname: 'trip_name',
                             label: 'Trip Name',
-                            description: 'Give this trip a name (e.g. "Morning Shift A")',
-                            placeholder: 'e.g. Morning Shift A'
+                            description: 'Auto-generated sequential trip name.',
+                            default: self.generateTripName(vehicleId),
+                            read_only: 1
                         },
                         { fieldtype: 'Section Break' },
                         {
@@ -1713,6 +1715,45 @@ function mountRoutePlannerApp(wrapper, data) {
             vehicleLabelForItem(item) {
                 const v = this.planData.vehicles.find(v => v.id === item.vehicleId);
                 return v ? v.label : item.vehicleId;
+            },
+
+            /**
+             * Auto-generate sequential trip name for a vehicle.
+             * Format: {vehicleNumber}{2-digit-sequence}
+             * Leased vehicles: S-{vehicleNumber}{2-digit-sequence}
+             *
+             * vehicleNumber is derived from VHL-#### name (e.g., VHL-0015 → 15)
+             * sequence is 01-based count of existing trips on that vehicle + 1
+             */
+            generateTripName(vehicleId) {
+                const vehicle = this.planData.vehicles.find(v => v.id === vehicleId);
+                if (!vehicle) return '';
+
+                // Extract integer from VHL-#### pattern
+                const match = vehicleId.match(/VHL-(\d+)/i);
+                const vehicleNumber = match ? parseInt(match[1], 10) : 0;
+                if (!vehicleNumber) return '';
+
+                // Count existing unique trips on this vehicle
+                const existingTripIds = new Set();
+                this.swimItems.forEach(item => {
+                    if (item.vehicleId !== vehicleId) return;
+                    // Each unique tripId = 1 trip. Items without tripId = standalone trip each.
+                    if (item.tripId) {
+                        existingTripIds.add(item.tripId);
+                    } else {
+                        existingTripIds.add(item.id); // each solo item is its own trip
+                    }
+                });
+                const nextSeq = existingTripIds.size + 1;
+
+                // Format: vehicleNumber + 2-digit sequence (e.g., 15 + 01 = "1501")
+                const seqStr = String(nextSeq).padStart(2, '0');
+                const tripName = `${vehicleNumber}${seqStr}`;
+
+                // Leased vehicles get "S-" prefix
+                const prefix = vehicle.is_leased ? 'S-' : '';
+                return `${prefix}${tripName}`;
             },
 
             // ─ Persistence (save/load to Route Plan DocType) ──────────────

--- a/one_fm/one_fm/page/route_planner/route_planner.py
+++ b/one_fm/one_fm/page/route_planner/route_planner.py
@@ -41,7 +41,7 @@ def get_route_planner_data():
         # ── 1. Vehicles (batch queries) ──
         transport_vehicles = frappe.get_all("Vehicle",
             filters={"transport_stop_vehicle": 1},
-            fields=["name", "license_plate", "location", "seats", "one_fm_vehicle_type", "make", "employee"],
+            fields=["name", "license_plate", "location", "seats", "one_fm_vehicle_type", "make", "employee", "one_fm_vehicle_category"],
             order_by="name asc"
         )
 
@@ -88,7 +88,8 @@ def get_route_planner_data():
                 "make":          v.make or "—",
                 "accommodation": acc_name,
                 "location":      v.location,
-                "coords":        {"lat": coords[0], "lng": coords[1]}
+                "coords":        {"lat": coords[0], "lng": coords[1]},
+                "is_leased":     v.one_fm_vehicle_category == "Leased"
             })
 
         # ── 2. Shipment cards ────────────────────────────────────────────


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Auto-generate sequential trip names when assigning shipments to vehicles on the Transportation Schedule. The trip name format combines the vehicle's integer number (extracted from `VHL-####`) with a 2-digit trip sequence (e.g., Vehicle `VHL-0001`'s first trip = `101`, second = `102`). Leased/subcontracted vehicles receive an `S-` prefix (e.g., `S-301`). The trip name field is read-only and fully automatic — no manual entry required.


## Analysis and design (optional)

- Vehicle number is derived from the `VHL-####` naming series (e.g., `VHL-0015` → `15`)
- Trip sequence counts unique trips per vehicle within the current plan session
- Leased status is determined by `one_fm_vehicle_category == "Leased"` on the Vehicle DocType
- When chaining a stop to an existing trip, the new stop inherits the existing trip name (no new sequence number)
- Direction (Outbound/Return) does not affect the sequence — all trips share one counter per vehicle


## Solution description

**Backend (`route_planner.py`):**
- Added `one_fm_vehicle_category` to the Vehicle query fields list
- Added `is_leased` boolean flag to the vehicle dict sent to the frontend

**Frontend (`route_planner.js`):**
- Added `generateTripName(vehicleId)` helper method that:
  - Extracts the integer from `VHL-####` pattern via regex
  - Counts existing unique trips (by `tripId`) on that vehicle in `swimItems`
  - Returns `{vehicleNumber}{2-digit-sequence}` with optional `S-` prefix for leased vehicles
- Updated the independent trip dialog (`_doPlaceWithDialog`) — trip name field is now auto-populated and `read_only: 1`
- Updated the standard placement dialog (`placeCard`) — trip name field is now auto-populated and `read_only: 1`


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

| Vehicle | Category | 1st Trip | 2nd Trip | 3rd Trip |
|---------|----------|----------|----------|----------|
| VHL-0001 | Owned | `101` | `102` | `103` |
| VHL-0015 | Owned | `1501` | `1502` | `1503` |
| VHL-0003 | Leased | `S-301` | `S-302` | `S-303` |


## Areas affected and ensured

- Transportation Schedule (Route Planner) — trip assignment dialogs
- Trip name display on timeline blocks and detail panel
- Plan save/load (trip names persist via existing `tripName` field)


## Is there any existing behavior change of other features due to this code change?

Yes. The trip name field in both assignment dialogs was previously a free-text manual input. It is now auto-generated and read-only. Users can no longer type custom trip names — the system generates them automatically.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No child table created.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox

<img width="683" height="522" alt="Screenshot 2026-06-10 at 8 26 25 PM" src="https://github.com/user-attachments/assets/7154e901-2110-4871-8ed0-3d7bc1dbea91" />
<img width="678" height="551" alt="Screenshot 2026-06-10 at 8 27 32 PM" src="https://github.com/user-attachments/assets/4a07e868-86f1-46f8-b1b7-ade0bfc6d3e2" />
