### PR TITLE
fix: render MOM action descriptions as readable plain text and handle JSON string in fetch_designation_of_users

### DIFF
--- a/one_fm/operations/doctype/mom/mom.js
+++ b/one_fm/operations/doctype/mom/mom.js
@@ -321,6 +321,39 @@ function fetch_and_set_last_actions(frm) {
 	});
 }
 
+function html_to_plain_text(html) {
+	// Task descriptions are stored as rich HTML (ql-editor). The MOM Pending Action
+	// "description" is a Small Text field, so raw markup shows through. Convert to
+	// readable plain text: keep link URLs, turn block tags into line breaks.
+	if (!html) {
+		return "";
+	}
+	if (!/<[a-z][\s\S]*>/i.test(html)) {
+		// Already plain text
+		return html;
+	}
+
+	const container = document.createElement("div");
+	container.innerHTML = html;
+
+	// Replace anchors with their href so links remain visible
+	container.querySelectorAll("a[href]").forEach((a) => {
+		const href = a.getAttribute("href");
+		const text = (a.textContent || "").trim();
+		a.replaceWith(document.createTextNode(text && text !== href ? `${text} (${href})` : href));
+	});
+
+	// Turn block-level tags and <br> into newlines before extracting text
+	container.querySelectorAll("br").forEach((br) => br.replaceWith(document.createTextNode("\n")));
+	container.querySelectorAll("p, div, li, tr").forEach((el) => el.append(document.createTextNode("\n")));
+
+	const text = container.textContent || "";
+	return text
+		.replace(/\n{3,}/g, "\n\n")   // collapse excess blank lines
+		.replace(/[ \t]+\n/g, "\n")   // trim trailing spaces on lines
+		.trim();
+}
+
 function set_last_action_table(frm, action_list){
 	frm.clear_table("last_action");
 	action_list.forEach((mom_action) => {
@@ -329,7 +362,7 @@ function set_last_action_table(frm, action_list){
 		child_row.subject = mom_action.subject;
 		child_row.status = mom_action.status;
 		child_row.priority = mom_action.priority;
-		child_row.description = mom_action.description;
+		child_row.description = html_to_plain_text(mom_action.description);
 		child_row.user = mom_action.user;
 		child_row.due_date = mom_action.due_date;
 	});
@@ -344,7 +377,7 @@ function set_pending_actions_table(frm, action_list){
 		child_row.subject = mom_action.subject;
 		child_row.status = mom_action.status;
 		child_row.priority = mom_action.priority;
-		child_row.description = mom_action.description;
+		child_row.description = html_to_plain_text(mom_action.description);
 		child_row.user = mom_action.user;
 		child_row.due_date = mom_action.due_date;
 	});

--- a/one_fm/operations/doctype/mom/mom.py
+++ b/one_fm/operations/doctype/mom/mom.py
@@ -418,13 +418,21 @@ def update_task_from_mom(task_name: str, subject: str = None, description: str =
 	return {"success": True, "task": task_name}
 
 @frappe.whitelist()
-def fetch_designation_of_users(list_of_users: list = []):
+def fetch_designation_of_users(list_of_users=None):
 	try:
-		return frappe.db.sql("""
-							SELECT employee_name, designation from `tabEmployee`
-							WHERE user_id IN %s
-							""",(tuple(loads(list_of_users)), ) ,as_dict=1)
-	except Exception as e:
+		# The client sends this as a JSON-encoded string; accept both str and list
+		if isinstance(list_of_users, str):
+			list_of_users = loads(list_of_users) if list_of_users else []
+
+		if not list_of_users:
+			return []
+
+		return frappe.get_all(
+			"Employee",
+			filters={"user_id": ["in", list_of_users]},
+			fields=["employee_name", "designation"],
+		)
+	except Exception:
 		frappe.log_error(message=frappe.get_traceback(), title="Error encountered while fetching users designation (MOM)")
 
 


### PR DESCRIPTION
Task descriptions are stored as rich HTML (ql-editor), but the MOM
Pending Action "description" is a Small Text field, so the raw markup
(div/span/p tags) was showing through in the child table grid.

- add html_to_plain_text helper that strips wrapper markup
- preserve link URLs and convert block tags/<br> to line breaks
- apply conversion when populating last_action and pending_actions rows

The client sends list_of_users as a JSON-encoded string, but the
"list_of_users: list" annotation made Frappe's type validator reject
the string with FrappeTypeError before the body could parse it.

- drop the list annotation and parse the string defensively
- return early for empty/None input
- replace raw SQL with parameterized frappe.get_all