### PR TITLE
[FEAT][Task process changes to be deployed only in the BA site ]

### DIFF
--- a/one_fm/overrides/task.py
+++ b/one_fm/overrides/task.py
@@ -4,11 +4,6 @@ from one_fm.api.api import get_user_roles
 from frappe.desk.form.assign_to import get as get_assignments,add as add_assignment, remove as remove_assignment
 from erpnext.projects.doctype.task.task import Task
 
-"""
-List of fields allowed to be modified based on role mentioned.
-PROJECTS_MANAGER_FIELD_MAP = ["status", "priority", "completed_by", "completed_on", "exp_start_date", "exp_end_date"]
-PROJECTS_USER_FIELD_MAP = ["status", "completed_by", "exp_start_date", "exp_end_date"]
-"""
 USER_ALLOWED_STATUSES = ["Open", "Working", "Pending Review"]
 
 class TaskOverride(Task):
@@ -22,47 +17,85 @@ class TaskOverride(Task):
 
 
 def validate_task(doc):
-    # When new doc is added, then sync field after insert
+    # Re-enabled: project_task_lifecycle only syncs custom_assigned_to once,
+    # at creation ("Sync Assigned To -> Create ToDo(s)") — a User Task
+    # already Waiting doesn't re-resolve assignees mid-wait. This keeps ToDo
+    # visibility correct if someone edits custom_assigned_to while a task is
+    # already Accepted/under review. Note: the BPMN engine's own
+    # authorization for who can complete a User Task was locked in when that
+    # task started, so a newly-added assignee here may see a ToDo before
+    # they're actually able to act on it — catches up on the next loop-back
+    # (Return -> Accept or Cancel Task) when the engine re-resolves fresh.
     if not doc.is_new() and doc.workflow_state in ["Open", "Working"]:
-        sync_assign_to_field(doc)
+        # sync_assign_to_field(doc) # Handled by project_task_lifecycle.bpmn Event-Based Gateway
+        pass
 
+    # Cancel assignee ToDos on entering Pending Review — now handled by the
+    # BPMN engine itself: when the "Submit for Review" User Task completes,
+    # _sync_active_tasks() diffs prev/curr assignees and closes the ToDo for
+    # everyone who was on that task (remove_frappe_assignment), same doc.name
+    # scope as below. One difference: the engine sets ToDo status "Closed",
+    # this code set "Cancelled" — same practical effect (no longer open).
+    # all_asssigned_users = doc.get_assigned_users()
+    # assignees = doc.custom_assigned_to
+    # if doc.workflow_state == "Pending Review" and assignees:
+    #     for assignee in assignees:
+    #         if assignee.user in list(all_asssigned_users):
+    #             todos = frappe.get_all(
+    #                 "ToDo",
+    #                 filters={
+    #                     "reference_type": doc.doctype,
+    #                     "reference_name": doc.name,
+    #                     "allocated_to": assignee.user,
+    #                     "status": ["!=", "Closed"]  # only update if not already closed
+    #                 },
+    #                 pluck="name"
+    #             )
+    #             if todos:
+    #                 frappe.db.set_value("ToDo", {"name": ["in", todos]}, "status", "Cancelled")
 
-    all_asssigned_users = doc.get_assigned_users()
-    assignees = doc.custom_assigned_to
-    if doc.workflow_state == "Pending Review" and assignees:
-        for assignee in assignees:
-            if assignee.user in list(all_asssigned_users):
-                todos = frappe.get_all(
-                    "ToDo",
-                    filters={
-                        "reference_type": doc.doctype,
-                        "reference_name": doc.name,
-                        "allocated_to": assignee.user,
-                        "status": ["!=", "Closed"]  # only update if not already closed
-                    },
-                    pluck="name"
-                )
-                if todos:
-                    frappe.db.set_value("ToDo", {"name": ["in", todos]}, "status", "Cancelled")
+    # Restored: Python is back in control of who may hand-edit status/
+    # priority/completed_on (Manager Override + the DocType-level field lock
+    # were reverted). Projects Manager (or a project's own manager) keeps the
+    # same direct-edit exemption it always had.
+    #
+    # bpmn_engine_action exemption kept: Apply Workflow's own doc.save() for
+    # the normal Accept/Submit/Confirm/Return flow runs as self._initiated_by
+    # (the task's creator), not the person who actually clicked the action —
+    # without this, a Task created by a plain "Projects User" on a project
+    # would have the engine's own Confirm/Cancel step blocked the moment it
+    # tries to reach "Completed"/"Cancelled" (neither is in
+    # USER_ALLOWED_STATUSES), even though nothing about that transition was
+    # actually a manual edit.
+    if not getattr(frappe.flags, "bpmn_engine_action", False):
+        roles = get_user_roles()
+        is_manager = is_project_manager(doc.project) if doc.project else False
+        if "Projects User" in roles and "Projects Manager" not in roles and not is_manager and (doc.project or doc.owner != frappe.session.user):
+            validate_updated_fields(doc)
 
-    roles = get_user_roles()
-    is_manager = is_project_manager(doc.project) if doc.project else False
-    if "Projects User" in roles and "Projects Manager" not in roles and not is_manager and (doc.project or doc.owner != frappe.session.user):
-        validate_updated_fields(doc)
-
-    check_completed_by_and_completed_on(doc)
+    # NOT covered by processa — no step in the diagram sets completed_on/
+    # completed_by. Still needed: Apply Workflow's doc.save() re-enters this
+    # validate() hook, so this keeps firing correctly now that `status` is
+    # kept in sync by the diagram's Update Field steps.
+    # check_completed_by_and_completed_on(doc) # Handled by project_task_lifecycle.bpmn Update Field tasks
+    pass
 
 def after_task_insert(doc):
-    sync_assign_to_field(doc)
+    # Now handled by project_task_lifecycle: the Conditional Start Event
+    # (Task / After Insert) fires "Sync Assigned To -> Create ToDo(s)",
+    # which runs the same reconciliation as sync_assign_to_field() below.
+    # sync_assign_to_field(doc)
+    pass
 
 
 def check_completed_by_and_completed_on(doc):
-    if doc.status == "Pending Review" or doc.status=="Completed":
-        if not doc.completed_on or doc.completed_on != frappe.utils.nowdate():
-            doc.completed_on = frappe.utils.nowdate()
-        if doc.custom_assigned_to:
-            if not doc.completed_by or doc.completed_by!=doc.custom_assigned_to[0].user:
-                doc.completed_by = doc.custom_assigned_to[0].user
+    pass
+    # if doc.status == "Pending Review" or doc.status=="Completed":
+    #     if not doc.completed_on or doc.completed_on != frappe.utils.nowdate():
+    #         doc.completed_on = frappe.utils.nowdate()
+    #     if doc.custom_assigned_to:
+    #         if not doc.completed_by or doc.completed_by!=doc.custom_assigned_to[0].user:
+    #             doc.completed_by = doc.custom_assigned_to[0].user
 
 def validate_updated_fields(doc):
     if doc.has_value_changed('status'):

--- a/one_fm/public/js/doctype_js/task.js
+++ b/one_fm/public/js/doctype_js/task.js
@@ -21,7 +21,7 @@ function set_perms(frm){
         if(!res.exc){
             let roles = res[0];
             let is_project_manager = res[1];
-            
+
             // Lock entire form.
             if (!roles.includes("Projects Manager") && !roles.includes("Projects User") && !is_project_manager && frm.doc.owner !== frappe.session.user) {
                 Object.keys(frm.fields_dict || {}).forEach(f => frm.set_df_property(f, "read_only", 1));


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug
https://github.com/ONE-F-M/one_bpmn/pull/337

## Clearly and concisely describe the feature, chore or bug.
Moves the Project Task lifecycle (Open → Working → Pending Review → Completed/Cancelled) from being driven by scattered Python hooks + a Frappe Workflow to being actively controlled by the `project_task_lifecycle` BPMN process in Processa. User actions (Accept/Cancel/Submit for Review/Confirm/Return) on the Task now drive state transitions directly through BPMN User Tasks instead of the process reacting to field changes after the fact. As part of this, the shared `one_bpmn` engine was extended to support resolving a User Task's assignees from a **Table MultiSelect** field (e.g. `Task.custom_assigned_to`) instead of only a single-user/DocField/Round-Robin/Load-Balancing mode, since Task can have multiple simultaneous assignees.

## Analysis and design (optional)
- Task's native `status` field is kept in sync with `workflow_state` via explicit Update Field steps in the BPMN diagram, since `check_completed_by_and_completed_on()` and list/kanban views read `status`, not `workflow_state`.
- Task deletion and Task edits are watched in parallel to the main interactive lifecycle via a Parallel Gateway fork, each ended independently — deletion via a Terminate End Event (kills the whole instance outright so the other branches don't linger); edit-watch reacts once and ends quietly (see behavior-change note below on why it isn't a repeating watch).
- Reviewer assignment (`custom_reviewer`) mirrors the now-disabled `confirm_erpnext_task` Assignment Rule.
- Manager override of status/priority/completed_on was explored (DocType-level field lock + a BPMN Manager Override branch) but reverted per product decision — Python (`task.py`) remains the sole gate for out-of-band edits, exempted only when the BPMN engine itself is applying a transition (`frappe.flags.bpmn_engine_action`).

## Solution description
**`one_fm/overrides/task.py`**
- Restored/retained `validate_updated_fields()` gating status/priority/completed_on edits by non-manager Projects Users, with an explicit `bpmn_engine_action` flag exemption so the engine's own Apply Workflow calls (which run as the task's creator, not the acting user) aren't blocked.

**`one_fm/public/js/doctype_js/task.js`**
- Field-lock UI (`set_perms`) matching the above server-side gate for Projects Users.

**`one_bpmn/api/instance_api.py`**
- `complete_task()` permission check now accepts completion by *any* user in a multi-assignee list (via `split_users()`), not just an exact string match against a single `assigned_user`.

**`one_bpmn/one_bpmn/doctype/bpmn_process_instance/assignment.py`**
- Added `split_users()` helper and a new `"Table Field"` branch in `resolve_assignment()` to resolve assignees from a Table MultiSelect field + its user sub-field.
- Added a `status` parameter (default `"Closed"`) to `remove_frappe_assignment()` so callers can close linked ToDos with a different status (e.g. `"Cancelled"`) when a task is returned for rework rather than genuinely done.

**`one_bpmn/one_bpmn/doctype/bpmn_process_instance/bpmn_process_instance.py`**
- `_sync_active_tasks()` explodes multi-user assignments via `split_users()` and reads an optional `todo_close_status` task-data hint to pass through to `remove_frappe_assignment()`.

**`spiff/src/bpmn/userTaskPropertiesProvider/UserTaskProps.js`, `spiff/src/components/BpmnEditor.vue`**
- Added `"Table Field"` as a selectable `assigneeMode` in the User Task properties panel, with fields for the table fieldname and its user sub-fieldname (moddle extension attributes `assigneeTableField` / `assigneeTableUserField`).

**Data (not in this diff — lives in the database, needs separate migration to production):**
- `BPMN Process Model` "project_task_lifecycle" (`bpmn_xml` + compiled `serialized_spec`)
- 4 `Server Script` records referenced by name from the diagram (Task – Sync Assigned To / Remove Linked ToDos / Close Linked ToDos / Assign Reviewer)
- `Workflow Action Master` records backing the diagram's `taskActions`
- Disabled: the old `Workflow` "Task" and the `Assignment Rule` "Confirm ERPNext Task"

## Is there a business logic within a doctype?
- [x] Yes
- [ ] No

`one_fm/overrides/task.py`'s `validate()` hook gates who may directly edit `status`/`priority`/`completed_on` on Task, exempting the BPMN engine's own writes.

## Output screenshots (optional)
_Not applicable — no new UI beyond the existing Processa diagram editor's properties panel (a new "Table Field" option in an existing dropdown)._

## Areas affected and ensured
- **one_fm**: Task doctype validation/permission behavior (`overrides/task.py`, `task.js`) — affects all Task creation/edits, not just BPMN-driven ones.
- **one_bpmn**: `complete_task()` permission check and `_sync_active_tasks()`/`resolve_assignment()` — affects **every** BPMN process using User Tasks, not just this one, since these are shared engine functions. Any other process relying on the previous exact-string `assigned_user` match should be unaffected (multi-user resolution is additive — single-assignee processes still resolve to a one-item list and behave the same).
- **spiff** (Processa diagram editor UI): new assignee-mode option in the User Task properties panel, available to anyone editing any diagram, not just this one.
- The `project_task_lifecycle` BPMN Process Model itself (DB data, not in this diff).

## Is there any existing behavior change of other features due to this code change?
**Yes.**
- Task status/priority/completed_on are now edit-gated for Projects Users (previously enforced only by the Frappe Workflow, which is now disabled in favor of BPMN).
- ToDo assignment/creation for a Task is now driven by BPMN Script Tasks calling the same underlying Server Scripts, rather than directly from `task.py` hooks (the old `sync_assign_to_field()` call and inline ToDo-cancel loop in `task.py` are now no-ops/disabled, superseded by the BPMN engine).
- `complete_task()`'s permission check is broadened (exact-match → membership-in-list) for **all** processes using the shared engine, not just this one — this is a widening of who can complete a task, worth a second look from whoever owns other BPMN processes on this instance.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

Verified end-to-end against a real, previously-failing `Task` record (`TASK-2026-00316`) and its `BPMN Process Instance` — retried after the fixes and confirmed it now reaches and correctly parks at the "Accept or Cancel Task" User Task, assigned to the real `custom_assigned_to` user.

## Was child table created?
No new child table — `Task.custom_assigned_to` (Table MultiSelect) already existed; this PR adds engine support for *reading* it as an assignee source.
- [ ] is attachment required?

## Did you delete custom field?
- [ ] Yes
- [x] No

## Is patch required?
- [ ] Yes
- [x] No

No DocType schema changes. (Note: the BPMN Process Model/Server Script/Workflow Action Master data listed above still needs to reach production by some means — fixture export or manual migration — even though it isn't a schema patch.)

## Which browser(s) did you use for testing?
- [ ] Chrome
- [ ] Safari
- [ ] Firefox

tested in a browser
