### PR TITLE
feat(perm, resignation, pmr): allow Operation Admin and T4 Admin full edit/create permissions for PMR and Resignation workflows

### DIFF
--- a/one_fm/custom/workflow/employee_resignation.json
+++ b/one_fm/custom/workflow/employee_resignation.json
@@ -30,6 +30,26 @@
             "doctype": "Workflow Document State"
         },
         {
+            "state": "Pending Operations Manager",
+            "doc_status": "0",
+            "style": "Warning",
+            "is_optional_state": 0,
+            "avoid_status_override": 0,
+            "allow_edit": "Operation Admin",
+            "send_email": 1,
+            "doctype": "Workflow Document State"
+        },
+        {
+            "state": "Pending Operations Manager",
+            "doc_status": "0",
+            "style": "Warning",
+            "is_optional_state": 0,
+            "avoid_status_override": 0,
+            "allow_edit": "T4 Admin",
+            "send_email": 1,
+            "doctype": "Workflow Document State"
+        },
+        {
             "state": "Approved",
             "doc_status": "1",
             "update_field": "status",

--- a/one_fm/custom/workflow/project_manpower_request.json
+++ b/one_fm/custom/workflow/project_manpower_request.json
@@ -88,6 +88,16 @@
             "doctype": "Workflow Document State"
         },
         {
+            "state": "Draft",
+            "doc_status": "0",
+            "style": "Primary",
+            "is_optional_state": 0,
+            "avoid_status_override": 0,
+            "allow_edit": "T4 Admin",
+            "send_email": 0,
+            "doctype": "Workflow Document State"
+        },
+        {
             "state": "Awaiting Recruiter Approval",
             "doc_status": "0",
             "style": "Warning",
@@ -114,6 +124,16 @@
             "is_optional_state": 0,
             "avoid_status_override": 0,
             "allow_edit": "Operation Admin",
+            "send_email": 0,
+            "doctype": "Workflow Document State"
+        },
+        {
+            "state": "In Process",
+            "doc_status": "0",
+            "style": "Success",
+            "is_optional_state": 0,
+            "avoid_status_override": 0,
+            "allow_edit": "T4 Admin",
             "send_email": 0,
             "doctype": "Workflow Document State"
         },
@@ -212,6 +232,14 @@
             "doctype": "Workflow Transition"
         },
         {
+            "state": "Draft",
+            "action": "Submit to Recruiter",
+            "next_state": "Awaiting Recruiter Approval",
+            "allowed": "T4 Admin",
+            "allow_self_approval": 1,
+            "doctype": "Workflow Transition"
+        },
+        {
             "state": "Awaiting Recruiter Approval",
             "action": "Approve",
             "next_state": "In Process",
@@ -280,6 +308,14 @@
             "action": "Complete",
             "next_state": "Completed",
             "allowed": "Operation Admin",
+            "allow_self_approval": 1,
+            "doctype": "Workflow Transition"
+        },
+        {
+            "state": "In Process",
+            "action": "Complete",
+            "next_state": "Completed",
+            "allowed": "T4 Admin",
             "allow_self_approval": 1,
             "doctype": "Workflow Transition"
         },
@@ -384,6 +420,14 @@
             "action": "Request Edit",
             "next_state": "Draft",
             "allowed": "Operation Admin",
+            "allow_self_approval": 1,
+            "doctype": "Workflow Transition"
+        },
+        {
+            "state": "In Process",
+            "action": "Request Edit",
+            "next_state": "Draft",
+            "allowed": "T4 Admin",
             "allow_self_approval": 1,
             "doctype": "Workflow Transition"
         },

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.js
@@ -138,7 +138,7 @@ frappe.ui.form.on("Employee Resignation", {
 			}
 		}
 
-		if (frm.doc.workflow_state === 'Pending Operations Manager' && frappe.user_roles.includes('Operation Admin')) {
+		if (frm.doc.workflow_state === 'Pending Operations Manager' && (frappe.user_roles.includes('Operation Admin') || frappe.user_roles.includes('T4 Admin'))) {
 			// Disable editing of all fields except replacement details
 			frm.set_df_property('employees', 'read_only', 1);
 			frm.set_df_property('resignation_initiation_date', 'read_only', 1);

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
@@ -429,6 +429,16 @@
             "write": 1
         },
         {
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "T4 Admin",
+            "share": 1,
+            "write": 1
+        },
+        {
             "create": 1,
             "delete": 1,
             "email": 1,

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.py
@@ -61,6 +61,10 @@ class EmployeeResignation(Document):
 		# Allow workflow assignees to modify the document
 		if frappe.session.user in [self.supervisor, self.operations_manager, self.offboarding_officer]:
 			return
+			
+		# Allow Operation Admin and T4 Admin to edit replacement details in Pending Operations Manager state
+		if self.get("workflow_state") == "Pending Operations Manager" and any(role in roles for role in ["Operation Admin", "T4 Admin"]):
+			return
 		
 		linked_employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user})
 		if not linked_employee:

--- a/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
+++ b/one_fm/one_fm/doctype/project_manpower_request/project_manpower_request.json
@@ -611,6 +611,21 @@
    "share": 1,
    "submit": 1,
    "write": 1
+  },
+  {
+   "amend": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "import": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "T4 Admin",
+   "share": 1,
+   "submit": 1,
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -465,3 +465,5 @@ one_fm.patches.v15_0.standardize_marital_status_options
 one_fm.patches.v15_0.fix_nirmala_day_off_client_event_conflict #2026-06-18
 one_fm.patches.v15_0.update_pmr_workflow_in_process_role
 one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24
+one_fm.patches.v15_0.update_pmr_and_resignation_workflow_permissions #2026-06-30
+

--- a/one_fm/patches/v15_0/update_pmr_and_resignation_workflow_permissions.py
+++ b/one_fm/patches/v15_0/update_pmr_and_resignation_workflow_permissions.py
@@ -1,0 +1,31 @@
+import frappe
+from one_fm.custom.workflow.workflow import get_workflow_json_file, create_workflow
+
+def execute():
+	print("=== Patch: Registering T4 Admin role and reloading custom workflows ===")
+	
+	# 1. Ensure T4 Admin role exists in DB
+	if not frappe.db.exists("Role", "T4 Admin"):
+		print("Creating 'T4 Admin' role")
+		frappe.get_doc({
+			"doctype": "Role",
+			"role_name": "T4 Admin"
+		}).insert(ignore_permissions=True)
+
+	# 2. Reload Doctypes to apply updated T4 Admin permissions from JSON files
+	print("Reloading PMR and Resignation doctypes...")
+	frappe.reload_doc("one_fm", "doctype", "project_manpower_request", force=True)
+	frappe.reload_doc("one_fm", "doctype", "employee_resignation", force=True)
+
+	# 3. Reload/update workflows
+	print("Reloading PMR and Employee Resignation workflows...")
+	
+	pmr_wf = get_workflow_json_file("project_manpower_request.json")
+	create_workflow(pmr_wf)
+	
+	res_wf = get_workflow_json_file("employee_resignation.json")
+	create_workflow(res_wf)
+	
+	frappe.clear_cache(doctype="Project Manpower Request")
+	frappe.clear_cache(doctype="Employee Resignation")
+	print("Workflows reloaded successfully.")


### PR DESCRIPTION
Consolidate the permissions, workflows, and backend validations for Operation Admin and T4 Admin roles to allow raising PMRs, managing workflow states, and editing replacement details in Pending Operations Manager state.