### PR TITLE
Hotfix/pmr erf status filter

### DIFF
--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.js
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.js
@@ -51,7 +51,7 @@ frappe.ui.form.on('Project Manpower Request', {
 				filters: {
 					designation: frm.doc.designation,
 					docstatus: 1,
-					status: ['not in', ['Cancelled', 'Closed']]
+					status: 'Accepted'
 				}
 			};
 		});
@@ -290,7 +290,8 @@ frappe.ui.form.on("Project Manpower Request", {
 		frm.set_query("erf", function() {
 			return {
 				filters: {
-					docstatus: 1
+					docstatus: 1,
+					status: "Accepted"
 				}
 			};
 		});


### PR DESCRIPTION
### Description
Previously, the Project Manpower Request (PMR) form filtered the `ERF` link field dropdown to show all ERFs whose status was not in `['Cancelled', 'Closed']`. This included temporary or invalid statuses such as `Open`, `Rejected`, `Under Review`, and `Hold`. 

This PR restricts the filter to strictly show ERFs that have been approved and marked as `Accepted` (active for recruitment).

### Changes
- Modified `frm.set_query('erf')` in the `refresh` hook of `project_manpower_request.js` to set `status: 'Accepted'`.
- Modified `frm.set_query('erf')` in the `setup` hook of `project_manpower_request.js` to set `status: 'Accepted'`.
