### PR TITLE
Location map

### DIFF
--- a/one_fm/overrides/employee_checkin.py
+++ b/one_fm/overrides/employee_checkin.py
@@ -73,6 +73,11 @@ class EmployeeCheckinOverride(EmployeeCheckin):
 		except Exception as e:
 			frappe.throw(frappe.get_traceback())
 
+		# HRMS builds the geolocation map point from latitude/longitude during its
+		# own validate(). This override replaces validate() without calling super(),
+		# so we must trigger it here or the Geolocation field is never populated.
+		self.set_geolocation()
+
 
 	def validate_duplicate_log(self):
 		doc = frappe.db.sql(f""" select name from `tabEmployee Checkin` where employee = '{self.employee}' and shift_assignment ='{self.shift_assignment}' and time = '{self.time}' and (NOT name = '{self.name}')""", as_dict=1)

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -478,3 +478,4 @@ one_fm.patches.v15_0.update_bank_account_workflow
 one_fm.patches.v15_0.add_vehicle_branding_details_fields
 one_fm.patches.v15_0.resync_resignation_workflow_draft_state #2026-07-07
 one_fm.patches.v15_0.mark_draft_pmr_as_completed #2026-07-07
+one_fm.patches.v15_0.backfill_checkin_geolocation_from_device_id #2026-07-12

--- a/one_fm/patches/v15_0/backfill_checkin_geolocation_from_device_id.py
+++ b/one_fm/patches/v15_0/backfill_checkin_geolocation_from_device_id.py
@@ -1,0 +1,107 @@
+import frappe
+
+# Only backfill recent checkins; older records are intentionally left untouched.
+BACKFILL_FROM = "2026-06-23 00:00:00"
+
+
+def execute():
+	"""Backfill latitude/longitude and the geolocation map point on Employee Checkin
+	records from the device_id string.
+
+	Mobile checkins store their GPS as a "latitude,longitude" string in the
+	`device_id` field, but leave the `latitude`/`longitude` float fields at 0 and
+	the `geolocation` field empty. As a result the map on the form has nothing to
+	plot. This patch parses device_id into the float fields and then calls the
+	document's own set_geolocation() so the GeoJSON is generated exactly the way a
+	normal save would, and existing records get reflected on the map.
+
+	Scope:
+	  - Only checkins with `time` on or after BACKFILL_FROM.
+	  - Only records whose latitude is still 0, so any checkin whose coordinates
+	    were already set (e.g. via "Fetch Geolocation") is left untouched.
+
+	Records are walked in keyset-paginated batches (by name) to keep memory
+	bounded and make the patch resumable.
+	"""
+	# set_geolocation() is a no-op unless geolocation tracking is enabled, so make
+	# sure the setting is on before backfilling.
+	if not frappe.db.get_single_value("HR Settings", "allow_geolocation_tracking"):
+		frappe.db.set_single_value("HR Settings", "allow_geolocation_tracking", 1)
+
+	batch_size = 5000
+	cursor = ""
+	updated = 0
+
+	while True:
+		records = frappe.get_all(
+			"Employee Checkin",
+			filters={
+				"device_id": ["is", "set"],
+				"latitude": 0,
+				"time": [">=", BACKFILL_FROM],
+				"name": [">", cursor],
+			},
+			fields=["name", "device_id"],
+			order_by="name asc",
+			limit_page_length=batch_size,
+		)
+		if not records:
+			break
+
+		# Advance the cursor by name regardless of parse success, so records with
+		# a non-coordinate device_id are skipped exactly once (no infinite loop).
+		cursor = records[-1].name
+
+		for record in records:
+			coordinates = parse_coordinates(record.device_id)
+			if not coordinates:
+				continue
+
+			latitude, longitude = coordinates
+
+			doc = frappe.get_doc("Employee Checkin", record.name)
+			doc.latitude = latitude
+			doc.longitude = longitude
+			# Generate the geolocation GeoJSON via the framework method so the
+			# result matches a normal save exactly.
+			doc.set_geolocation()
+
+			# Persist just these fields without re-running validate() (which would
+			# trigger the heavy shift/permission logic on every record).
+			doc.db_set(
+				{
+					"latitude": doc.latitude,
+					"longitude": doc.longitude,
+					"geolocation": doc.geolocation,
+				},
+				update_modified=False,
+			)
+			updated += 1
+
+		frappe.db.commit()
+
+	frappe.logger().info(
+		f"backfill_checkin_geolocation_from_device_id: updated {updated} records"
+	)
+
+
+def parse_coordinates(device_id):
+	"""Return (latitude, longitude) parsed from a "lat,long" string, or None if
+	the value is not a valid coordinate pair."""
+	parts = str(device_id).split(",")
+	if len(parts) != 2:
+		return None
+
+	try:
+		latitude = float(parts[0].strip())
+		longitude = float(parts[1].strip())
+	except (ValueError, TypeError):
+		return None
+
+	# Skip zero/garbage coordinates and anything outside valid GPS ranges.
+	if not (latitude and longitude):
+		return None
+	if not (-90 <= latitude <= 90 and -180 <= longitude <= 180):
+		return None
+
+	return latitude, longitude


### PR DESCRIPTION
fix: populate checkin geolocation on save in override
EmployeeCheckinOverride replaces HRMS's validate() without calling
super(), which dropped the set_geolocation() call. As a result the
Geolocation field was never generated from latitude/longitude, so the
map on the Employee Checkin form had nothing to plot.

- call self.set_geolocation() at the end of the override's validate()
  so the GeoJSON map point is built from the coordinates on every save

feat: backfill checkin geolocation from device_id
Mobile checkins store their GPS as a "latitude,longitude" string in the
device_id field but leave the latitude/longitude floats at 0 and the
geolocation field empty, so historical checkins never showed on the map.

- add patch parsing device_id into latitude/longitude and calling the
  document's set_geolocation() to generate the GeoJSON map point
- scope to checkins with time on or after 2026-06-23
- only touch records with latitude 0, preserving fetched coordinates
- walk records in keyset-paginated batches to bound memory and stay
  resumable; skip device_id values that are not valid coordinate pairs
- register patch in patches.txt under post_model_sync
