### PR TITLE
fix: resolve enqueue method kwarg collision in todo google task sync

### DIFF
--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -139,9 +139,9 @@ def create_google_task_on_todo_creation(doc, method):
     # Skip if general trigger is not enabled
     if not is_google_task_synchronization_enabled():
         return
-    frappe.enqueue(create_google_task_on_todo_creation_in_erp(doc=doc, method=method),is_async=True)
+    frappe.enqueue(create_google_task_on_todo_creation_in_erp, doc=doc, trigger_method=method, is_async=True)
 
-def create_google_task_on_todo_creation_in_erp(doc, method):
+def create_google_task_on_todo_creation_in_erp(doc, trigger_method):
     """Create a Google Task for the ToDo document if not already created."""
     employee_email = doc.allocated_to
     if doc.custom_google_task_id:
@@ -152,8 +152,8 @@ def create_google_task_on_todo_creation_in_erp(doc, method):
         service = get_google_task_service(employee_email)
         if not service:
             return
-        if method == "on_update":
-            prev_service = before_save(doc, method)
+        if trigger_method == "on_update":
+            prev_service = before_save(doc, trigger_method)
             if doc.custom_google_task_id and prev_service:
                 check_google_task_exists(doc.custom_google_task_id, prev_service)
         task_notes = create_description_for_google_todo(doc)


### PR DESCRIPTION
The ToDo google task enqueue passed method=method, which collided with frappe.enqueue's own reserved first parameter (method, the job to run), raising "enqueue() got multiple values for argument 'method'" during Task/MoM validation.

- rename forwarded kwarg to trigger_method in the enqueue call
- rename the job function parameter to trigger_method and update its internal references
