### PR TITLE
fix: backfill employee schedules for OJT-0042 and OJT-0043

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -427,7 +427,7 @@ one_fm.patches.v15_0.add_recurring_bonus_process_task
 one_fm.patches.v15_0.fix_parentfield_bonus_items
 one_fm.patches.v15_0.add_nationality_read_permission
 one_fm.patches.v15_0.update_workflows_for_ops_admin_edit
-one_fm.patches.v15_0.backfill_ojt_employee_schedules
+one_fm.patches.v15_0.backfill_ojt_employee_schedules #2026-06-18
 one_fm.patches.v15_0.delete_medical_appointment_todos #2026-06-15
 one_fm.patches.v15_0.sync_erf_workflow_state_with_closed_status #2026-06-15
 one_fm.patches.v15_0.close_job_openings_for_closed_erf #2026-06-15

--- a/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
+++ b/one_fm/patches/v15_0/backfill_ojt_employee_schedules.py
@@ -3,21 +3,22 @@ import frappe
 
 
 def execute():
-    """Backfill Employee Schedules for OJT-06-2026-0041.
+    """Backfill Employee Schedules for OJT-06-2026-0042 and OJT-06-2026-0043.
 
     This OJT was approved before schedule creation moved to on_submit, so no
     Employee Schedules were ever created for it. create_or_update_employee_schedules()
     is idempotent (get_or_create), so this is a no-op if schedules already exist.
     """
-    ojt_name = "OJT-06-2026-0041"
+    ojt_names = ["OJT-06-2026-0042", "OJT-06-2026-0043"]
 
-    if not frappe.db.exists("On the Job Training", ojt_name):
-        return
+    for ojt_name in ojt_names:
+        if not frappe.db.exists("On the Job Training", ojt_name):
+            continue
 
-    doc = frappe.get_doc("On the Job Training", ojt_name)
+        doc = frappe.get_doc("On the Job Training", ojt_name)
 
-    if not doc.employee or not doc.start_date:
-        return
+        if not doc.employee or not doc.start_date:
+            return
 
-    doc.create_or_update_employee_schedules()
-    frappe.db.commit()
+        doc.create_or_update_employee_schedules()
+        frappe.db.commit()


### PR DESCRIPTION
Extend the OJT employee schedule backfill patch to cover two additional OJTs that were approved before schedule creation moved to on_submit, so no Employee Schedules were ever created for them.

- Replace single OJT-0041 target with a list of OJT-0042 and OJT-0043, iterating over each
- Re-register the patch in patches.txt with a #2026-06-18 suffix so Frappe re-executes the already-run patch

<img width="868" height="422" alt="Screenshot 2026-06-18 at 11 52 44 AM" src="https://github.com/user-attachments/assets/41c71ec3-9be0-4453-a6fa-9dded02d48bc" />
