### PR TITLE
feat: employee property in vehicle

### DIFF
--- a/one_fm/custom/property_setter/vehicle.py
+++ b/one_fm/custom/property_setter/vehicle.py
@@ -18,25 +18,8 @@ def get_vehicle_properties():
             "doc_type": "Vehicle",
             "doctype_or_field": "DocField",
             "field_name": "employee",
-            "property": "reqd",
-            "value": "1",
-            "property_type": "Check",
-        },
-        {
-            "doc_type": "Vehicle",
-            "doctype_or_field": "DocField",
-            "field_name": "employee",
-            "property": "fieldtype",
-            "value": "Link",
-            "property_type": "Select",
-        },
-        {
-            "doc_type": "Vehicle",
-            "doctype_or_field": "DocField",
-            "field_name": "employee",
-            "property": "options",
-            "value": "Employee",
-            "property_type": "Small Text",
+            "property": "mandatory_depends_on",
+            "value": "eval:doc.one_fm_vehicle_category != 'Subcontractor'"
         },
         {
             "doc_type": "Vehicle",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -306,6 +306,7 @@ one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
 one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants
 one_fm.patches.v15_0.add_phone_option_to_job_applicant_contact_number
 one_fm.patches.v15_0.remove_employee_marital_status_property_setter
+one_fm.patches.v15_0.update_vehicle_property_setter
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/update_vehicle_property_setter.py
+++ b/one_fm/patches/v15_0/update_vehicle_property_setter.py
@@ -1,0 +1,18 @@
+from one_fm.setup.setup import add_property_setter
+import frappe
+
+def execute():
+    frappe.db.delete("Property Setter", {
+		"doc_type": "Vehicle",
+		"field_name": "employee",
+	})
+    property_setters = [
+        {
+            "doc_type": "Vehicle",
+            "doctype_or_field": "DocField",
+            "field_name": "employee",
+            "property": "mandatory_depends_on",
+            "value": "eval:doc.one_fm_vehicle_category != 'Subcontractor'"
+        }
+    ]
+    add_property_setter(property_setters)


### PR DESCRIPTION
Updated the validation logic for the **Employee** field in the Vehicle form based on the selected **Vehicle Category**. When the vehicle category is set to **Subcontractor**, the **Employee** field is optional. When the vehicle category is set to **Owned** or **Leased**, the **Employee** field is mandatory, ensuring that company-owned and leased vehicles are always associated with an employee while allowing subcontractor vehicles to exist without an employee assignment.
