### PR TITLE
feat(amp): add reusable AMP verification email sender + one-time patch

### DIFF
--- a/one_fm/api/amp_verification.py
+++ b/one_fm/api/amp_verification.py
@@ -1,0 +1,115 @@
+"""Send a real AMP-for-Email test message through the actual production
+sending pipeline — used to verify DKIM/SPF/DMARC alignment for
+notifications@one-fm.com before the Google AMP sender registration
+submission, and later to send the actual submission email to Google's
+review address.
+
+Two ways to run this:
+
+1. From ``bench console``::
+
+	from one_fm.api.amp_verification import send_amp_verification_email
+	send_amp_verification_email()
+	# or send_amp_verification_email(recipient="ampforemail.whitelisting@gmail.com")
+
+2. Automatically, once, via the companion patch
+   ``one_fm.patches.v15_0.send_amp_verification_test_email`` — see that
+   module for why a patch is (and isn't) an appropriate trigger for this.
+
+Sends through ``one_bpmn.email_builder.renderer`` so the message is a
+genuine AMP4Email document — the same rendering path real BPMN task
+notifications use — not a synthetic stand-in.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+
+DEFAULT_SENDER = "notifications@one-fm.com"
+DEFAULT_RECIPIENT = "s.shariff@one-fm.com"
+
+
+def send_amp_verification_email(
+	sender: str = DEFAULT_SENDER,
+	recipient: str = DEFAULT_RECIPIENT,
+) -> dict:
+	"""Render and send a real AMP email from *sender* to *recipient*.
+
+	Args:
+		sender: Must be an existing ``Email Account`` with
+			``enable_outgoing = 1`` — this is checked explicitly so a
+			misconfiguration fails with a clear message instead of a
+			confusing SMTP error.
+		recipient: Defaults to the address used for DKIM verification.
+			Pass ``"ampforemail.whitelisting@gmail.com"`` for the actual
+			Google submission — only after verification has confirmed
+			``DKIM: PASS`` for *sender*'s domain.
+
+	Returns:
+		dict with ``email_queue``, ``status``, ``error``, and
+		``amp_html_length`` — inspect ``status``/``error`` to confirm the
+		send actually succeeded; a truthy return does not by itself mean
+		delivery succeeded, only that it was accepted for queuing/sending.
+
+	Raises:
+		frappe.ValidationError: If *sender* has no matching, outgoing-enabled
+			Email Account.
+	"""
+	account_name = frappe.db.get_value("Email Account", {"email_id": sender}, "name")
+	if not account_name:
+		frappe.throw(
+			_("No Email Account found for {0}.").format(sender),
+			frappe.ValidationError,
+		)
+	if not frappe.db.get_value("Email Account", account_name, "enable_outgoing"):
+		frappe.throw(
+			_("Email Account '{0}' ({1}) has outgoing mail disabled.").format(
+				account_name, sender
+			),
+			frappe.ValidationError,
+		)
+
+	from one_bpmn.email_builder.renderer import render_amp, render_html_fallback
+
+	site_url = frappe.utils.get_url()
+	task_content = {
+		"subject": "AMP Verification Test — notifications@one-fm.com",
+		"body": (
+			"<p>This is a real message sent through the production email "
+			f"pipeline from <b>{sender}</b>, to verify DKIM/SPF/DMARC "
+			"alignment ahead of the Google AMP-for-Email sender "
+			"registration.</p>"
+		),
+		"open_link": f"{site_url}/app",
+		"doctype": "",
+		"name": "",
+	}
+	amp_html = render_amp(task_content)
+	html_body = render_html_fallback(task_content)
+
+	frappe.flags.amp_html = amp_html
+	email_queue = frappe.sendmail(
+		recipients=[recipient],
+		sender=sender,
+		subject=task_content["subject"],
+		message=html_body,
+		now=True,
+	)
+	frappe.db.commit()
+
+	status = frappe.db.get_value("Email Queue", email_queue.name, "status") if email_queue else None
+	error = frappe.db.get_value("Email Queue", email_queue.name, "error") if email_queue else None
+	stored_amp_html = frappe.db.get_value("Email Queue", email_queue.name, "amp_html") if email_queue else None
+
+	result = {
+		"email_queue": email_queue.name if email_queue else None,
+		"status": status,
+		"error": error,
+		"amp_html_length": len(stored_amp_html) if stored_amp_html else 0,
+	}
+
+	frappe.logger("amp_verification").info(
+		f"AMP verification email {sender} -> {recipient}: {result}"
+	)
+	return result

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -483,3 +483,4 @@ one_fm.patches.v15_0.normalize_user_mobile_country_code #2026-07-13
 one_fm.patches.v15_0.warm_zenquote_cache #2026-07-13
 one_fm.patches.v15_0.backfill_subcontractor_name_in_onboard_subcontract_employee #2026-07-12
 one_fm.patches.v15_0.delete_pending_approval_attendance_checks_airport_t4_jul12 #2026-07-13
+one_fm.patches.v15_0.send_amp_verification_test_email #2026-07-14

--- a/one_fm/patches/v15_0/send_amp_verification_test_email.py
+++ b/one_fm/patches/v15_0/send_amp_verification_test_email.py
@@ -1,0 +1,30 @@
+import frappe
+
+
+def execute():
+	"""One-time trigger: send a real AMP-for-Email test message from
+	notifications@one-fm.com to s.shariff@one-fm.com through the actual
+	production sending pipeline, to verify DKIM/SPF/DMARC alignment ahead
+	of the Google AMP sender registration submission.
+
+	This runs automatically, once, the first time `bench migrate` executes
+	on any site with this patch present (Frappe's Patch Log ensures it
+	never re-runs after that) — including production, which is the whole
+	point: the SMTP connection needs to originate from production's
+	registered IP for Google Workspace's SMTP relay to accept it, and
+	`bench migrate` is the one thing guaranteed to execute there.
+
+	Deliberately does not raise — a transient email/SMTP failure must
+	never block or fail a production migration. Check the "amp_verification"
+	logger (or the returned Email Queue row) for the actual outcome instead.
+	"""
+	try:
+		from one_fm.api.amp_verification import send_amp_verification_email
+
+		result = send_amp_verification_email()
+		frappe.logger("amp_verification").info(f"Patch send result: {result}")
+	except Exception:
+		frappe.log_error(
+			title="AMP verification test email failed",
+			message=frappe.get_traceback(),
+		)


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
Adds a reusable method to send a real AMP-for-Email test message through the actual production sending pipeline (`notifications@one-fm.com`), plus a one-time patch that triggers it automatically on the next `bench migrate`. This is needed to verify DKIM/SPF/DMARC alignment for the sending domain ahead of the Google AMP-for-Email sender registration submission — Google Workspace's SMTP relay only accepts connections from production's registered IP, so the send has to originate from wherever `bench migrate` actually runs in production, not a local dev machine or console session run from elsewhere.

## Analysis and design (optional)
Analyse and attach the design documentation
N/A — small, self-contained utility + patch; no separate design doc. Context/rationale is documented in the module docstrings (`one_fm/api/amp_verification.py`, `one_fm/patches/v15_0/send_amp_verification_test_email.py`).

## Solution description
- `one_fm/api/amp_verification.py::send_amp_verification_email(sender=, recipient=)` — validates the sending `Email Account` exists and has `enable_outgoing=1` (fails with a clear message otherwise), renders a real AMP4Email document via `one_bpmn.email_builder.renderer` (the same path real BPMN task notifications use), sends it via `frappe.sendmail`, and returns the resulting Email Queue name/status/error/amp_html length. Callable directly from `bench console` with either the default recipient (`s.shariff@one-fm.com`, for DKIM verification) or `ampforemail.whitelisting@gmail.com` (for the actual Google submission, only after verification passes).
- `one_fm/patches/v15_0/send_amp_verification_test_email.py` — wraps that call as a one-time patch so it fires automatically the next time `bench migrate` runs wherever this lands. Catches and logs any failure via `frappe.log_error` rather than raising, so a transient SMTP/email issue can never block a migration.
- `one_fm/patches.txt` — registered the new patch.

## Is there a business logic within a doctype?
- [ ] Yes
- [x] No


## Output screenshots (optional)
N/A — backend-only change, no UI affected.

## Areas affected and ensured
- New files only: `one_fm/api/amp_verification.py`, `one_fm/patches/v15_0/send_amp_verification_test_email.py`
- `one_fm/patches.txt` (one line appended)
- Reads (does not modify) the `Email Account` doctype to validate the sender before sending
- Depends on `one_bpmn.email_builder.renderer` being installed/available on the site

## Is there any existing behavior change of other features due to this code change?
No. Purely additive — no existing function, doctype, or workflow is modified.

## Did you test with the following dataset?
- [x] Existing Data
- [ ] New Data

Tested against the existing `Notifications` (`notifications@one-fm.com`) Email Account record — no new data created.

## Was child table created?
- [ ] is attachment required?
    did you test attachment
No child table involved.

## Did you delete custom field?
- [ ] Yes
- [x] No
    If yes, did you write a delete patch?

## Is patch required?
- [x] Yes
- [ ] No
    ## Was the patch test?
Yes — verified locally that `execute()` runs the send logic and completes without raising even when the send itself fails (confirmed via the real SMTP attempt, which correctly reached Google's relay and failed only on the expected "wrong source IP" restriction — proving the code path itself is correct); confirmed the failure is properly recorded in Error Log rather than surfacing as an unhandled exception.

## Which browser(s) did you use for testing?
- [ ] Chrome
- [ ] Safari
- [ ] Firefox

N/A — no UI/browser involved; tested via `bench console` / direct script execution only.
