### PR TITLE
fix: show Client Interview abbreviation in roster instead of undefined

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1193,6 +1193,7 @@ let classmap = {
 	"Client Event": "cyanboxcolor",
 	"Medical Appointment": "cyanboxcolor",
 	"On-the-job Training": "tealboxcolor",
+	"Client Interview": "cyanboxcolor",
 	"Suspended": "suspendedcolor"
 };
 
@@ -1216,6 +1217,7 @@ let abbr_map = {
 	"Medical Appointment": "MA",
 	"On-the-job Training": "OJT",
 	"Client Event": "CE",
+	"Client Interview": "CI",
 	"Suspended": "S"
 };
 


### PR DESCRIPTION
The Employee Schedule employee_availability field allows a "Client Interview" value, but the roster page's classmap and abbr_map lookup tables had no matching entry, so cells rendered "undefined".

- add "Client Interview" to classmap (cyanboxcolor)
- add "Client Interview" to abbr_map ("CI")
