### PR TITLE
fix: add fallbacks param to get_valuation_rate override

### DIFF
--- a/one_fm/overrides/stock_ledger.py
+++ b/one_fm/overrides/stock_ledger.py
@@ -12,6 +12,7 @@ def get_valuation_rate_(
     allow_zero_rate=False,
     currency=None,
     company=None,
+    fallbacks=True,
     raise_error_if_no_rate=True,
     batch_no=None,
     serial_and_batch_bundle=None,
@@ -67,21 +68,24 @@ def get_valuation_rate_(
     if last_valuation_rate:
         return flt(last_valuation_rate[0][0])
 
-    if not last_valuation_rate and last_valuation_rate_ :
+    if not last_valuation_rate and last_valuation_rate_:
         return flt(last_valuation_rate_[0][0])
-    # If negative stock allowed, and item delivered without any incoming entry,
-    # system does not found any SLE, then take valuation rate from Item
-    valuation_rate = frappe.db.get_value("Item", item_code, "valuation_rate")
 
-    if not valuation_rate:
-        # try Item Standard rate
-        valuation_rate = frappe.db.get_value("Item", item_code, "standard_rate")
+    valuation_rate = None
+    if fallbacks:
+        # If negative stock allowed, and item delivered without any incoming entry,
+        # system does not found any SLE, then take valuation rate from Item
+        valuation_rate = frappe.db.get_value("Item", item_code, "valuation_rate")
 
         if not valuation_rate:
-            # try in price list
-            valuation_rate = frappe.db.get_value(
-                "Item Price", dict(item_code=item_code, buying=1, currency=currency), "price_list_rate"
-            )
+            # try Item Standard rate
+            valuation_rate = frappe.db.get_value("Item", item_code, "standard_rate")
+
+            if not valuation_rate:
+                # try in price list
+                valuation_rate = frappe.db.get_value(
+                    "Item Price", dict(item_code=item_code, buying=1, currency=currency), "price_list_rate"
+                )
 
     if (
         not allow_zero_rate


### PR DESCRIPTION
The get_valuation_rate_ monkeypatch broke on Employee Uniform submit because current ERPNext calls get_valuation_rate with a fallbacks keyword argument the override did not accept, raising TypeError.

- add fallbacks=True to the signature in ERPNext's argument position
- gate the Item valuation_rate / standard_rate / price-list fallback chain behind the fallbacks flag to match ERPNext semantics