### PR TITLE
[FEAT][Leave Applications created programmatically by the **Leave Extension Request** TO UPDATE THE STATUS TO APPROVED]

### DIFF
--- a/one_fm/one_fm/doctype/leave_extension_request/leave_extension_request.py
+++ b/one_fm/one_fm/doctype/leave_extension_request/leave_extension_request.py
@@ -109,6 +109,7 @@ class LeaveExtensionRequest(Document):
 		leave_application.custom_reliever_name = custom_reliever_name
 		leave_application.custom_leave_extension_request = self.name
 
+		leave_application.status = "Approved"
 		leave_application.flags.ignore_permissions = True
 		leave_application.insert()
 		leave_application.submit()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -465,3 +465,4 @@ one_fm.patches.v15_0.standardize_marital_status_options
 one_fm.patches.v15_0.fix_nirmala_day_off_client_event_conflict #2026-06-18
 one_fm.patches.v15_0.update_pmr_workflow_in_process_role
 one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24
+one_fm.patches.v15_0.fix_leave_extension_request_leave_application_status #2026-06-30

--- a/one_fm/patches/v15_0/fix_leave_extension_request_leave_application_status.py
+++ b/one_fm/patches/v15_0/fix_leave_extension_request_leave_application_status.py
@@ -1,0 +1,47 @@
+"""
+Fix Leave Application status for leaves created via Leave Extension Request.
+
+When Leave Extension Request creates leave applications programmatically,
+it calls .insert() and .submit() directly, bypassing the workflow transition
+that normally sets `status = 'Approved'`. This leaves the `status` field as
+'Open' even though the document is submitted (docstatus=1) and
+workflow_state='Approved'.
+
+This patch updates all such affected Leave Applications.
+"""
+import frappe
+
+
+def execute():
+    # Fix all leave applications created via Leave Extension Request
+    frappe.db.sql("""
+        UPDATE `tabLeave Application`
+        SET status = 'Approved'
+        WHERE docstatus = 1
+          AND workflow_state = 'Approved'
+          AND status != 'Approved'
+          AND custom_leave_extension_request IS NOT NULL
+          AND custom_leave_extension_request != ''
+    """)
+
+    # Also fix these specific known affected leave applications
+    specific_leaves = (
+        'HR-LAP-2026-00686',
+        'HR-LAP-2026-00710',
+        'HR-LAP-2026-00729',
+        'HR-LAP-2026-00797',
+        'HR-LAP-2026-00798',
+        'HR-LAP-2026-00799',
+        'HR-LAP-2026-00800',
+    )
+
+    frappe.db.sql("""
+        UPDATE `tabLeave Application`
+        SET status = 'Approved'
+        WHERE docstatus = 1
+          AND workflow_state = 'Approved'
+          AND status != 'Approved'
+          AND name IN %s
+    """, [specific_leaves])
+
+    frappe.db.commit()


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [ ] Feature
- [ ] Chore
- [x] Bug


## Clearly and concisely describe the feature, chore or bug.

Leave Applications created programmatically by the **Leave Extension Request** (`create_leave_application()`) have their `status` field stuck as `"Open"` instead of `"Approved"`, even though `workflow_state = "Approved"` and `docstatus = 1`. This causes the **Roster Day Off Checker** to ignore these leave dates (it filters on `status = 'Approved'`), resulting in false day-off discrepancy records being created for employees who are fully on approved leave.

**Root Cause:** The `create_leave_application()` method in `leave_extension_request.py` calls `.insert()` then `.submit()` directly, bypassing the workflow transition that normally sets `update_field: "status"` to `update_value: "Approved"`. The workflow's `update_field`/`update_value` mechanism only triggers during interactive workflow transitions, not programmatic `.submit()` calls.


## Analysis and design (optional)

**Affected employee example:** HR-EMP-03423 (Belal Hossen Ali)
- Leave Application HR-LAP-2026-00685 (Annual Leave, Jun 03 – Jul 21) → `status = "Approved"` ✅ (created via normal workflow)
- Leave Application HR-LAP-2026-00686 (LWOP, Jul 22 – Aug 03) → `status = "Open"` ❌ (created via Leave Extension Request HR-LER-2026-00011)

The Roster Day Off Checker query in `get_leave_dates_by_employee()` filters `AND status = 'Approved'`, so it missed the second leave application, treated Jul 22–31 as working days, and created a checker record with `repeat_count: 29` (flagged for 29 consecutive days).


## Solution description

### 1. Code Fix — `leave_extension_request.py`
Added `leave_application.status = "Approved"` before `.insert()` in the `create_leave_application()` method. This ensures that leave applications created programmatically by Leave Extension Requests have the correct `status` field, matching what the workflow would set during a normal transition.

```diff
+ leave_application.status = "Approved"
  leave_application.flags.ignore_permissions = True
  leave_application.insert()
  leave_application.submit()
```

### 2. Data Patch — `fix_leave_extension_request_leave_application_status.py`
A migration patch that fixes all existing affected Leave Applications:
- **Generic fix:** Updates all submitted Leave Applications with `workflow_state = 'Approved'` and a `custom_leave_extension_request` set but `status != 'Approved'`
- **Specific fix:** Also targets 7 known affected records: HR-LAP-2026-00686, 00710, 00729, 00797, 00798, 00799, 00800


## Is there a business logic within a doctype?
- [x] Yes
- [ ] No


## Output screenshots (optional)
N/A — No UI changes. Backend-only fix.


## Areas affected and ensured
- **Leave Extension Request** — `create_leave_application()` method now sets `status = "Approved"`
- **Roster Day Off Checker** — will correctly recognize leave dates from Leave Extension Request leave applications (no code change needed here, the data is now correct)
- **Leave Application** — existing records with wrong `status` are fixed via patch


## Is there any existing behavior change of other features due to this code change?
No. The change only ensures the `status` field matches what it should already be (`"Approved"`) for submitted, workflow-approved Leave Applications. No other features are impacted.


## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data


## Was child table created?
N/A — No child table changes.

## Did you delete custom field?
- [ ] Yes
- [x] No


## Is patch required?
- [x] Yes
- [ ] No

Patch: `one_fm.patches.v15_0.fix_leave_extension_request_leave_application_status`
Registered in `patches.txt` with tag `#2026-06-30`


## Which browser(s) did you use for testing?
- [x] Chrome
- [ ] Safari
- [ ] Firefox