### PR TITLE
feat: restrict ToDo notifications to Action type only

### DIFF
--- a/one_fm/custom/property_setter/todo.py
+++ b/one_fm/custom/property_setter/todo.py
@@ -7,5 +7,13 @@ def get_todo_properties():
             "property": "reqd",
             "property_type": "Check",
             "value": "1"
-        }
+        },
+        {
+            "doc_type": "ToDo",
+            "doctype_or_field": "DocField",
+            "field_name": "type",
+            "property": "read_only",
+            "property_type": "Check",
+            "value": "1"
+        },
     ]

--- a/one_fm/overrides/notification_log.py
+++ b/one_fm/overrides/notification_log.py
@@ -8,6 +8,11 @@ from one_fm.processor import sendemail
 
 class NotificationLogOverride(NotificationLog):
     def after_insert(self):
+        # Skip notification entirely for non-Action ToDo assignments.
+        # Processa handles notifications for Process-type tasks independently.
+        if self.type == "Assignment" and self._is_non_action_todo_assignment():
+            return
+
         frappe.publish_realtime("notification", after_commit=True, user=self.for_user)
         set_notifications_as_unseen(self.for_user)
         if is_email_notifications_enabled_for_type(self.for_user, self.type):
@@ -18,8 +23,30 @@ class NotificationLogOverride(NotificationLog):
             except Exception:
                 # Never let email failures block workflow transitions, but distinctly log them
                 frappe.log_error(frappe.get_traceback(), "Notification Email Failed (non-blocking)")
-                
-                
+
+    def _is_non_action_todo_assignment(self):
+        """Return True if this Assignment notification is for a non-Action ToDo.
+
+        Looks up the open ToDo that matches the notification's document and
+        recipient. If the ToDo has a type explicitly set to something other
+        than "Action" (e.g. "Process"), the standard notification is skipped.
+        Empty/None type is treated as "Action" (the default).
+        """
+        if not (self.document_type and self.document_name and self.for_user):
+            return False
+
+        todo_type = frappe.db.get_value(
+            "ToDo",
+            {
+                "reference_type": self.document_type,
+                "reference_name": self.document_name,
+                "allocated_to": self.for_user,
+                "status": "Open",
+            },
+            "type",
+        )
+        return bool(todo_type and todo_type != "Action")
+
 
 def custom_send_notification_email(doc):
     if doc.type == "Energy Point" and doc.email_content is None:

--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -36,6 +36,9 @@ def notify_todo_status_change(doc):
     """Notify user if ToDo status changes. Modular, clear, and logs notification."""
     if doc.is_new():
         return
+    # Only send notifications for Action-type ToDos; Processa handles Process tasks
+    if getattr(doc, "type", "") and doc.type != "Action":
+        return
     if not doc.notify_allocated_to_via_email:
         return
     status_in_db = frappe.db.get_value(doc.doctype, doc.name, "status")
@@ -413,6 +416,9 @@ def sync_google_tasks_for_users(user_emails=[], timedelta_kwargs=None):
 
 @frappe.whitelist()
 def send_email_on_todo_created(doc, method):
+    # Only send notifications for Action-type ToDos; Processa handles Process tasks
+    if getattr(doc, "type", "") and doc.type != "Action":
+        return
     if not doc.notify_allocated_to_via_email:
         return
     user_id = frappe.session.user

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -448,3 +448,4 @@ one_fm.patches.v15_0.add_client_event_field_to_attendance
 one_fm.patches.v15_0.add_asset_serial_and_warranty_fields
 one_fm.patches.v15_0.add_asset_repair_custom_fields
 one_fm.patches.v15_0.add_asset_repair_workflow_and_assignment_rules
+one_fm.patches.v15_0.set_todo_type_read_only

--- a/one_fm/patches/v15_0/set_todo_type_read_only.py
+++ b/one_fm/patches/v15_0/set_todo_type_read_only.py
@@ -1,0 +1,7 @@
+from one_fm.setup.setup import add_property_setter
+from one_fm.custom.property_setter.todo import get_todo_properties
+
+
+def execute():
+	"""Make the ToDo type field read-only."""
+	add_property_setter(get_todo_properties())


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.
https://one-fm.com/app/work-item/WI-001150

## Analysis and design (optional)
Analyse and attach the design documentation


## Solution description
Describe your code changes in detail for reviewers.
Added a patch to make it read only
Updated notification log

## Is there a business logic within a doctype?
    - [] Yes
    - [] No


## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1134" height="298" alt="image" src="https://github.com/user-attachments/assets/b08ee492-b358-47c5-935b-de41459e91d4" />


## Areas affected and ensured
List out the areas affected by your code changes.
Notification log
todo

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.


## Did you test with the following dataset?
- [] Existing Data
- [x] New Data

## Was child table created?
    - [] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [] Yes
    - [] No
        If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [] No
    ## Was the patch test?
    Yes


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [] Safari
  - [] Firefox
