### PR TITLE
fix(interview-console): actually send the magic link on Accept & Issue Job Offer

### DIFF
--- a/one_fm/one_fm/page/interview_console/interview_console.py
+++ b/one_fm/one_fm/page/interview_console/interview_console.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe import _
 from frappe.utils import getdate, nowdate
+from one_fm.templates.pages.applicant_docs import send_applicant_doc_magic_link
 
 ALLOWED_ROLES = {"System Manager", "HR Manager", "Interviewer", "HR User", "Recruiter", "Senior Recruiter"}
 
@@ -210,6 +211,9 @@ def _update_applicant_status(applicant: str, status: str, height: str | None):
     if height:
         doc.one_fm_height = float(height)
     doc.save(ignore_permissions=True)
+
+    if status == "Accepted":
+        send_applicant_doc_magic_link(doc.name, doc.applicant_name, doc.one_fm_designation)
 
 def _parse_scores_detail(scores_detail: str | None) -> list:
     import json


### PR DESCRIPTION
## Summary
- The Interview Console's "Accept & Issue Job Offer" button already showed an alert claiming *"Applicant Accepted. Magic Link sent to candidate."* - but nothing in `_update_applicant_status()` ever actually sent one.
- Now calls the same `send_applicant_doc_magic_link()` already used by the other "Mark as Accepted" path (`overrides/interview.py`), reusing it here instead of duplicating it, so the console's own claim is actually true.

## Test plan
- [x] Verified end-to-end on a local dev site: calling the Accept path generates a real encrypted magic link URL (`applicant_doc_ml_url`) with no errors.
- [ ] Click "Accept & Issue Job Offer" on a real candidate in the Interview Console and confirm the magic link email actually goes out.