### PR TITLE
fix: guard against None in shift assignment and type lookups

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -164,12 +164,12 @@ def after_insert_background(employee_checkin,current_shift):
 		current_shift = validate_shift_assignment(employee_checkin,current_shift)
 		if not current_shift:
 			shift_details = get_current_shift(self.employee)
-			if shift_details:
+			if shift_details and shift_details.get('data'):
 				current_shift = shift_details.get('data').get('name')
 
 		# update shift if not exists
-		curr_shift = frappe.get_doc("Shift Assignment", current_shift)
-		if curr_shift:
+		if current_shift and frappe.db.exists("Shift Assignment", current_shift):
+			curr_shift = frappe.get_doc("Shift Assignment", current_shift)
 			shift_type = frappe.db.sql(f"""SELECT * FROM `tabShift Type` WHERE name='{curr_shift.shift_type}' """, as_dict=1)[0]
 			# calculate entry
 			early_exit = 0

--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -168,9 +168,10 @@ def after_insert_background(employee_checkin,current_shift):
 				current_shift = shift_details.get('data').get('name')
 
 		# update shift if not exists
-		if current_shift and frappe.db.exists("Shift Assignment", current_shift):
+		if current_shift and frappe.db.exists("Shift Assignment", current_shift) \
+			and frappe.db.exists("Shift Type", frappe.db.get_value("Shift Assignment", current_shift, "shift_type")):
 			curr_shift = frappe.get_doc("Shift Assignment", current_shift)
-			shift_type = frappe.db.sql(f"""SELECT * FROM `tabShift Type` WHERE name='{curr_shift.shift_type}' """, as_dict=1)[0]
+			shift_type = frappe.get_cached_doc("Shift Type", curr_shift.shift_type)
 			# calculate entry
 			early_exit = 0
 			late_entry = 0


### PR DESCRIPTION
This pull request improves the logic for handling employee check-ins by making the shift assignment process more robust and efficient. The main changes ensure that shift and shift type records exist before accessing them, and optimize how shift type data is retrieved.

**Improvements to shift assignment validation:**

* Added checks to confirm that both the `Shift Assignment` and corresponding `Shift Type` records exist before attempting to fetch and use them, preventing potential errors if records are missing.
* Updated the retrieval of shift type data to use `frappe.get_cached_doc` instead of a direct SQL query, improving performance and consistency with best practices.