### PR TITLE
fix: sync ERF workflow_state with Closed status

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -430,3 +430,4 @@ one_fm.patches.v15_0.update_workflows_for_ops_admin_edit
 one_fm.patches.v15_0.backfill_ojt_employee_schedules
 one_fm.patches.v15_0.delete_medical_appointment_todos #2026-06-15
 one_fm.patches.v15_0.sync_erf_workflow_state_with_closed_status #2026-06-15
+one_fm.patches.v15_0.close_job_openings_for_closed_erf #2026-06-15

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -429,3 +429,4 @@ one_fm.patches.v15_0.add_nationality_read_permission
 one_fm.patches.v15_0.update_workflows_for_ops_admin_edit
 one_fm.patches.v15_0.backfill_ojt_employee_schedules
 one_fm.patches.v15_0.delete_medical_appointment_todos #2026-06-15
+one_fm.patches.v15_0.sync_erf_workflow_state_with_closed_status #2026-06-15

--- a/one_fm/patches/v15_0/close_job_openings_for_closed_erf.py
+++ b/one_fm/patches/v15_0/close_job_openings_for_closed_erf.py
@@ -1,0 +1,18 @@
+import frappe
+
+
+def execute():
+	"""Close Job Openings linked to ERFs whose status is 'Closed'.
+
+	Reuses the ERF controller's close_job_opening method so the closing
+	logic stays in one place (sets publish=0 and status='Closed' on each
+	linked Job Opening)."""
+	erf_names = frappe.get_all(
+		"ERF",
+		filters={"status": "Closed"},
+		pluck="name",
+	)
+
+	for erf_name in erf_names:
+		erf = frappe.get_doc("ERF", erf_name)
+		erf.close_job_opening()

--- a/one_fm/patches/v15_0/sync_erf_workflow_state_with_closed_status.py
+++ b/one_fm/patches/v15_0/sync_erf_workflow_state_with_closed_status.py
@@ -1,0 +1,22 @@
+import frappe
+
+
+def execute():
+	"""Set workflow_state to 'Closed' for ERFs whose status is 'Closed' but
+	whose workflow_state is out of sync (anything other than 'Closed')."""
+	erf_names = frappe.get_all(
+		"ERF",
+		filters={"status": "Closed", "workflow_state": ["!=", "Closed"]},
+		pluck="name",
+	)
+
+	if not erf_names:
+		return
+
+	frappe.db.set_value(
+		"ERF",
+		{"name": ["in", erf_names]},
+		"workflow_state",
+		"Closed",
+		update_modified=False,
+	)


### PR DESCRIPTION
This pull request introduces two new patch scripts to improve data consistency for closed ERFs (Employee Requisition Forms) and their related Job Openings. These scripts ensure that all ERFs marked as closed have their workflow state updated accordingly and that any linked Job Openings are also properly closed.

**Data consistency for closed ERFs and related Job Openings:**

* Added `sync_erf_workflow_state_with_closed_status.py` patch to set the `workflow_state` to "Closed" for all ERFs where the status is "Closed" but the workflow state is not, ensuring workflow and status fields are aligned.
* Added `close_job_openings_for_closed_erf.py` patch to close all Job Openings linked to ERFs whose status is "Closed", by invoking the ERF controller’s `close_job_opening` method for each relevant ERF.

**Patch registration:**

* Registered the new patches in `one_fm/patches.txt` so they will be executed during the next patch run.

<img width="901" height="387" alt="Screenshot 2026-06-15 at 5 33 13 PM" src="https://github.com/user-attachments/assets/fe3c70f5-6d16-4258-98b3-5aef6d14cd41" />

<img width="996" height="511" alt="Screenshot 2026-06-15 at 5 53 52 PM" src="https://github.com/user-attachments/assets/5e448ba3-112a-453c-9982-0243d2f1ea5e" />
