### PR TITLE
[WI-001253][RFM is assigned to the default approver when no employee is selected for the type department which should be mandatory]

### DIFF
--- a/one_fm/purchase/doctype/request_for_material/request_for_material.js
+++ b/one_fm/purchase/doctype/request_for_material/request_for_material.js
@@ -883,8 +883,10 @@ var set_employee_or_project = function(frm) {
 		}
 		else if(frm.doc.type=='Department'){
 			frm.set_df_property('department', 'reqd', true);
-			// Check if employee exit for the session user to set employee field
-			set_employee_from_the_session_user(frm);
+			frm.set_df_property('employee', 'reqd', true);
+			// Clear employee so it is not prefilled from session user or previous type selection
+			frm.set_value('employee', '');
+			frm.set_value('employee_name', '');
 		}
 		else if(frm.doc.type=='Project'|| frm.doc.type=='Project Mobilization'){
 			frm.set_df_property('project', 'reqd', true);


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
When the **Type** "Department" is selected on a Request for Material (RFM), the **Employee** field should be **mandatory** but should **not be prefilled** with the session user's employee record. Previously, selecting "Department" would auto-populate the employee field with the logged-in user's employee, same as the "Individual" type.


## Analysis and design (optional)
The `set_employee_or_project` function in the RFM client script was calling `set_employee_from_the_session_user(frm)` for both Individual and Department types. The requirement is to only auto-fill for Individual, while Department should leave the employee field empty for manual selection.


## Solution description
Modified `request_for_material.js` in the `set_employee_or_project` function:

1. **Removed** the `set_employee_from_the_session_user(frm)` call from the `Department` branch — this prevents auto-populating the employee from the session user.
2. **Added** `frm.set_df_property('employee', 'reqd', true)` — makes the employee field mandatory when Department is selected.
3. **Added** `frm.set_value('employee', '')` and `frm.set_value('employee_name', '')` — explicitly clears any previously set employee value (e.g., if user switched from Individual to Department).

No changes were made to the Individual type behavior — it still auto-fills the employee as before.


## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)
N/A


## Areas affected and ensured
- Request for Material form — Type field change handler (client-side only)
- Employee field mandatory/prefill behavior when Type = "Department"


## Is there any existing behavior change of other features due to this code change?
**Yes.** Previously, selecting "Department" type would auto-fill the employee field with the current session user's employee record. Now it will be left empty for manual selection. The approver logic in Python (`set_request_for_material_accepter_and_approver`) still works the same — it uses whatever employee is set in the field to determine the approver via `reports_to`.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox


https://github.com/user-attachments/assets/bf27b3d6-4afa-4a55-8fd8-3991a422bc6d

