### PR TITLE
fix: prepend 965 country code to bare Kuwaiti mobile numbers for SMS

### DIFF
--- a/one_fm/api/mobile/authentication.py
+++ b/one_fm/api/mobile/authentication.py
@@ -198,7 +198,8 @@ def reset_password(user, password_expired=False):
 		{link}
 	""".format(username=user.full_name, link=link)
 
-	send_sms([user.mobile_no], msg)
+	from one_fm.sms_utils import normalize_kw_mobile
+	send_sms([normalize_kw_mobile(user.mobile_no)], msg)
 
 
 def process_2fa_for_whatsapp(user, token, otp_secret):

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -445,6 +445,7 @@ doc_events = {
 		"on_update":"one_fm.tasks.erpnext.customer.on_update",
 	},
 	"User": {
+		"validate": "one_fm.sms_utils.normalize_user_mobile_no",
 		"after_insert":"one_fm.tasks.erpnext.user.after_insert",
 	},
 	"Email Queue": {

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -479,3 +479,4 @@ one_fm.patches.v15_0.add_vehicle_branding_details_fields
 one_fm.patches.v15_0.resync_resignation_workflow_draft_state #2026-07-07
 one_fm.patches.v15_0.mark_draft_pmr_as_completed #2026-07-07
 one_fm.patches.v15_0.backfill_checkin_geolocation_from_device_id #2026-07-12
+one_fm.patches.v15_0.normalize_user_mobile_country_code #2026-07-13

--- a/one_fm/patches/v15_0/normalize_user_mobile_country_code.py
+++ b/one_fm/patches/v15_0/normalize_user_mobile_country_code.py
@@ -1,0 +1,44 @@
+import frappe
+
+from one_fm.sms_utils import normalize_kw_mobile
+
+
+def execute():
+	"""Prepend the 965 country code to bare 8-digit Kuwaiti mobile numbers on
+	User records.
+
+	The SMS gateway (kwtsms) rejects bare local numbers with "ERR025: No valid
+	numbers found" (HTTP 406), so 2FA/OTP and password-reset messages to those
+	users fail. The core Frappe 2FA path reads User.mobile_no directly, so the
+	stored value has to be correct.
+
+	Scope:
+	  - Only User records whose mobile_no actually changes under
+	    normalize_kw_mobile() (i.e. bare 8-digit Kuwaiti mobiles). Numbers that
+	    already carry a country code - Kuwaiti or foreign - are left untouched,
+	    so international numbers are never corrupted.
+	  - mobile_no is updated directly (db_set) without re-running User.validate(),
+	    keeping the patch fast and side-effect free.
+	"""
+	users = frappe.get_all(
+		"User",
+		filters={"mobile_no": ["is", "set"]},
+		fields=["name", "mobile_no"],
+	)
+
+	updated = 0
+	for user in users:
+		normalized = normalize_kw_mobile(user.mobile_no)
+		if normalized == user.mobile_no:
+			continue
+
+		frappe.db.set_value(
+			"User", user.name, "mobile_no", normalized, update_modified=False
+		)
+		updated += 1
+
+	frappe.db.commit()
+
+	frappe.logger().info(
+		f"normalize_user_mobile_country_code: updated {updated} of {len(users)} users"
+	)

--- a/one_fm/patches/v15_0/normalize_user_mobile_country_code.py
+++ b/one_fm/patches/v15_0/normalize_user_mobile_country_code.py
@@ -1,4 +1,5 @@
 import frappe
+from pymysql.err import IntegrityError
 
 from one_fm.sms_utils import normalize_kw_mobile
 
@@ -19,6 +20,11 @@ def execute():
 	    so international numbers are never corrupted.
 	  - mobile_no is updated directly (db_set) without re-running User.validate(),
 	    keeping the patch fast and side-effect free.
+
+	Duplicates: User.mobile_no has a unique index. If normalizing a bare number
+	would collide with a number that already exists on another user (e.g. one
+	account stored as "94409316" and another as "96594409316"), the record is
+	skipped and logged for manual review rather than failing the whole migration.
 	"""
 	users = frappe.get_all(
 		"User",
@@ -26,19 +32,42 @@ def execute():
 		fields=["name", "mobile_no"],
 	)
 
+	# Existing numbers, used to detect collisions before attempting the update.
+	existing = {user.mobile_no for user in users}
+
 	updated = 0
+	conflicts = []
 	for user in users:
 		normalized = normalize_kw_mobile(user.mobile_no)
 		if normalized == user.mobile_no:
 			continue
 
-		frappe.db.set_value(
-			"User", user.name, "mobile_no", normalized, update_modified=False
-		)
+		# The unique index forbids two users sharing a number; skip and record it.
+		if normalized in existing:
+			conflicts.append((user.name, user.mobile_no, normalized))
+			continue
+
+		try:
+			frappe.db.set_value(
+				"User", user.name, "mobile_no", normalized, update_modified=False
+			)
+		except IntegrityError:
+			# Safety net for any collision not caught above (e.g. concurrent edits).
+			conflicts.append((user.name, user.mobile_no, normalized))
+			continue
+
+		existing.discard(user.mobile_no)
+		existing.add(normalized)
 		updated += 1
 
 	frappe.db.commit()
 
 	frappe.logger().info(
-		f"normalize_user_mobile_country_code: updated {updated} of {len(users)} users"
+		f"normalize_user_mobile_country_code: updated {updated} of {len(users)} users; "
+		f"{len(conflicts)} skipped due to duplicate mobile numbers"
 	)
+	for name, old, new in conflicts:
+		frappe.logger().warning(
+			f"normalize_user_mobile_country_code: skipped {name} "
+			f"({old} -> {new}) - number already in use by another user"
+		)

--- a/one_fm/sms_utils.py
+++ b/one_fm/sms_utils.py
@@ -1,0 +1,54 @@
+import re
+
+import frappe
+
+# Kuwaiti mobile numbers are 8 digits and begin with 5, 6 or 9.
+KW_MOBILE_PREFIXES = ("5", "6", "9")
+KW_COUNTRY_CODE = "965"
+
+
+def normalize_kw_mobile(number):
+	"""Return a phone number in a format the Kuwaiti SMS gateway accepts.
+
+	Numbers are stored inconsistently: most Kuwaiti mobiles already carry the
+	965 country code, but some are saved as the bare 8-digit local number. The
+	gateway (kwtsms) rejects bare local numbers with "ERR025: No valid numbers
+	found" (HTTP 406), which is why 2FA/OTP and password-reset SMS fail.
+
+	The 965 country code is prepended ONLY to bare 8-digit Kuwaiti mobile
+	numbers (local prefixes 5, 6, 9). Numbers that already carry a country
+	code - Kuwaiti (965...) or foreign (India 91, Nepal 977, Sri Lanka 94...,
+	Kenya 254, Bangladesh 880, etc.) - are returned unchanged so international
+	numbers are never corrupted. Landlines and unrecognised values are also
+	left exactly as provided.
+
+	Returns the (possibly unchanged) number.
+	"""
+	if not number:
+		return number
+
+	digits = re.sub(r"\D", "", number)
+
+	# Drop a leading international access code, e.g. "0096594761527".
+	if digits.startswith("00"):
+		digits = digits[2:]
+
+	# Bare 8-digit Kuwaiti mobile -> add the country code.
+	if len(digits) == 8 and digits[0] in KW_MOBILE_PREFIXES:
+		return KW_COUNTRY_CODE + digits
+
+	# Anything else already has a country code (Kuwaiti or foreign) or is not a
+	# Kuwaiti mobile, so leave it untouched.
+	return number
+
+
+def normalize_user_mobile_no(doc, method=None):
+	"""User `validate` hook: keep `mobile_no` gateway-safe so OTP/2FA and
+	password-reset SMS through kwtsms don't fail on bare local numbers.
+
+	The core Frappe 2FA path reads User.mobile_no directly and hands it to the
+	SMS gateway, so normalizing here fixes that path at the source and prevents
+	newly entered 8-digit numbers from breaking again. See normalize_kw_mobile().
+	"""
+	if doc.mobile_no:
+		doc.mobile_no = normalize_kw_mobile(doc.mobile_no)

--- a/one_fm/sms_utils.py
+++ b/one_fm/sms_utils.py
@@ -50,5 +50,20 @@ def normalize_user_mobile_no(doc, method=None):
 	SMS gateway, so normalizing here fixes that path at the source and prevents
 	newly entered 8-digit numbers from breaking again. See normalize_kw_mobile().
 	"""
-	if doc.mobile_no:
-		doc.mobile_no = normalize_kw_mobile(doc.mobile_no)
+	if not doc.mobile_no:
+		return
+
+	normalized = normalize_kw_mobile(doc.mobile_no)
+	if normalized == doc.mobile_no:
+		return
+
+	# mobile_no is unique; if adding the country code would collide with another
+	# user, leave the value as entered rather than blocking the save. The
+	# duplicate is a data issue to resolve manually.
+	clash = frappe.db.get_value(
+		"User", {"mobile_no": normalized, "name": ["!=", doc.name]}, "name"
+	)
+	if clash:
+		return
+
+	doc.mobile_no = normalized


### PR DESCRIPTION
fix: prepend 965 country code to bare Kuwaiti mobile numbers for SMS
The kwtsms SMS gateway rejects bare 8-digit local numbers with
"ERR025: No valid numbers found" (HTTP 406), causing 2FA/OTP and
password-reset SMS to fail. The core Frappe 2FA path reads
User.mobile_no directly, so the stored value must carry the country
code.

- add one_fm.sms_utils.normalize_kw_mobile() which prepends 965 only
  to bare 8-digit Kuwaiti mobiles (prefixes 5/6/9), leaving numbers
  that already carry a country code (Kuwaiti or foreign) and landlines
  untouched so international numbers are never corrupted
- register a User validate hook (normalize_user_mobile_no) so newly
  entered numbers are normalized on save and never break again
- add post_model_sync patch normalize_user_mobile_country_code to fix
  existing bare 8-digit numbers on User records (idempotent, db_set
  without re-validating)
- normalize the number at the password-reset send_sms call site in
  api/mobile/authentication.py

fix: skip duplicate mobile numbers when adding country code
User.mobile_no has a unique index. When one account is stored as a bare
local number and another already carries the 965 country code (e.g.
"94409316" vs "96594409316"), normalizing the bare one collides and
raised IntegrityError 1062, aborting the whole migration.

- patch: detect the collision before updating and skip + log the
  conflicting record (with an IntegrityError safety net) instead of
  failing, then continue with the rest
- validate hook: if adding the country code would clash with another
  user, leave the number as entered rather than blocking the save

Duplicate pairs are genuine data issues (two accounts, one phone), so
both paths surface them for manual review instead of guessing.


<img width="1119" height="697" alt="Screenshot 2026-07-13 at 12 49 45 PM" src="https://github.com/user-attachments/assets/1d3dcf77-6bd4-4ac9-a805-66e23f83eaef" />
