### PR TITLE
fix: clear stale Client Event linkage on day off schedule rows

### DIFF
--- a/one_fm/api/mobile/roster.py
+++ b/one_fm/api/mobile/roster.py
@@ -245,6 +245,13 @@ def create_day_off(employee, date):
 		roster.post_abbrv = None
 		roster.site = None
 		roster.project = None
+		# Clear any stale Client Event linkage so the Day Off row is not treated as an event.
+		roster.client_event = None
+		roster.reference_doctype = None
+		roster.reference_docname = None
+		roster.event_staff = None
+		roster.event_location = None
+		roster.is_event_schedule = 0
 	else:
 		roster = frappe.new_doc("Employee Schedule")
 		roster.employee = employee

--- a/one_fm/api/v1/flutter/roster.py
+++ b/one_fm/api/v1/flutter/roster.py
@@ -983,6 +983,12 @@ def dayoff(employees, selected_dates=0, repeat=0, repeat_freq=None, week_days=[]
                 shift_type = "",
                 day_off_ot = 0,
                 roster_type = "Basic",
+                client_event = "",
+                reference_doctype = "",
+                reference_docname = "",
+                event_staff = "",
+                event_location = "",
+                is_event_schedule = 0,
                 employee_availability = "Day Off"
             """
             frappe.db.sql(query, values=[], as_dict=1)

--- a/one_fm/api/v1/roster.py
+++ b/one_fm/api/v1/roster.py
@@ -270,6 +270,13 @@ def create_day_off(employee, date):
         roster.post_abbrv = None
         roster.site = None
         roster.project = None
+        # Clear any stale Client Event linkage so the Day Off row is not treated as an event.
+        roster.client_event = None
+        roster.reference_doctype = None
+        roster.reference_docname = None
+        roster.event_staff = None
+        roster.event_location = None
+        roster.is_event_schedule = 0
     else:
         roster = frappe.new_doc("Employee Schedule")
         roster.employee = employee

--- a/one_fm/api/v2/flutter/roster.py
+++ b/one_fm/api/v2/flutter/roster.py
@@ -1187,6 +1187,12 @@ def dayoff(employees, selected_dates=0, repeat=0, repeat_freq=None, week_days=[]
                 shift_type = "",
                 day_off_ot = 0,
                 roster_type = "Basic",
+                client_event = "",
+                reference_doctype = "",
+                reference_docname = "",
+                event_staff = "",
+                event_location = "",
+                is_event_schedule = 0,
                 employee_availability = "Day Off"
             """
             frappe.db.sql(query, values=[], as_dict=1)

--- a/one_fm/api/v2/roster.py
+++ b/one_fm/api/v2/roster.py
@@ -268,6 +268,13 @@ def create_day_off(employee, date):
         roster.post_abbrv = None
         roster.site = None
         roster.project = None
+        # Clear any stale Client Event linkage so the Day Off row is not treated as an event.
+        roster.client_event = None
+        roster.reference_doctype = None
+        roster.reference_docname = None
+        roster.event_staff = None
+        roster.event_location = None
+        roster.is_event_schedule = 0
     else:
         roster = frappe.new_doc("Employee Schedule")
         roster.employee = employee

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -2253,6 +2253,12 @@ def dayoff(employees, client_day_off=0, selected_dates=0, selected_reliever=None
 				site = "",
 				shift_type = "",
 				day_off_ot = 0,
+				client_event = "",
+				reference_doctype = "",
+				reference_docname = "",
+				event_staff = "",
+				event_location = "",
+				is_event_schedule = 0,
 				employee_availability = "{employee_availability}"
 			"""
 			frappe.db.sql(query_main)

--- a/one_fm/operations/doctype/employee_schedule/employee_schedule.py
+++ b/one_fm/operations/doctype/employee_schedule/employee_schedule.py
@@ -56,19 +56,26 @@ class EmployeeSchedule(Document):
 				frappe.delete_doc("Employee Schedule", ot.name, ignore_permissions=True)
 
 	def validate(self):
-		# Clear Client Event-specific fields when transitioning AWAY from Client Event.
-		# This handles saves done from the Desk form (roster uses direct SQL).
-		if not self.is_new():
-			previous_availability = frappe.db.get_value(
-				"Employee Schedule", self.name, "employee_availability"
-			)
-			if previous_availability == "Client Event" and self.employee_availability != "Client Event":
+		# Clear stale Client Event linkage whenever this row is no longer a Client
+		# Event but still carries a Client Event marker. A Client Event schedule
+		# (set by Event Staff) has employee_availability "Client Event",
+		# is_event_schedule=1, client_event set and reference_doctype "Event Staff".
+		# When it is changed to anything else (Day Off, Client Day Off, Working, ...)
+		# those markers are stale and, if left, keep the attendance job treating the
+		# row as an event. The Desk roster page and mobile/flutter dayoff paths write
+		# via direct SQL and bypass this controller, so this also self-heals rows
+		# those paths already left with a stale link.
+		#
+		# Only the Event Staff reference is cleared here — OJT and Shift Request also
+		# use reference_doctype/reference_docname on non-event rows and must survive.
+		if self.employee_availability != "Client Event" and (self.is_event_schedule or self.client_event):
+			self.is_event_schedule = 0
+			self.client_event = ""
+			self.event_staff = ""
+			self.event_location = ""
+			if self.reference_doctype == "Event Staff":
 				self.reference_doctype = ""
 				self.reference_docname = ""
-				self.is_event_schedule = 0
-				self.client_event = ""
-				self.event_staff = ""
-				self.event_location = ""
 
 		self.validate_ojt_change()
 		self.validate_leave_application()

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -467,4 +467,5 @@ one_fm.patches.v15_0.update_pmr_workflow_in_process_role
 one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24
 one_fm.patches.v15_0.fix_leave_extension_request_leave_application_status #2026-06-30
 one_fm.patches.v15_0.update_pmr_and_resignation_workflow_permissions #2026-06-30
+one_fm.patches.v15_0.fix_day_off_client_event_conflict_bulk #2026-07-03
 

--- a/one_fm/patches/v15_0/fix_day_off_client_event_conflict_bulk.py
+++ b/one_fm/patches/v15_0/fix_day_off_client_event_conflict_bulk.py
@@ -1,0 +1,141 @@
+import frappe
+
+# Data repair for the recurring "Day Off / Client Day Off still linked to a Client
+# Event" conflict (same root cause as fix_nirmala_day_off_client_event_conflict, but
+# that patch only repaired one employee).
+#
+# Root cause: the roster "day off" write paths (Desk roster page + mobile/flutter)
+# set employee_availability to "Day Off"/"Client Day Off" via direct SQL and never
+# cleared the Client Event linkage (client_event, reference_doctype/docname,
+# event_staff, event_location, is_event_schedule). A row changed from a Client Event
+# to a day off therefore kept a stale event link, which the attendance job could
+# treat as an event and (for plain Day Off) overwrite with "Absent".
+#
+# The code fix clears those fields on every write path going forward. This patch
+# repairs existing data:
+#   1. GENERIC: clear the stale Client Event linkage on every Day Off / Client Day Off
+#      schedule row that still carries one.
+#   2. TARGETED: for the reported employees, correct any conflicting "Absent"
+#      attendance so it matches their day-off schedule.
+#   3. Report any lingering active Shift Assignment that could re-trigger an Absent.
+
+# Employees reported with the conflict (all linked to the same Client Event).
+REPORTED_EMPLOYEES = [
+	"HR-EMP-04277",  # Ishanatu Salankolay
+	"HR-EMP-02800",  # Soniya Sunar
+	"HR-EMP-03553",  # Jaswant Kumar Bishwakarma
+	"HR-EMP-03319",  # Thillinathan Sellathambie
+]
+
+DAY_OFF_AVAILABILITIES = ["Day Off", "Client Day Off"]
+
+STALE_LINK_FIELDS = {
+	"client_event": "",
+	"reference_doctype": "",
+	"reference_docname": "",
+	"event_staff": "",
+	"event_location": "",
+	"is_event_schedule": 0,
+}
+
+
+def execute():
+	clear_stale_links()
+	repair_reported_attendance()
+	frappe.db.commit()
+
+
+def clear_stale_links():
+	"""Clear the stale Client Event linkage on all day-off schedule rows."""
+	stale_rows = frappe.get_all(
+		"Employee Schedule",
+		filters={
+			"employee_availability": ["in", DAY_OFF_AVAILABILITIES],
+			"client_event": ["is", "set"],
+		},
+		fields=["name", "employee", "date", "employee_availability"],
+	)
+
+	for row in stale_rows:
+		frappe.db.set_value(
+			"Employee Schedule",
+			row.name,
+			STALE_LINK_FIELDS,
+			update_modified=False,
+		)
+
+	print(
+		f"Cleared stale Client Event linkage on {len(stale_rows)} "
+		f"Day Off / Client Day Off Employee Schedule row(s)."
+	)
+
+
+def repair_reported_attendance():
+	"""For the reported employees, fix Absent attendance that conflicts with a day off."""
+	for employee in REPORTED_EMPLOYEES:
+		schedules = frappe.get_all(
+			"Employee Schedule",
+			filters={
+				"employee": employee,
+				"employee_availability": ["in", DAY_OFF_AVAILABILITIES],
+			},
+			fields=["name", "date", "employee_availability"],
+		)
+
+		for es in schedules:
+			# The correct attendance status mirrors the schedule availability.
+			correct_status = es.employee_availability
+
+			attendance = frappe.db.get_value(
+				"Attendance",
+				{
+					"employee": employee,
+					"attendance_date": es.date,
+					"roster_type": "Basic",
+				},
+				["name", "status", "docstatus"],
+				as_dict=True,
+			)
+
+			if not attendance:
+				continue
+
+			# Only correct wrong Absent marks; leave anything else untouched.
+			if attendance.status == "Absent":
+				comment = f"Employee Schedule - {es.name}"
+				frappe.db.set_value(
+					"Attendance",
+					attendance.name,
+					{"status": correct_status, "comment": comment},
+					update_modified=False,
+				)
+				print(
+					f"Corrected Attendance {attendance.name} for {employee} on "
+					f"{es.date} from 'Absent' to '{correct_status}'."
+				)
+
+		# Report lingering active Shift Assignments that could re-trigger an Absent mark.
+		lingering = frappe.get_all(
+			"Shift Assignment",
+			filters={
+				"employee": employee,
+				"status": "Active",
+				"docstatus": 1,
+			},
+			fields=["name", "start_date", "shift", "shift_type"],
+		)
+		for sa in lingering:
+			# Only flag those overlapping a day-off schedule date.
+			if frappe.db.exists(
+				"Employee Schedule",
+				{
+					"employee": employee,
+					"date": sa.start_date,
+					"employee_availability": ["in", DAY_OFF_AVAILABILITIES],
+				},
+			):
+				print(
+					f"WARNING: Active Shift Assignment {sa.name} (shift: {sa.shift}, "
+					f"type: {sa.shift_type}) exists for {employee} on {sa.start_date}, "
+					f"which is a day off. Review/cancel it to avoid a re-triggered Absent."
+				)


### PR DESCRIPTION
When an employee assigned to a Client Event had their roster changed to Day Off or Client Day Off, the schedule row kept its Client Event linkage (client_event, reference_doctype/docname, event_staff, event_location, is_event_schedule). The attendance job then still treated the row as an event, which could overwrite the day off with Absent. PR #6358 only repaired one employee's data; the root-cause code fix was never applied, so the conflict recurred for other staff.

Clear the linkage on every day off write path and self-heal existing rows:

- desk roster page dayoff() SQL: clear the six event fields in the ON DUPLICATE KEY UPDATE clause
- v1/v2 flutter dayoff() SQL: same clause fix
- v1/v2/mobile create_day_off() ORM: null the event fields alongside the existing shift/site/project reset
- Employee Schedule validate(): self-heal any non-Client-Event row still carrying an event marker, scoped to the Event Staff reference so OJT and Shift Request references on non-event rows are preserved
- add data-repair patch fix_day_off_client_event_conflict_bulk to clear stale links on all day off / client day off rows and correct conflicting Absent attendance for the four reported employees