### PR TITLE
feat: user doctype permission insight

### DIFF
--- a/one_fm/one_fm/report/user_doctype_permission_insight/user_doctype_permission_insight.js
+++ b/one_fm/one_fm/report/user_doctype_permission_insight/user_doctype_permission_insight.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, ONE FM and contributors
+// For license information, please see license.txt
+/* eslint-disable */
+
+frappe.query_reports["User Doctype Permission Insight"] = {
+	"filters": [
+		{
+			"fieldname": "user",
+			"label": __("User"),
+			"fieldtype": "Link",
+			"options": "User",
+			"reqd": 1,
+		},
+		{
+			"fieldname": "target_doctype",
+			"label": __("DocType"),
+			"fieldtype": "Link",
+			"options": "DocType",
+			"reqd": 1,
+		},
+	],
+	"formatter": function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+		if (column.fieldname == "status" && data) {
+			if (data.user_has_role) {
+				value = `<span class="indicator-pill green">${value}</span>`;
+			} else {
+				value = `<span class="indicator-pill orange">${value}</span>`;
+			}
+		}
+		return value;
+	},
+};

--- a/one_fm/one_fm/report/user_doctype_permission_insight/user_doctype_permission_insight.json
+++ b/one_fm/one_fm/report/user_doctype_permission_insight/user_doctype_permission_insight.json
@@ -1,0 +1,27 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2026-06-11 00:00:00.000000",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "ONEFM",
+ "modified": "2026-06-11 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "User Doctype Permission Insight",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "User",
+ "report_name": "User Doctype Permission Insight",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ]
+}

--- a/one_fm/one_fm/report/user_doctype_permission_insight/user_doctype_permission_insight.py
+++ b/one_fm/one_fm/report/user_doctype_permission_insight/user_doctype_permission_insight.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+
+# Permission actions exposed by a DocPerm / Custom DocPerm row.
+PERMISSION_ACTIONS = [
+	"select",
+	"read",
+	"write",
+	"create",
+	"delete",
+	"submit",
+	"cancel",
+	"amend",
+	"report",
+	"export",
+	"import",
+	"print",
+	"email",
+	"share",
+]
+
+
+def execute(filters=None):
+	filters = frappe._dict(filters or {})
+
+	if not filters.user:
+		frappe.throw(_("Please select a User"))
+	if not filters.target_doctype:
+		frappe.throw(_("Please select a DocType"))
+
+	# Only privileged users should inspect another user's roles/permissions.
+	frappe.only_for(["System Manager", "Administrator"])
+
+	columns = get_columns()
+	data, summary = get_data(filters)
+	return columns, data, None, None, summary
+
+
+def get_columns():
+	columns = [
+		{
+			"fieldname": "role",
+			"label": _("Role"),
+			"fieldtype": "Link",
+			"options": "Role",
+			"width": 220,
+		},
+		{
+			"fieldname": "user_has_role",
+			"label": _("User Has Role"),
+			"fieldtype": "Check",
+			"width": 110,
+		},
+		{
+			"fieldname": "status",
+			"label": _("Status"),
+			"fieldtype": "Data",
+			"width": 170,
+		},
+		{
+			"fieldname": "permlevel",
+			"label": _("Perm Level"),
+			"fieldtype": "Int",
+			"width": 90,
+		},
+	]
+	for action in PERMISSION_ACTIONS:
+		columns.append({
+			"fieldname": action,
+			"label": _(action.title()),
+			"fieldtype": "Check",
+			"width": 75,
+		})
+	return columns
+
+
+def get_data(filters):
+	# Roles the user currently holds (includes "All" / standard roles).
+	user_roles = set(frappe.get_roles(filters.user))
+
+	# Effective permissions for the doctype: returns Custom DocPerm rows when
+	# the doctype has been customized, otherwise the standard DocPerm rows.
+	meta = frappe.get_meta(filters.target_doctype)
+	permissions = meta.get_permissions()
+
+	data = []
+	roles_with_perm = set()
+	assignable_roles = set()
+
+	for perm in permissions:
+		user_has_role = 1 if perm.role in user_roles else 0
+		roles_with_perm.add(perm.role)
+
+		if user_has_role:
+			status = _("Already assigned")
+		else:
+			status = _("Can be assigned")
+			assignable_roles.add(perm.role)
+
+		row = {
+			"role": perm.role,
+			"user_has_role": user_has_role,
+			"status": status,
+			"permlevel": perm.permlevel or 0,
+		}
+		for action in PERMISSION_ACTIONS:
+			row[action] = perm.get(action) or 0
+
+		data.append(row)
+
+	# Sort: roles the user already has first, then by role name.
+	data.sort(key=lambda r: (not r["user_has_role"], r["role"], r["permlevel"]))
+
+	summary = get_report_summary(
+		user_roles=user_roles,
+		roles_with_perm=roles_with_perm,
+		assignable_roles=assignable_roles,
+	)
+	return data, summary
+
+
+def get_report_summary(user_roles, roles_with_perm, assignable_roles):
+	already_assigned = roles_with_perm & user_roles
+	return [
+		{
+			"value": len(user_roles),
+			"label": _("Total Roles User Has"),
+			"datatype": "Int",
+			"indicator": "blue",
+		},
+		{
+			"value": len(roles_with_perm),
+			"label": _("Roles With Permission on DocType"),
+			"datatype": "Int",
+			"indicator": "blue",
+		},
+		{
+			"value": len(already_assigned),
+			"label": _("Permission Roles User Already Has"),
+			"datatype": "Int",
+			"indicator": "green",
+		},
+		{
+			"value": len(assignable_roles),
+			"label": _("Permission Roles Available to Assign"),
+			"datatype": "Int",
+			"indicator": "orange" if assignable_roles else "green",
+		},
+	]


### PR DESCRIPTION
This pull request introduces a new "User Doctype Permission Insight" report to the codebase. The report helps System Managers and Administrators analyze which roles a user has (or can be assigned) for a specific DocType, detailing permissions per role and providing a summary of assignable and already assigned roles.

**New Report: User Doctype Permission Insight**

_Report Definition and Access Control:_
* Added a new script report definition in `user_doctype_permission_insight.json`, restricting access to System Managers, referencing the `User` DocType, and setting the report type to "Script Report".
* Enforced access control in the Python backend to ensure only privileged users (System Manager or Administrator) can run the report.

_Report Backend Logic:_
* Implemented `user_doctype_permission_insight.py` to:
  - Validate required filters (`user` and `target_doctype`).
  - Gather all roles for the user and effective permissions for the selected DocType.
  - For each permission, indicate whether the user has the role, its status (assigned/assignable), permlevel, and a matrix of permission actions.
  - Return a summary with counts of total roles, roles with permissions, already assigned roles, and roles available to assign.

_Report Frontend:_
* Added `user_doctype_permission_insight.js` to define report filters (user and DocType) and a custom formatter for the status column, visually distinguishing assigned and assignable roles with colored indicators.