### PR TITLE
fix: prevent get_project_users error when project is empty

### DIFF
--- a/one_fm/operations/doctype/mom/mom.js
+++ b/one_fm/operations/doctype/mom/mom.js
@@ -10,7 +10,7 @@ frappe.ui.form.on('MOM', {
 		frm.refresh_fields("attendees");
 	},
 	project: function(frm) {
-		if(frm.doc.project_type != "External"){
+		if(frm.doc.project && frm.doc.project_type != "External"){
 			frappe.call({
                 method: "one_fm.operations.doctype.mom.mom.get_project_users",
                 args: {

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -429,7 +429,9 @@ def fetch_designation_of_users(list_of_users: list = []):
 
 
 @frappe.whitelist()
-def get_project_users(project):
+def get_project_users(project: str | None = None):
+	if not project:
+		return []
 	doc = frappe.get_doc("Project", project)
 	users = []
 	users.append(doc.project_manager_name) if all((doc.project_manager_name, doc.project_manager, doc.project_type == "Internal")) else None


### PR DESCRIPTION
The MOM project field trigger fires on any change, including when the field is cleared. With no value, the project arg was dropped from the request, raising a missing-positional-argument TypeError.

- make project arg optional and return an empty list when missing
- guard the client-side call to only fire when a project is set
