### PR TITLE
chore: add v15.9.0 release notes and bump version

### DIFF
--- a/one_fm/__init__.py
+++ b/one_fm/__init__.py
@@ -56,7 +56,7 @@ from one_fm.overrides.workflow import confirm_action as custom_confirm_action
 from one_fm.overrides.purchase_order import calculate_margin
 
 
-__version__ = '15.8.0'
+__version__ = '15.9.0'
 
 wa.confirm_action = custom_confirm_action
 user_permission.get_user_permissions = get_custom_user_permissions

--- a/one_fm/change_log/v15/v15_9_0.md
+++ b/one_fm/change_log/v15/v15_9_0.md
@@ -1,0 +1,84 @@
+# Version v15.9.0 Release Notes
+
+## Features & Enhancements
+
+### one_fm
+- Employee Resignation — update workflow to include draft state and conditional supervisor approval transitions, shift_working-based dynamic routing, and operational impact section with enforced required fields (WI-000850, WI-000863, #6141, #6143, #6175)
+- Candidate Country Process — restore data-driven CCP tracking and dependency fields, add recruitment and manager roles to permissions (#6189, #6195)
+- Project Manpower Request — change gender and nationality fields to select dropdowns, enable allow_import and grant import permissions to PMR roles (#6188, #6165, #6169, #6176)
+- Custom DocPerm — add Custom DocPerm context fields to Version and override Permission Manager to log permission changes (WI-000994)
+- Bonus Request — grid migration with recurring bonus process task and parentfield fix (WI-000978, WI-000977, WI-000976, WI-001005)
+- Contracts — workflow update with inactive to draft state transition (WI-001009)
+- Transport — route planner updates and transport enhancements (WI-001010)
+- Minutes of Meeting — add MOM custom field to Task DocType (WI-000983)
+- Vehicle — naming series update and vehicle sequence changes (WI-000980)
+- Helpdesk — send message to process from HD ticket update, ticket edit optimisation with validated required fields (WI-000928, #6126)
+- Purchase Receipt — update posting date for PRC-2026-000101 (WI-001012)
+- Courier Tracking — add courier tracking custom fields (WI-001011)
+- Client Interview Shortlist — update workflow (WI-000966)
+- Sales Invoice — update property setter
+
+### frappe_agile
+- Sprint Metrics — track stories and points brought forward and carried forward at sprint completion, add Points Accepted field (WI-000826, WI-000827, WI-000876)
+- Sprint Goal — make Sprint Goal field mandatory (WI-000838)
+- Sprint Reports — add Sprint Report per Business Analyst, Sprint Report per Developer, remove Sprint Summary (Party) report (WI-000823, WI-000824, WI-000825, WI-000828)
+- AI Usage Report — add AI Tools feedback to usage report with sprint work item queries (WI-000823)
+- Work Item — add epic title to list view, update work item list (WI-000981)
+- Assignee User — move Assignee User to Implementation Details section (WI-000842)
+
+### one_bpmn
+- DMN Support — add Decision Model and Notation (DMN) functionality with select support and save/XML fixes (WI-000929, WI-000935, WI-000963)
+- API Refactor — decompose api.py monolith into 12 focused submodules with updated frontend endpoints (WI-000962)
+- Process DocTypes — migrate Processa DocTypes from one_fm to one_bpmn
+- Blank Canvas — start new process maps with a blank canvas
+- Prohibited Shapes — add validation for prohibited shapes in process maps
+- CTC Implementation — updated CTC (Compliance-to-Code) implementation with expiry handling
+- Prompt Caching — implement prompt caching for AI agent interactions
+- Auto Layout — implement auto layout for process diagrams
+- Swim Lanes — add swim lane support to process diagrams
+- Gateway Node — improved gateway node rendering
+- Filter Functionality — add filtering to process list
+- Logix UI — improved Logix UI for testing with updated instructions and canvas styling
+
+## Bug Fixes
+
+### one_fm
+- Interview Console — fix Workflow permission error for standard users (#6194)
+- Resignation — resolve shift_working client desync for operations/site worker forms, fix schema and API mapping issues, mock database calls in tests (#6141, #6143, #6175)
+- Helpdesk — validate required fields in ticket edit, optimise ticket edit performance, fix ticket template fields, remove process field validation (#6126)
+- Shift Working — check shift_working synchronously in client visibility check
+- Dependencies — fix dependency resolution issues (#6184)
+- Permission Manager — address Copilot PR review comments on permission_manager override
+
+### frappe_agile
+- AI Tools Feedback — remove depends-on condition that blocked saves
+- Sprint — fix velocity reset and child table disappearing on sprint close, handle missing sprint_goal column in patch (WI-000877)
+- Reports — compute rates from unrounded values, deduplicate labels, fix percentage rounding (WI-000823, WI-000825)
+
+### one_bpmn
+- Save Error — fix save error with dmn_xml
+- Expiry Setting — fix issue with setting expiry
+- DMN Saving — fix issue with saving DMN
+- Import Issue — fix import dependencies after API refactor
+- Toolbar — fix toolbar issue
+- Lanes — fix bug preventing lanes from being added
+- New Message — fix new message creation
+
+## Security
+
+### one_bpmn
+- Harden lxml XML parsers against XXE attacks
+
+## Chores
+
+### one_fm
+- Pre-commit — add pre-commit configuration and eslint setup (WI-000740)
+
+### frappe_agile
+- CI/CD — fix server-tests.yml workflow with erpnext installation (WI-000775)
+
+### one_bpmn
+- CI/CD — configure full fetch depth in type-check workflow, update Python version, align Frappe linting configuration (WI-000762, WI-000767, WI-000771)
+- Documentation — expand AGENTS.md and README.md for api/ submodule migration (WI-000768)
+- Refactor — remove custom shape feature (frontend and backend), split bpmn_process_instance into focused modules
+- Remove dead code flagged by Copilot review


### PR DESCRIPTION
## Summary

Add v15.9.0 release notes and bump version from `15.8.0` to `15.9.0`.

### Changes
- **New file**: `one_fm/change_log/v15/v15_9_0.md` — changelog covering features, bug fixes, security, and chores across `one_fm`, `frappe_agile`, and `one_bpmn` for Sprint Review May 20 – June 9
- **Modified**: `one_fm/__init__.py` — version bump `15.8.0` → `15.9.0`