### PR TITLE
fix(job-applicant): skip mandatory personal-detail fields when Shortlisted

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1527,7 +1527,7 @@ def validate_job_applicant(doc, method):
     # validate_pam_file_number_and_pam_designation(doc, method)
     validate_transferable_field(doc)
     set_job_applicant_fields(doc)
-    if not doc.one_fm_is_easy_apply:
+    if not doc.one_fm_is_easy_apply and doc.one_fm_applicant_status != "Shortlisted":
         validate_mandatory_fields(doc)
     set_job_applicant_status(doc, method)
     if doc.is_new():


### PR DESCRIPTION
## Summary

**1. Skip mandatory personal-detail fields when Shortlisted**
- Passport Number, Place of Birth, Marital Status, Gender, Religion, Date of Birth, Educational Qualification, and University are collected from the candidate via the magic link sent out **after** they're shortlisted, not before.
- `validate_mandatory_fields()` (hooked to Job Applicant's `validate` event) previously required all of these to already be filled in before **any** save of a Job Applicant would succeed - which made it impossible to even save the Shortlisted status change for a candidate who hasn't gone through the magic link flow yet.
- Now skips that validation specifically when `one_fm_applicant_status == "Shortlisted"`. It's still enforced at every other status (including Selected), so these fields are required again once the applicant moves further along - after the magic link response comes back.
- Draft Job Offer creation (from the already-merged #6460) is unaffected by this - it only reads `applicant_name`, `employment_type`, `day_off_category`, `number_of_days_off`, and `designation`, none of which are part of this mandatory-fields check.

**2. Actually send the magic link on "Accept & Issue Job Offer"**
- The Interview Console's "Accept & Issue Job Offer" button already showed an alert claiming *"Applicant Accepted. Magic Link sent to candidate."* - but nothing in `_update_applicant_status()` ever actually sent one.
- Now calls the same `send_applicant_doc_magic_link()` already used by the other "Mark as Accepted" path (`overrides/interview.py`), reusing it here instead of duplicating it, so the console's own claim is actually true.

## Test plan
- [ ] Shortlist a candidate missing passport/personal details in the Interview Console - should now save successfully and create the Draft Job Offer.
- [ ] Confirm the same candidate is still blocked by the mandatory-fields check when attempting to move to Selected without those fields filled in.
- [x] Verified end-to-end on a local dev site: calling the Accept path generates a real encrypted magic link URL (`applicant_doc_ml_url`) with no errors.