### PR TITLE
fix: leave application permission issues and improve data access

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -863,6 +863,7 @@ override_whitelisted_methods = {
     "hrms.hr.doctype.leave_application.leave_application.get_number_of_leave_days": "one_fm.api.doc_methods.leave_application_calculation.custom_get_number_of_leave_days",
 	"hrms.hr.doctype.leave_application.leave_application.get_leave_approver" : "one_fm.overrides.leave_application.get_leave_approver",
 	"hrms.hr.doctype.leave_application.leave_application.get_leave_details" : "one_fm.overrides.leave_application.get_leave_details",
+	"hrms.hr.doctype.leave_application.leave_application.get_leave_balance_on" : "one_fm.overrides.leave_application.get_leave_balance_on",
     "frappe.desk.form.load.getdoc": "one_fm.permissions.getdoc",
     "frappe.desk.form.load.get_docinfo": "one_fm.permissions.get_docinfo",
 	"hrms.hr.doctype.goal.goal.get_children":"one_fm.overrides.goal.get_childrens",

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -267,6 +267,43 @@ class LeaveApplicationOverride(LeaveApplication):
         self.reset_status_on_amend()
         self.validate_loan_repayment()
 
+    def validate_balance_leaves(self):
+        precision = cint(frappe.db.get_single_value("System Settings", "float_precision")) or 2
+
+        if self.from_date and self.to_date:
+            self.total_leave_days = get_number_of_leave_days(
+                self.employee,
+                self.leave_type,
+                self.from_date,
+                self.to_date,
+                self.half_day,
+                self.half_day_date,
+            )
+
+            if self.total_leave_days <= 0:
+                frappe.throw(
+                    _(
+                        "The day(s) on which you are applying for leave are holidays. You need not apply for leave."
+                    )
+                )
+
+            if not is_lwp(self.leave_type):
+                leave_balance = get_leave_balance_on(
+                    self.employee,
+                    self.leave_type,
+                    self.from_date,
+                    self.to_date,
+                    consider_all_leaves_in_the_allocation_period=True,
+                    for_consumption=True,
+                )
+                leave_balance_for_consumption = flt(
+                    leave_balance.get("leave_balance_for_consumption"), precision
+                )
+                if self.status != "Rejected" and (
+                    leave_balance_for_consumption < self.total_leave_days or not leave_balance_for_consumption
+                ):
+                    self.show_insufficient_balance_message(leave_balance_for_consumption)
+
     def validate_loan_repayment(self):
         if self.leave_type != "Annual Leave":
             return

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -679,6 +679,52 @@ def get_leave_details(employee, date):
     }
 
 @frappe.whitelist()
+def get_leave_balance_on(
+	employee: str,
+	leave_type: str,
+	date: datetime.date,
+	to_date: datetime.date | None = None,
+	consider_all_leaves_in_the_allocation_period: bool = False,
+	for_consumption: bool = False,
+):
+	"""
+	Returns leave balance till date
+	:param employee: employee name
+	:param leave_type: leave type
+	:param date: date to check balance on
+	:param to_date: future date to check for allocation expiry
+	:param consider_all_leaves_in_the_allocation_period: consider all leaves taken till the allocation end date
+	:param for_consumption: flag to check if leave balance is required for consumption or display
+	        eg: employee has leave balance = 10 but allocation is expiring in 1 day so employee can only consume 1 leave
+	        in this case leave_balance = 10 but leave_balance_for_consumption = 1
+	        if True, returns a dict eg: {'leave_balance': 10, 'leave_balance_for_consumption': 1}
+	        else, returns leave_balance (in this case 10)
+	"""
+	if not to_date:
+		to_date = nowdate()
+
+	allocation_records = get_leave_allocation_records(employee, date, leave_type)
+	allocation = allocation_records.get(leave_type, frappe._dict())
+	end_date = (
+		allocation.to_date if (allocation and cint(consider_all_leaves_in_the_allocation_period)) else date
+	)
+	cf_expiry = get_allocation_expiry_for_cf_leaves(employee, leave_type, to_date, allocation.from_date)
+
+	leaves_taken = get_leaves_for_period(employee, leave_type, allocation.from_date, end_date)
+	manually_expired_leaves = get_manually_expired_leaves(
+		employee, leave_type, allocation.from_date, end_date
+	)
+
+	remaining_leaves = get_remaining_leaves(
+		allocation, leaves_taken, date, cf_expiry, manually_expired_leaves
+	)
+
+	if for_consumption:
+		return remaining_leaves
+	else:
+		return remaining_leaves.get("leave_balance")
+
+@frappe.whitelist()
 def get_leave_approver(employee):
     approver = get_approver_user(employee)
     return approver

--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -593,7 +593,14 @@ class LeaveApplicationOverride(LeaveApplication):
     @frappe.whitelist()
     def get_leave_extension_request(self):
         leave_extension_requests = frappe.get_all("Leave Extension Request", filters={"leave_application": self.name}, fields=["*"])
-        return leave_extension_requests[0] if leave_extension_requests else None
+        # Read the single value server-side so employees without read access to
+        # "HR and Payroll Additional Settings" don't hit a PermissionError on the
+        # client-side frappe.client.get_single_value endpoint.
+        threshold_days = cint(frappe.db.get_single_value("HR and Payroll Additional Settings", "leave_extension_request_allowance"))
+        return {
+            "request": leave_extension_requests[0] if leave_extension_requests else None,
+            "threshold_days": threshold_days,
+        }
 
     @frappe.whitelist()
     def create_leave_extension_request(self, new_resumption_date):

--- a/one_fm/public/js/doctype_js/leave_application.js
+++ b/one_fm/public/js/doctype_js/leave_application.js
@@ -397,10 +397,9 @@ function manage_leave_extension(frm) {
         frappe.call({
             doc: frm.doc,
             method: 'get_leave_extension_request',
-            callback: async function(res) {
-                const leaveExtensionRequest = res.message
-                
-                const thresholdDays = await frappe.db.get_single_value("HR and Payroll Additional Settings", "leave_extension_request_allowance") || 0;
+            callback: function(res) {
+                const leaveExtensionRequest = res.message ? res.message.request : null
+                const thresholdDays = (res.message && res.message.threshold_days) || 0;
 
                 const today = frappe.datetime.get_today()
                 const leavePostingDate = frm.doc.posting_date


### PR DESCRIPTION
This pull request introduces several improvements and new features related to leave application processing, with a focus on leave balance validation and leave extension requests. The main changes include adding a new server-side method for retrieving leave balances, enhancing validation logic to prevent leave applications when balance is insufficient, and optimizing how leave extension request thresholds are accessed to avoid client-side permission errors.

**Leave Balance Validation and Calculation:**
- Added a new method `get_leave_balance_on` in `one_fm.overrides.leave_application` for retrieving an employee's leave balance, including logic for allocation expiry and consumption limits. This method is now exposed as a server-side API and mapped in `one_fm/hooks.py` for use throughout the system. [[1]](diffhunk://#diff-9435f6d4493efb88be99ff3773f994a02bd7a23d7b9c694a8a4eba9d38a8c521R725-R770) [[2]](diffhunk://#diff-8ee4e2b80ead6731700d0dd811c0a06250f680d2fd1a2297f7c2b427a9a7ef1aR866)
- Enhanced the `validate_balance_leaves` method to use the new `get_leave_balance_on` logic, ensuring that users cannot apply for leave if their balance is insufficient or if the requested days are holidays.

**Leave Extension Request Improvements:**
- Updated the `get_leave_extension_request` method to return both the extension request and the `leave_extension_request_allowance` threshold value server-side, preventing client-side permission errors when accessing system settings.
- Refactored the frontend logic in `leave_application.js` to use the new server-side response structure for threshold days, eliminating redundant client-side database calls and improving reliability.