### PR TITLE
feat: mark draft project manpower requests as completed

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -473,3 +473,4 @@ one_fm.patches.v15_0.update_pmr_and_resignation_workflow_permissions #2026-06-30
 # --- Operations-011 (24th-30th) release patches ---
 one_fm.patches.v15_0.update_bank_account_workflow
 one_fm.patches.v15_0.add_vehicle_branding_details_fields
+one_fm.patches.v15_0.mark_draft_pmr_as_completed #2026-07-07

--- a/one_fm/patches/v15_0/mark_draft_pmr_as_completed.py
+++ b/one_fm/patches/v15_0/mark_draft_pmr_as_completed.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.utils import create_batch
+
+
+def execute():
+	"""Mark all Project Manpower Requests currently in Draft as Completed.
+
+	In the PMR workflow the "Completed" state maps to docstatus 1 (submitted),
+	while every "Draft" state maps to docstatus 0, so we update both fields.
+
+	We write directly via frappe.db.set_value to bypass the controller's
+	validate_completion() check (which requires linked employees) since this is
+	an administrative bulk state correction.
+	"""
+	names = frappe.get_all(
+		"Project Manpower Request",
+		filters={"workflow_state": "Draft"},
+		pluck="name",
+	)
+
+	if not names:
+		return
+
+	for batch in create_batch(names, 100):
+		for name in batch:
+			frappe.db.set_value(
+				"Project Manpower Request",
+				name,
+				{
+					"workflow_state": "Completed",
+					"docstatus": 1,
+				},
+				update_modified=False,
+			)
+		frappe.db.commit()


### PR DESCRIPTION
Add a data patch that moves all Project Manpower Requests currently in the Draft workflow state to Completed. Needed to bulk-close outstanding draft requests as an administrative correction.

- Set both workflow_state and docstatus, since Completed maps to docstatus 1 while Draft maps to docstatus 0 in the PMR workflow
- Write via frappe.db.set_value to bypass validate_completion(), which would otherwise block records lacking linked employees
- Batch updates with per-batch commits; idempotent on re-run
- Register patch under post_model_sync in patches.txt

<img width="931" height="486" alt="Screenshot 2026-07-07 at 1 29 06 PM" src="https://github.com/user-attachments/assets/476a11bc-8ae1-4910-9eb9-e5d71d2d304f" />


