### PR TITLE
fix: enqueue google task creation by reference not inline call

### DIFF
--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -139,7 +139,7 @@ def create_google_task_on_todo_creation(doc, method):
     # Skip if general trigger is not enabled
     if not is_google_task_synchronization_enabled():
         return
-    frappe.enqueue(create_google_task_on_todo_creation_in_erp(doc=doc, method=method),is_async=True)
+    frappe.enqueue(create_google_task_on_todo_creation_in_erp, doc=doc, method=method, is_async=True)
 
 def create_google_task_on_todo_creation_in_erp(doc, method):
     """Create a Google Task for the ToDo document if not already created."""


### PR DESCRIPTION
create_google_task_on_todo_creation invoked the target function inline and passed its return value as the enqueue method argument. The worker then failed with AttributeError on method.__module__ because it received a dict (Google API result) or None (early return path) instead of a callable.

- pass create_google_task_on_todo_creation_in_erp as a reference
- forward doc and method as keyword arguments so the job runs asynchronously as intended
