### PR TITLE
fix: restore Maintenance KPI Master + child DocTypes (bench migrate broken on version-15)

### DIFF
--- a/one_fm/one_fm/doctype/kpi_target_item/__init__.py
+++ b/one_fm/one_fm/doctype/kpi_target_item/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt

--- a/one_fm/one_fm/doctype/kpi_target_item/kpi_target_item.json
+++ b/one_fm/one_fm/doctype/kpi_target_item/kpi_target_item.json
@@ -1,0 +1,59 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-05-31 08:50:07.701891",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "kpi_name",
+  "kpi_code_key",
+  "kpi_category",
+  "points_weight",
+  "conditions"
+ ],
+ "fields": [
+  {
+   "fieldname": "kpi_name",
+   "fieldtype": "Data",
+   "label": "KPI Name"
+  },
+  {
+   "description": "Auto-generated unique identifier that links this rule to the monthly calculation engine.",
+   "fieldname": "kpi_code_key",
+   "fieldtype": "Data",
+   "label": "KPI Code Key",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "kpi_category",
+   "fieldtype": "Select",
+   "label": "KPI Category",
+   "options": "\nService Compliance\nService Efficiency\nService Reliability"
+  },
+  {
+   "fieldname": "points_weight",
+   "fieldtype": "Float",
+   "label": "Points Weight"
+  },
+  {
+   "description": "The 'Complied' rule for this KPI, written in plain terms, e.g. \"Planned Maintenance Percentage = 100%\", \"Asset Breakdowns <= 3\", or \"Mean Time Between Failures >= 5000\". Approved metrics: Planned Maintenance Percentage, Helpdesk Request Percentage, Management Reporting Percentage, Response Timeframe Percentage, Resolution Timeframe Percentage, Asset Breakdowns, First-Time Fix Rate, Mean Time Between Failures.",
+   "fieldname": "conditions",
+   "fieldtype": "Code",
+   "label": "Conditions"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-03 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "KPI Target Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/one_fm/doctype/kpi_target_item/kpi_target_item.py
+++ b/one_fm/one_fm/doctype/kpi_target_item/kpi_target_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class KPITargetItem(Document):
+	pass

--- a/one_fm/one_fm/doctype/maintenance_kpi_master/__init__.py
+++ b/one_fm/one_fm/doctype/maintenance_kpi_master/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt

--- a/one_fm/one_fm/doctype/maintenance_kpi_master/maintenance_kpi_master.js
+++ b/one_fm/one_fm/doctype/maintenance_kpi_master/maintenance_kpi_master.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, ONE FM and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Maintenance KPI Master", {
+	client: function (frm) {
+		// Client is fetched from the Contract; when it lands (or is cleared),
+		// re-resolve the Active Service Level Agreement.
+		fetch_service_level_agreement(frm);
+	},
+	validate: function (frm) {
+		// Rearrange the penalty tiers on screen before the save round-trips,
+		// then flag any row whose logic the server will reject.
+		sort_penalty_tiers(frm);
+		highlight_bad_penalty_tiers(frm);
+	},
+});
+
+function fetch_service_level_agreement(frm) {
+	// No client means nothing to match against — clear the read-only field.
+	if (!frm.doc.client) {
+		frm.set_value("service_level_agreement", null);
+		return;
+	}
+
+	frappe.call({
+		method: "one_fm.one_fm.doctype.maintenance_kpi_master.maintenance_kpi_master.fetch_service_level_agreement",
+		args: { client: frm.doc.client },
+		callback: function (r) {
+			if (!r.message) {
+				return;
+			}
+
+			frm.set_value("service_level_agreement", r.message.sla || null);
+
+			// Ambiguous match: surface the non-blocking warning to the user.
+			if (r.message.message) {
+				frappe.show_alert({ message: r.message.message, indicator: "orange" }, 7);
+			}
+		},
+	});
+}
+
+function sort_penalty_tiers(frm) {
+	const rows = frm.doc.penalty_information || [];
+	if (!rows.length) {
+		return;
+	}
+
+	// Highest Score Floor Threshold first, lowest last.
+	rows.sort((a, b) => flt(b.score_floor_threshold) - flt(a.score_floor_threshold));
+	rows.forEach((row, index) => {
+		row.idx = index + 1;
+	});
+
+	frm.refresh_field("penalty_information");
+}
+
+function highlight_bad_penalty_tiers(frm) {
+	const grid = frm.fields_dict.penalty_information.grid;
+	const rows = frm.doc.penalty_information || [];
+
+	let previous_floor = null;
+	let previous_deduction = null;
+
+	rows.forEach((row) => {
+		const grid_row = grid.grid_rows_by_docname[row.name];
+		let is_invalid = false;
+
+		const current_floor = flt(row.score_floor_threshold);
+		const current_deduction = flt(row.deduction_percentage);
+
+		if (previous_floor !== null) {
+			const duplicate_floor = current_floor === previous_floor;
+			const cheaper_penalty = current_deduction <= previous_deduction;
+			is_invalid = duplicate_floor || cheaper_penalty;
+		}
+
+		if (grid_row && grid_row.wrapper) {
+			// bg-danger is a predefined Bootstrap utility class bundled with Frappe.
+			grid_row.wrapper.toggleClass("bg-danger", is_invalid);
+		}
+
+		previous_floor = current_floor;
+		previous_deduction = current_deduction;
+	});
+}

--- a/one_fm/one_fm/doctype/maintenance_kpi_master/maintenance_kpi_master.json
+++ b/one_fm/one_fm/doctype/maintenance_kpi_master/maintenance_kpi_master.json
@@ -1,0 +1,177 @@
+{
+ "actions": [],
+ "allow_import": 1,
+ "allow_rename": 1,
+ "autoname": "naming_series:",
+ "creation": "2026-05-31 08:38:00.622021",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "basic_information_section",
+  "contract",
+  "service_level_agreement",
+  "column_break_uqjz",
+  "client",
+  "effective_from",
+  "column_break_ofyw",
+  "project",
+  "effective_to",
+  "is_active",
+  "section_break_pwds",
+  "kpi_information",
+  "section_break_kloc",
+  "penalty_information",
+  "amended_from",
+  "naming_series"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Naming Series",
+   "options": "KPI-.{client}.-.YYYY.-.#####"
+  },
+  {
+   "fieldname": "basic_information_section",
+   "fieldtype": "Section Break",
+   "label": "Basic Information"
+  },
+  {
+   "fieldname": "contract",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Contract",
+   "options": "Contracts",
+   "reqd": 1
+  },
+  {
+   "fieldname": "service_level_agreement",
+   "fieldtype": "Link",
+   "label": "Service Level Agreement",
+   "options": "Maintenance Service Level Agreement",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_uqjz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "contract.client",
+   "fieldname": "client",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Client",
+   "options": "Customer",
+   "read_only": 1
+  },
+  {
+   "fieldname": "effective_from",
+   "fieldtype": "Date",
+   "label": "Effective From",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_ofyw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "contract.project",
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Project",
+   "options": "Project",
+   "read_only": 1
+  },
+  {
+   "fieldname": "effective_to",
+   "fieldtype": "Date",
+   "label": "Effective To",
+   "reqd": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "label": "Is Active"
+  },
+  {
+   "fieldname": "section_break_pwds",
+   "fieldtype": "Section Break",
+   "label": "KPI Information"
+  },
+  {
+   "fieldname": "kpi_information",
+   "fieldtype": "Table",
+   "label": "KPI Information",
+   "options": "KPI Target Item"
+  },
+  {
+   "fieldname": "section_break_kloc",
+   "fieldtype": "Section Break",
+   "label": "Penalty Information"
+  },
+  {
+   "fieldname": "penalty_information",
+   "fieldtype": "Table",
+   "label": "Penalty Information",
+   "options": "Penalty Tier Matrix"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Maintenance KPI Master",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-07-04 00:34:22.797125",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Maintenance KPI Master",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Maintenance Manager",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/one_fm/one_fm/doctype/maintenance_kpi_master/maintenance_kpi_master.py
+++ b/one_fm/one_fm/doctype/maintenance_kpi_master/maintenance_kpi_master.py
@@ -1,0 +1,384 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+import re
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import cint, flt, getdate, today
+
+# Prefix used for the auto-generated, calculation-engine-facing KPI Code Key.
+KPI_CODE_PREFIX = "KPI-REQ-"
+
+# Approved KPI metrics a manager may reference inside a "Conditions" rule.
+# Maps the calculation-engine identifier -> the human-friendly label managers type.
+# The engine computes each metric (percent / count / hours) from operational data;
+# the condition only tests the "Complied" threshold against that finished value.
+# NOTE: extend this map as new measurable KPI metrics are introduced.
+KPI_VARIABLES = {
+	"planned_maintenance_percentage": "Planned Maintenance Percentage",
+	"helpdesk_request_percentage": "Helpdesk Request Percentage",
+	"management_reporting_percentage": "Management Reporting Percentage",
+	"response_timeframe_percentage": "Response Timeframe Percentage",
+	"resolution_timeframe_percentage": "Resolution Timeframe Percentage",
+	"asset_breakdowns": "Asset Breakdowns",
+	"first_time_fix_rate": "First-Time Fix Rate",
+	"mean_time_between_failures": "Mean Time Between Failures",
+}
+
+
+def normalize_kpi_condition(condition: str) -> str:
+	"""Turn a human-friendly KPI rule into a valid Python comparison.
+
+	Managers write rules the way the PM's KPI sheet reads them, e.g.
+	"Planned Maintenance Percentage = 100%". This translates that into the
+	identifier form safe_eval can validate, e.g.
+	"planned_maintenance_percentage == 100":
+
+	- friendly labels -> engine identifiers (longest label first, case-insensitive)
+	- a lone "=" -> "==" (comparison), leaving >=, <=, !=, == untouched
+	- the "%" sign stripped (percentages are compared as plain numbers)
+	"""
+	normalized = condition
+
+	# Longest label first so multi-word labels win over any shorter overlap.
+	for label, identifier in sorted(
+		((v, k) for k, v in KPI_VARIABLES.items()),
+		key=lambda pair: len(pair[0]),
+		reverse=True,
+	):
+		normalized = re.sub(re.escape(label), identifier, normalized, flags=re.IGNORECASE)
+
+	normalized = normalized.replace("%", "")
+	# Single "=" (not part of >=, <=, ==, !=) becomes "==".
+	normalized = re.sub(r"(?<![<>=!])=(?!=)", "==", normalized)
+
+	return normalized
+
+
+class MaintenanceKPIMaster(Document):
+	def before_insert(self):
+		# Client/Project are fetched from the Contract. They must be populated
+		# before autoname runs, because the naming series embeds {client}.
+		self.set_client_and_project()
+
+	def validate(self):
+		self.set_client_and_project()
+		self.set_service_level_agreement()
+		self.validate_date_range()
+		self.validate_kpi_conditions()
+		self.sort_penalty_tiers()
+		self.validate_penalty_tiers()
+		self.set_kpi_code_keys()
+		self.validate_no_overlapping_master()
+
+	def set_client_and_project(self):
+		"""Keep Client and Project in sync with the linked Contract.
+
+		These are read-only fetch fields, but we set them server-side so the
+		values are guaranteed present for naming and the overlap check even if
+		the client-side fetch has not run.
+		"""
+		if not self.contract:
+			return
+
+		client, project = frappe.db.get_value(
+			"Contracts", self.contract, ["client", "project"]
+		)
+		self.client = client
+		self.project = project
+
+	def set_service_level_agreement(self):
+		"""Keep the read-only Service Level Agreement in sync with the Client.
+
+		Server-side guarantee for the SLA fetch/fallback story: even when the
+		record is created via API or import (where the client script never runs),
+		the read-only field is re-resolved from the Client so it is always
+		authoritative. An ambiguous match leaves the field blank and warns the
+		user (non-blocking) rather than interrupting the save.
+		"""
+		result = get_active_service_level_agreement(self.client)
+		self.service_level_agreement = result.get("sla")
+
+		if result.get("message"):
+			frappe.msgprint(
+				result["message"],
+				title=_("Service Level Agreement"),
+				indicator="orange",
+			)
+
+	def validate_date_range(self):
+		"""Effective From must not be after Effective To."""
+		if self.effective_from and self.effective_to:
+			if getdate(self.effective_from) > getdate(self.effective_to):
+				frappe.throw(_("Effective To cannot be before Effective From"))
+
+	def validate_kpi_conditions(self):
+		"""Confirm each KPI rule makes logical sense (AC1).
+
+		Managers write rules in the human-friendly form from the KPI sheet, e.g.
+		"Planned Maintenance Percentage = 100%". The rule is normalized to its
+		identifier form and then validated with frappe.safe_eval: it must parse,
+		reference only approved KPI metrics, and resolve to true/false so it can
+		never break the monthly calculation engine.
+		"""
+		if not self.kpi_information:
+			return
+
+		approved_labels = ", ".join(sorted(KPI_VARIABLES.values()))
+		# Dummy numeric values so a comparison resolves to True/False.
+		context = {identifier: 1 for identifier in KPI_VARIABLES}
+
+		for row in self.kpi_information:
+			if not row.conditions:
+				continue
+
+			condition = row.conditions.strip()
+			normalized = normalize_kpi_condition(condition)
+
+			try:
+				result = frappe.safe_eval(normalized, eval_locals=context)
+			except NameError:
+				frappe.throw(
+					_(
+						"Row {0}: The KPI rule \"{1}\" uses an unapproved metric. "
+						"Approved metrics are: {2}."
+					).format(row.idx, condition, approved_labels)
+				)
+			except SyntaxError:
+				frappe.throw(
+					_(
+						"Row {0}: The KPI rule \"{1}\" is not a valid comparison. "
+						"Write it like \"Response Timeframe Percentage >= 98%\"."
+					).format(row.idx, condition)
+				)
+			except Exception:
+				frappe.throw(
+					_(
+						"Row {0}: The KPI rule \"{1}\" could not be evaluated. "
+						"Please correct it."
+					).format(row.idx, condition)
+				)
+
+			# A valid rule must be a comparison (yields a boolean), not a bare
+			# value or assignment.
+			if not isinstance(result, bool):
+				frappe.throw(
+					_(
+						"Row {0}: The KPI rule must be a comparison that yields "
+						"true or false, e.g. \"Asset Breakdowns <= 3\"."
+					).format(row.idx)
+				)
+
+	def sort_penalty_tiers(self):
+		"""Auto-arrange penalty rows from highest to lowest Score Floor Threshold.
+
+		Fixes messy manual entry so the tiers always read top-to-bottom in
+		descending score order (Example 4, Case A).
+		"""
+		if not self.penalty_information:
+			return
+
+		self.penalty_information.sort(
+			key=lambda row: flt(row.score_floor_threshold), reverse=True
+		)
+
+		# Re-sequence idx so the reordering persists and renders correctly.
+		for position, row in enumerate(self.penalty_information, start=1):
+			row.idx = position
+
+	def validate_penalty_tiers(self):
+		"""Confirm penalty logic after sorting (Example 4, Case B).
+
+		Reading the descending table top-to-bottom:
+		- a Score Floor Threshold must not be duplicated, and
+		- the Deduction Percentage must strictly increase as the score floor drops
+		  (a lower performance target can never carry a cheaper penalty).
+		"""
+		previous_floor = None
+		previous_deduction = None
+
+		for row in self.penalty_information:
+			current_floor = flt(row.score_floor_threshold)
+			current_deduction = flt(row.deduction_percentage)
+
+			if previous_floor is not None:
+				if current_floor == previous_floor:
+					frappe.throw(
+						_(
+							"Row {0}: Score Floor Threshold {1} is duplicated. "
+							"Each tier must have a unique score floor."
+						).format(row.idx, current_floor)
+					)
+
+				# Rows are sorted descending, so this row's floor is the lower one.
+				if current_deduction <= previous_deduction:
+					frappe.throw(
+						_(
+							"Row {0}: Deduction Percentage must be greater than {1}% "
+							"because a lower score floor ({2}) cannot carry a cheaper "
+							"or equal penalty than the higher tier."
+						).format(row.idx, previous_deduction, current_floor)
+					)
+
+			previous_floor = current_floor
+			previous_deduction = current_deduction
+
+	def set_kpi_code_keys(self):
+		"""Lock each KPI rule to a unique, read-only KPI Code Key (Example 2).
+
+		The monthly calculation engine reads this key to grade the right rule,
+		so every row must carry a stable, globally-unique identifier.
+		"""
+		if not self.kpi_information:
+			return
+
+		# Collect keys already assigned system-wide plus any already on this doc.
+		existing_keys = frappe.get_all(
+			"KPI Target Item",
+			filters={"kpi_code_key": ["like", f"{KPI_CODE_PREFIX}%"]},
+			pluck="kpi_code_key",
+		)
+		used_keys = set(existing_keys) | {
+			row.kpi_code_key for row in self.kpi_information if row.kpi_code_key
+		}
+
+		max_number = 0
+		for key in used_keys:
+			suffix = key.replace(KPI_CODE_PREFIX, "", 1)
+			if suffix.isdigit():
+				max_number = max(max_number, cint(suffix))
+
+		for row in self.kpi_information:
+			if not row.kpi_code_key:
+				max_number += 1
+				row.kpi_code_key = f"{KPI_CODE_PREFIX}{max_number:04d}"
+
+	def validate_no_overlapping_master(self):
+		"""Block double-booked evaluation plans (Example 3).
+
+		A submitted + active Maintenance KPI Master for the same Client and
+		Project must not share any calendar day with this record's date range.
+		get_all is used deliberately: the conflict must be detected regardless of
+		the current user's row-level read permissions on other records.
+		"""
+		if not (self.client and self.effective_from and self.effective_to):
+			return
+
+		conflicts = frappe.get_all(
+			"Maintenance KPI Master",
+			filters={
+				"name": ["!=", self.name],
+				"client": self.client,
+				"project": self.project,
+				"docstatus": 1,
+				"is_active": 1,
+				# Two ranges overlap when each starts on or before the other ends.
+				"effective_from": ["<=", self.effective_to],
+				"effective_to": [">=", self.effective_from],
+			},
+			limit=1,
+		)
+
+		if conflicts:
+			frappe.throw(
+				_(
+					"Configuration Error: A Maintenance KPI Master is already "
+					"active for this Client and Project during this date range."
+				)
+			)
+
+
+def _is_active_on(sla, on_date):
+	"""Return True if the SLA is valid on on_date.
+
+	Blank Start/End Dates are treated as open-ended, so an SLA with no dates is
+	always active.
+	"""
+	start = getdate(sla.start_date) if sla.start_date else None
+	end = getdate(sla.end_date) if sla.end_date else None
+
+	if start and on_date < start:
+		return False
+	if end and on_date > end:
+		return False
+	return True
+
+
+def get_active_service_level_agreement(client):
+	"""Resolve the Maintenance Service Level Agreement that applies to a client.
+
+	Returns {"sla": <name or None>, "message": <warning or None>}.
+
+	Matching rules (Story: SLA Fetching and Fallback):
+	1. Enabled, client-specific SLAs (entity_type "Customer", entity = client)
+	   that are active today (today within Start/End Date, blank = open-ended):
+	     - exactly one   -> use it
+	     - more than one -> ambiguous: no SLA, warn the user to pick manually
+	2. If there is no clean client-specific match, fall back to the enabled
+	   Default Service Level Agreement that is active today:
+	     - exactly one   -> use it
+	     - more than one -> ambiguous: no SLA, warn the user to pick manually
+	3. Otherwise no SLA is set.
+
+	get_all is used so the resolution is identical whether it runs in the
+	controller (server guarantee) or behind the permission-checked endpoint,
+	regardless of the current user's row-level read permissions on SLA records.
+	"""
+	if not client:
+		return {"sla": None, "message": None}
+
+	on_date = getdate(today())
+
+	client_slas = frappe.get_all(
+		"Maintenance Service Level Agreement",
+		# docstatus 1 only: a cancelled (2) or draft (0) SLA is never "active",
+		# matching how Maintenance Work Order resolves its SLA.
+		filters={"enabled": 1, "docstatus": 1, "entity_type": "Customer", "entity": client},
+		fields=["name", "start_date", "end_date"],
+	)
+	active = [sla for sla in client_slas if _is_active_on(sla, on_date)]
+
+	if len(active) == 1:
+		return {"sla": active[0].name, "message": None}
+	if len(active) > 1:
+		return {
+			"sla": None,
+			"message": _(
+				"Multiple active Service Level Agreements are assigned to {0}. "
+				"Please select the correct one manually."
+			).format(client),
+		}
+
+	# Fallback: the global Default Service Level Agreement.
+	default_slas = frappe.get_all(
+		"Maintenance Service Level Agreement",
+		filters={"enabled": 1, "docstatus": 1, "default_service_level_agreement": 1},
+		fields=["name", "start_date", "end_date"],
+	)
+	active_defaults = [sla for sla in default_slas if _is_active_on(sla, on_date)]
+
+	if len(active_defaults) == 1:
+		return {"sla": active_defaults[0].name, "message": None}
+	if len(active_defaults) > 1:
+		return {
+			"sla": None,
+			"message": _(
+				"Multiple active Default Service Level Agreements exist. "
+				"Please select one manually."
+			),
+		}
+
+	return {"sla": None, "message": None}
+
+
+@frappe.whitelist()
+def fetch_service_level_agreement(client: str):
+	"""Endpoint for the KPI Master form to resolve the SLA live on Client change.
+
+	Read permission on the SLA doctype is required; the actual matching mirrors
+	the server-side controller logic so the form and the saved record agree.
+	"""
+	frappe.has_permission("Maintenance Service Level Agreement", "read", throw=True)
+	return get_active_service_level_agreement(client)

--- a/one_fm/one_fm/doctype/maintenance_kpi_master/test_maintenance_kpi_master.py
+++ b/one_fm/one_fm/doctype/maintenance_kpi_master/test_maintenance_kpi_master.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe import ValidationError
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.maintenance_kpi_master.maintenance_kpi_master import (
+	get_active_service_level_agreement,
+)
+
+
+class TestMaintenanceKPIMaster(FrappeTestCase):
+	def make_master(self, **overrides):
+		"""Build an in-memory Maintenance KPI Master for unit-testing logic.
+
+		Client/Project are set directly (instead of fetched from a Contract) so
+		the tests stay focused on the business rules without heavy fixtures.
+		"""
+		doc = frappe.get_doc(
+			{
+				"doctype": "Maintenance KPI Master",
+				"client": "_Test Client",
+				"project": "_Test Project",
+				"effective_from": "2026-01-01",
+				"effective_to": "2026-12-31",
+				"kpi_information": [],
+				"penalty_information": [],
+			}
+		)
+
+		for key, value in overrides.items():
+			doc.set(key, value)
+
+		return doc
+
+	# --- Date range -----------------------------------------------------------
+
+	def test_rejects_effective_to_before_effective_from(self):
+		doc = self.make_master(effective_from="2026-12-31", effective_to="2026-01-01")
+
+		with self.assertRaises(ValidationError):
+			doc.validate_date_range()
+
+	# --- KPI condition validation (AC1 / Example 1) ---------------------------
+
+	def test_friendly_condition_with_equals_and_percent_passes(self):
+		# PM-sheet form: Title Case label, single "=", trailing "%".
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "PMP", "conditions": "Planned Maintenance Percentage = 100%"},
+			]
+		)
+
+		# Should not raise.
+		doc.validate_kpi_conditions()
+
+	def test_friendly_count_and_hours_conditions_pass(self):
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "Breakdowns", "conditions": "Asset Breakdowns <= 3"},
+				{"kpi_name": "MTBF", "conditions": "Mean Time Between Failures >= 5000"},
+			]
+		)
+
+		# Should not raise.
+		doc.validate_kpi_conditions()
+
+	def test_identifier_form_still_accepted(self):
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "FTFR", "conditions": "first_time_fix_rate >= 85"},
+			]
+		)
+
+		# Should not raise.
+		doc.validate_kpi_conditions()
+
+	def test_plain_text_condition_blocked(self):
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "Bad Rule", "conditions": "respond fast please"},
+			]
+		)
+
+		with self.assertRaises(Exception):
+			doc.validate_kpi_conditions()
+
+	def test_unapproved_metric_condition_blocked(self):
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "Typo Metric", "conditions": "Planned Maintanance Percentage = 100"},
+			]
+		)
+
+		with self.assertRaises(Exception):
+			doc.validate_kpi_conditions()
+
+	def test_non_comparison_condition_blocked(self):
+		# A bare value is valid syntax but is not a true/false rule.
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "Bare Value", "conditions": "45"},
+			]
+		)
+
+		with self.assertRaises(Exception):
+			doc.validate_kpi_conditions()
+
+	def test_normalize_kpi_condition_translation(self):
+		from one_fm.one_fm.doctype.maintenance_kpi_master.maintenance_kpi_master import (
+			normalize_kpi_condition,
+		)
+
+		self.assertEqual(
+			normalize_kpi_condition("Planned Maintenance Percentage = 100%"),
+			"planned_maintenance_percentage == 100",
+		)
+		# Existing >= / <= operators must be left intact.
+		self.assertEqual(
+			normalize_kpi_condition("Asset Breakdowns <= 3"),
+			"asset_breakdowns <= 3",
+		)
+
+	# --- Penalty tier auto-sort (Example 4, Case A) ---------------------------
+
+	def test_penalty_tiers_sorted_highest_to_lowest(self):
+		doc = self.make_master(
+			penalty_information=[
+				{"score_floor_threshold": 85, "deduction_percentage": 5},
+				{"score_floor_threshold": 95, "deduction_percentage": 0},
+				{"score_floor_threshold": 90, "deduction_percentage": 2},
+			]
+		)
+
+		doc.sort_penalty_tiers()
+
+		floors = [row.score_floor_threshold for row in doc.penalty_information]
+		self.assertEqual(floors, [95, 90, 85])
+		# idx must be re-sequenced so the reordering persists.
+		self.assertEqual([row.idx for row in doc.penalty_information], [1, 2, 3])
+
+	# --- Penalty tier logic (Example 4, Case B) -------------------------------
+
+	def test_valid_descending_penalty_tiers_pass(self):
+		doc = self.make_master(
+			penalty_information=[
+				{"score_floor_threshold": 95, "deduction_percentage": 0},
+				{"score_floor_threshold": 90, "deduction_percentage": 2},
+				{"score_floor_threshold": 85, "deduction_percentage": 5},
+			]
+		)
+
+		# Should not raise.
+		doc.validate_penalty_tiers()
+
+	def test_duplicate_score_floor_blocked(self):
+		doc = self.make_master(
+			penalty_information=[
+				{"score_floor_threshold": 90, "deduction_percentage": 2},
+				{"score_floor_threshold": 90, "deduction_percentage": 5},
+			]
+		)
+
+		with self.assertRaises(ValidationError):
+			doc.validate_penalty_tiers()
+
+	def test_cheaper_penalty_for_lower_score_blocked(self):
+		# Sorted descending: 90 -> 2%, then 80 -> 1% (penalty got cheaper).
+		doc = self.make_master(
+			penalty_information=[
+				{"score_floor_threshold": 90, "deduction_percentage": 2},
+				{"score_floor_threshold": 80, "deduction_percentage": 1},
+			]
+		)
+		doc.sort_penalty_tiers()
+
+		with self.assertRaises(ValidationError):
+			doc.validate_penalty_tiers()
+
+	# --- KPI Code Key auto-generation (Example 2) -----------------------------
+
+	def test_kpi_code_keys_generated_for_empty_rows(self):
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "Monthly AC Filter Punctuality", "conditions": "Actual Response Minutes <= 30"},
+				{"kpi_name": "Response Time", "conditions": "Actual Response Minutes <= 45"},
+			]
+		)
+
+		with patch("frappe.get_all", return_value=[]):
+			doc.set_kpi_code_keys()
+
+		keys = [row.kpi_code_key for row in doc.kpi_information]
+		self.assertTrue(all(key.startswith("KPI-REQ-") for key in keys))
+		# Keys must be unique across the rows.
+		self.assertEqual(len(set(keys)), len(keys))
+
+	def test_existing_kpi_code_key_preserved(self):
+		doc = self.make_master(
+			kpi_information=[
+				{"kpi_name": "Locked Rule", "kpi_code_key": "KPI-REQ-0042"},
+				{"kpi_name": "New Rule"},
+			]
+		)
+
+		with patch("frappe.get_all", return_value=["KPI-REQ-0042"]):
+			doc.set_kpi_code_keys()
+
+		self.assertEqual(doc.kpi_information[0].kpi_code_key, "KPI-REQ-0042")
+		# The new row must not collide with the existing key.
+		self.assertNotEqual(doc.kpi_information[1].kpi_code_key, "KPI-REQ-0042")
+		self.assertTrue(doc.kpi_information[1].kpi_code_key.startswith("KPI-REQ-"))
+
+	# --- Double-booking protection (Example 3) --------------------------------
+
+	def test_overlapping_active_master_blocked(self):
+		doc = self.make_master()
+
+		with patch("frappe.get_all", return_value=[{"name": "KPI-EXISTING-0001"}]):
+			with self.assertRaises(ValidationError) as cm:
+				doc.validate_no_overlapping_master()
+
+		self.assertIn(
+			"Configuration Error: A Maintenance KPI Master is already active "
+			"for this Client and Project during this date range.",
+			str(cm.exception),
+		)
+
+	def test_no_conflict_when_no_overlap(self):
+		doc = self.make_master()
+
+		with patch("frappe.get_all", return_value=[]):
+			# Should not raise.
+			doc.validate_no_overlapping_master()
+
+	# --- SLA fetching & fallback ----------------------------------------------
+
+	def _sla_get_all(self, client_slas=None, default_slas=None):
+		"""Build a frappe.get_all side effect that answers the resolver's two
+		queries (client-specific SLAs, then Default SLAs) by inspecting filters.
+		"""
+		client_slas = client_slas or []
+		default_slas = default_slas or []
+
+		def side_effect(doctype, filters=None, fields=None, **kwargs):
+			filters = filters or {}
+			if filters.get("default_service_level_agreement"):
+				return default_slas
+			return client_slas
+
+		return side_effect
+
+	def test_no_client_returns_nothing(self):
+		result = get_active_service_level_agreement(None)
+		self.assertEqual(result, {"sla": None, "message": None})
+
+	def test_single_client_sla_is_selected(self):
+		side = self._sla_get_all(
+			client_slas=[frappe._dict(name="SLA-ISSUE-Gold", start_date=None, end_date=None)],
+		)
+
+		with patch("frappe.get_all", side_effect=side):
+			result = get_active_service_level_agreement("_Test Client")
+
+		self.assertEqual(result["sla"], "SLA-ISSUE-Gold")
+		self.assertIsNone(result["message"])
+
+	def test_out_of_date_range_client_sla_falls_back_to_default(self):
+		# Client SLA expired before today (2026-07-03); default takes over.
+		side = self._sla_get_all(
+			client_slas=[
+				frappe._dict(name="SLA-Old", start_date="2020-01-01", end_date="2020-12-31")
+			],
+			default_slas=[frappe._dict(name="SLA-Default", start_date=None, end_date=None)],
+		)
+
+		with patch("frappe.get_all", side_effect=side):
+			result = get_active_service_level_agreement("_Test Client")
+
+		self.assertEqual(result["sla"], "SLA-Default")
+		self.assertIsNone(result["message"])
+
+	def test_multiple_client_slas_leave_blank_and_warn(self):
+		side = self._sla_get_all(
+			client_slas=[
+				frappe._dict(name="SLA-A", start_date=None, end_date=None),
+				frappe._dict(name="SLA-B", start_date=None, end_date=None),
+			],
+			default_slas=[frappe._dict(name="SLA-Default", start_date=None, end_date=None)],
+		)
+
+		with patch("frappe.get_all", side_effect=side):
+			result = get_active_service_level_agreement("_Test Client")
+
+		# Ambiguous match must NOT silently fall back — leave blank and warn.
+		self.assertIsNone(result["sla"])
+		self.assertIn("Multiple active Service Level Agreements", result["message"])
+
+	def test_falls_back_to_default_when_no_client_sla(self):
+		side = self._sla_get_all(
+			client_slas=[],
+			default_slas=[frappe._dict(name="SLA-Default", start_date=None, end_date=None)],
+		)
+
+		with patch("frappe.get_all", side_effect=side):
+			result = get_active_service_level_agreement("_Test Client")
+
+		self.assertEqual(result["sla"], "SLA-Default")
+		self.assertIsNone(result["message"])
+
+	def test_no_match_and_no_default_leaves_blank(self):
+		side = self._sla_get_all(client_slas=[], default_slas=[])
+
+		with patch("frappe.get_all", side_effect=side):
+			result = get_active_service_level_agreement("_Test Client")
+
+		self.assertEqual(result, {"sla": None, "message": None})
+
+	def test_multiple_defaults_leave_blank_and_warn(self):
+		side = self._sla_get_all(
+			client_slas=[],
+			default_slas=[
+				frappe._dict(name="SLA-Default-1", start_date=None, end_date=None),
+				frappe._dict(name="SLA-Default-2", start_date=None, end_date=None),
+			],
+		)
+
+		with patch("frappe.get_all", side_effect=side):
+			result = get_active_service_level_agreement("_Test Client")
+
+		self.assertIsNone(result["sla"])
+		self.assertIn("Multiple active Default Service Level Agreements", result["message"])

--- a/one_fm/one_fm/doctype/penalty_tier_matrix/__init__.py
+++ b/one_fm/one_fm/doctype/penalty_tier_matrix/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt

--- a/one_fm/one_fm/doctype/penalty_tier_matrix/penalty_tier_matrix.json
+++ b/one_fm/one_fm/doctype/penalty_tier_matrix/penalty_tier_matrix.json
@@ -1,0 +1,40 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-05-31 08:55:40.053781",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "score_floor_threshold",
+  "deduction_percentage"
+ ],
+ "fields": [
+  {
+   "fieldname": "score_floor_threshold",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Score Floor Threshold",
+   "reqd": 1
+  },
+  {
+   "fieldname": "deduction_percentage",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "Deduction Percentage",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-03 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "One Fm",
+ "name": "Penalty Tier Matrix",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_fm/one_fm/doctype/penalty_tier_matrix/penalty_tier_matrix.py
+++ b/one_fm/one_fm/doctype/penalty_tier_matrix/penalty_tier_matrix.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class PenaltyTierMatrix(Document):
+	pass


### PR DESCRIPTION
## Problem

Every `bench migrate` on current `version-15` fails during schema sync:

```
ImportError: Module import failed for Maintenance KPI Assessment
Error: No module named 'one_fm.one_fm.doctype.maintenance_kpi_master'
```

## Root cause

Today's merge `3c4f8502b` ("Merge staging (sprint-end) into test-production, preferring test-production") resolved in favour of a side that lacked the KPI master DocTypes, silently deleting **Maintenance KPI Master**, **KPI Target Item**, and **Penalty Tier Matrix** from the branch — while **Maintenance KPI Assessment** (WI-000960 / WI-000961, PR #6384 / #6389), whose controller imports the master module, remained. Timeline for context: the July 5 sprint revert (`14a485d9c`, reverting PR #6365 / WI-000955) first removed the master; the WI-000960 merge reinstated it alongside the new assessment; today's merge dropped it again.

## Fix

Restore the three DocType folders exactly as they last existed on `version-15` (`6e936b46b`, 2026-07-06 — the newest commit containing them). No other changes.

- `one_fm/one_fm/doctype/maintenance_kpi_master/` (incl. controller, JS, tests)
- `one_fm/one_fm/doctype/kpi_target_item/` (child table of the master)
- `one_fm/one_fm/doctype/penalty_tier_matrix/` (child table of the master)

## Verification

- `bench migrate` reproduced the ImportError on `261742354`, then completed with exit 0 on this branch (site: local prod-backup copy).
- Both assessment child tables (`Monthly KPI Assessment Item`, `Maintenance Assessment Penalty Item`) already exist on the branch; the master's two child tables are the ones restored here.

cc @ONE-F-M — owners of WI-000955/960/961 may want to double-check the merge policy that preferred test-production over staging for these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)