### PR TITLE
fix: exclude cancelled attendance from roster post checker

### DIFF
--- a/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
+++ b/one_fm/one_fm/doctype/roster_post_actions/roster_post_actions.py
@@ -135,11 +135,12 @@ def create_roster_post_actions():
             ORDER BY es.date ASC
         """, as_dict=1)
 
-        attendance_list = frappe.db.sql(""" 
-            SELECT employee, attendance_date 
+        attendance_list = frappe.db.sql("""
+            SELECT employee, attendance_date
             FROM `tabAttendance`
-            WHERE attendance_date BETWEEN %s AND %s 
-            AND status = 'On Leave' 
+            WHERE attendance_date BETWEEN %s AND %s
+            AND status = 'On Leave'
+            AND docstatus = 1
         """, (start_date, end_date), as_dict=1)
 
         attendance_dict = {}


### PR DESCRIPTION
The roster post actions checker excluded employees from the effective headcount whenever any Attendance row had status "On Leave", regardless of docstatus. Cancelled attendance (docstatus 2) retains its "On Leave" status value, so a cancelled leave still dropped the employee and produced phantom "not filled" posts against fully staffed shifts.

- Add "AND docstatus = 1" to the On Leave attendance query so only submitted leave attendance excludes an employee from the count
