### PR TITLE
feat: add total_amount calc for HR Settings renewal costing

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -132,7 +132,8 @@ doctype_js = {
     "Loan": "public/js/doctype_js/loan.js",
     "Quality Feedback": "public/js/doctype_js/quality_feedback.js",
     "Quality Feedback Template": "public/js/doctype_js/quality_feedback_template.js",
-    "Interview Round": "public/js/doctype_js/interview_round.js"
+    "Interview Round": "public/js/doctype_js/interview_round.js",
+    "HR Settings": "public/js/doctype_js/hr_settings.js"
 }
 doctype_list_js = {
 	"Job Applicant" : "public/js/doctype_js/job_applicant_list.js",

--- a/one_fm/public/js/doctype_js/hr_settings.js
+++ b/one_fm/public/js/doctype_js/hr_settings.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2020, ONE FM and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('GRD Renewal Extension Cost', {
+	work_permit_amount: function(frm, cdt, cdn) {
+		var child = locals[cdt][cdn];
+		caclulate_renewal_extension_cost_total(frm, child);
+	},
+	medical_insurance_amount: function(frm, cdt, cdn) {
+		var child = locals[cdt][cdn];
+		caclulate_renewal_extension_cost_total(frm, child);
+	},
+	residency_stamp_amount: function(frm, cdt, cdn) {
+		var child = locals[cdt][cdn];
+		caclulate_renewal_extension_cost_total(frm, child);
+	},
+	civil_id_amount: function(frm, cdt, cdn) {
+		var child = locals[cdt][cdn];
+		caclulate_renewal_extension_cost_total(frm, child);
+	}
+});
+
+var caclulate_renewal_extension_cost_total = function(frm, child) {
+	var total_cost = 0;
+	if(child.work_permit_amount && child.work_permit_amount > 0){
+		total_cost += child.work_permit_amount;
+	}
+	if(child.medical_insurance_amount && child.medical_insurance_amount > 0){
+		total_cost += child.medical_insurance_amount;
+	}
+	if(child.residency_stamp_amount && child.residency_stamp_amount > 0){
+		total_cost += child.residency_stamp_amount;
+	}
+	if(child.civil_id_amount && child.civil_id_amount > 0){
+		total_cost += child.civil_id_amount;
+	}
+	frappe.model.set_value(child.doctype, child.name, 'total_amount', total_cost);
+	frm.refresh_field('renewal_extension_cost');
+};


### PR DESCRIPTION
Add a client script for the HR Settings doctype that auto-calculates total_amount for the renewal_extension_cost (GRD Renewal Extension Cost) child table, mirroring the existing GRD Settings behavior after the child table was migrated to HR Settings.

- add public/js/doctype_js/hr_settings.js summing work permit, medical insurance, residency stamp and civil id amounts into total_amount
- register the script under doctype_js in hooks.py