### PR TITLE
[TASK][TODO hooks are commented for the processa to work]

### DIFF
--- a/one_fm/custom/custom_field/todo.py
+++ b/one_fm/custom/custom_field/todo.py
@@ -3,13 +3,6 @@ def get_todo_custom_fields():
     return {
         "ToDo": [
             {
-                "fieldname": "notify_allocated_to_via_email",
-                "fieldtype": "Check",
-                "label": "Notify Allocated To Via Email",
-                "insert_after": "allocated_to",
-                "allow_in_quick_entry": 1
-            },
-            {
                 "fieldname": "custom_column_break_x8z6v",
                 "fieldtype": "Column Break",
                 "label": "",
@@ -19,7 +12,7 @@ def get_todo_custom_fields():
                 "fieldname": "custom_google_task",
                 "fieldtype": "Section Break",
                 "label": "Google Task",
-                "insert_after": "notify_allocated_to_via_email"
+                "insert_after": "allocated_to"
             },
             {
                 "fieldname": "custom_google_task_id",

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -453,15 +453,15 @@ doc_events = {
 		"after_insert": "one_fm.one_fm.task_assignment_from_email.assign_task_to_user_from_communication_content"
 	},
 	# COMMENTED OUT: ToDo hooks now handled by SpiffWorkflow/BPMN server scripts
-	"ToDo": {
-		"validate": "one_fm.overrides.todo.validate_todo",
-		"before_save":"one_fm.overrides.todo.before_save",
-		"after_insert":[
-			"one_fm.overrides.todo.create_google_task_on_todo_creation",
-			"one_fm.overrides.todo.send_email_on_todo_created"
-		],
-		"on_update": "one_fm.overrides.todo.update_google_task_on_todo_status_change"
-	},
+	# "ToDo": {
+	# 	"validate": "one_fm.overrides.todo.validate_todo",
+	# 	"before_save":"one_fm.overrides.todo.before_save",
+	# 	"after_insert":[
+	# 		"one_fm.overrides.todo.create_google_task_on_todo_creation",
+	# 		"one_fm.overrides.todo.send_email_on_todo_created"
+	# 	],
+	# 	"on_update": "one_fm.overrides.todo.update_google_task_on_todo_status_change"
+	# },
 	"OAuth Bearer Token": {
 		"after_insert": "one_fm.api.doc_methods.oauth_bearer_token.revoke_and_delete_existing_tokens",
 	}

--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -36,9 +36,6 @@ def notify_todo_status_change(doc):
     """Notify user if ToDo status changes. Modular, clear, and logs notification."""
     if doc.is_new():
         return
-    # Only send notifications for Action-type ToDos; Processa handles Process tasks
-    if getattr(doc, "type", "") and doc.type != "Action":
-        return
     if not doc.notify_allocated_to_via_email:
         return
     status_in_db = frappe.db.get_value(doc.doctype, doc.name, "status")
@@ -416,9 +413,6 @@ def sync_google_tasks_for_users(user_emails=[], timedelta_kwargs=None):
 
 @frappe.whitelist()
 def send_email_on_todo_created(doc, method):
-    # Only send notifications for Action-type ToDos; Processa handles Process tasks
-    if getattr(doc, "type", "") and doc.type != "Action":
-        return
     if not doc.notify_allocated_to_via_email:
         return
     user_id = frappe.session.user

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -447,5 +447,6 @@ one_fm.patches.v15_0.add_accommodation_checked_out_field_and_update_approved_rul
 one_fm.patches.v15_0.add_client_event_field_to_attendance
 one_fm.patches.v15_0.add_asset_serial_and_warranty_fields
 one_fm.patches.v15_0.add_asset_repair_custom_fields
-one_fm.patches.v15_0.add_asset_repair_workflow_and_assignment_rules #4
+one_fm.patches.v15_0.add_asset_repair_workflow_and_assignment_rules
 one_fm.patches.v15_0.set_todo_type_read_only
+

--- a/one_fm/public/js/doctype_js/todo.js
+++ b/one_fm/public/js/doctype_js/todo.js
@@ -1,8 +1,5 @@
 frappe.ui.form.on('ToDo', {
     refresh: function(frm) {
-      if (frm.is_new()) {
-        frm.set_value("notify_allocated_to_via_email", 1);
-        console.log("DDD");
-      }
+        frm.set_df_property('notify_allocated_to_via_email', 'hidden', 1);
     }
 })

--- a/one_fm/public/js/doctype_list_js/todo_list.js
+++ b/one_fm/public/js/doctype_list_js/todo_list.js
@@ -6,17 +6,22 @@ frappe.listview_settings['ToDo'] = {
 
 const sync_my_google_tasks = function(listview) {
 	listview.page.add_button(__('Sync My Google Tasks'), function() {
+        frappe.show_alert({
+            message: __('Syncing Google Tasks...'),
+            indicator: 'blue'
+        }, 3);
         frappe.call({
-			method: 'one_bpmn.api.instance_api.start_process_async',
+			method: 'one_bpmn.api.instance_api.start_process',
 			args: {
 				model_name: 'Sync Google Task to ERPNext ToDo'
 			},
 			callback: function (r) {
 				if (!r.exc) {
 					frappe.show_alert({
-						message: __('Google Task sync started in background'),
+						message: __('Google Tasks synced successfully'),
 						indicator: 'green'
 					}, 5);
+					listview.refresh();
 				}
 			}
 		});


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [] Feature
- [x] Chore
- [] Bug


## Clearly and concisely describe the feature, chore or bug.

Migrate ToDo lifecycle hooks from native `one_fm` Python hooks to BPMN server scripts in the "ToDo Process - Creation to Completion" process. This includes commenting out legacy doc_events, removing obsolete custom fields, updating the BPMN diagram with Action-type filtering gateways, and aligning the BPMN email/notification configuration to match the existing Python logic.


## Analysis and design (optional)

The ToDo lifecycle (creation, validation, Google Task sync, email notifications, status change notifications) was previously handled by Python hooks in `one_fm/hooks.py` and `one_fm/overrides/todo.py`. These have been migrated to BPMN server scripts that run within the "ToDo Process - Creation to Completion" process model. The BPMN diagram was updated to:
- Add `is_action_type` gateway filtering (only Action-type ToDos get notifications, Process/Project types are skipped)
- Match the creation email template to the existing Python HTML table format
- Use Notification Log (in-app bell) instead of email for status change notifications
- Remove the push notification on creation (not present in original Python flow)


## Solution description

### 1. `one_fm/hooks.py`
- **Commented out** all ToDo `doc_events` (validate, before_save, after_insert, on_update) — now handled by BPMN server scripts

### 2. `one_fm/overrides/todo.py`
- **Removed** Action-type filtering guards from `notify_todo_status_change()` and `send_email_on_todo_created()` — filtering is now handled by BPMN gateways using `is_action_type`

### 3. `one_fm/public/js/doctype_list_js/todo_list.js`
- Changed Google Task sync button from `start_process_async` to synchronous `start_process`
- Added blue loading indicator while syncing
- Added `listview.refresh()` on success
- Updated success message to "Google Tasks synced successfully"

### 4. `one_fm/public/js/doctype_js/todo.js`
- Removed auto-setting of `notify_allocated_to_via_email` checkbox
- Added `frm.set_df_property('notify_allocated_to_via_email', 'hidden', 1)` to hide the field

### 5. `one_fm/custom/custom_field/todo.py`
- **Removed** `notify_allocated_to_via_email` custom field definition
- **Deleted** the custom field record from the database
- Updated `insert_after` reference for `custom_google_task` section (now points to `allocated_to`)

### 6. `one_fm/custom/property_setter/todo.py`
- **Kept** the `type` field `read_only` property setter (re-added after initial removal)

### 7. `one_fm/patches.txt` & `one_fm/patches/v15_0/set_todo_type_read_only.py`
- **Kept** the `set_todo_type_read_only` patch entry and file

### 8. Server Scripts (Database — BPMN)
- **Updated** `ToDo – Validate (Create)`: Added `result["is_action_type"] = (doc.type == "Action") or not doc.type`
- **Updated** `ToDo – Validate (Update)`: Added `result["is_action_type"] = (doc.type == "Action") or not doc.type`
- **Created** `ToDo – Notify Status Change`: New server script that creates a Notification Log (matching Python `notify_todo_status_change` logic with conditional Alert/Assignment type)

### 9. BPMN Diagram — "ToDo Process - Creation to Completion"
- **Added** `gw_action_type_create` gateway after Validate (Create) — routes Action-type to notifications, non-Action to Google Sync directly
- **Added** `gw_action_type_update` gateway after Validate (Update) — routes Action-type to status change check, non-Action to Google Sync directly
- **Updated** creation email subject to: `A Task has been Created via {{ source }} by {{ user }}`
- **Updated** creation email body to HTML table format matching Python template (Task ID, Title, Description+References, Due Date, Status, Source)
- **Changed** `todo_notify` from `serviceTask` (send_email) to `scriptTask` using `ToDo – Notify Status Change` server script (creates Notification Log instead of email)
- **Removed** push notification on creation (`todo_email_assignee`, `Gateway_0ephaa7`, `Gateway_1cnm2da`)


## Is there a business logic within a doctype?
- [x] Yes
- [] No

ToDo doctype — lifecycle hooks are now managed by BPMN server scripts instead of Python doc_events.


## Output screenshots (optional)

N/A — No UI changes, backend logic migration only.


## Areas affected and ensured

- **ToDo creation** — validation, type setting, Google Task title, email notification
- **ToDo update** — status change notification, Google Task sync
- **ToDo list view** — Google Task sync button behavior
- **Google Task integration** — sync button, task create/update/delete
- **Email notifications** — creation email format and delivery
- **In-app notifications** — status change Notification Log


## Is there any existing behavior change of other features due to this code change?

Yes.
- The `notify_allocated_to_via_email` checkbox is removed from the ToDo form — email notifications for ToDo creation are now controlled by the BPMN process flow (Self-Assigned? gateway) instead of a user checkbox.
- Non-Action type ToDos (Process, Project) no longer trigger email or notification — they are filtered by the new `is_action_type` BPMN gateways.
- Status change notifications are now in-app Notification Logs only (no email), matching the existing Python behavior.


## Did you test with the following dataset?
- [x] Existing Data
- [] New Data

## Was child table created?
N/A

## Did you delete custom field?
- [x] Yes
- [] No

`notify_allocated_to_via_email` custom field was deleted from the ToDo doctype. No delete patch required — the field was removed from the custom field definition file and deleted directly from the database via `frappe.delete_doc`.

## Is patch required?
- [] Yes
- [x] No

Existing patch `set_todo_type_read_only` is retained. No new patches needed.


## Which browser(s) did you use for testing?
- [x] Chrome
- [] Safari
- [] Firefox
