### PR TITLE
fix: serve zenquotes from daily cache to avoid rate limiting

### DIFF
--- a/one_fm/api/v2/zenquotes.py
+++ b/one_fm/api/v2/zenquotes.py
@@ -5,6 +5,31 @@ from one_fm.api.v1.utils import response
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+# Cache key holding the full filtered pool of quotes fetched once per day by the
+# scheduled set_cached_quote(). User-facing endpoints pick randomly from this pool
+# so they never call the external zenquotes.io API (which rate-limits with 429s).
+QUOTE_POOL_CACHE_KEY = "zenquote_pool"
+ZENQUOTES_URL = "https://zenquotes.io/api/quotes?maxLength=200"
+FALLBACK_QUOTE = {"quote": "No quote available", "author": "Unknown", "html": ""}
+
+
+def _get_quote_from_pool():
+	"""Return a random quote dict from the daily-cached pool. Never calls the external API.
+
+	Falls back to the legacy single-quote cache, and finally to a static default,
+	so a cold cache degrades gracefully instead of hitting (and being throttled by)
+	zenquotes.io on every request.
+	"""
+	pool = frappe.cache().get_value(QUOTE_POOL_CACHE_KEY)
+	if pool:
+		try:
+			quotes = json.loads(pool)
+			if quotes:
+				return random.choice(quotes)
+		except (ValueError, TypeError):
+			pass
+	return get_cached_quote()
+
 
 def get_session_with_retries():
     """Create a requests session with retry logic"""
@@ -28,44 +53,17 @@ def get_session_with_retries():
 @frappe.whitelist()
 def fetch_quote(direct_response = False):
     """
-        Fetch a quote from zenquotes.io based on configured keywords
-        
+        Return a quote from the daily-cached pool (populated by set_cached_quote).
+
+        Serves from cache only — no live call to zenquotes.io — so frequent
+        callers (desk popup, face recognition, bug buster) can never trigger the
+        external API's rate limiting.
     """
-    try:
-        keyword = fetch_keyword().lower()
-        base_url = "https://zenquotes.io/api/quotes?maxLength=200"
-        
-        session = get_session_with_retries()
-        res = session.get(base_url, timeout=10)
-        
-        if res.status_code == 200:
-            json_response = json.loads(res.text)
-            
-            # Filter quotes that match the keyword
-            matching_quotes = [q for q in json_response if keyword.lower() in q.get('q', '').lower() or keyword.lower() in q.get('a', '').lower()]
-            
-            # If no keyword matches found, use all quotes
-            if not matching_quotes:
-                matching_quotes = json_response
-            
-            if matching_quotes and len(matching_quotes) > 0:
-                selected_quote = random.choice(matching_quotes)
-                data = {
-                    'quote': selected_quote.get('q', ''), 
-                    'author': selected_quote.get('a', 'Unknown'),
-                    'html': selected_quote.get('h', '')
-                }
-                if not direct_response:
-                    return response("Success", 200, data)
-                else:
-                    return data
-            else:
-                return get_cached_quote()
-    except Exception as error:
-        frappe.log_error(message=frappe.get_traceback(), title="Error fetching Quote")
-        return response("Internal Server Error", 500, None, error)
-        
-    
+    data = _get_quote_from_pool()
+    if direct_response:
+        return data
+    return response("Success", 200, data)
+
 
 
 def get_cached_quote():
@@ -81,35 +79,40 @@ def get_cached_quote():
 
 
 def set_cached_quote():
-    #Set a daily quote in cache everyday, with keyword filtering
-    base_url = "https://zenquotes.io/api/quotes?maxLength=200"
+    # Scheduled daily: fetch quotes once and cache the full filtered pool so all
+    # user-facing endpoints can serve from cache without hitting the external API.
+    # This is the ONLY place that calls zenquotes.io.
     try:
         keyword = fetch_keyword().lower()
         session = get_session_with_retries()
-        res = session.get(base_url, timeout=10)
-        
-        if res.status_code == 200:
-            json_response = json.loads(res.text)
-            
-            # Filter quotes that match the keyword
-            matching_quotes = [q for q in json_response if keyword.lower() in q.get('q', '').lower() or keyword.lower() in q.get('a', '').lower()]
-            
-            # If no keyword matches found, use all quotes
-            if not matching_quotes:
-                matching_quotes = json_response
-            
-            if matching_quotes and len(matching_quotes) > 0:
-                selected_quote = random.choice(matching_quotes)
-                quote_dict = json.dumps({
-                    'quote': selected_quote.get('q', ''), 
-                    'author': selected_quote.get('a', 'Unknown'),
-                    'html': selected_quote.get('h', '')
-                })
-                frappe.cache().set_value('daily_quote', quote_dict)
-                return
-            
-    except Exception as error:
-        frappe.log_error(message=frappe.get_traceback(), title="Error Setting Quote in cache")
+        res = session.get(ZENQUOTES_URL, timeout=10)
+
+        if res.status_code != 200:
+            # Transient (e.g. 429). Keep the previous cache and log a warning
+            # instead of an Error Log — this is expected and not actionable.
+            frappe.logger("zenquotes").warning(
+                f"zenquotes.io returned {res.status_code}; keeping previous cached pool"
+            )
+            return
+
+        json_response = json.loads(res.text)
+
+        # Filter quotes that match the keyword; fall back to all quotes if none match
+        matching_quotes = [q for q in json_response if keyword in q.get('q', '').lower() or keyword in q.get('a', '').lower()]
+        if not matching_quotes:
+            matching_quotes = json_response
+
+        pool = [
+            {'quote': q.get('q', ''), 'author': q.get('a', 'Unknown'), 'html': q.get('h', '')}
+            for q in matching_quotes
+        ]
+        if pool:
+            frappe.cache().set_value(QUOTE_POOL_CACHE_KEY, json.dumps(pool))
+            # Keep the legacy single-quote key populated for backward compatibility
+            frappe.cache().set_value('daily_quote', json.dumps(random.choice(pool)))
+
+    except Exception:
+        frappe.logger("zenquotes").warning("Error setting quote cache", exc_info=True)
         return
     
     
@@ -129,36 +132,6 @@ def fetch_keyword():
     
 @frappe.whitelist()
 def run_quotes():
-    try:
-        base_url = "https://zenquotes.io/api/quotes?maxLength=200"
-        keyword = fetch_keyword().lower()
-        
-        session = get_session_with_retries()
-        res = session.get(base_url, timeout=10)
-        
-        if res.status_code == 200:
-            json_response = json.loads(res.text)
-            
-            # Filter quotes that match the keyword
-            matching_quotes = [q for q in json_response if keyword.lower() in q.get('q', '').lower() or keyword.lower() in q.get('a', '').lower()]
-            
-            # If no keyword matches found, use all quotes
-            if not matching_quotes:
-                matching_quotes = json_response
-            
-            if matching_quotes and len(matching_quotes) > 0:
-                selected_quote = random.choice(matching_quotes)
-                data = {
-                    'quote': selected_quote.get('q', ''),
-                    'author': selected_quote.get('a', 'Unknown'),
-                    'html': selected_quote.get('h', '')
-                }
-                return {'results': data}
-            else:
-                return {'results': {'quote': 'No quotes available', 'author': 'Unknown', 'html': ''}}
-        else:
-            frappe.log_error(message=res.text, title="Error fetching Quote")
-            return {'results': {'quote': 'Error fetching quotes', 'author': 'Unknown', 'html': ''}}
-    except Exception as e:
-        frappe.log_error(message=frappe.get_traceback(), title="Error fetching Quote")
-        return {'results': {'quote': 'Error fetching quotes', 'author': 'Unknown', 'html': ''}}
+    # Serve from the daily-cached pool only. The desk popup (desk.js) calls this on
+    # every load and hourly per user, so it must never hit zenquotes.io live.
+    return {'results': _get_quote_from_pool()}

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -472,7 +472,6 @@ one_fm.patches.v15_0.update_pmr_and_resignation_workflow_permissions #2026-06-30
 one_fm.patches.v15_0.fix_day_off_client_event_conflict_bulk #2026-07-03
 one_fm.patches.v15_0.update_bonus_request_workflow #1
 one_fm.patches.v15_0.update_bonus_request_assignment_rules #3
-
 # --- Operations-011 (24th-30th) release patches ---
 one_fm.patches.v15_0.update_bank_account_workflow
 one_fm.patches.v15_0.add_vehicle_branding_details_fields
@@ -480,3 +479,4 @@ one_fm.patches.v15_0.resync_resignation_workflow_draft_state #2026-07-07
 one_fm.patches.v15_0.mark_draft_pmr_as_completed #2026-07-07
 one_fm.patches.v15_0.backfill_checkin_geolocation_from_device_id #2026-07-12
 one_fm.patches.v15_0.normalize_user_mobile_country_code #2026-07-13
+one_fm.patches.v15_0.warm_zenquote_cache #2026-07-13

--- a/one_fm/patches/v15_0/warm_zenquote_cache.py
+++ b/one_fm/patches/v15_0/warm_zenquote_cache.py
@@ -1,0 +1,9 @@
+import frappe
+
+from one_fm.api.v2.zenquotes import set_cached_quote
+
+
+def execute():
+	"""Warm the zenquote cache pool so user-facing endpoints have quotes to serve
+	immediately, instead of waiting for the daily scheduler's first run."""
+	set_cached_quote()


### PR DESCRIPTION
The desk popup called run_quotes on every load and hourly per user, and fetch_quote (face recognition, bug buster) hit zenquotes.io live too. This flooded the free public API, causing 429 responses and an Error Log on every failure. set_cached_quote already ran daily but the live endpoints ignored its cache.

- Cache the full filtered quote pool once daily in set_cached_quote; make it the only place that calls zenquotes.io
- Serve run_quotes and fetch_quote from the cached pool via a new _get_quote_from_pool helper (random pick preserves variety)
- Downgrade fetch failures from frappe.log_error to logger warnings so expected 429s no longer spam Error Log or trigger the agent hook
- Add warm_zenquote_cache patch to populate the pool on migrate