### PR TITLE
fix: allow GRD Supervisor to save work permit without expiry date

### DIFF
--- a/one_fm/grd/doctype/work_permit/work_permit.py
+++ b/one_fm/grd/doctype/work_permit/work_permit.py
@@ -62,7 +62,13 @@ class WorkPermit(Document):
                 frappe.throw(_("{0}'s Relieving Date has been set to {1}. Work Permit processing is not allowed.").format(employee_details.employee_name, employee_details.relieving_date))
 
     def validate_workflow_state_fields(self):
-        states = ['Pending By Supervisor', 'Pending By PAM']
+        # NOTE: 'Pending By Supervisor' is intentionally excluded. At that stage the
+        # GRD Supervisor only attaches the work permit and hands the document over to
+        # the operator; the invoice and updated expiry date do not exist yet (they are
+        # produced later, after PAM payment/completion). Requiring them here blocked the
+        # supervisor from saving. These fields are enforced at the operator/completion
+        # stage below and in on_submit().
+        states = ['Pending By PAM']
         db_state = frappe.db.get_value("Work Permit", self.name, 'workflow_state')
         # check for required fields based on workflow
         if db_state in states:


### PR DESCRIPTION
The workflow-state field gate required attach_invoice and new_work_permit_expiry_date whenever the document's current state was 'Pending By Supervisor'. At that stage the GRD Supervisor only attaches the work permit and hands it to the operator, so those fields do not exist yet, which blocked the supervisor from saving.

- Remove 'Pending By Supervisor' from the required-fields state list
- Keep enforcement at 'Pending By PAM' and in on_submit()
- Document why the supervisor stage is excluded
