### PR TITLE
[feat][Transportation Manifest and Transportation Schedule in the workspace]

### DIFF
--- a/one_fm/one_fm/workspace/transportation/transportation.json
+++ b/one_fm/one_fm/workspace/transportation/transportation.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Transportation</span>\",\"col\":12}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Schedule\",\"col\":3}},{\"type\":\"card\",\"data\":{\"card_name\":\"Vehicles & Masters\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Scheduling & Dispatch\",\"col\":4}}]",
+ "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Transportation</span>\",\"col\":12}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Schedule\",\"col\":3}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Manifest\",\"col\":3}},{\"type\":\"card\",\"data\":{\"card_name\":\"Vehicles & Masters\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Scheduling & Dispatch\",\"col\":4}}]",
  "creation": "2026-06-10 20:00:00.000000",
  "docstatus": 0,
  "doctype": "Workspace",
@@ -102,7 +102,7 @@
    "is_query_report": 0,
    "label": "Transportation Schedule",
    "link_count": 0,
-   "link_to": "transportation_schedule",
+   "link_to": "transportation-schedule",
    "link_type": "Page",
    "onboard": 0,
    "type": "Link"
@@ -110,9 +110,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Manifest View",
+   "label": "Transportation Manifest",
    "link_count": 0,
-   "link_to": "transportation_schedule",
+   "link_to": "transportation-manifest",
    "link_type": "Page",
    "onboard": 0,
    "type": "Link"
@@ -132,7 +132,13 @@
   {
    "color": "Blue",
    "label": "Transportation Schedule",
-   "link_to": "transportation_schedule",
+   "link_to": "transportation-schedule",
+   "type": "Page"
+  },
+  {
+   "color": "Green",
+   "label": "Transportation Manifest",
+   "link_to": "transportation-manifest",
    "type": "Page"
   }
  ],

--- a/one_fm/one_fm/workspace/transportation/transportation.json
+++ b/one_fm/one_fm/workspace/transportation/transportation.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Transportation</span>\",\"col\":12}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Schedule\",\"col\":3}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Manifest\",\"col\":3}},{\"type\":\"card\",\"data\":{\"card_name\":\"Vehicles & Masters\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Scheduling & Dispatch\",\"col\":4}}]",
+ "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Transportation</span>\",\"col\":12}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Schedule\",\"col\":3}},{\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Transportation Manifest\",\"col\":3}},{\"type\":\"spacer\",\"data\":{\"col\":12}},{\"type\":\"card\",\"data\":{\"card_name\":\"Vehicles & Masters\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Scheduling & Dispatch\",\"col\":4}}]",
  "creation": "2026-06-10 20:00:00.000000",
  "docstatus": 0,
  "doctype": "Workspace",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.

Update the **Transportation** workspace to include direct links and shortcut tiles for the **Transportation Schedule** page and the **Transportation Manifest** page. Previously, the "Manifest View" link incorrectly pointed to the `transportation_schedule` page instead of the dedicated `transportation-manifest` page, and both page links used underscores instead of the correct hyphenated page names.


## Analysis and design (optional)

The workspace JSON defines two mechanisms for surfacing pages:
1. **Links** — appear under card sections (e.g. "Scheduling & Dispatch")
2. **Shortcuts** — appear as colored tiles at the top of the workspace

Both mechanisms needed to be updated to reference the correct Frappe Page names (`transportation-schedule` and `transportation-manifest`).


## Solution description

### [transportation.json](file:///Users/samdanikousera/Desktop/frappe-bench/apps/one_fm/one_fm/one_fm/workspace/transportation/transportation.json)
- Fixed **Transportation Schedule** link: changed `link_to` from `transportation_schedule` → `transportation-schedule` (matching the actual Page name)
- Fixed **Manifest View** link: renamed label to **"Transportation Manifest"** and changed `link_to` from `transportation_schedule` → `transportation-manifest` (now points to the correct dedicated page)
- Added a new **Transportation Manifest** shortcut tile (green) alongside the existing Transportation Schedule shortcut (blue)
- Updated the `content` layout JSON to render both shortcut tiles

### [patches.txt](file:///Users/samdanikousera/Desktop/frappe-bench/apps/one_fm/one_fm/patches.txt)
- Bumped patch version from `#2` → `#3` to force re-execution of the workspace cleanup patch, ensuring the database record is refreshed with the updated JSON


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)

Expected workspace layout after migration:

| Section | Links |
|---|---|
| **Shortcut tiles** | Transportation Schedule (blue), Transportation Manifest (green) |
| **Vehicles & Masters** | Vehicle, Vehicle Leasing Contract, Site Transportation Stop Location, Governorate Area, Operation Site, Operation Shift |
| **Scheduling & Dispatch** | Route Plan, Transportation Schedule, Transportation Manifest |


## Areas affected and ensured

- **Transportation workspace** — links and shortcuts updated
- **Patch execution** — workspace records (Transportation, Rambo) are deleted and recreated from JSON on `bench migrate`


## Is there any existing behavior change of other features due to this code change?

No. Only the Transportation workspace display is affected. No DocType logic, APIs, or other workspaces are modified.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No child table was created.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [x] Yes
- [ ] No

### Was the patch tested?
Yes — `bench --site onefm.localhost migrate` ran successfully. The patch deleted stale workspace records and the updated JSON was loaded.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox