### PR TITLE
[WI-001254][FIX TOTAL NUMBER OF LEAVE DAYS IN THE LEAVE APPLICATION]

### DIFF
--- a/one_fm/overrides/leave_application.py
+++ b/one_fm/overrides/leave_application.py
@@ -271,7 +271,7 @@ class LeaveApplicationOverride(LeaveApplication):
         precision = cint(frappe.db.get_single_value("System Settings", "float_precision")) or 2
 
         if self.from_date and self.to_date:
-            self.total_leave_days = get_number_of_leave_days(
+            self.total_leave_days = custom_get_number_of_leave_days(
                 self.employee,
                 self.leave_type,
                 self.from_date,

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -446,3 +446,4 @@ one_fm.patches.v15_0.update_interview_console_permissions
 one_fm.patches.v15_0.standardize_marital_status_options
 one_fm.patches.v15_0.fix_nirmala_day_off_client_event_conflict #2026-06-18
 one_fm.patches.v15_0.update_pmr_workflow_in_process_role
+one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24

--- a/one_fm/patches/v15_0/fix_shift_worker_annual_leave_total_days.py
+++ b/one_fm/patches/v15_0/fix_shift_worker_annual_leave_total_days.py
@@ -1,0 +1,101 @@
+import frappe
+from frappe.utils import flt, now
+from one_fm.api.doc_methods.leave_application_calculation import custom_get_number_of_leave_days
+
+
+def execute():
+	"""
+	Patch to fix total_leave_days for shift worker Annual Leave applications
+	affected by the regression introduced on 2026-06-17 (commit db192e80d).
+
+	The validate_balance_leaves override was calling the original hrms
+	get_number_of_leave_days (which does not exclude Fridays for shift workers)
+	instead of custom_get_number_of_leave_days.
+
+	This patch:
+	1. Finds all submitted Annual Leave applications for shift workers
+	   created/modified on or after 2026-06-17
+	2. Recalculates total_leave_days using custom_get_number_of_leave_days
+	3. Updates the Leave Application and Leave Ledger Entry if the value differs
+	"""
+
+	# Find affected leave applications:
+	# - Annual Leave
+	# - Submitted (docstatus=1)
+	# - Employee is a shift worker
+	# - Modified on or after 2026-06-17 (date the regression was introduced)
+	affected_leaves = frappe.db.sql("""
+		SELECT
+			la.name,
+			la.employee,
+			la.from_date,
+			la.to_date,
+			la.half_day,
+			la.half_day_date,
+			la.total_leave_days as old_total_leave_days,
+			la.leave_balance
+		FROM `tabLeave Application` la
+		JOIN `tabEmployee` e ON la.employee = e.name
+		WHERE la.leave_type = 'Annual Leave'
+			AND la.docstatus = 1
+			AND e.shift_working = 1
+			AND la.modified >= '2026-06-17'
+	""", as_dict=True)
+
+	if not affected_leaves:
+		frappe.logger().info(
+			"[Fix Shift Worker Leave Days] No affected leave applications found."
+		)
+		return
+
+	updated_count = 0
+
+	for leave in affected_leaves:
+		# Recalculate using the correct custom function
+		correct_total = custom_get_number_of_leave_days(
+			employee=leave.employee,
+			leave_type="Annual Leave",
+			from_date=leave.from_date,
+			to_date=leave.to_date,
+			half_day=leave.half_day,
+			half_day_date=leave.half_day_date,
+		)
+
+		correct_total = flt(correct_total)
+		old_total = flt(leave.old_total_leave_days)
+
+		# Only update if the value actually differs
+		if correct_total == old_total:
+			continue
+
+		# Update Leave Application
+		frappe.db.set_value("Leave Application", leave.name, {
+			"total_leave_days": correct_total,
+			"modified": now(),
+		})
+
+		# Update corresponding Leave Ledger Entry (leaves are stored as negative)
+		# The ledger entry stores: leaves = -total_leave_days
+		frappe.db.sql("""
+			UPDATE `tabLeave Ledger Entry`
+			SET leaves = %s, modified = %s
+			WHERE transaction_type = 'Leave Application'
+				AND transaction_name = %s
+				AND docstatus = 1
+		""", (-correct_total, now(), leave.name))
+
+		updated_count += 1
+
+		frappe.logger().info(
+			f"[Fix Shift Worker Leave Days] Updated {leave.name} "
+			f"(Employee: {leave.employee}): "
+			f"total_leave_days {old_total} → {correct_total}, "
+			f"ledger entry leaves {-old_total} → {-correct_total}"
+		)
+
+	frappe.db.commit()
+
+	frappe.logger().info(
+		f"[Fix Shift Worker Leave Days] Patch complete. "
+		f"Updated {updated_count} of {len(affected_leaves)} leave applications checked."
+	)

--- a/one_fm/patches/v15_0/fix_shift_worker_annual_leave_total_days.py
+++ b/one_fm/patches/v15_0/fix_shift_worker_annual_leave_total_days.py
@@ -5,97 +5,68 @@ from one_fm.api.doc_methods.leave_application_calculation import custom_get_numb
 
 def execute():
 	"""
-	Patch to fix total_leave_days for shift worker Annual Leave applications
-	affected by the regression introduced on 2026-06-17 (commit db192e80d).
+	Patch to fix total_leave_days for HR-LAP-2026-00801.
 
-	The validate_balance_leaves override was calling the original hrms
-	get_number_of_leave_days (which does not exclude Fridays for shift workers)
-	instead of custom_get_number_of_leave_days.
+	The validate_balance_leaves override (commit db192e80d, 2026-06-17) was
+	calling the original hrms get_number_of_leave_days instead of
+	custom_get_number_of_leave_days, so Fridays were not excluded for this
+	shift worker's Annual Leave.
 
-	This patch:
-	1. Finds all submitted Annual Leave applications for shift workers
-	   created/modified on or after 2026-06-17
-	2. Recalculates total_leave_days using custom_get_number_of_leave_days
-	3. Updates the Leave Application and Leave Ledger Entry if the value differs
+	Result: total_leave_days was 36 instead of 30 (6 Fridays in the period).
 	"""
 
-	# Find affected leave applications:
-	# - Annual Leave
-	# - Submitted (docstatus=1)
-	# - Employee is a shift worker
-	# - Modified on or after 2026-06-17 (date the regression was introduced)
-	affected_leaves = frappe.db.sql("""
-		SELECT
-			la.name,
-			la.employee,
-			la.from_date,
-			la.to_date,
-			la.half_day,
-			la.half_day_date,
-			la.total_leave_days as old_total_leave_days,
-			la.leave_balance
-		FROM `tabLeave Application` la
-		JOIN `tabEmployee` e ON la.employee = e.name
-		WHERE la.leave_type = 'Annual Leave'
-			AND la.docstatus = 1
-			AND e.shift_working = 1
-			AND la.modified >= '2026-06-17'
-	""", as_dict=True)
+	leave_name = "HR-LAP-2026-00801"
 
-	if not affected_leaves:
+	leave = frappe.db.get_value("Leave Application", leave_name, [
+		"employee", "from_date", "to_date", "half_day", "half_day_date",
+		"total_leave_days", "docstatus"
+	], as_dict=True)
+
+	if not leave:
+		frappe.logger().info(f"[Fix Leave Days] {leave_name} not found. Skipping.")
+		return
+
+	if leave.docstatus != 1:
+		frappe.logger().info(f"[Fix Leave Days] {leave_name} is not submitted. Skipping.")
+		return
+
+	correct_total = flt(custom_get_number_of_leave_days(
+		employee=leave.employee,
+		leave_type="Annual Leave",
+		from_date=leave.from_date,
+		to_date=leave.to_date,
+		half_day=leave.half_day,
+		half_day_date=leave.half_day_date,
+	))
+
+	old_total = flt(leave.total_leave_days)
+
+	if correct_total == old_total:
 		frappe.logger().info(
-			"[Fix Shift Worker Leave Days] No affected leave applications found."
+			f"[Fix Leave Days] {leave_name} already has correct total_leave_days={old_total}. Skipping."
 		)
 		return
 
-	updated_count = 0
+	# Update Leave Application
+	frappe.db.set_value("Leave Application", leave_name, {
+		"total_leave_days": correct_total,
+		"modified": now(),
+	})
 
-	for leave in affected_leaves:
-		# Recalculate using the correct custom function
-		correct_total = custom_get_number_of_leave_days(
-			employee=leave.employee,
-			leave_type="Annual Leave",
-			from_date=leave.from_date,
-			to_date=leave.to_date,
-			half_day=leave.half_day,
-			half_day_date=leave.half_day_date,
-		)
-
-		correct_total = flt(correct_total)
-		old_total = flt(leave.old_total_leave_days)
-
-		# Only update if the value actually differs
-		if correct_total == old_total:
-			continue
-
-		# Update Leave Application
-		frappe.db.set_value("Leave Application", leave.name, {
-			"total_leave_days": correct_total,
-			"modified": now(),
-		})
-
-		# Update corresponding Leave Ledger Entry (leaves are stored as negative)
-		# The ledger entry stores: leaves = -total_leave_days
-		frappe.db.sql("""
-			UPDATE `tabLeave Ledger Entry`
-			SET leaves = %s, modified = %s
-			WHERE transaction_type = 'Leave Application'
-				AND transaction_name = %s
-				AND docstatus = 1
-		""", (-correct_total, now(), leave.name))
-
-		updated_count += 1
-
-		frappe.logger().info(
-			f"[Fix Shift Worker Leave Days] Updated {leave.name} "
-			f"(Employee: {leave.employee}): "
-			f"total_leave_days {old_total} → {correct_total}, "
-			f"ledger entry leaves {-old_total} → {-correct_total}"
-		)
+	# Update Leave Ledger Entry (leaves stored as negative)
+	frappe.db.sql("""
+		UPDATE `tabLeave Ledger Entry`
+		SET leaves = %s, modified = %s
+		WHERE transaction_type = 'Leave Application'
+			AND transaction_name = %s
+			AND docstatus = 1
+	""", (-correct_total, now(), leave_name))
 
 	frappe.db.commit()
 
 	frappe.logger().info(
-		f"[Fix Shift Worker Leave Days] Patch complete. "
-		f"Updated {updated_count} of {len(affected_leaves)} leave applications checked."
+		f"[Fix Leave Days] Updated {leave_name}: "
+		f"total_leave_days {old_total} → {correct_total}, "
+		f"ledger entry leaves {-old_total} → {-correct_total}"
 	)
+


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.

Leave Application `total_leave_days` for shift workers on Annual Leave was showing raw calendar days (e.g., 36) instead of excluding Fridays (e.g., 30). This regression was introduced on June 17, 2026 (commit `db192e80d`) when `validate_balance_leaves` was overridden to fix a permission error. The overridden method used `get_number_of_leave_days` from the local namespace, which resolves to the original hrms function (imported via `from hrms... import *`) instead of the custom `custom_get_number_of_leave_days` that subtracts Fridays for shift workers.


## Analysis and design (optional)

**Python Import Binding Issue:**
- Line 12: `from hrms.hr.doctype.leave_application.leave_application import *` binds `get_number_of_leave_days` to the original hrms function at import time.
- Line 16: `hrms...get_number_of_leave_days = custom_get_number_of_leave_days` replaces the function in the hrms module, but does NOT update the local binding.
- Line 274 (before fix): `get_number_of_leave_days(...)` calls the original function, bypassing the Friday-exclusion logic.

**Example — HR-LAP-2026-00801 (Kabita Rai, HR-EMP-02936):**
- Leave period: June 26 – July 31, 2026 = 36 calendar days
- Fridays in period: 6 (Jun 26, Jul 3, 10, 17, 24, 31)
- Expected: 36 − 6 = 30 | Actual (before fix): 36


## Solution description

In `one_fm/overrides/leave_application.py`, line 274 inside the `validate_balance_leaves` method, replaced:

```diff
- self.total_leave_days = get_number_of_leave_days(
+ self.total_leave_days = custom_get_number_of_leave_days(
```

`custom_get_number_of_leave_days` is already imported at line 14 of the same file. This ensures:
- **Shift workers on Annual Leave**: Fridays are subtracted from total calendar days.
- **Non-shift workers on Annual Leave**: Holidays from the employee's Holiday List are subtracted.
- **All other leave types**: Falls back to the standard hrms calculation.

The permission bypass (the original reason for the `validate_balance_leaves` override) is preserved — the method still calls the local `get_leave_balance_on` which does not include `validate_leave_access`.


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No


## Output screenshots (optional)

N/A — No UI change. The `total_leave_days` field will now correctly display 30 instead of 36 for the example case.


## Areas affected and ensured

- Leave Application validation (`validate_balance_leaves`) for **Annual Leave** with **shift workers**
- `total_leave_days` calculation on Leave Application
- Leave balance consumption check


## Is there any existing behavior change of other features due to this code change?

No. This restores the behavior that existed before the June 17 regression. The leave day calculation for non-shift workers and non-Annual Leave types is unchanged.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
N/A — No child table changes.

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

Note: Previously approved leave applications between June 17–24 with incorrect `total_leave_days` may need manual review/correction.

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
<img width="687" height="688" alt="Screenshot 2026-06-24 at 2 29 09 PM" src="https://github.com/user-attachments/assets/3e310e5f-c914-48ae-acde-b13a073bab4c" />
