### PR TITLE
feat: standardize Employee marital status options

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -462,6 +462,7 @@ one_fm.patches.v15_0.sync_erf_workflow_state_with_closed_status #2026-06-15
 one_fm.patches.v15_0.close_job_openings_for_closed_erf #2026-06-15
 one_fm.patches.v15_0.update_interview_console_permissions
 one_fm.patches.v15_0.standardize_marital_status_options
+one_fm.patches.v15_0.standardize_employee_marital_status_options
 one_fm.patches.v15_0.fix_nirmala_day_off_client_event_conflict #2026-06-18
 one_fm.patches.v15_0.update_pmr_workflow_in_process_role
 one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24

--- a/one_fm/patches/v15_0/standardize_employee_marital_status_options.py
+++ b/one_fm/patches/v15_0/standardize_employee_marital_status_options.py
@@ -1,0 +1,43 @@
+"""
+Patch to standardize Employee marital status options
+Maps old values to new standardized values:
+- Unmarried -> Single
+- Married -> Married
+- Divorce -> Divorced
+- Widow -> Widowed
+- Unknown -> Single
+"""
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute():
+    """
+    Migrate Employee marital status data from old options to new standardized
+    options using Query Builder for optimal performance
+    """
+
+    # Mapping of old values to new values
+    marital_status_mapping = {
+        "Unmarried": "Single",
+        "Married": "Married",
+        "Divorce": "Divorced",
+        "Widow": "Widowed",
+        "Unknown": "Single",
+    }
+
+    # Update Employee marital status field using Query Builder
+    Employee = DocType("Employee")
+
+    for old_value, new_value in marital_status_mapping.items():
+        if old_value != new_value:
+            try:
+                (
+                    frappe.qb.update(Employee)
+                    .set(Employee.marital_status, new_value)
+                    .where(Employee.marital_status == old_value)
+                ).run()
+            except Exception as e:
+                frappe.log_error(f"Error updating Employee: {str(e)}")
+
+    frappe.db.commit()


### PR DESCRIPTION
Add a v15_0 patch that migrates the Employee marital_status field from legacy values to the standardized option set, matching the existing standardization applied to other modules.

- add standardize_employee_marital_status_options patch mapping Unmarried->Single, Divorce->Divorced, Widow->Widowed, Unknown->Single
- register the patch in patches.txt

<img width="1024" height="445" alt="Screenshot 2026-07-01 at 10 43 32 PM" src="https://github.com/user-attachments/assets/2aeceab4-6502-45ea-bb04-e6df6af46bf3" />
