### PR TITLE
fix: add missing version-15 patches to resolve PR #6326 conflict

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -271,6 +271,7 @@ one_fm.patches.v15_0.update_job_offer_for_ERF_2026_00004
 one_fm.patches.v15_0.add_index_to_leave_application_in_attendance
 one_fm.patches.v15_0.update_attendance_request_assignment_rule
 one_fm.patches.v15_0.remove_hd_property_setter_from_non_existing_doc #3
+
 one_fm.patches.v15_0.add_assignment_rule_submit_timesheet_employee
 one_fm.patches.v15_0.add_assignment_rule_approve_timesheet_approver
 one_fm.patches.v15_0.add_assignment_rule_leave_acknowledgement_form_pending_confirmation
@@ -293,6 +294,7 @@ one_fm.patches.v15_0.add_sales_invoice_contract_fields #3
 one_fm.patches.v15_0.add_sales_taxes_charges_add_or_deduct_field
 one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
+one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
 one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
 one_fm.patches.v15_0.update_vehicle_naming_series
 one_fm.patches.v15_0.remove_vehicle_autoname_property_setter
@@ -300,7 +302,10 @@ one_fm.patches.v15_0.update_vehicle_category_naming #2026-06-17
 one_fm.patches.v15_0.rename_fleet_workspace_to_transportation #2026-06-10 #2
 one_fm.patches.v15_0.rename_route_planner_page_to_transportation_schedule
 one_fm.patches.v15_0.cleanup_todo_type_field
-
+one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
+one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants
+one_fm.patches.v15_0.add_phone_option_to_job_applicant_contact_number
+one_fm.patches.v15_0.remove_employee_marital_status_property_setter
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task
@@ -322,7 +327,7 @@ one_fm.patches.v15_0.add_task_assignment_rule
 one_fm.patches.v15_0.add_values_to_rank_factor_table
 one_fm.patches.v15_0.update_existing_designation_to_main_head_hunt_doctype
 one_fm.patches.v15_0.attendance_check_create #09-09-2025
-one_fm.patches.v15_0.update_job_applicant_field
+one_fm.patches.v15_0.update_job_applicant_field #04-06-2026
 one_fm.patches.v15_0.create_compliance_checker_process_task
 one_fm.patches.v15_0.update_preparation_records
 one_fm.patches.v15_0.update_hr_settings_with_grd_settings #2025-10-07
@@ -413,7 +418,6 @@ one_fm.patches.v15_0.add_qcs_link_to_purchase_order
 one_fm.patches.v15_0.add_rfq_and_sq_custom_fields
 one_fm.patches.v15_0.add_attendance_amendment_to_sales_invoice
 one_fm.patches.v15_0.backfill_governorate_in_site_to_location_mapping
-one_fm.patches.v15_0.update_bank_account_workflow
 one_fm.patches.v15_0.add_courier_tracking_custom_fields
 one_fm.patches.v15_0.update_client_interview_shortlist_workflow #2026-05-13
 one_fm.patches.v15_0.add_resignation_fields_to_employee
@@ -450,3 +454,14 @@ one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_operations_manager
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_gsd_supervisor
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_offboarding_officer
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_finance_manager
+one_fm.patches.v15_0.add_nationality_read_permission
+one_fm.patches.v15_0.update_workflows_for_ops_admin_edit
+one_fm.patches.v15_0.backfill_ojt_employee_schedules #2026-06-18
+one_fm.patches.v15_0.delete_medical_appointment_todos #2026-06-15
+one_fm.patches.v15_0.sync_erf_workflow_state_with_closed_status #2026-06-15
+one_fm.patches.v15_0.close_job_openings_for_closed_erf #2026-06-15
+one_fm.patches.v15_0.update_interview_console_permissions
+one_fm.patches.v15_0.standardize_marital_status_options
+one_fm.patches.v15_0.fix_nirmala_day_off_client_event_conflict #2026-06-18
+one_fm.patches.v15_0.update_pmr_workflow_in_process_role
+one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24


### PR DESCRIPTION
## Summary

Adds missing `version-15` patches into `test-production`'s `patches.txt` to resolve the patches.txt conflict in [PR #6326](https://github.com/ONE-F-M/one_fm/pull/6326).

**1 file changed** — `patches.txt` only (18 insertions, 3 deletions).

## Remaining: `contracts.py`

`contracts.py` has a structural conflict — both branches rewrote `sync_item_prices()` differently. This cannot be pre-resolved without a merge commit. When merging PR #6326, keep **test-production's version** (it has `ItemPriceDuplicateItem` handling and `days_off` support).