### PR TITLE
fix: avoid PermissionError when force-sending queued emails

### DIFF
--- a/one_fm/events/email_queue.py
+++ b/one_fm/events/email_queue.py
@@ -1,5 +1,21 @@
 import frappe
-from frappe.email.doctype.email_queue.email_queue import send_now
+from frappe.email.doctype.email_queue.email_queue import send_now, EmailQueue
+
+
+def _force_send_email(name):
+	"""Send a queued email from a background job without the whitelisted-API
+	permission gate.
+
+	``send_now`` is a whitelisted method that runs ``check_permission()`` first.
+	Background jobs run as the enqueuing session user, so when a non-privileged
+	user (e.g. an employee) triggers the mail, that permission check fails on the
+	System-Manager-only Email Queue DocType. Sending is a system operation — the
+	queue doc is created with ``ignore_permissions`` and the framework scheduler
+	itself calls ``EmailQueue.send()`` directly — so we do the same here.
+	"""
+	record = EmailQueue.find(name)
+	if record:
+		record.send()
 
 
 def after_insert(doc, event):
@@ -28,7 +44,7 @@ def after_insert(doc, event):
 	if found:
 		# Enqueue it safely in the background rather than blocking the main transaction
 		frappe.enqueue(
-			send_now,
+			_force_send_email,
 			name=doc.name,
 			now=frappe.flags.in_test,
 			enqueue_after_commit=True


### PR DESCRIPTION
The Email Queue after_insert hook force-sends small emails by enqueuing the whitelisted send_now, which runs check_permission() first. Because background jobs execute as the enqueuing session user, mails triggered by a non-privileged user (e.g. an employee) failed the permission check on the System-Manager-only Email Queue DocType, raising PermissionError.

- Add internal _force_send_email helper that loads the queue doc and calls EmailQueue.send() directly, mirroring the framework scheduler's flush() which sends without a per-user permission gate
- Route the after_insert force-send job to the new helper instead of the whitelisted send_now
- Keep send_now for the scheduled flush_emails path, which runs as Administrator and is unaffected