### PR TITLE
fix: doc link in processa notification

### DIFF
--- a/one_fm/overrides/notification_log.py
+++ b/one_fm/overrides/notification_log.py
@@ -31,6 +31,8 @@ def custom_send_notification_email(doc):
 
     if doc.document_type == "HD Ticket":
         doc_link = frappe.utils.get_url(f"/helpdesk/tickets/{doc.document_name}")
+    elif doc.document_type == "BPMN Process Model" and doc.link:
+        doc_link = frappe.utils.get_url(f"{doc.link}")
     else:
         doc_link = get_url_to_form(doc.document_type, doc.document_name)
     header = get_email_header(doc)


### PR DESCRIPTION
This pull request updates the notification email logic in `one_fm/overrides/notification_log.py` to handle a new document type. Now, when sending notifications for the "BPMN Process Model" document type, the email will include a link specified in the document's `link` field, if present.

Enhancement to notification links:

* Updated `custom_send_notification_email` to generate the notification link from the `link` field for "BPMN Process Model" documents, improving flexibility for this document type.