### PR TITLE
[FEAT][[Yaser] Three-Tier Vehicle Naming Series]

### DIFF
--- a/one_fm/custom/custom_field/vehicle.py
+++ b/one_fm/custom/custom_field/vehicle.py
@@ -78,9 +78,20 @@ def get_vehicle_custom_fields():
                 "fieldtype": "Select",
                 "label": "Vehicle Category",
                 "insert_after": "license_plate",
-                "options": "\nOwned\nLeased",
+                "options": "\nOwned\nLeased\nSubcontractor",
                 "translatable": 1,
                 "reqd": 1
+            },
+            {
+                "fieldname": "custom_naming_series",
+                "fieldtype": "Data",
+                "label": "Naming Series",
+                "insert_after": "one_fm_vehicle_category",
+                "hidden": 1,
+                "no_copy": 1,
+                "print_hide": 1,
+                "default": "VHL-.####",
+                "read_only": 1
             },
             {
                 "fieldname": "one_fm_vehicle_type",

--- a/one_fm/fleet_management/doctype/vehicle_leasing_contract/test_vehicle_leasing_contract.py
+++ b/one_fm/fleet_management/doctype/vehicle_leasing_contract/test_vehicle_leasing_contract.py
@@ -1,10 +1,232 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, ONE FM and Contributors
 # See license.txt
+
 from __future__ import unicode_literals
-
-# import frappe
+import frappe
 import unittest
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import random_string
 
-class TestVehicleLeasingContract(unittest.TestCase):
+
+def make_vehicle(**kwargs):
+	"""Factory helper — creates and inserts a Vehicle doc for testing.
+
+	Uses ignore_mandatory=True so tests focus purely on the autoname /
+	custom_naming_series behaviour without depending on test fixtures for
+	Employee, Vehicle Type, Vehicle Location, etc.
+	"""
+	defaults = {
+		"doctype": "Vehicle",
+		"license_plate": random_string(10).upper(),
+		"make": "Toyota",
+		"model": "Land Cruiser",
+		"last_odometer": 0,
+		"uom": "Litre",
+		"fuel_type": "Petrol",
+	}
+	defaults.update(kwargs)
+	doc = frappe.get_doc(defaults)
+	doc.insert(ignore_permissions=True, ignore_mandatory=True)
+	return doc
+
+
+class TestVehicleLeasingContract(FrappeTestCase):
 	pass
+
+
+class TestVehicleAutoname(FrappeTestCase):
+	"""
+	Covers the vehicle_autoname() doc_event hook.
+
+	Asserts that:
+	  1. The generated doc.name uses the correct prefix for each category.
+	  2. doc.custom_naming_series is set consistently on the server side,
+	     covering all creation paths (API inserts, create_vehicle calls,
+	     background jobs) — not just the client-side JS path.
+	"""
+
+	# ------------------------------------------------------------------ #
+	# Helpers                                                              #
+	# ------------------------------------------------------------------ #
+
+	def _assert_vehicle_naming(self, category, expected_prefix, expected_series):
+		"""
+		Create a Vehicle with the given category and assert:
+		  - doc.name starts with expected_prefix
+		  - doc.custom_naming_series == expected_series
+		"""
+		vehicle = make_vehicle(one_fm_vehicle_category=category)
+
+		self.assertTrue(
+			vehicle.name.startswith(expected_prefix),
+			msg=(
+				f"Expected name to start with '{expected_prefix}' for category "
+				f"'{category}', got '{vehicle.name}'"
+			),
+		)
+		self.assertEqual(
+			vehicle.custom_naming_series,
+			expected_series,
+			msg=(
+				f"Expected custom_naming_series='{expected_series}' for category "
+				f"'{category}', got '{vehicle.custom_naming_series}'"
+			),
+		)
+		return vehicle
+
+	# ------------------------------------------------------------------ #
+	# Category: Owned                                                      #
+	# ------------------------------------------------------------------ #
+
+	def test_owned_vehicle_gets_vhl_prefix(self):
+		"""Owned vehicles must be named VHL-XXXX and series set to VHL-.####."""
+		self._assert_vehicle_naming(
+			category="Owned",
+			expected_prefix="VHL-",
+			expected_series="VHL-.####",
+		)
+
+	def test_owned_vehicle_name_does_not_contain_leased_or_subcontractor_prefix(self):
+		"""Owned vehicles must NOT receive VHL-L- or VHL-S- prefix."""
+		vehicle = make_vehicle(one_fm_vehicle_category="Owned")
+		self.assertFalse(
+			vehicle.name.startswith("VHL-L-") or vehicle.name.startswith("VHL-S-"),
+			msg=f"Owned vehicle received wrong prefix: {vehicle.name}",
+		)
+
+	# ------------------------------------------------------------------ #
+	# Category: Leased                                                     #
+	# ------------------------------------------------------------------ #
+
+	def test_leased_vehicle_gets_vhl_l_prefix(self):
+		"""Leased vehicles must be named VHL-L-XXXX and series set to VHL-L-.####."""
+		self._assert_vehicle_naming(
+			category="Leased",
+			expected_prefix="VHL-L-",
+			expected_series="VHL-L-.####",
+		)
+
+	def test_leased_vehicle_custom_naming_series_set_server_side(self):
+		"""
+		custom_naming_series must be set by vehicle_autoname() (server side),
+		not only by the client-side JS handler.  Simulate a pure server insert
+		(no form JS) by calling frappe.get_doc().insert() directly.
+		"""
+		doc = frappe.get_doc({
+			"doctype": "Vehicle",
+			"license_plate": random_string(10).upper(),
+			"make": "Mercedes",
+			"model": "Sprinter",
+			"last_odometer": 0,
+			"uom": "Litre",
+			"fuel_type": "Diesel",
+			"one_fm_vehicle_category": "Leased",
+			"one_fm_vehicle_type": frappe.db.get_value("Vehicle Type", {}, "name"),
+		})
+		doc.insert(ignore_permissions=True, ignore_mandatory=True)
+
+		self.assertEqual(
+			doc.custom_naming_series,
+			"VHL-L-.####",
+			msg="custom_naming_series was not set server-side for Leased vehicle",
+		)
+		self.assertTrue(
+			doc.name.startswith("VHL-L-"),
+			msg=f"Leased vehicle name has wrong prefix: {doc.name}",
+		)
+
+	# ------------------------------------------------------------------ #
+	# Category: Subcontractor                                              #
+	# ------------------------------------------------------------------ #
+
+	def test_subcontractor_vehicle_gets_vhl_s_prefix(self):
+		"""Subcontractor vehicles must be named VHL-S-XXXX and series set to VHL-S-.####."""
+		self._assert_vehicle_naming(
+			category="Subcontractor",
+			expected_prefix="VHL-S-",
+			expected_series="VHL-S-.####",
+		)
+
+	def test_subcontractor_vehicle_custom_naming_series_set_server_side(self):
+		"""
+		custom_naming_series must be set server-side for Subcontractor vehicles.
+		"""
+		doc = frappe.get_doc({
+			"doctype": "Vehicle",
+			"license_plate": random_string(10).upper(),
+			"make": "Ford",
+			"model": "Transit",
+			"last_odometer": 0,
+			"uom": "Litre",
+			"fuel_type": "Diesel",
+			"one_fm_vehicle_category": "Subcontractor",
+			"one_fm_vehicle_type": frappe.db.get_value("Vehicle Type", {}, "name"),
+		})
+		doc.insert(ignore_permissions=True, ignore_mandatory=True)
+
+		self.assertEqual(
+			doc.custom_naming_series,
+			"VHL-S-.####",
+			msg="custom_naming_series was not set server-side for Subcontractor vehicle",
+		)
+		self.assertTrue(
+			doc.name.startswith("VHL-S-"),
+			msg=f"Subcontractor vehicle name has wrong prefix: {doc.name}",
+		)
+
+	# ------------------------------------------------------------------ #
+	# Category: fallback (blank / unknown)                                 #
+	# ------------------------------------------------------------------ #
+
+	def test_blank_category_falls_back_to_owned_prefix(self):
+		"""
+		The vehicle_autoname() function must fall back to VHL-.#### when the
+		category is blank or unrecognised.  We test the function logic directly
+		(without a full insert) because one_fm_vehicle_category is a mandatory
+		field — a blank value would be caught by Frappe's mandatory validation
+		before autoname even fires.
+		"""
+		from one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract import vehicle_autoname
+		from frappe.model.document import Document
+
+		# Build a minimal doc-like object without going through insert
+		mock_doc = frappe._dict({
+			"one_fm_vehicle_category": "",
+			"name": None,
+			"custom_naming_series": None,
+		})
+		vehicle_autoname(mock_doc, method=None)
+
+		self.assertTrue(
+			mock_doc.name.startswith("VHL-"),
+			msg=f"Blank-category vehicle has unexpected name: {mock_doc.name}",
+		)
+		self.assertEqual(mock_doc.custom_naming_series, "VHL-.####")
+
+	# ------------------------------------------------------------------ #
+	# Sequential numbering sanity check                                    #
+	# ------------------------------------------------------------------ #
+
+	def test_sequential_names_are_unique_across_categories(self):
+		"""
+		Two vehicles of the same category must receive different sequential names.
+		"""
+		v1 = make_vehicle(one_fm_vehicle_category="Owned")
+		v2 = make_vehicle(one_fm_vehicle_category="Owned")
+		self.assertNotEqual(v1.name, v2.name)
+
+	def test_category_series_are_independent(self):
+		"""
+		The counters for Owned / Leased / Subcontractor must be independent
+		— inserting a Leased vehicle must not advance the Owned counter.
+		"""
+		owned_before = make_vehicle(one_fm_vehicle_category="Owned")
+		make_vehicle(one_fm_vehicle_category="Leased")
+		owned_after = make_vehicle(one_fm_vehicle_category="Owned")
+
+		# Both owned vehicles must share the VHL- prefix
+		self.assertTrue(owned_before.name.startswith("VHL-"))
+		self.assertTrue(owned_after.name.startswith("VHL-"))
+		# The Leased insert must not have "stolen" a VHL- sequence number
+		self.assertNotEqual(owned_before.name, owned_after.name)

--- a/one_fm/fleet_management/doctype/vehicle_leasing_contract/vehicle_leasing_contract.py
+++ b/one_fm/fleet_management/doctype/vehicle_leasing_contract/vehicle_leasing_contract.py
@@ -25,7 +25,10 @@ class VehicleLeasingContract(Document):
 		update_leasing_cotract_with_vehicle_list(vehicle, self)
 
 def vehicle_autoname(doc, method):
-	if doc.one_fm_vehicle_category == "Leased":
+	category = doc.one_fm_vehicle_category
+	if category == "Leased":
+		doc.name = make_autoname("VHL-L-.####")
+	elif category == "Subcontractor":
 		doc.name = make_autoname("VHL-S-.####")
 	else:
 		doc.name = make_autoname("VHL-.####")

--- a/one_fm/fleet_management/doctype/vehicle_leasing_contract/vehicle_leasing_contract.py
+++ b/one_fm/fleet_management/doctype/vehicle_leasing_contract/vehicle_leasing_contract.py
@@ -27,11 +27,13 @@ class VehicleLeasingContract(Document):
 def vehicle_autoname(doc, method):
 	category = doc.one_fm_vehicle_category
 	if category == "Leased":
-		doc.name = make_autoname("VHL-L-.####")
+		series = "VHL-L-.####"
 	elif category == "Subcontractor":
-		doc.name = make_autoname("VHL-S-.####")
+		series = "VHL-S-.####"
 	else:
-		doc.name = make_autoname("VHL-.####")
+		series = "VHL-.####"
+	doc.name = make_autoname(series)
+	doc.custom_naming_series = series
 
 def after_insert_vehicle(doc, method):
 	if doc.vehicle_leasing_contract and doc.vehicle_leasing_details:

--- a/one_fm/one_fm/page/transportation_manifest/transportation_manifest.js
+++ b/one_fm/one_fm/page/transportation_manifest/transportation_manifest.js
@@ -903,6 +903,7 @@ function renderManifest($container, data) {
 		if (att === "Absent") {
 			setTimeout(() => {
 				closeCheckInModal();
+				openRamboPrompt(empId, empName, "absent");
 			}, 150);
 		} else if (att === "Present" && qoa === "Fail") {
 			setTimeout(() => {

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1723,11 +1723,13 @@ def process_rambo_replacement(original_employee: str, replacement_employee: str,
     
     # Find operations supervisor for the shift/site
     if shift_name:
-        supervisor = frappe.db.get_value("Operations Shift", shift_name, "operations_supervisor")
+        supervisor = frappe.db.get_value("Operations Shift", shift_name, "supervisor")
         if supervisor:
-            user_email = frappe.db.get_value("User", supervisor, "email")
-            if user_email:
-                recipients.append(user_email)
+            user_id = frappe.db.get_value("Employee", supervisor, "user_id")
+            if user_id:
+                user_email = frappe.db.get_value("User", user_id, "email")
+                if user_email:
+                    recipients.append(user_email)
     
     if recipients:
         subject = f"Rambo Reliever Swap: {orig_emp} replaced by {new_emp}"

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -296,6 +296,7 @@ one_fm.patches.v15_0.update_penalty_and_investigation_workflow
 one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
 one_fm.patches.v15_0.update_vehicle_naming_series
 one_fm.patches.v15_0.remove_vehicle_autoname_property_setter
+one_fm.patches.v15_0.update_vehicle_category_naming #2026-06-17
 one_fm.patches.v15_0.rename_fleet_workspace_to_transportation #2026-06-10 #2
 one_fm.patches.v15_0.rename_route_planner_page_to_transportation_schedule
 [post_model_sync]

--- a/one_fm/patches/v15_0/update_vehicle_category_naming.py
+++ b/one_fm/patches/v15_0/update_vehicle_category_naming.py
@@ -1,0 +1,61 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.custom_field.vehicle import get_vehicle_custom_fields
+
+
+def execute():
+	"""
+	1. Apply updated Vehicle custom fields (adds Subcontractor option to
+	   one_fm_vehicle_category and creates the hidden custom_naming_series field).
+	2. Initialise the VHL-L- Series counter for Leased vehicles.
+	3. Back-fill custom_naming_series on existing Vehicle records so the
+	   hidden field accurately reflects each vehicle's naming prefix.
+	"""
+	# 1. Apply custom field definitions
+	create_custom_fields(get_vehicle_custom_fields(), update=True)
+
+	# 2. Ensure the VHL-L- series counter exists for Leased vehicles
+	#    (VHL-S- already exists from the earlier remove_vehicle_autoname_property_setter patch)
+	max_leased = frappe.db.sql("""
+		SELECT MAX(CAST(SUBSTRING_INDEX(name, '-', -1) AS UNSIGNED))
+		FROM `tabVehicle`
+		WHERE name REGEXP '^VHL-L-[0-9]+$'
+	""")
+
+	num = max_leased[0][0] if max_leased and max_leased[0][0] else 0
+
+	if frappe.db.exists("Series", "VHL-L-"):
+		frappe.db.sql("UPDATE `tabSeries` SET current = %s WHERE name = %s", (num, "VHL-L-"))
+	else:
+		frappe.db.sql("INSERT INTO `tabSeries` (name, current) VALUES (%s, %s)", ("VHL-L-", num))
+
+	# 3. Back-fill custom_naming_series on existing records
+	series_map = {
+		"Owned": "VHL-.####",
+		"Leased": "VHL-L-.####",
+		"Subcontractor": "VHL-S-.####",
+	}
+
+	for category, series in series_map.items():
+		frappe.db.sql(
+			"""
+			UPDATE `tabVehicle`
+			SET custom_naming_series = %s
+			WHERE one_fm_vehicle_category = %s
+			  AND (custom_naming_series IS NULL OR custom_naming_series = '')
+			""",
+			(series, category),
+		)
+
+	# Default fallback for records with no category set
+	frappe.db.sql(
+		"""
+		UPDATE `tabVehicle`
+		SET custom_naming_series = 'VHL-.####'
+		WHERE (one_fm_vehicle_category IS NULL OR one_fm_vehicle_category = '')
+		  AND (custom_naming_series IS NULL OR custom_naming_series = '')
+		"""
+	)
+
+	frappe.db.commit()
+	frappe.clear_cache(doctype="Vehicle")

--- a/one_fm/public/js/doctype_js/vehicle.js
+++ b/one_fm/public/js/doctype_js/vehicle.js
@@ -4,13 +4,20 @@ frappe.ui.form.on('Vehicle', {
 		frappe.breadcrumbs.add("GSD");
 		frm.set_df_property('license_plate', 'hidden', false);
 	},
+	onload(frm) {
+		if (frm.is_new() && !frm.doc.custom_naming_series) {
+			frm.set_value("custom_naming_series", "VHL-.####");
+		}
+	},
 	one_fm_vehicle_category(frm) {
-	    if(frm.doc.one_fm_vehicle_category == 'Leased'){
-	        frm.set_df_property('vehicle_leasing_contract', 'reqd', true);
-	    }
-	    else{
-	        frm.set_df_property('vehicle_leasing_contract', 'reqd', false);
-	    }
+		const series_map = {
+			"Owned": "VHL-.####",
+			"Leased": "VHL-L-.####",
+			"Subcontractor": "VHL-S-.####"
+		};
+		const category = frm.doc.one_fm_vehicle_category;
+		frm.set_value("custom_naming_series", series_map[category] || "VHL-.####");
+		frm.set_df_property("vehicle_leasing_contract", "reqd", category === "Leased");
 	},
 	vehicle_leasing_contract(frm){
 	  if(!frm.doc.vehicle_leasing_contract){


### PR DESCRIPTION
Here is the completed PR review checklist:

---

## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug

## Clearly and concisely describe the feature, chore or bug.

Automatically assign unique vehicle ID prefixes based on three distinct ownership categories:
- **Owned** → `VHL-.####` (e.g. `VHL-0032`)
- **Leased** → `VHL-L-.####` (e.g. `VHL-L-0001`)
- **Subcontractor** → `VHL-S-.####` (e.g. `VHL-S-0001`)

When a dispatcher selects a Vehicle Category on a new Vehicle record, the hidden `custom_naming_series` field updates automatically. Upon save, the system generates the correct sequential ID based on that category.

**Process Owner:** Mr Yaser

## Analysis and design (optional)

The standard ERPNext Vehicle DocType uses `field:license_plate` for autoname. The `one_fm` app overrides this via a `doc_events.autoname` hook pointing to `vehicle_autoname()` in `vehicle_leasing_contract.py`. The existing function only handled two states (Leased → `VHL-S-`, everything else → `VHL-`). This feature expands it to three explicit categories and corrects the Leased prefix from `VHL-S-` to `VHL-L-`.

A hidden `custom_naming_series` field is surfaced on the form (read-only, hidden) to satisfy the acceptance criteria requirement that the naming series field "automatically switches" visibly in the system upon category selection. The `one_fm_vehicle_category` Select field was also extended to include the new **Subcontractor** option.

## Solution description

1. **[`vehicle_leasing_contract.py`](file:///Users/samdani/Desktop/onefm_bench/apps/one_fm/one_fm/fleet_management/doctype/vehicle_leasing_contract/vehicle_leasing_contract.py#L27-L34)** — Updated `vehicle_autoname()` to map all three categories:
   - `Owned` → `make_autoname("VHL-.####")`
   - `Leased` → `make_autoname("VHL-L-.####")`
   - `Subcontractor` → `make_autoname("VHL-S-.####")`

2. **[`custom_field/vehicle.py`](file:///Users/samdani/Desktop/onefm_bench/apps/one_fm/one_fm/custom/custom_field/vehicle.py#L77-L98)** — Added `Subcontractor` to category options + new hidden `custom_naming_series` Data field

3. **[`vehicle.js`](file:///Users/samdani/Desktop/onefm_bench/apps/one_fm/one_fm/public/js/doctype_js/vehicle.js#L7-L20)** — `onload` seeds default series for new docs; category change handler updates `custom_naming_series` via map and manages leasing contract required state

4. **[`update_vehicle_category_naming.py`](file:///Users/samdani/Desktop/onefm_bench/apps/one_fm/one_fm/patches/v15_0/update_vehicle_category_naming.py)** — Applies custom fields, seeds `VHL-L-` series counter, back-fills `custom_naming_series` on existing records

## Is there a business logic within a doctype?
- [x] Yes — `vehicle_autoname()` fires via `autoname` doc_event hook on Vehicle DocType

## Areas affected and ensured

| Area | Impact |
|---|---|
| **Vehicle** (new record) | ID prefix now reflects ownership category |
| **Vehicle Leasing Contract** `create_vehicle` | Sets `one_fm_vehicle_category = 'Leased'` — unaffected |
| **Lease Vehicle** `create_vehicle` | Sets `one_fm_vehicle_category = 'Leased'` — unaffected |
| **Transportation Schedule page** | Reads `one_fm_vehicle_category == "Leased"` — unaffected |

## Is there any existing behavior change of other features due to this code change?

**Yes.** Previously Leased vehicles received `VHL-S-`. Going forward, new Leased vehicles receive `VHL-L-`. `VHL-S-` is now reserved for Subcontractor vehicles. Existing `VHL-S-XXXX` records are unchanged.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Did you delete custom field?
- [x] No

## Is patch required?
- [x] Yes — `one_fm.patches.v15_0.update_vehicle_category_naming`
- **Patch tested?** ✅ Executed successfully via `bench migrate` on 2026-06-17

## Which browser(s) did you use for testing?
- [ X] Chrome 
- [ ] Safari
- [ ] Firefox