### PR TITLE
fix: exclude inactive operations roles and posts from roster

### DIFF
--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -51,7 +51,21 @@ class PostMap():
 		filters.update({"post_status": "Planned",'operations_role':['in',self.operation_roles]})
 		filters.pop('operations_role')
 		self.filters = filters
-		self.post_schedule_count = frappe.db.get_all("Post Schedule", ['operations_role',"name", "date"], filters, ignore_permissions=True)
+		self.post_schedule_count = frappe.db.get_all("Post Schedule", ['operations_role',"name", "date", "post"], filters, ignore_permissions=True)
+
+		# Exclude planned schedules that belong to Inactive Operations Posts so the
+		# post count reflects only active posts (e.g. a role with 2 active + 2 inactive
+		# posts should count as 2, not 4).
+		post_names = list({row.post for row in self.post_schedule_count if row.post})
+		if post_names:
+			inactive_posts = set(frappe.get_all(
+				"Operations Post",
+				filters={"name": ["in", post_names], "status": "Inactive"},
+				pluck="name"
+			))
+			if inactive_posts:
+				self.post_schedule_count = [row for row in self.post_schedule_count if row.post not in inactive_posts]
+
 		self.start_mapping()
 
 	def create_template(self,row):

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -246,6 +246,17 @@ def get_roster_view(start_date, end_date, employee_search_id=None, employee_sear
 		else:
 			post_schedule_filters = get_post_schedule_filters(start_date, end_date, project, site, shift, operations_role)
 			operations_roles = frappe.get_all("Post Schedule", post_schedule_filters, ["distinct operations_role", "post_abbrv"])
+
+			# Exclude Inactive Operations Roles so they don't appear in the roster.
+			role_names = [row.operations_role for row in operations_roles if row.operations_role]
+			if role_names:
+				active_roles = set(frappe.get_all(
+					"Operations Role",
+					filters={"name": ["in", role_names], "status": "Active"},
+					pluck="name"
+				))
+				operations_roles = [row for row in operations_roles if row.operations_role in active_roles]
+
 			post_map_filters = {}
 			if project:
 				post_map_filters["project"] = project


### PR DESCRIPTION
Inactive Operations Roles and posts were still shown in the roster view because the role and post-count queries had no status filter.

- Filter out Operations Roles with status "Inactive" before building the roster's operations role rows in get_roster_view
- Exclude planned Post Schedules linked to Inactive Operations Posts from the PostMap count so a role's denominator reflects only active posts
