### PR TITLE
fix: allow Career History submit for rejected Job Applicant

### DIFF
--- a/one_fm/one_fm/doctype/career_history/career_history.py
+++ b/one_fm/one_fm/doctype/career_history/career_history.py
@@ -59,8 +59,11 @@ class CareerHistory(Document):
 
 	def validate_with_applicant(self):
 		if self.job_applicant:
+			# If the Job Applicant is already Rejected, do not block the Career History.
+			# Allow it to be saved/submitted, but flag it so the linked Interview and
+			# Interview Feedback flow bypasses any further Job Applicant status update.
 			if frappe.db.get_value('Job Applicant', self.job_applicant, 'status') == 'Rejected':
-				frappe.throw(_('Applicant is Rejected'))
+				self.flags.skip_job_applicant_update = True
 			# validate_applicant_overseas_transferable(self.job_applicant)
 		if not self.name:
 			# hack! if name is null, it could cause problems with !=
@@ -175,6 +178,11 @@ def update_interview_and_feedback(career_history, submit=False):
 		interview_feedback.submit()
 		interview = frappe.get_doc('Interview', interview_feedback.interview)
 		interview.status = interview_feedback.result
+		# If the Job Applicant is already Rejected, bypass the Job Applicant update
+		# prompt triggered on Interview submit.
+		if career_history.job_applicant and frappe.db.get_value(
+			'Job Applicant', career_history.job_applicant, 'status') == 'Rejected':
+			interview.flags.skip_job_applicant_update = True
 		interview.submit()
 
 	frappe.msgprint(_('Interview Feedback {0} {1} successfully').format(

--- a/one_fm/overrides/interview.py
+++ b/one_fm/overrides/interview.py
@@ -45,6 +45,10 @@ def update_interview_rounds_in_job_applicant(doc, method):
 class InterviewOverride(Interview):
 
     def show_job_applicant_update_dialog(self):
+        # Bypass the Job Applicant update when explicitly flagged (e.g. the linked
+        # Career History flow when the Job Applicant is already Rejected).
+        if self.flags.get('skip_job_applicant_update'):
+            return
         job_applicant_status = self.get_job_applicant_status()
         if not job_applicant_status:
             return


### PR DESCRIPTION
Closing a submitted Career History assigned to a recruiter failed with "Applicant is Rejected" because validate_with_applicant hard-blocked any save/submit when the linked Job Applicant was already Rejected.

Allow the Career History (and its linked Interview and Interview Feedback) to complete, while bypassing any further Job Applicant status update.

- Replace the blocking throw in validate_with_applicant with a skip_job_applicant_update flag when the applicant is Rejected
- Flag the linked Interview on submit so its on_submit does not prompt a Job Applicant status update
- Honor the flag in InterviewOverride.show_job_applicant_update_dialog