### PR TITLE
patch: delete medical appointment todo

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -428,3 +428,4 @@ one_fm.patches.v15_0.fix_parentfield_bonus_items
 one_fm.patches.v15_0.add_nationality_read_permission
 one_fm.patches.v15_0.update_workflows_for_ops_admin_edit
 one_fm.patches.v15_0.backfill_ojt_employee_schedules
+one_fm.patches.v15_0.delete_medical_appointment_todos #2026-06-15

--- a/one_fm/patches/v15_0/delete_medical_appointment_todos.py
+++ b/one_fm/patches/v15_0/delete_medical_appointment_todos.py
@@ -1,0 +1,26 @@
+import frappe
+
+REFERENCE_TYPE = "Medical Appointment"
+REFERENCE_NAMES = ["MAP-2026-00114", "MAP-2026-00108"]
+
+
+def execute():
+	"""Delete orphaned ToDo records referencing specific Medical Appointment documents."""
+	todos = frappe.get_all(
+		"ToDo",
+		filters={
+			"reference_type": REFERENCE_TYPE,
+			"reference_name": ["in", REFERENCE_NAMES],
+		},
+		pluck="name",
+	)
+
+	if not todos:
+		print("Patch delete_medical_appointment_todos: No matching ToDo records found.")
+		return
+
+	for name in todos:
+		frappe.delete_doc("ToDo", name, force=True, ignore_permissions=True)
+
+	frappe.db.commit()
+	print(f"Patch delete_medical_appointment_todos: Deleted {len(todos)} ToDo record(s).")


### PR DESCRIPTION
This pull request introduces a new patch to clean up orphaned `ToDo` records related to specific `Medical Appointment` documents. The main focus is on maintaining data integrity by removing unnecessary records.

**Database Cleanup:**

* Added a new patch file `one_fm.patches.v15_0.delete_medical_appointment_todos` that deletes `ToDo` records referencing the `Medical Appointment` documents with names `MAP-2026-00114` and `MAP-2026-00108`. The patch ensures only orphaned records are targeted and logs the outcome.
* Registered the patch in `one_fm/patches.txt` so it will be executed during the next patch run.