### PR TITLE
fix: suppress assignment-rule-driven "removed by" emails

### DIFF
--- a/one_fm/overrides/notification_log.py
+++ b/one_fm/overrides/notification_log.py
@@ -8,10 +8,17 @@ from one_fm.processor import sendemail
 
 class NotificationLogOverride(NotificationLog):
     def after_insert(self):
-        # Skip notification entirely for non-Action ToDo assignments.
-        # Processa handles notifications for Process-type tasks independently.
-        if self.type == "Assignment" and self._is_non_action_todo_assignment():
-            return
+        if self.type == "Assignment":
+            todo = self._get_matching_todo()
+            # Skip notification entirely for non-Action ToDo assignments.
+            # Processa handles notifications for Process-type tasks independently.
+            if self._is_non_action_todo_assignment(todo):
+                return
+            # Skip the "... has been removed by ..." email when the un-assignment
+            # was driven by an assignment rule re-running on a workflow transition
+            # (i.e. reassignment noise). Manual UI removals still notify.
+            if self._is_assignment_rule_removal(todo):
+                return
 
         frappe.publish_realtime("notification", after_commit=True, user=self.for_user)
         set_notifications_as_unseen(self.for_user)
@@ -24,28 +31,54 @@ class NotificationLogOverride(NotificationLog):
                 # Never let email failures block workflow transitions, but distinctly log them
                 frappe.log_error(frappe.get_traceback(), "Notification Email Failed (non-blocking)")
 
-    def _is_non_action_todo_assignment(self):
-        """Return True if this Assignment notification is for a non-Action ToDo.
+    def _get_matching_todo(self):
+        """Return the most recently modified ToDo matching this notification.
 
-        Looks up the open ToDo that matches the notification's document and
-        recipient. If the ToDo has a type explicitly set to something other
-        than "Action" (e.g. "Process"), the standard notification is skipped.
-        Empty/None type is treated as "Action" (the default).
+        Status is intentionally NOT filtered: removal/close notifications
+        ("... has been removed by ...") are created *after* `set_status` has
+        already flipped the ToDo to Cancelled/Closed, so an "Open"-only lookup
+        would miss them. Returns a dict with `type`, `status` and
+        `assignment_rule`, or None if no ToDo matches.
         """
         if not (self.document_type and self.document_name and self.for_user):
-            return False
+            return None
 
-        todo_type = frappe.db.get_value(
+        todo = frappe.get_all(
             "ToDo",
-            {
+            filters={
                 "reference_type": self.document_type,
                 "reference_name": self.document_name,
                 "allocated_to": self.for_user,
-                "status": "Open",
             },
-            "type",
+            fields=["type", "status", "assignment_rule"],
+            order_by="modified desc",
+            limit=1,
         )
+        return todo[0] if todo else None
+
+    def _is_non_action_todo_assignment(self, todo=None):
+        """Return True if this Assignment notification is for a non-Action ToDo.
+
+        If the ToDo has a type explicitly set to something other than "Action"
+        (e.g. "Process"), the standard notification is skipped. Empty/None type
+        is treated as "Action" (the default).
+        """
+        todo_type = todo.type if todo else None
         return bool(todo_type and todo_type != "Action")
+
+    def _is_assignment_rule_removal(self, todo=None):
+        """Return True if this is a removal notification for a rule-driven ToDo.
+
+        When a workflow transition re-runs the assignment rules, the previous
+        state's rule un-assigns its ToDo (status -> Cancelled/Closed), and
+        Frappe core unconditionally emails the assignee "... has been removed
+        by ...". That email is pure reassignment noise. We detect it by the
+        ToDo being Cancelled/Closed AND carrying an `assignment_rule` (manual
+        UI removals have no `assignment_rule`, so they are left untouched).
+        """
+        if not todo:
+            return False
+        return bool(todo.assignment_rule) and todo.status in ("Cancelled", "Closed")
 
 
 def custom_send_notification_email(doc):


### PR DESCRIPTION
Every workflow transition re-runs assignment rules, and each state's rule un-assigns the prior assignee. Frappe core unconditionally emails that assignee "Your assignment on <doc> has been removed by <user>", producing recurring noise across every doctype that uses the per-state assignment rule pattern (Bonus Request, Client Interview Shortlist, Leave Application, etc.).

- fix existing non-Action suppression: drop the status="Open" filter so removal notifications (created after the ToDo is Cancelled/Closed) are matched instead of missed
- add _is_assignment_rule_removal: skip the "removed by" email when the matched ToDo is Cancelled/Closed and carries an assignment_rule, i.e. the un-assignment was workflow/rule driven
- share a single ToDo lookup (_get_matching_todo) across both checks

Manual UI un-assignments (no assignment_rule) and "new task assigned" emails are left untouched.