### PR TITLE
fix(resignation): patch to resync workflow on already-migrated sites

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -473,3 +473,4 @@ one_fm.patches.v15_0.update_pmr_and_resignation_workflow_permissions #2026-06-30
 # --- Operations-011 (24th-30th) release patches ---
 one_fm.patches.v15_0.update_bank_account_workflow
 one_fm.patches.v15_0.add_vehicle_branding_details_fields
+one_fm.patches.v15_0.resync_resignation_workflow_draft_state #2026-07-07

--- a/one_fm/patches/v15_0/resync_resignation_workflow_draft_state.py
+++ b/one_fm/patches/v15_0/resync_resignation_workflow_draft_state.py
@@ -1,0 +1,20 @@
+import frappe
+from one_fm.custom.workflow.workflow import get_workflow_json_file, create_workflow
+
+
+def execute():
+	"""
+	Re-sync the Employee Resignation workflow from its JSON definition.
+
+	PR #6393 added a Draft state and corrected transitions to
+	one_fm/custom/workflow/employee_resignation.json, but any site that had
+	already run update_pmr_and_resignation_workflow_permissions (2026-06-30)
+	does not pick up file changes automatically -- that patch only runs once.
+	Without this re-sync, the Workflow record in the database keeps its old
+	transitions (Pending Supervisor -> Pending Operations Manager directly),
+	so new resignations skip the Pending Supervisor step entirely and fail
+	the "specify Operations Manager" check at creation time.
+	"""
+	res_wf = get_workflow_json_file("employee_resignation.json")
+	create_workflow(res_wf)
+	frappe.clear_cache(doctype="Employee Resignation")


### PR DESCRIPTION
## Summary
Follow-up to #6393. That PR fixed `employee_resignation.json` (added `Draft` state, corrected transitions), but any site that already ran `update_pmr_and_resignation_workflow_permissions` (2026-06-30) doesn't pick up the file change automatically -- patches only run once per site.

Without this resync, already-migrated sites (including production) keep the OLD workflow transitions: `Pending Supervisor` goes straight to `Pending Operations Manager`. That means new resignations for shift-working employees skip the Pending Supervisor step entirely and immediately fail the "specify Operations Manager" validation at creation time -- a brand new, worse failure mode than the original bug, introduced purely by the missing migration.

Confirmed this actually happened in production: the same employee from the original bug report (`2302009NP100`) hit this new failure right after #6393 merged.

## Fix
New patch `resync_resignation_workflow_draft_state` re-calls `create_workflow()` against the (now-correct) `employee_resignation.json`, same mechanism the original 2026-06-30 patch used. Safe/idempotent to run on any site regardless of current state.

## Test plan
- [x] Verified locally: patch runs cleanly, `Workflow: Employee Resignation` ends up with `Draft` + corrected transitions
- [x] Verified `create_resignation` lands in `Pending Supervisor` (not stuck, not skipping to Pending Operations Manager) after running the patch
- [ ] Run `bench migrate` on production and confirm the same