### PR TITLE
Remove ToDo→BPMN migration from test-production

### DIFF
--- a/one_fm/custom/custom_field/todo.py
+++ b/one_fm/custom/custom_field/todo.py
@@ -3,6 +3,13 @@ def get_todo_custom_fields():
     return {
         "ToDo": [
             {
+                "fieldname": "notify_allocated_to_via_email",
+                "fieldtype": "Check",
+                "label": "Notify Allocated To Via Email",
+                "insert_after": "allocated_to",
+                "allow_in_quick_entry": 1
+            },
+            {
                 "fieldname": "custom_column_break_x8z6v",
                 "fieldtype": "Column Break",
                 "label": "",
@@ -12,7 +19,7 @@ def get_todo_custom_fields():
                 "fieldname": "custom_google_task",
                 "fieldtype": "Section Break",
                 "label": "Google Task",
-                "insert_after": "allocated_to"
+                "insert_after": "notify_allocated_to_via_email"
             },
             {
                 "fieldname": "custom_google_task_id",

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -453,16 +453,15 @@ doc_events = {
 	"Communication": {
 		"after_insert": "one_fm.one_fm.task_assignment_from_email.assign_task_to_user_from_communication_content"
 	},
-	# COMMENTED OUT: ToDo hooks now handled by SpiffWorkflow/BPMN server scripts
-	# "ToDo": {
-	# 	"validate": "one_fm.overrides.todo.validate_todo",
-	# 	"before_save":"one_fm.overrides.todo.before_save",
-	# 	"after_insert":[
-	# 		"one_fm.overrides.todo.create_google_task_on_todo_creation",
-	# 		"one_fm.overrides.todo.send_email_on_todo_created"
-	# 	],
-	# 	"on_update": "one_fm.overrides.todo.update_google_task_on_todo_status_change"
-	# },
+	"ToDo": {
+		"validate": "one_fm.overrides.todo.validate_todo",
+		"before_save":"one_fm.overrides.todo.before_save",
+		"after_insert":[
+			"one_fm.overrides.todo.create_google_task_on_todo_creation",
+			"one_fm.overrides.todo.send_email_on_todo_created"
+		],
+		"on_update": "one_fm.overrides.todo.update_google_task_on_todo_status_change"
+	},
 	"OAuth Bearer Token": {
 		"after_insert": "one_fm.api.doc_methods.oauth_bearer_token.revoke_and_delete_existing_tokens",
 	}

--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -36,6 +36,9 @@ def notify_todo_status_change(doc):
     """Notify user if ToDo status changes. Modular, clear, and logs notification."""
     if doc.is_new():
         return
+    # Only send notifications for Action-type ToDos; Processa handles Process tasks
+    if getattr(doc, "type", "") and doc.type != "Action":
+        return
     if not doc.notify_allocated_to_via_email:
         return
     status_in_db = frappe.db.get_value(doc.doctype, doc.name, "status")
@@ -98,6 +101,8 @@ def set_todo_type_from_refernce_doc(doc):
         meta = frappe.get_meta(doc.reference_type)
         if meta.has_field("type"):
             doc.type = frappe.db.get_value(doc.reference_type, doc.reference_name, "type")
+            if doc.type not in ["Action", "Process", "Project"]:
+                doc.type = "Action"
             return
     doc.type = "Action"
 
@@ -187,7 +192,7 @@ def create_description_for_google_todo(doc):
     if doc.reference_type and doc.reference_name:
         todo_reference = get_url_to_form("Todo", doc.name) if doc.name else ""
         todo_doc_type = doc.reference_type or ""
-        todo_reference_link = get_url_to_form(todo_doc_type, doc.reference_name) if doc.reference_name else ""
+        todo_reference_link = get_url_to_todo_reference_doc(todo_doc_type, doc.reference_name) if doc.reference_name else ""
         warning_msg = f"""
         Hey you can't update this task on Google Task, Close the task in ERPNext
 
@@ -413,6 +418,9 @@ def sync_google_tasks_for_users(user_emails=[], timedelta_kwargs=None):
 
 @frappe.whitelist()
 def send_email_on_todo_created(doc, method):
+    # Only send notifications for Action-type ToDos; Processa handles Process tasks
+    if getattr(doc, "type", "") and doc.type != "Action":
+        return
     if not doc.notify_allocated_to_via_email:
         return
     user_id = frappe.session.user
@@ -426,7 +434,7 @@ def send_email_on_todo_created(doc, method):
     if doc.reference_type and doc.reference_name:
         todo_reference = get_url_to_form("Todo", doc.name)
         todo_doc_type = doc.reference_type
-        todo_reference_link = get_url_to_form(todo_doc_type, doc.reference_name)
+        todo_reference_link = get_url_to_todo_reference_doc(todo_doc_type, doc.reference_name)
     args = frappe._dict({
                     "task_id": doc.custom_google_task_id,
                     "source": doc.custom_source,
@@ -444,3 +452,17 @@ def send_email_on_todo_created(doc, method):
     message = frappe.render_template("one_fm/templates/emails/email_notification_on_task_creation.html", args)
     subject = f"""A Task has been Created via {doc.custom_source} by {user_id}"""
     sendemail(recipients= recipients, message=message, subject=subject)
+
+def get_url_to_todo_reference_doc(document_type, name):
+    url = ""
+    if not document_type or not name:
+        return ""
+    try:
+        if document_type == "HD Ticket":
+            url = frappe.utils.get_url(f"/helpdesk/tickets/{name}")
+        else:
+            url = get_url_to_form(document_type, name)
+        return url
+    except Exception as e:
+        frappe.log_error(message=str(e), title=f"Failed to get URL for {document_type} {name}")
+        return ""

--- a/one_fm/public/js/doctype_js/todo.js
+++ b/one_fm/public/js/doctype_js/todo.js
@@ -1,5 +1,8 @@
 frappe.ui.form.on('ToDo', {
     refresh: function(frm) {
-        frm.set_df_property('notify_allocated_to_via_email', 'hidden', 1);
+      if (frm.is_new()) {
+        frm.set_value("notify_allocated_to_via_email", 1);
+        console.log("DDD");
+      }
     }
 })

--- a/one_fm/public/js/doctype_list_js/todo_list.js
+++ b/one_fm/public/js/doctype_list_js/todo_list.js
@@ -6,24 +6,16 @@ frappe.listview_settings['ToDo'] = {
 
 const sync_my_google_tasks = function(listview) {
 	listview.page.add_button(__('Sync My Google Tasks'), function() {
-        frappe.show_alert({
-            message: __('Syncing Google Tasks...'),
-            indicator: 'blue'
-        }, 3);
         frappe.call({
-			method: 'one_bpmn.api.instance_api.start_process',
-			args: {
-				model_name: 'Sync Google Task to ERPNext ToDo'
-			},
+			method: 'one_fm.overrides.todo.sync_my_google_tasks_with_todos',
 			callback: function (r) {
 				if (!r.exc) {
-					frappe.show_alert({
-						message: __('Google Tasks synced successfully'),
-						indicator: 'green'
-					}, 5);
+					frappe.msgprint(__(r.message || "Tasks Synched!"));
 					listview.refresh();
 				}
-			}
+			},
+			freeze: true,
+			freeze_message: __('Syncing My Google Tasks')
 		});
     }, 'primary');
 };


### PR DESCRIPTION
Removes the ToDo→BPMN migration (PRs #6286/#6288 BA_TODO_PROCESS + #6327 BA_CHANGES_ON_TODO) from test-production so it does not ship to production.

Restores the 5 affected files to version-15's clean non-migration state:
- `hooks.py` — native ToDo hooks re-activated (BPMN comment block removed)
- `todo_list.js` / `todo.js` — native Google-task sync restored
- `overrides/todo.py`, `custom/custom_field/todo.py` — version-15 versions

Note: #6327 alone was NOT the source — the core migration came from BA_TODO_PROCESS (#6286/#6288). version-15 never had the migration; after this lands, the test-production→version-15 PR (#6382) no longer conflicts on ToDo and won't carry it. No Operations Done work touched.

cc @NoBoneZ