### PR TITLE
chore: add patch to create attendance checks for 2026-07-11

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -553,3 +553,4 @@ one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
 one_fm.patches.v15_0.add_onboarding_officer_arrival_deployment_permission #2026-08-04
+one_fm.patches.v15_0.create_attendance_check_jul11_2026 #1

--- a/one_fm/patches/v15_0/create_attendance_check_jul11_2026.py
+++ b/one_fm/patches/v15_0/create_attendance_check_jul11_2026.py
@@ -1,0 +1,16 @@
+# one_fm/patches/v15_0/create_attendance_check_jul11_2026.py
+import frappe
+
+from one_fm.one_fm.doctype.attendance_check.attendance_check import create_attendance_check
+
+
+def execute():
+    """Create Attendance Check records for 11th July 2026.
+
+    Reuses the standard scheduled entry point, which creates checks for
+    absentees and for shift-working employees with no attendance marked on
+    the date. The function is guarded by production_domain(), so it only
+    does work on the production site.
+    """
+    create_attendance_check("2026-07-11")
+    frappe.db.commit()


### PR DESCRIPTION
Add a one-time data patch that generates Attendance Check records for 11th July 2026 by reusing the standard create_attendance_check entry point, covering both absentees and shift-working employees with no attendance marked on the date.

- add patch one_fm/patches/v15_0/create_attendance_check_jul11_2026.py
- register the patch in patches.txt


<img width="1274" height="490" alt="Screenshot 2026-07-21 at 3 15 55 PM" src="https://github.com/user-attachments/assets/fa030905-b6d0-4526-952b-5a26a6ff0713" />
