### PR TITLE
fix: ojt employee schedule creation issue

### DIFF
--- a/one_fm/one_fm/doctype/on_the_job_training/on_the_job_training.py
+++ b/one_fm/one_fm/doctype/on_the_job_training/on_the_job_training.py
@@ -179,10 +179,9 @@ class OntheJobTraining(Document):
 
 
     def on_submit(self):
-        # The "Approve" workflow action submits the document (docstatus 0 -> 1),
-        # which fires on_submit and NOT on_update. Schedule creation that runs at
-        # the "Pending Approval" save (on_update) is therefore not guaranteed to
-        # have happened (e.g. OJTs approved before that logic was deployed, or a
+        # The "Approve" workflow action submits the document (docstatus 0 -> 1).
+        # Schedule creation currently runs during the "Pending Approval" save (on_update),
+        # which may not have occurred (e.g. OJTs approved before that logic was deployed, or a
         # bypassed/rolled-back Pending Approval step). Re-run schedule creation here
         # so an Approved OJT always has Employee Schedules. get_or_create is
         # idempotent, so this is safe when schedules already exist.

--- a/one_fm/one_fm/doctype/on_the_job_training/on_the_job_training.py
+++ b/one_fm/one_fm/doctype/on_the_job_training/on_the_job_training.py
@@ -178,6 +178,17 @@ class OntheJobTraining(Document):
                 )
 
 
+    def on_submit(self):
+        # The "Approve" workflow action submits the document (docstatus 0 -> 1),
+        # which fires on_submit and NOT on_update. Schedule creation that runs at
+        # the "Pending Approval" save (on_update) is therefore not guaranteed to
+        # have happened (e.g. OJTs approved before that logic was deployed, or a
+        # bypassed/rolled-back Pending Approval step). Re-run schedule creation here
+        # so an Approved OJT always has Employee Schedules. get_or_create is
+        # idempotent, so this is safe when schedules already exist.
+        if self.workflow_state == "Approved":
+            self.create_or_update_employee_schedules()
+
     def on_update_after_submit(self):
         self.on_update()
 

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -427,3 +427,4 @@ one_fm.patches.v15_0.add_recurring_bonus_process_task
 one_fm.patches.v15_0.fix_parentfield_bonus_items
 one_fm.patches.v15_0.add_nationality_read_permission
 one_fm.patches.v15_0.update_workflows_for_ops_admin_edit
+one_fm.patches.v15_0.backfill_ojt_employee_schedules

--- a/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
+++ b/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
@@ -9,7 +9,7 @@ def execute():
     Employee Schedules were ever created for it. create_or_update_employee_schedules()
     is idempotent (get_or_create), so this is a no-op if schedules already exist.
     """
-    ojt_name = "OJT-06-2026-0036"
+    ojt_name = "OJT-06-2026-0041"
 
     if not frappe.db.exists("On the Job Training", ojt_name):
         return

--- a/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
+++ b/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
@@ -1,0 +1,24 @@
+# one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
+import frappe
+
+
+def execute():
+    """Backfill Employee Schedules for OJT-06-2026-0041.
+
+    This OJT was approved before schedule creation moved to on_submit, so no
+    Employee Schedules were ever created for it. create_or_update_employee_schedules()
+    is idempotent (get_or_create), so this is a no-op if schedules already exist.
+    """
+    # ojt_name = "OJT-06-2026-0041"
+    ojt_name = "OJT-06-2026-0036"
+
+    if not frappe.db.exists("On the Job Training", ojt_name):
+        return
+
+    doc = frappe.get_doc("On the Job Training", ojt_name)
+
+    if not doc.employee or not doc.start_date:
+        return
+
+    doc.create_or_update_employee_schedules()
+    frappe.db.commit()

--- a/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
+++ b/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
@@ -9,7 +9,6 @@ def execute():
     Employee Schedules were ever created for it. create_or_update_employee_schedules()
     is idempotent (get_or_create), so this is a no-op if schedules already exist.
     """
-    # ojt_name = "OJT-06-2026-0041"
     ojt_name = "OJT-06-2026-0036"
 
     if not frappe.db.exists("On the Job Training", ojt_name):


### PR DESCRIPTION
This pull request ensures that Employee Schedules are reliably created for approved On the Job Training (OJT) documents, even for those approved before recent workflow changes. It introduces an idempotent check on submission and backfills existing data for a specific OJT record.

**Workflow reliability improvements:**

* Added an `on_submit` method to the `On the Job Training` DocType to ensure `create_or_update_employee_schedules()` runs whenever an OJT is approved, guaranteeing schedules are created even if earlier workflow steps were skipped or missed.

**Data backfill and migration:**

* Added a patch script `backfill_ojt_employee_schedules.py` to backfill Employee Schedules for a specific OJT record that was approved before the schedule creation logic was moved to `on_submit`. The script is safe to run multiple times due to the idempotent schedule creation.
* Registered the new patch in `patches.txt` so it will be applied during system updates.


<img width="1022" height="468" alt="Screenshot 2026-06-15 at 3 47 07 PM" src="https://github.com/user-attachments/assets/0fa8e600-693f-4787-b350-0ef8c32beaff" />
