### PR TITLE
fix: persist edit-ticket public/auth meta on migrate

### DIFF
--- a/one_fm/after_migrate/execute.py
+++ b/one_fm/after_migrate/execute.py
@@ -541,6 +541,8 @@ def deploy_ticket_views():
     meta: {
       onSuccessRoute: "TicketCustomer",
       parent: "TicketsCustomer",
+      public: true,
+      auth: true,
     },
   },'''
 


### PR DESCRIPTION
The deploy_ticket_views() step re-injects the TicketEdit route into the vendored helpdesk router on every migrate. Without the public/auth meta flags, customers hitting /edit-ticket were redirected to /my-tickets, and the fix in the helpdesk repo would be lost on the next migrate.

- add public: true and auth: true to the injected route meta so the fix survives bench migrate