### PR TITLE
chore: remove unwnated mom followups

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -594,7 +594,6 @@ scheduler_events = {
 		'one_fm.utils.check_upload_original_visa_submission_daily',
 		'one_fm.hiring.utils.notify_finance_job_offer_salary_advance',
 		'one_fm.uniform_management.doctype.employee_uniform.employee_uniform.notify_gsd_and_employee_before_uniform_expiry',
-		'one_fm.operations.doctype.mom_followup.mom_followup.mom_followup_reminder',
 		'one_fm.one_fm.depreciation_custom.post_depreciation_entries',
 		'one_fm.operations.doctype.contracts.contracts.auto_renew_contracts',
 		'one_fm.hiring.utils.update_leave_policy_assignments_expires_today',
@@ -620,12 +619,6 @@ scheduler_events = {
 		"one_fm.api.tasks.validate_shift_assignment",
 		'one_fm.overrides.employee_checkin.auto_generate_checkin'
 	],
-
-	"weekly": [
-		'one_fm.operations.doctype.mom_followup.mom_followup.mom_sites_followup',
-		'one_fm.operations.doctype.mom_followup.mom_followup.mom_followup_penalty',
-   ],
-
 	"monthly": [
 		"one_fm.accommodation.utils.execute_monthly",
 		"one_fm.utils.send_roster_report"


### PR DESCRIPTION
This pull request removes scheduled tasks related to `mom_followup` from the `one_fm/hooks.py` file. These tasks are no longer scheduled to run as part of the application's periodic jobs.

**Removal of scheduled `mom_followup` tasks:**

* Removed the daily scheduled task `mom_followup_reminder` from the list of daily jobs.
* Removed the weekly scheduled tasks `mom_sites_followup` and `mom_followup_penalty` from the list of weekly jobs.