### PR TITLE
fix: allow scheduling actions on Over-Time Client Event cells

### DIFF
--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1455,11 +1455,31 @@ function render_roster(res, page) {
 						ot_count++;
 						bgclass = bgclass ? `${bgclass}-sameot` : "sameot";
 						data_ot = `${employee}|${date}|${operations_role}|${shift}|${employee_availability}`;
+						// Over-Time Client Event / OJT cells must still carry a data-selectid and the
+						// event metadata so the "Change Employee Schedule (Others)" action can target them.
+						if (employee_availability == "Client Event" || employee_availability == "On-the-job Training") {
+							data_selectid = `${employee}|${date}|${operations_role}|${shift}|${employee_availability}`;
+							if (employee_availability == "Client Event") {
+								data_extra_attrs = ` data-event-location="${event_location || ""}" data-shift="${shift || ""}" data-operations-role="${operations_role || ""}" data-project="${project || ""}" data-site="${site || ""}" data-day-off-ot="0" data-client-event="${client_event || ""}" data-ojt=""`;
+							} else {
+								data_extra_attrs = ` data-event-location="" data-shift="${shift || ""}" data-operations-role="${operations_role || ""}" data-project="${project || ""}" data-site="${site || ""}" data-day-off-ot="0" data-client-event="" data-ojt="${on_the_job_training || ""}"`;
+							}
+						}
 					}
 					else if (!attendance && roster_type == "Over-Time" && page.filters[applied_filter] != record[applied_filter]) {
 						ot_count++;
 						bgclass = bgclass ? `${bgclass}-diffot` : "diffot";
 						data_ot = `${employee}|${date}|${operations_role}|${shift}|${employee_availability}`;
+						// Over-Time Client Event / OJT cells must still carry a data-selectid and the
+						// event metadata so the "Change Employee Schedule (Others)" action can target them.
+						if (employee_availability == "Client Event" || employee_availability == "On-the-job Training") {
+							data_selectid = `${employee}|${date}|${operations_role}|${shift}|${employee_availability}`;
+							if (employee_availability == "Client Event") {
+								data_extra_attrs = ` data-event-location="${event_location || ""}" data-shift="${shift || ""}" data-operations-role="${operations_role || ""}" data-project="${project || ""}" data-site="${site || ""}" data-day-off-ot="0" data-client-event="${client_event || ""}" data-ojt=""`;
+							} else {
+								data_extra_attrs = ` data-event-location="" data-shift="${shift || ""}" data-operations-role="${operations_role || ""}" data-project="${project || ""}" data-site="${site || ""}" data-day-off-ot="0" data-client-event="" data-ojt="${on_the_job_training || ""}"`;
+							}
+						}
 					}
 					else if (!attendance && roster_type == "Basic" && page.filters[applied_filter] == record[applied_filter] && day_off_ot == 1) {
 						if (employee_availability == "Working") basic_count++;

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1571,7 +1571,10 @@ function render_roster(res, page) {
 							}
 							abbrv += `${abbr_map[attendance]}<br>`;
 						} else if (employee_availability && !post_abbrv) {
-							tooltiptext = ``;
+							// Do NOT reset tooltiptext here: a cell can hold multiple records
+							// (e.g. a Basic "Working" shift plus an Over-Time Client Event on the
+							// same day). Resetting would discard the earlier record's tooltip and
+							// show only this one. Append so every record contributes its own line.
 							abbrv += `${abbr_map[employee_availability]}<br>`;
 							if (employee_availability == "Client Event") {
 								tooltiptext += `Client Event<br>Event Location: ${event_location}<br>Start: ${shift_start}<br>End: ${shift_end}<br>`;

--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -462,6 +462,13 @@ def schedule_staff(employees, shift, operations_role, otRoster, start_date, proj
 		if not employees:
 			frappe.throw("Employees must be selected.")
 
+		# Drop entries without a valid employee. These occur when an Over-Time-only cell
+		# (e.g. an Over-Time Client Event) is selected for a Basic action: such cells have an
+		# empty data-selectid, so the client sends an entry with a blank employee.
+		employees = [obj for obj in employees if obj.get("employee")]
+		if not employees:
+			frappe.throw(_("The selected cell cannot be scheduled as Basic. Use 'Change Employee Schedule (OT)' or 'Change Employee Schedule (Others)' for Over-Time / Client Event cells."))
+
 		employee_list = list({obj["employee"] for obj in employees})
 		employee_leave_attendance = get_employee_leave_attendance(employee_list,start_date)
 		if cint(project_end_date) and not end_date:


### PR DESCRIPTION
fix: allow scheduling actions on Over-Time Client Event cells
Over-Time-only roster cells (e.g. an Over-Time Client Event) rendered their data into data-ot and left data-selectid empty. Because every schedule action reads data-selectid, selecting such a cell produced a blank employee: the Basic action crashed on a None lookup and the "Others" action rejected it as not a Client Event / OJT cell.

- carry data-selectid and the event metadata (event location, shift, role, project, site, client event / OJT links) on Over-Time Client Event and On-the-job Training cells so the "Others" action can target them, matching the existing Day Off OT rendering
- drop blank-employee entries in schedule_staff and throw a clear message directing the user to the OT / Others actions instead of failing with 'NoneType' object has no attribute 'get'

fix: show all records in roster cell tooltip
A roster cell can hold multiple records for one day (e.g. a Basic Working shift plus an Over-Time Client Event). When the last record was a Client Event, the tooltip builder reset the accumulated text, so the cell showed only the Client Event and dropped the earlier Basic line.

- stop resetting tooltiptext for availability records without a post abbreviation, so every record in the cell contributes its own line