### PR TITLE
Restore add_asset_repair_requestor_fields patch file

### DIFF
--- a/one_fm/patches/v15_0/add_asset_repair_requestor_fields.py
+++ b/one_fm/patches/v15_0/add_asset_repair_requestor_fields.py
@@ -1,0 +1,5 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.custom_field.asset_repair import get_asset_repair_custom_fields
+
+def execute():
+	create_custom_fields(get_asset_repair_custom_fields())


### PR DESCRIPTION
## Summary
- The `Revert "Sprint 24th-30th — cleanup"` commit (`17c0e581f`) deleted `one_fm/patches/v15_0/add_asset_repair_requestor_fields.py` as collateral damage from an unrelated revert.
- `patches.txt` still references the patch (line 453), so `bench migrate` fails trying to import a module that no longer exists.
- Restores the file content unchanged from the original commit `8b7022ba9` (PR #6356, WI-001321). No other changes.

## Test plan
- [ ] `bench migrate` runs `one_fm.patches.v15_0.add_asset_repair_requestor_fields` without error
- [ ] Asset Repair custom fields (`custom_serial_no`, `custom_asset_location`, etc.) are present after migration