### PR TITLE
revert: remove WI-001425 (Double Shift OT checkbox in Operations Shift) from version-15

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -2867,9 +2867,8 @@ function change_ot_schedule(page) {
 							});
 					}
 				}, get_query: function () {
-					// Only shifts that permit double-shift OT can be selected as a second (OT) shift.
 					return {
-						"filters": { "status": "Active", "double_shift_ot_allowed": 1 },
+						"filters": { "status": "Active" },
 						"page_length": 9999
 					};
 				}

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -745,18 +745,10 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 	operations_shift_doc = frappe.get_doc("Operations Shift", shift, ignore_permissions=True)
 	operations_role_doc = frappe.get_doc("Operations Role", operations_role, ignore_permissions=True)
 	day_off_ot = cint(day_off_ot)
-	# roster_type is driven solely by whether the OT (second-shift) dialog was used.
-	# day_off_ot is an independent flag: a Day Off OT first shift is still "Basic".
-	roster_type = "Over-Time" if otRoster == "true" else "Basic"
-
-	# A second (Over-Time) shift is only permitted when the target shift explicitly
-	# allows double-shift OT in the Operations Shift master. The OT dialog already
-	# filters the Shift dropdown, so this is defense-in-depth against API/import bypass.
-	if roster_type == "Over-Time" and not cint(operations_shift_doc.double_shift_ot_allowed):
-		frappe.throw(_(
-			"Double Shift OT is not allowed for shift {0}. Enable 'Double Shift OT Allowed' "
-			"in the Operations Shift master to schedule a second (overtime) shift."
-		).format(shift))
+	if otRoster == "false":
+		roster_type = "Basic"
+	elif otRoster == "true" or day_off_ot == 1:
+		roster_type = "Over-Time"
 
 	# check for end date
 	if end_date:
@@ -814,21 +806,6 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 			if day_off_ot_map.get((i["employee"], i["date"])):
 				i["day_off_ot"] = 1
 
-	# When a Basic shift is scheduled onto a day the employee currently has off,
-	# it is a Day Off OT entry: mark day_off_ot = 1 automatically. This entry stays
-	# roster_type = "Basic" and bypasses the double-shift OT check (that check only
-	# gates the second/Over-Time shift of the day).
-	if roster_type == "Basic" and employees:
-		existing_day_off = frappe.db.get_list("Employee Schedule", filters={
-			"employee": ["IN", [i["employee"] for i in employees]],
-			"date": ["IN", [i["date"] for i in employees]],
-			"employee_availability": "Day Off"
-		}, fields=["employee", "date"])
-		day_off_set = {(i.employee, str(i.date)) for i in existing_day_off}
-		for i in employees:
-			if (i["employee"], str(i["date"])) in day_off_set:
-				i["day_off_ot"] = 1
-
 	employees_list_db = frappe.db.get_list("Employee", filters={"name": ["IN", employee_list]}, fields=["name", "employee_name", "department","date_of_joining", "relieving_date"], ignore_permissions=True)
 	employees_dict = {}
 	for i in employees_list_db:
@@ -857,7 +834,7 @@ def extreme_schedule(employees, shift, operations_role, otRoster, start_date, en
 						"day_off_ot": i.get("day_off_ot")
 					})
 				else:
-					employees_date_dict[i["employee"]] =[{"date":i["date"], "start_datetime": datetime.strptime(f"{i['date']} {shift_start_time}", "%Y-%m-%d %H:%M:%S"), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end_time}", "%Y-%m-%d %H:%M:%S"), "day_off_ot": i.get("day_off_ot")}]
+					employees_date_dict[i["employee"]] =[{"date":i["date"], "start_datetime": datetime.strptime(f"{i['date']} {shift_start_time}", "%Y-%m-%d %H:%M:%S"), "end_datetime":datetime.strptime(f"{add_days(i['date'], 1) if next_day else i['date']} {shift_end_time}", "%Y-%m-%d %H:%M:%S")}]
 		else:
 			# Log or handle cases where employee details or date_of_joining is missing
 			frappe.log_error(message=f"Employee {i.get('employee')} missing details or date_of_joining.", title="Extreme Schedule Data Prep")

--- a/one_fm/operations/doctype/operations_shift/operations_shift.js
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.js
@@ -7,8 +7,6 @@ frappe.ui.form.on('Operations Shift', {
 	},
 
 	refresh: function(frm) {
-		set_double_shift_ot_allowed_access(frm);
-
 		if(!frm.doc.__islocal){
 			frm.add_custom_button(
 				'Add Posts',
@@ -229,15 +227,6 @@ frappe.ui.form.on('Operations Shift', {
 	}
 	
 });
-
-// Only Operations Manager, Operation Admin and Facility Engineer may edit the
-// "Double Shift OT Allowed" flag. Everyone else (e.g. Operations Supervisor)
-// sees it read-only. Server-side controller enforces the same rule.
-function set_double_shift_ot_allowed_access(frm){
-	const editor_roles = ["Operations Manager", "Operation Admin", "Facility Engineer"];
-	const can_edit = editor_roles.some((role) => frappe.user_roles.includes(role));
-	frm.set_df_property("double_shift_ot_allowed", "read_only", can_edit ? 0 : 1);
-}
 
 function  validate_linked_schedules(frm){
 	if (frm.doc.status == "Inactive" && !frm.__confirmed_inactive && !frm.is_new()){

--- a/one_fm/operations/doctype/operations_shift/operations_shift.json
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.json
@@ -16,7 +16,6 @@
   "shift_number",
   "shift_type",
   "day_off_ot_allowed",
-  "double_shift_ot_allowed",
   "automate_roster",
   "supervisor",
   "supervisor_name",
@@ -194,12 +193,6 @@
    "fieldname": "day_off_ot_allowed",
    "fieldtype": "Check",
    "label": "Day Off OT Allowed"
-  },
-  {
-   "default": "0",
-   "fieldname": "double_shift_ot_allowed",
-   "fieldtype": "Check",
-   "label": "Double Shift OT Allowed"
   }
  ],
  "links": [
@@ -209,7 +202,7 @@
    "link_fieldname": "shift"
   }
  ],
- "modified": "2026-07-08 20:24:45.560363",
+ "modified": "2026-03-05 20:20:22.004307",
  "modified_by": "Administrator",
  "module": "Operations",
  "name": "Operations Shift",

--- a/one_fm/operations/doctype/operations_shift/operations_shift.py
+++ b/one_fm/operations/doctype/operations_shift/operations_shift.py
@@ -8,10 +8,7 @@ from datetime import timedelta
 from frappe.model.document import Document
 from frappe import _
 from frappe.model.rename_doc import rename_doc
-from frappe.utils import cstr, cint, get_datetime, today, formatdate, getdate, add_days, get_time
-
-# Roles allowed to change the "Double Shift OT Allowed" flag on Operations Shift.
-DOUBLE_SHIFT_OT_EDITOR_ROLES = {"Operations Manager", "Operation Admin", "Facility Engineer"}
+from frappe.utils import cstr, get_datetime, today, formatdate, getdate, add_days, get_time
 
 class OperationsShift(Document):
 	def autoname(self):
@@ -46,37 +43,11 @@ class OperationsShift(Document):
 				frappe.throw("Kindly, make sure all required fields are not missing")
 
 	def validate(self):
-		self.validate_double_shift_ot_allowed_permission()
 		if self.status != 'Active':
 			self.set_operation_role_inactive()
 		self.validate_operations_site_status()
 		self.validate_operations_shift_link_to_employees()
 		self.validate_duration()
-
-	def validate_double_shift_ot_allowed_permission(self):
-		"""Only Operations Manager, Operation Admin or Facility Engineer may change
-		the "Double Shift OT Allowed" flag. This mirrors the client-side read-only
-		rule and prevents bypass via API, import or scripting."""
-		# Allow framework operations (migrations, installs, patches) to set the value.
-		if frappe.flags.in_migrate or frappe.flags.in_install or frappe.flags.in_patch:
-			return
-
-		if self.is_new():
-			# On create, only guard when the flag is actively enabled (default is unchecked).
-			if not cint(self.double_shift_ot_allowed):
-				return
-		elif not self.has_value_changed("double_shift_ot_allowed"):
-			return
-
-		user_roles = set(frappe.get_roles())
-		# System Manager (the only role with write access on this DocType) retains full control.
-		if "System Manager" in user_roles or not DOUBLE_SHIFT_OT_EDITOR_ROLES.isdisjoint(user_roles):
-			return
-
-		frappe.throw(_(
-			"You are not permitted to change 'Double Shift OT Allowed'. "
-			"This can only be updated by Operations Manager, Operation Admin or Facility Engineer."
-		))
 
 	def validate_duration(self):
 		if self.shift_type:


### PR DESCRIPTION
Reverts the WI-001425 merge (#6413, merge commit 30ff1ed10) on version-15, removing the Double Shift OT checkbox from Operations Shift and its roster/controller handling.

- Clean revert of all 5 files — nothing on version-15 had built on top of it, and no references to the feature remain in the touched files.
- The Operations Shift doctype JSON drops the checkbox field; the existing DB column is left behind by design (harmless, standard Frappe practice on field removal).
- ⚠️ WI-001425 also lives on `staging` (it merged there first). If it should not ride the next release back into version-15, revert it on staging too — say the word and a matching PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)