### PR TITLE
[[WI-001272]fix: suppress unwanted assignment emails on Contracts save/submit]

### DIFF
--- a/one_fm/custom/workflow/contracts.json
+++ b/one_fm/custom/workflow/contracts.json
@@ -14,7 +14,7 @@
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Sales Manager",
-      "send_email": 1,
+      "send_email": 0,
       "doctype": "Workflow Document State"
     },
     {
@@ -24,7 +24,7 @@
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Operation Admin",
-      "send_email": 1,
+      "send_email": 0,
       "doctype": "Workflow Document State"
     },
     {
@@ -34,7 +34,7 @@
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Finance Manager",
-      "send_email": 1,
+      "send_email": 0,
       "doctype": "Workflow Document State"
     },
     {
@@ -44,7 +44,7 @@
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Finance Manager",
-      "send_email": 1,
+      "send_email": 0,
       "doctype": "Workflow Document State"
     },
     {
@@ -54,7 +54,7 @@
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Legal Manager",
-      "send_email": 1,
+      "send_email": 0,
       "doctype": "Workflow Document State"
     },
     {
@@ -64,7 +64,7 @@
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Finance Manager",
-      "send_email": 1,
+      "send_email": 0,
       "doctype": "Workflow Document State"
     },
     {
@@ -74,7 +74,7 @@
       "is_optional_state": 0,
       "avoid_status_override": 0,
       "allow_edit": "Operation Admin",
-      "send_email": 1,
+      "send_email": 0,
       "doctype": "Workflow Document State"
     }
   ],

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -76,34 +76,39 @@ class Contracts(Document):
         """
         import frappe.desk.form.assign_to as assign_module
 
+        if getattr(self.flags, "_restore_assignment_notify", False):
+            return  # Already patched
+
         # Store original so on_change can restore it
         self._original_notify_assignment = assign_module.notify_assignment
         self.flags._restore_assignment_notify = True
 
-        if not self.has_value_changed("workflow_state"):
-            # Plain save — no workflow transition happened
-            assign_module.notify_assignment = lambda *a, **kw: None
-        elif self.workflow_state in ("Active", "Inactive"):
-            # "Submit" (to Active) or "Set Inactive" — terminal states,
-            # nobody new is being assigned
-            assign_module.notify_assignment = lambda *a, **kw: None
-        else:
-            # "Submit for Further Action" or "Return to ..." —
-            # suppress "removed" emails, allow "new assignment" emails
-            original = self._original_notify_assignment
+        target_doctype = self.doctype
+        target_name = self.name
 
-            def _selective_notify(
-                assigned_by, allocated_to, doc_type, doc_name,
-                action="CLOSE", description=None,
-            ):
+        plain_save = not self.has_value_changed("workflow_state")
+        terminal_state = self.workflow_state in ("Active", "Inactive")
+        
+        original = self._original_notify_assignment
+
+        def _scoped_notify(
+            assigned_by, allocated_to, doc_type, doc_name,
+            action="CLOSE", description=None,
+        ):
+            # Only apply suppression to THIS specific document
+            if doc_type == target_doctype and doc_name == target_name:
+                if plain_save or terminal_state:
+                    return  # suppress all assignment emails
                 if action == "CLOSE":
                     return  # skip "your assignment has been removed" emails
-                return original(
-                    assigned_by, allocated_to, doc_type, doc_name,
-                    action=action, description=description,
-                )
 
-            assign_module.notify_assignment = _selective_notify
+            # For other documents or allowed actions, call original
+            return original(
+                assigned_by, allocated_to, doc_type, doc_name,
+                action=action, description=description,
+            )
+
+        assign_module.notify_assignment = _scoped_notify
 
     def on_change(self):
         """Restore the original notify_assignment after all on_update hooks."""

--- a/one_fm/operations/doctype/contracts/contracts.py
+++ b/one_fm/operations/doctype/contracts/contracts.py
@@ -56,6 +56,61 @@ class Contracts(Document):
 
         sync_contract_item_prices(self.name)
 
+        # Suppress unwanted assignment notification emails.
+        # Must be at the END of on_update so the monkey-patch is active
+        # when the assignment_rule.apply hook runs after this method.
+        self._setup_assignment_notification_control()
+
+    def _setup_assignment_notification_control(self):
+        """
+        Control which assignment notification emails are sent during saves.
+
+        - Plain save (no workflow state change): suppress ALL assignment emails.
+        - Submit / Set Inactive (terminal states): suppress ALL assignment emails.
+        - Submit for Further Action / Return to X: suppress only "removed"
+          emails; allow the new-assignment email through so only the next
+          assignee is notified.
+
+        The original ``notify_assignment`` is restored in ``on_change``,
+        which Frappe calls after all ``on_update`` hooks have completed.
+        """
+        import frappe.desk.form.assign_to as assign_module
+
+        # Store original so on_change can restore it
+        self._original_notify_assignment = assign_module.notify_assignment
+        self.flags._restore_assignment_notify = True
+
+        if not self.has_value_changed("workflow_state"):
+            # Plain save — no workflow transition happened
+            assign_module.notify_assignment = lambda *a, **kw: None
+        elif self.workflow_state in ("Active", "Inactive"):
+            # "Submit" (to Active) or "Set Inactive" — terminal states,
+            # nobody new is being assigned
+            assign_module.notify_assignment = lambda *a, **kw: None
+        else:
+            # "Submit for Further Action" or "Return to ..." —
+            # suppress "removed" emails, allow "new assignment" emails
+            original = self._original_notify_assignment
+
+            def _selective_notify(
+                assigned_by, allocated_to, doc_type, doc_name,
+                action="CLOSE", description=None,
+            ):
+                if action == "CLOSE":
+                    return  # skip "your assignment has been removed" emails
+                return original(
+                    assigned_by, allocated_to, doc_type, doc_name,
+                    action=action, description=description,
+                )
+
+            assign_module.notify_assignment = _selective_notify
+
+    def on_change(self):
+        """Restore the original notify_assignment after all on_update hooks."""
+        if self.flags.get("_restore_assignment_notify"):
+            import frappe.desk.form.assign_to as assign_module
+            assign_module.notify_assignment = self._original_notify_assignment
+
     def send_inactivation_email(self):
         """Send email notification when a contract is set to Inactive."""
         recipients = [


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.

All 4 workflow users (Sales Manager, Legal Manager, Finance Manager, Operations Admin) receive assignment notification emails on every save/submit of a Contract. The expected behavior is:
- **Save** or **Submit** (to Active): No emails should be sent.
- **Submit for Further Action**: Only the newly assigned user (e.g., Legal Manager) should receive an email.

**Reported by**: Abbas (Finance) submitted the Weatherford contract for Operations, and Mariam (plus other users) received 3 unwanted "Your assignment has been removed" emails.


## Analysis and design (optional)

**Root Cause**: There are 4 Assignment Rules configured for the Contracts doctype (one per workflow role). Frappe's `assignment_rule.apply()` hook runs on every `on_update` (i.e., every Save). When the workflow state changes, the unassign condition triggers `assign_to.clear()` which cancels ALL existing ToDos for the contract and sends "Your assignment has been removed" emails to every previously-assigned user. On terminal transitions (to Active/Inactive), only "removed" emails go out since no new rule matches.


## Solution description

**1. `contracts.py` — Added assignment notification control (`_setup_assignment_notification_control` + `on_change`)**

At the end of `on_update()`, the `notify_assignment` function in `frappe.desk.form.assign_to` is temporarily monkey-patched based on the type of transition:

| Scenario | Email Behavior |
|----------|---------------|
| Plain Save (no state change) | All assignment emails suppressed |
| Submit to Active | All assignment emails suppressed |
| Set Inactive | All assignment emails suppressed |
| Submit for Further Action | Only "removed" emails suppressed; new assignment email allowed |
| Return to X | Only "removed" emails suppressed; new assignment email allowed |

The original `notify_assignment` function is restored in `on_change()`, which Frappe calls after all `on_update` hooks have completed. This ensures the monkey-patch is only active for the duration of the assignment rule hook execution and does not affect other doctypes.

**2. `contracts.json` (workflow) — Set `send_email: 0` on all 7 workflow states**

Previously all states had `send_email: 1`. While currently blocked by `send_email_alert: 0` at the workflow level, this change is defense-in-depth to prevent Frappe's built-in workflow action emails from being sent if someone enables the workflow-level flag in the future.


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No


## Output screenshots (optional)

N/A — Email suppression cannot be shown via UI screenshots. Verified by confirming no unwanted Notification Log entries are created.


## Areas affected and ensured

- **Contracts doctype** — `on_update` and new `on_change` lifecycle methods
- **Assignment notification emails** — Only for Contracts doctype; other doctypes are unaffected
- **Workflow email configuration** — `send_email` set to `0` on all Contracts workflow states


## Is there any existing behavior change of other features due to this code change?

No. The monkey-patch is scoped to the Contracts `on_update` → `on_change` lifecycle only and is restored immediately after. No other doctypes or assignment rules are affected.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

## Was child table created?
No.

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

The workflow JSON changes will be applied via `bench migrate` or by importing the workflow fixture. No data migration patch is needed.


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
