### PR TITLE
[WI-001271][Workflow Permitted user, as per workflow, is unable to make transition to Contracts]

### DIFF
--- a/one_fm/custom/workflow/contracts.json
+++ b/one_fm/custom/workflow/contracts.json
@@ -270,6 +270,19 @@
       "doctype": "Workflow Transition"
     },
     {
+      "state": "Inactive",
+      "action": "Return To Draft",
+      "next_state": "Draft",
+      "allowed": "Finance Manager",
+      "allow_self_approval": 1,
+      "send_email_to_creator": 0,
+      "skip_multiple_action": 0,
+      "skip_creation_of_workflow_action": 0,
+      "custom_confirm_transition": 0,
+      "require_digital_signature": 0,
+      "doctype": "Workflow Transition"
+    },
+    {
       "state": "Submit to Finance Manager",
       "action": "Return to Legal Manager",
       "next_state": "Submit to Legal Manager",


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug

## Clearly and concisely describe the feature, chore or bug.
Finance Manager (a.magar@one-fm.com) is unable to transition a Contracts document from **Inactive** → **Draft**. The Contracts workflow was missing this transition — only `Inactive → Active` ("Set as Active") existed. There was no "Return To Draft" action from the Inactive state.

## Analysis and design (optional)
Reviewed the [Contracts workflow](file:///Users/samdanikousera/Desktop/frappe-bench/apps/one_fm/one_fm/custom/workflow/contracts.json) and identified that the `Inactive` state only had one outgoing transition (`Set as Active → Active`). A `Return To Draft` transition for Finance Manager was missing, preventing the user from moving a contract back to Draft state.

## Solution description
Added a new **Workflow Transition** entry in `one_fm/custom/workflow/contracts.json`:

| Field | Value |
|---|---|
| State | Inactive |
| Action | Return To Draft |
| Next State | Draft |
| Allowed | Finance Manager |
| Allow Self Approval | Yes |

No other files were modified.

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No

## Output screenshots (optional)
N/A — The Finance Manager will now see a **"Return To Draft"** button (in addition to the existing "Set as Active" button) when viewing a Contract in the Inactive state.

## Areas affected and ensured
- Contracts workflow transitions (Inactive state only)
- Finance Manager workflow actions on Contracts doctype

## Is there any existing behavior change of other features due to this code change?
**No.** The existing `Inactive → Active` ("Set as Active") transition is untouched. This only adds an additional transition option.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No child table was created.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

A `bench migrate` is required on production to sync the workflow changes.

## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
