### PR TITLE
chore: delete pending approval attendance checks for airport t4

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -481,3 +481,4 @@ one_fm.patches.v15_0.backfill_checkin_geolocation_from_device_id #2026-07-12
 one_fm.patches.v15_0.normalize_user_mobile_country_code #2026-07-13
 one_fm.patches.v15_0.warm_zenquote_cache #2026-07-13
 one_fm.patches.v15_0.backfill_subcontractor_name_in_onboard_subcontract_employee #2026-07-12
+one_fm.patches.v15_0.delete_pending_approval_attendance_checks_airport_t4_jul12 #2026-07-13

--- a/one_fm/patches/v15_0/delete_pending_approval_attendance_checks_airport_t4_jul12.py
+++ b/one_fm/patches/v15_0/delete_pending_approval_attendance_checks_airport_t4_jul12.py
@@ -1,0 +1,36 @@
+import frappe
+
+
+def execute():
+	"""Delete Pending Approval Attendance Checks for Airport Terminal 4 on 2026-07-12."""
+
+	attendance_checks = frappe.get_all(
+		"Attendance Check",
+		filters={
+			"workflow_state": "Pending Approval",
+			"operations_site": "Airport Terminal 4",
+			"date": "2026-07-12",
+		},
+		pluck="name",
+	)
+
+	deleted_count = 0
+
+	for name in attendance_checks:
+		try:
+			frappe.delete_doc(
+				"Attendance Check", name, force=True, ignore_permissions=True
+			)
+			deleted_count += 1
+			frappe.db.commit()
+		except Exception as e:
+			frappe.log_error(
+				message=f"Error deleting Attendance Check {name}: {str(e)}",
+				title="Delete Airport T4 Attendance Checks Patch",
+			)
+			frappe.db.rollback()
+
+	print(
+		f"Successfully deleted {deleted_count} Pending Approval Attendance Check "
+		f"records for Airport Terminal 4 on 2026-07-12."
+	)


### PR DESCRIPTION
Add a data migration patch to remove Attendance Check records in the Pending Approval workflow state for Airport Terminal 4 on 2026-07-12.

- add patch deleting matching records with force and per-record commit
- log failures via frappe.log_error without aborting the run
- register patch under post_model_sync in patches.txt
