### PR TITLE
[WI-001270][User cannot see the task in task doctype with filter]

### DIFF
--- a/one_fm/overrides/task.py
+++ b/one_fm/overrides/task.py
@@ -22,28 +22,11 @@ class TaskOverride(Task):
 
 
 def validate_task(doc):
-    # When new doc is added, then sync field after insert
-    if not doc.is_new() and doc.workflow_state in ["Open", "Working"]:
+    # Sync custom_assigned_to with ToDo/_assign for all workflow states
+    # Previously this only ran for "Open" and "Working", which caused _assign
+    # to go out of sync when tasks moved to other states like "Pending Review"
+    if not doc.is_new():
         sync_assign_to_field(doc)
-
-
-    all_asssigned_users = doc.get_assigned_users()
-    assignees = doc.custom_assigned_to
-    if doc.workflow_state == "Pending Review" and assignees:
-        for assignee in assignees:
-            if assignee.user in list(all_asssigned_users):
-                todos = frappe.get_all(
-                    "ToDo",
-                    filters={
-                        "reference_type": doc.doctype,
-                        "reference_name": doc.name,
-                        "allocated_to": assignee.user,
-                        "status": ["!=", "Closed"]  # only update if not already closed
-                    },
-                    pluck="name"
-                )
-                if todos:
-                    frappe.db.set_value("ToDo", {"name": ["in", todos]}, "status", "Cancelled")
 
     roles = get_user_roles()
     is_manager = is_project_manager(doc.project) if doc.project else False

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -447,3 +447,4 @@ one_fm.patches.v15_0.standardize_marital_status_options
 one_fm.patches.v15_0.fix_nirmala_day_off_client_event_conflict #2026-06-18
 one_fm.patches.v15_0.update_pmr_workflow_in_process_role
 one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24
+one_fm.patches.v15_0.fix_task_assign_field_sync #2026-06-25

--- a/one_fm/patches/v15_0/fix_task_assign_field_sync.py
+++ b/one_fm/patches/v15_0/fix_task_assign_field_sync.py
@@ -1,0 +1,45 @@
+import frappe
+from frappe.desk.form.assign_to import add as add_assignment
+
+
+def execute():
+    """
+    Fix out-of-sync _assign field on Task doctype.
+
+    When tasks moved to 'Pending Review', ToDos for assignees were cancelled,
+    which removed them from the _assign field. This patch re-creates missing
+    ToDo assignments for all tasks where custom_assigned_to has users not
+    reflected in _assign.
+    """
+    task_assignments = frappe.db.sql("""
+        SELECT ta.parent as task_name, ta.user
+        FROM `tabTask Assignment` ta
+        JOIN `tabTask` t ON t.name = ta.parent
+        WHERE (t._assign IS NULL
+               OR t._assign = ''
+               OR t._assign NOT LIKE CONCAT('%%', ta.user, '%%'))
+        AND ta.user IS NOT NULL
+        AND ta.user != ''
+    """, as_dict=True)
+
+    if not task_assignments:
+        return
+
+    frappe.log_error(
+        message=f"Fixing {len(task_assignments)} out-of-sync Task assignments",
+        title="Patch: fix_task_assign_field_sync"
+    )
+
+    for row in task_assignments:
+        try:
+            add_assignment({
+                'assign_to': [row.user],
+                'doctype': 'Task',
+                'name': row.task_name,
+                'description': frappe.db.get_value('Task', row.task_name, 'subject'),
+            })
+        except Exception:
+            frappe.log_error(
+                message=f"Failed to fix assignment for {row.task_name} → {row.user}",
+                title="Patch: fix_task_assign_field_sync"
+            )


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.

User `m.alsubaie@one-fm.com` is unable to see any of their assigned tasks when filtering by "Assigned To" in the Task list view on production. The sidebar "Assigned To" also shows incorrect users (reviewer instead of assignee). This issue does not occur for other users.

**Root Cause:** In `one_fm/overrides/task.py`, the `validate_task` function had two problems:
1. `sync_assign_to_field()` only ran for `workflow_state in ["Open", "Working"]` — when a task moved to "Pending Review" or any other state, the `_assign` field was not synced with `custom_assigned_to`.
2. When `workflow_state == "Pending Review"`, all ToDos for assignees were **cancelled** via `frappe.db.set_value`. This removed the user from the `_assign` field (which is built from open ToDos), causing:
   - The "Assigned To" list filter (`_assign LIKE '%user%'`) to return no results
   - The sidebar "Assigned To" to not show the assignee


## Analysis and design (optional)

The `_assign` field on Task is a denormalized JSON cache of assigned users, populated from open ToDo records via `ToDo.update_in_reference()`. The "Assigned To" list filter uses `_assign LIKE '%email%'` to find tasks. When ToDos are cancelled, the user is removed from `_assign`, making the task invisible in filtered views.

Flow before fix:
```
Task → "Pending Review" → sync_assign_to_field SKIPPED → ToDos CANCELLED → _assign CLEARED → user can't find task
```

Flow after fix:
```
Task → "Pending Review" → sync_assign_to_field RUNS → ToDos KEPT OPEN → _assign INTACT → user finds task ✅
```


## Solution description

**File modified:** `one_fm/overrides/task.py` → `validate_task()`

1. **Changed `sync_assign_to_field` to run for ALL workflow states**, not just "Open" and "Working". This ensures `custom_assigned_to` is always synced to ToDo/`_assign` regardless of the task's workflow state.

2. **Removed the Pending Review ToDo cancellation block.** This code was cancelling all open ToDos for assignees when a task moved to "Pending Review", which broke `_assign` and the sidebar. This is unnecessary because:
   - "Pending Review" is an intermediate state — the reviewer may reject the task back to "Working"
   - ERPNext already handles ToDo closure automatically when a task is "Completed" (`close_all_assignments` in `task.py`) and ToDo clearing when "Cancelled" (`clear` in `task.py`)

**Patch script required on production** to fix existing out-of-sync tasks — re-creates missing ToDo assignments for tasks where `custom_assigned_to` has users not present in `_assign`.


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No

The assignment sync logic (`sync_assign_to_field`) and ToDo lifecycle management within the Task doctype override.


## Areas affected and ensured
- Task list view — "Assigned To" filter now returns correct results for all workflow states
- Task form sidebar — "Assigned To" section now correctly shows assignees from `custom_assigned_to`
- ToDo records linked to Tasks — ToDos remain open during "Pending Review" instead of being cancelled


## Is there any existing behavior change of other features due to this code change?

Yes. Previously, when a task moved to "Pending Review", the assignee's ToDos were cancelled (removed from their ToDo list). Now, ToDos remain **open** until the task is marked "Completed" (handled by ERPNext core) or "Cancelled". This means assignees will still see the task in their ToDo list during the review period.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data


## Was child table created?
N/A — No child table changes.


## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [x] Yes
- [ ] No

A data patch is required on production to fix existing tasks where `_assign` is out of sync with `custom_assigned_to`. The patch re-creates missing ToDo assignments:

```python
import frappe
from frappe.desk.form.assign_to import add as add_assignment

task_assignments = frappe.db.sql("""
    SELECT ta.parent as task_name, ta.user
    FROM `tabTask Assignment` ta
    JOIN `tabTask` t ON t.name = ta.parent
    WHERE (t._assign IS NULL 
           OR t._assign = '' 
           OR t._assign NOT LIKE CONCAT('%%', ta.user, '%%'))
    AND ta.user IS NOT NULL
    AND ta.user != ''
""", as_dict=True)

print(f"Found {len(task_assignments)} out-of-sync assignments")

for row in task_assignments:
    try:
        add_assignment({
            'assign_to': [row.user],
            'doctype': 'Task',
            'name': row.task_name,
            'description': frappe.db.get_value('Task', row.task_name, 'subject'),
        })
        print(f"Fixed: {row.task_name} → {row.user}")
    except Exception as e:
        print(f"Error: {row.task_name} → {row.user}: {e}")

frappe.db.commit()
```


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
