### PR TITLE
fix: backfill subcontractor_name in Onboard Subcontract Employee

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -480,3 +480,4 @@ one_fm.patches.v15_0.mark_draft_pmr_as_completed #2026-07-07
 one_fm.patches.v15_0.backfill_checkin_geolocation_from_device_id #2026-07-12
 one_fm.patches.v15_0.normalize_user_mobile_country_code #2026-07-13
 one_fm.patches.v15_0.warm_zenquote_cache #2026-07-13
+one_fm.patches.v15_0.backfill_subcontractor_name_in_onboard_subcontract_employee #2026-07-12

--- a/one_fm/patches/v15_0/backfill_subcontractor_name_in_onboard_subcontract_employee.py
+++ b/one_fm/patches/v15_0/backfill_subcontractor_name_in_onboard_subcontract_employee.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe.utils import create_batch
+
+
+def execute():
+	"""Backfill subcontractor_name on Onboard Subcontract Employee from the linked
+	Subcontract Staff Shortlist for records where it was never fetched."""
+
+	# Records missing subcontractor_name but linked to a Subcontract Staff Shortlist
+	records = frappe.get_all(
+		"Onboard Subcontract Employee",
+		filters={
+			"subcontractor_name": ["is", "not set"],
+			"subcontract_staff_shortlist": ["is", "set"],
+		},
+		fields=["name", "subcontract_staff_shortlist"],
+	)
+
+	if not records:
+		return
+
+	# Cache the subcontractor value per shortlist to avoid repeated lookups
+	shortlist_names = list({r.subcontract_staff_shortlist for r in records})
+	shortlists = frappe.get_all(
+		"Subcontract Staff Shortlist",
+		filters={"name": ["in", shortlist_names]},
+		fields=["name", "subcontractor"],
+	)
+	subcontractor_map = {s.name: s.subcontractor for s in shortlists}
+
+	for batch in create_batch(records, 100):
+		for record in batch:
+			subcontractor = subcontractor_map.get(record.subcontract_staff_shortlist)
+			if subcontractor:
+				frappe.db.set_value(
+					"Onboard Subcontract Employee",
+					record.name,
+					"subcontractor_name",
+					subcontractor,
+					update_modified=False,
+				)
+		frappe.db.commit()


### PR DESCRIPTION
The subcontractor_name field is fetched from the linked Subcontract Staff Shortlist, so records created before the fetch ran show up with it unset. Backfill these from the shortlist's subcontractor value.

- Add patch to populate subcontractor_name for existing records missing it, sourced from subcontract_staff_shortlist.subcontractor
- Bulk-fetch shortlist values to avoid N+1 queries; batch writes
- Register patch in patches.txt under post_model_sync
