### PR TITLE
hot-fix: read agency from job opening child table in ccp creation

### DIFF
--- a/one_fm/overrides/job_offer.py
+++ b/one_fm/overrides/job_offer.py
@@ -282,8 +282,13 @@ class JobOfferOverride(JobOffer):
         if not job_applicant.job_title:
             return
 
-        # Fetch Agency from Job Opening
-        agency = frappe.db.get_value("Job Opening", job_applicant.job_title, "agency")
+        # Agencies are stored in the Job Opening child table (one_fm_active_willing_agency),
+        # not as a single field on Job Opening. Use the first willing agency.
+        job_opening = frappe.get_doc("Job Opening", job_applicant.job_title)
+        if not job_opening.one_fm_active_willing_agency:
+            return
+
+        agency = job_opening.one_fm_active_willing_agency[0].agency
         if not agency:
             return
 


### PR DESCRIPTION
### Summary

Fixes an `OperationalError: Unknown column 'agency' in 'SELECT'` that broke Job Offer workflow transitions during Candidate Country Process (CCP) creation.

### Changes

#### Backend
- **`one_fm/overrides/job_offer.py`** — `create_candidate_country_process()` previously queried a non-existent `agency` field on **Job Opening**, causing the workflow `apply_workflow` → `on_update_after_submit` chain to crash on save.
- Now fetches the agency from the Job Opening **`one_fm_active_willing_agency`** child table (linked to the **Active Willing Agency** doctype), using the first willing-agency row.
- Returns early when the child table is empty, preserving the existing single-CCP-per-Job-Offer guard.

### Deployment Notes
- No schema changes. Run `bench restart` after deploy to reload the override.
