### PR TITLE
fix: prevent roster post-view tooltip from being covered

### DIFF
--- a/one_fm/one_fm/page/roster/roster.css
+++ b/one_fm/one_fm/page/roster/roster.css
@@ -28,38 +28,55 @@ body[data-route="roster"] .postname {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* The in-table tooltip is only a data holder now; it stays hidden because the
+   scrolling/scaled .table-parent container clips any tooltip rendered inside
+   it. The visible tooltip is rendered as .roster-post-tooltip on <body>. */
 body[data-route="roster"] .simplecheckbox .tooltiptext {
-  visibility: hidden;
-  width: 300px;
+  display: none;
+}
+
+/* Floating tooltip appended to <body> so it escapes the .table-parent
+   overflow/transform clipping and is never covered by the sticky header. */
+.roster-post-tooltip {
+  position: fixed;
+  max-width: 320px;
   background-color: #c7c7c7;
   color: #444;
   text-align: center;
   border-radius: 6px;
   font-weight: 400;
-  padding: 5px 0;
-  position: absolute;
-  z-index: 1;
-  bottom: 125%;
-  left: 50%;
-  margin-left: -90px;
+  padding: 6px 10px;
+  font-size: 13px;
+  z-index: 1080;
+  pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s;
+  transition: opacity 0.15s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
-body[data-route="roster"] .simplecheckbox .tooltiptext::after {
+.roster-post-tooltip.show {
+  opacity: 1;
+}
+
+.roster-post-tooltip::after {
   content: "";
   position: absolute;
-  top: 100%;
   left: 50%;
-  margin-left: -60px;
-  border-width: 5px;
+  margin-left: -6px;
+  border-width: 6px;
   border-style: solid;
+}
+
+/* Arrow points down when the tooltip sits above the cell (default). */
+.roster-post-tooltip.tooltip-above::after {
+  top: 100%;
   border-color: #c7c7c7 transparent transparent transparent;
 }
 
-body[data-route="roster"] .simplecheckbox:hover .tooltiptext {
-  visibility: visible;
-  opacity: 1;
+/* Arrow points up when the tooltip is flipped below the sticky header. */
+.roster-post-tooltip.tooltip-below::after {
+  bottom: 100%;
+  border-color: transparent transparent #c7c7c7 transparent;
 }
 body[data-route="roster"] .sticky {
   position: -webkit-sticky;

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1763,10 +1763,64 @@ function get_post_data(page) {
 
 
 				bind_events(page);
+				setup_post_tooltip_position();
 			}).catch(e => {
 				console.log(e);
 			});
 	}
+}
+
+// Show the full post name in a floating tooltip on hover. The tooltip is
+// appended to <body> (not inside the table) because .table-parent has
+// overflow/scroll and a transform that would clip any tooltip rendered inside
+// it. It shows above the cell by default, but flips below when showing above
+// would place it behind the sticky column header.
+function setup_post_tooltip_position() {
+	let $postMonth = $(".postMonth");
+
+	// Single reusable floating tooltip element on <body>.
+	let $tooltip = $("#roster-post-tooltip");
+	if (!$tooltip.length) {
+		$tooltip = $('<div id="roster-post-tooltip" class="roster-post-tooltip"></div>').appendTo("body");
+	}
+
+	function position_tooltip(cell) {
+		let cell_rect = cell.getBoundingClientRect();
+		let $thead = $postMonth.find("#calenderviewtable thead");
+		let header_bottom = $thead.length ? $thead[0].getBoundingClientRect().bottom : 0;
+
+		let tip_width = $tooltip.outerWidth();
+		let tip_height = $tooltip.outerHeight();
+		let gap = 10;
+
+		// Center horizontally over the cell, clamped to the viewport.
+		let left = cell_rect.left + cell_rect.width / 2 - tip_width / 2;
+		left = Math.max(8, Math.min(left, window.innerWidth - tip_width - 8));
+
+		// Prefer above; flip below if the header would cover it.
+		let top_above = cell_rect.top - tip_height - gap;
+		let below = top_above < header_bottom;
+		let top = below ? cell_rect.bottom + gap : top_above;
+
+		$tooltip
+			.toggleClass("tooltip-below", below)
+			.toggleClass("tooltip-above", !below)
+			.css({ left: left + "px", top: top + "px" });
+	}
+
+	// Rebind cleanly so repeated renders don't stack duplicate handlers.
+	$postMonth.off(".tooltipflip", ".simplecheckbox")
+		.on("mouseenter.tooltipflip", ".simplecheckbox", function () {
+			let text = $(this).find(".tooltiptext").text().trim()
+				|| $(this).find(".postname").text().trim();
+			if (!text) return;
+			$tooltip.text(text);
+			position_tooltip(this);
+			$tooltip.addClass("show");
+		})
+		.on("mouseleave.tooltipflip", ".simplecheckbox", function () {
+			$tooltip.removeClass("show");
+		});
 }
 
 function escape_values(string) {


### PR DESCRIPTION
The post-name tooltip in roster Post View was rendered inside .table-parent, which clips it via overflow/scroll and a transform, and it appeared behind the sticky column header for top rows.

- render the tooltip as a floating element on <body> so it escapes the container's overflow and transform clipping
- flip the tooltip below the cell when showing it above would place it behind the sticky header, otherwise show it above
- clamp the tooltip horizontally so it never runs off-screen

Before the PR
<img width="1920" height="1080" alt="Roster" src="https://github.com/user-attachments/assets/c6b41a33-d2e5-4647-95d1-dbc77fa2092b" />


After the PR
<img width="600" height="377" alt="Screenshot 2026-07-08 at 11 59 58 PM" src="https://github.com/user-attachments/assets/589d1659-9435-4601-b9f9-e19008106218" />
