### PR TITLE
fix: item filters updated

### DIFF
--- a/one_fm/public/js/doctype_js/item.js
+++ b/one_fm/public/js/doctype_js/item.js
@@ -6,39 +6,39 @@ frappe.ui.form.on('Item', {
 		set_field_access_for_unauthorized_users(frm);
 		frm.set_query("subitem_group", function() {
 			return {
-				filters: [
-					['Item Group', 'parent_item_group', '=', cur_frm.doc.parent_item_group]
-				]
+				filters: {
+					"parent_item_group": cur_frm.doc.parent_item_group
+				}
 			};
 		});
 		frm.set_query("item_group", function() {
 			return {
-				filters: [
-					['Item Group', 'parent_item_group', '=', cur_frm.doc.subitem_group]
-				]
+				filters: {
+					"parent_item_group": cur_frm.doc.subitem_group
+				}
 			};
 		});
 		frm.set_query("item_type", function() {
 			return {
-				filters: [
-					['Item Type', 'item_group', '=', cur_frm.doc.item_group]
-				]
+				filters: {
+					"item_group": cur_frm.doc.item_group
+				}
 			};
 		});
 		frm.set_query("item_model", function() {
 			return {
-				filters: [
-					['Item Model', 'item_brand', '=', cur_frm.doc.brand]
-				]
+				filters: {
+					"item_brand": cur_frm.doc.brand
+				}
 			};
 		});
 		var fields = ["linked_items"];
 		for ( var i=0; i< fields.length; i++ ){
 			frm.set_query(fields[i], function(){
-				return{
-					filters: [
-						['Item', 'subitem_group', '=', cur_frm.doc.subitem_group]
-					]
+				return {
+					filters: {
+						"subitem_group": cur_frm.doc.subitem_group
+					}
 				}
 			});
 		}

--- a/one_fm/public/js/doctype_js/item.js
+++ b/one_fm/public/js/doctype_js/item.js
@@ -37,7 +37,7 @@ frappe.ui.form.on('Item', {
 			frm.set_query(fields[i], function(){
 				return {
 					filters: {
-						"subitem_group": cur_frm.doc.subitem_group
+						"subitem_group": frm.doc.subitem_group
 					}
 				}
 			});

--- a/one_fm/public/js/doctype_js/item.js
+++ b/one_fm/public/js/doctype_js/item.js
@@ -21,7 +21,7 @@ frappe.ui.form.on('Item', {
 		frm.set_query("item_type", function() {
 			return {
 				filters: {
-					"item_group": cur_frm.doc.item_group
+					"item_group": frm.doc.item_group
 				}
 			};
 		});

--- a/one_fm/public/js/doctype_js/item.js
+++ b/one_fm/public/js/doctype_js/item.js
@@ -28,7 +28,7 @@ frappe.ui.form.on('Item', {
 		frm.set_query("item_model", function() {
 			return {
 				filters: {
-					"item_brand": cur_frm.doc.brand
+					"item_brand": frm.doc.brand
 				}
 			};
 		});

--- a/one_fm/public/js/doctype_js/item.js
+++ b/one_fm/public/js/doctype_js/item.js
@@ -7,7 +7,7 @@ frappe.ui.form.on('Item', {
 		frm.set_query("subitem_group", function() {
 			return {
 				filters: {
-					"parent_item_group": cur_frm.doc.parent_item_group
+					"parent_item_group": frm.doc.parent_item_group
 				}
 			};
 		});

--- a/one_fm/public/js/doctype_js/item.js
+++ b/one_fm/public/js/doctype_js/item.js
@@ -14,7 +14,7 @@ frappe.ui.form.on('Item', {
 		frm.set_query("item_group", function() {
 			return {
 				filters: {
-					"parent_item_group": cur_frm.doc.subitem_group
+					"parent_item_group": frm.doc.subitem_group
 				}
 			};
 		});


### PR DESCRIPTION
This pull request refactors the way filters are set for queries in the `frappe.ui.form.on('Item', ...)` JavaScript code. The main change is replacing array-based filter syntax with object-based filter syntax for better readability and consistency.

**Query filter refactoring:**

* Updated all `frm.set_query` calls in `one_fm/public/js/doctype_js/item.js` to use object-based filter syntax instead of the previous array-based syntax, improving code clarity and maintainability.