### PR TITLE
fix(pmr): load autocomplete options from DB bypassing lookup permissions

### DIFF
--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.js
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.js
@@ -12,36 +12,21 @@ frappe.ui.form.on('Project Manpower Request', {
 			localStorage.removeItem('__bundled_resignations');
 			// Defer refresh and trigger until after standard UI elements load
 			setTimeout(() => {
-			    frm.refresh_field('resignation_links');
-			    frm.set_value('count', names.length);
-			    frm.set_df_property('count', 'read_only', true);
+				frm.refresh_field('resignation_links');
+				frm.set_value('count', names.length);
+				frm.set_df_property('count', 'read_only', true);
 			}, 500);
 		}
 
-		// Dynamically populate options for gender Select field from universal Gender table
-		frappe.db.get_list('Gender', {fields: ['name'], limit_page_length: 0}).then(records => {
-			let options = ['Any', 'Male', 'Female'];
-			records.forEach(r => {
-				if (r.name && !options.includes(r.name)) {
-					options.push(r.name);
-				}
-			});
-			frm.set_df_property('gender', 'options', options);
-		});
-
-		// Dynamically populate options for nationality Select field from universal Nationality table
-		frappe.db.get_list('Nationality', {fields: ['name'], limit_page_length: 0}).then(records => {
-			let options = ['Any', 'African', 'Asian'];
-			records.forEach(r => {
-				if (r.name && !options.includes(r.name)) {
-					options.push(r.name);
-				}
-			});
-			frm.set_df_property('nationality', 'options', options);
-		});
+		// Populate nationality and gender Autocomplete fields from the DB.
+		// Called in both onload and refresh.
+		load_pmr_autocomplete_options(frm);
 	},
 	
 	refresh: function(frm) {
+		// Re-apply options every refresh (widget is mounted here, setTimeout(0) ensures
+		// the render cycle has finished before we push data into awesomplete).
+		load_pmr_autocomplete_options(frm);
 		setup_status_indicator(frm);
 
 		if (frm.doc.workflow_state === 'Draft' && frm.doc.reason_for_rejection) {
@@ -313,3 +298,69 @@ frappe.ui.form.on("Project Manpower Request", {
 	},
 
 });
+
+// ─── Nationality / Gender Autocomplete helpers ────────────────────────────────
+//
+// How Frappe Autocomplete works (from the source):
+//   on 'input' event → if (this.get_query) { server call }
+//                       else { this.awesomplete.list = this._data }
+//   set_data(arr)    → this._data = arr; this.awesomplete.list = arr
+//
+// Correct pattern:
+//   1. Do NOT set field.get_query (that hijacks input to make server calls)
+//   2. Call field.set_data(full_list) AFTER the awesomplete widget is mounted
+//   3. 'refresh' hook fires with a mounted widget — use setTimeout(0) to defer
+//      to the next tick so the current render cycle finishes first
+//   4. Cache globally on the frappe object so we only fetch from DB once
+
+function _populate_autocomplete(frm, fieldname, options) {
+	// Ensure no get_query is overriding the local filter path
+	let field = frm.fields_dict[fieldname];
+	if (!field) return;
+	if (field.get_query) delete field.get_query;
+
+	// Push data into awesomplete after the current call stack clears
+	setTimeout(() => {
+		let f = frm.fields_dict[fieldname];
+		if (f && typeof f.set_data === "function") {
+			f.set_data(options);
+		}
+	}, 0);
+}
+
+function load_pmr_autocomplete_options(frm) {
+	const NATIONALITY_KEY = "__pmr_nationality_options";
+	const GENDER_KEY = "__pmr_gender_options";
+
+	if (frappe[NATIONALITY_KEY] && frappe[GENDER_KEY]) {
+		_populate_autocomplete(frm, "nationality", frappe[NATIONALITY_KEY]);
+		_populate_autocomplete(frm, "gender", frappe[GENDER_KEY]);
+		return;
+	}
+
+	frappe.call({
+		method: "one_fm.one_fm.doctype.project_manpower_request.project_manpower_request.get_autocomplete_options",
+		callback: function(r) {
+			if (r.message) {
+				let nationalities = ["Any", "African", "Asian"];
+				(r.message.nationalities || []).forEach(n => {
+					if (!nationalities.includes(n)) {
+						nationalities.push(n);
+					}
+				});
+				frappe[NATIONALITY_KEY] = nationalities;
+				_populate_autocomplete(frm, "nationality", nationalities);
+
+				let genders = ["Any", "Male", "Female"];
+				(r.message.genders || []).forEach(g => {
+					if (!genders.includes(g)) {
+						genders.push(g);
+					}
+				});
+				frappe[GENDER_KEY] = genders;
+				_populate_autocomplete(frm, "gender", genders);
+			}
+		}
+	});
+}
+

--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
@@ -304,7 +304,7 @@
   {
    "default": "Any",
    "fieldname": "gender",
-   "fieldtype": "Select",
+   "fieldtype": "Autocomplete",
    "label": "Gender",
    "options": "Any\nMale\nFemale",
    "search_index": 1
@@ -316,7 +316,7 @@
   {
    "default": "Any",
    "fieldname": "nationality",
-   "fieldtype": "Select",
+   "fieldtype": "Autocomplete",
    "label": "Nationality",
    "options": "Any\nAfrican\nAsian",
    "search_index": 1

--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.py
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.py
@@ -263,9 +263,27 @@ class ProjectManpowerRequest(Document):
 				field.options = "\n".join(opts)
 
 @frappe.whitelist()
-def set_edit_reason(name, reason):
+def set_edit_reason(name: str, reason: str):
 	doc = frappe.get_doc("Project Manpower Request", name)
 	doc.check_permission("read")
 	frappe.db.set_value("Project Manpower Request", name, "reason_for_rejection", reason)
 	frappe.clear_document_cache("Project Manpower Request", name)
+
+
+@frappe.whitelist()
+def get_autocomplete_options() -> dict:
+	"""Fetch all Nationality and Gender options for PMR Autocomplete fields."""
+	# Ensure the caller has permission to read PMR
+	if not frappe.has_permission("Project Manpower Request", "read"):
+		frappe.throw(_("Not permitted to access manpower request details."), frappe.PermissionError)
+
+	nationalities = frappe.get_all("Nationality", fields=["name"], order_by="name asc", ignore_permissions=True)
+	genders = frappe.get_all("Gender", fields=["name"], order_by="name asc", ignore_permissions=True)
+
+	return {
+		"nationalities": [n.name for n in nationalities if n.name],
+		"genders": [g.name for g in genders if g.name]
+	}
+
+
 

--- a/one_fm/one_fm/doctype/project_manpower_request/test_project_manpower_request.py
+++ b/one_fm/one_fm/doctype/project_manpower_request/test_project_manpower_request.py
@@ -64,7 +64,7 @@ class TestProjectManpowerRequest(FrappeTestCase):
 		
 		# Gender field check
 		gender_df = meta.get_field("gender")
-		self.assertEqual(gender_df.fieldtype, "Select")
+		self.assertEqual(gender_df.fieldtype, "Autocomplete")
 		gender_opts = gender_df.options.split("\n")
 		self.assertIn("Any", gender_opts)
 		self.assertIn("Male", gender_opts)
@@ -72,7 +72,7 @@ class TestProjectManpowerRequest(FrappeTestCase):
 		
 		# Nationality field check
 		nationality_df = meta.get_field("nationality")
-		self.assertEqual(nationality_df.fieldtype, "Select")
+		self.assertEqual(nationality_df.fieldtype, "Autocomplete")
 		nationality_opts = nationality_df.options.split("\n")
 		self.assertIn("Any", nationality_opts)
 		self.assertIn("African", nationality_opts)
@@ -83,6 +83,15 @@ class TestProjectManpowerRequest(FrappeTestCase):
 		self.assertFalse(frappe.db.exists("Nationality", "African"))
 		self.assertFalse(frappe.db.exists("Nationality", "Asian"))
 		self.assertFalse(frappe.db.exists("Gender", "Any"))
+
+	def test_get_autocomplete_options(self):
+		from one_fm.one_fm.doctype.project_manpower_request.project_manpower_request import get_autocomplete_options
+		frappe.set_user("Administrator")
+		res = get_autocomplete_options()
+		self.assertIn("nationalities", res)
+		self.assertIn("genders", res)
+		self.assertTrue(len(res["nationalities"]) > 0)
+		self.assertTrue(len(res["genders"]) > 0)
 
 	def test_validate_change_request_reason(self):
 		# Setup initial workflow state as Awaiting Recruiter Approval


### PR DESCRIPTION
Description
This PR changes the gender and nationality fields on the Project Manpower Request form to support searching and autocomplete.
Converted Field Types: Changed gender and nationality fields from standard Select to Autocomplete in the DocType schema JSON (project_manpower_request.json).
Created Whitelisted Server Method: Introduced a new server-side function get_autocomplete_options in the PMR Python controller. It fetches all Gender and Nationality records from the DB using frappe.get_all(ignore_permissions=True) to prevent permission blocks for non-admin users, while checking read access to the parent document.
Unified Javascript Fetch: Rewrote the JS controller to call get_autocomplete_options in one call, populate the Awesomplete inputs with the database options, and preserve the default/pinned option groups (Any, Male, Female, African, Asian) at the top of the lists.
Updated Unit Tests: Adjusted the expected field types in PMR unit tests to Autocomplete and added a test case to verify the get_autocomplete_options method.