### PR TITLE
fix(pmr): prevent TimestampMismatchError on Request Change

### DIFF
--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.js
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.js
@@ -102,19 +102,8 @@ frappe.ui.form.on('Project Manpower Request', {
 					fieldtype: 'Small Text',
 					reqd: 1
 				}, (values) => {
-					frappe.call({
-						method: "one_fm.one_fm.doctype.project_manpower_request.project_manpower_request.set_edit_reason",
-						args: {
-							name: frm.doc.name,
-							reason: values.reason_for_rejection
-						},
-						callback: function(r) {
-							resolve();
-						},
-						error: function(err) {
-							reject(err);
-						}
-					});
+					frm.doc._reason_for_rejection = values.reason_for_rejection;
+					resolve();
 				}, __('Change Request Reason'), __('Submit'));
 			} else {
 				if (frm.selected_workflow_action === "Submit to Recruiter" || frm.selected_workflow_action === "Request Edit") {

--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.py
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.py
@@ -28,6 +28,9 @@ class ProjectManpowerRequest(Document):
 		self.project_request_code = self.name
 
 	def validate(self):
+		if getattr(self, "_reason_for_rejection", None):
+			self.reason_for_rejection = self._reason_for_rejection
+
 		self.update_select_field_options()
 		if self.reason == "Exit":
 			if self.get("resignation_links"):


### PR DESCRIPTION
This hotfix resolves the TimestampMismatchError on the Project Manpower Request (PMR) 'Request Change' workflow action. Replaces the separate set_edit_reason API call with a single-transaction approach using a custom client-side attribute passed in the document payload.