### PR TITLE
fix: validate and normalize whatsapp numbers before sending

### DIFF
--- a/one_fm/overrides/employee.py
+++ b/one_fm/overrides/employee.py
@@ -321,10 +321,11 @@ class EmployeeOverride(EmployeeMaster):
                 push_message = f"Dear {context.first_name}, Your residency registration process has been completed and your employee ID has been updated to {self.employee_id}."
                 push_notification_rest_api_for_checkin(employee_id=self.name,title=subject,body=push_message,checkin=False,arriveLate=False,checkout=False)
                 if self.cell_number:
-                    if '(' in self.cell_number or ')' in self.cell_number or '+' in self.cell_number:
-                        cell_number = "".join(i for i in self.cell_number if i.isdigit())
-                    else:
-                        cell_number = self.cell_number
+                    # Preserve a leading '+' so Twilio Lookup reads an existing
+                    # country code as E.164; national numbers are normalized via
+                    # the KW country hint in validate_whatsapp_number.
+                    digits = "".join(i for i in self.cell_number if i.isdigit())
+                    cell_number = "+" + digits if "+" in self.cell_number else digits
                 content_variables= {
 	                    	'1':context.first_name,
                             '2':self.get_doc_before_save().employee_id or '',

--- a/one_fm/processor.py
+++ b/one_fm/processor.py
@@ -2,6 +2,7 @@ import frappe
 import requests
 import json
 from twilio.rest import Client as TwilioClient
+from twilio.base.exceptions import TwilioRestException
 import xml.etree.ElementTree as ET
 from frappe.utils.jinja import (get_email_from_template)
 from frappe.desk.doctype.notification_settings.notification_settings import(
@@ -134,20 +135,42 @@ def is_user_id_company_prefred_email_in_employee(user_id):
 
 	return True
 
+def validate_whatsapp_number(raw_number, country_code="KW"):
+	"""Validate WhatsApp reachability and normalize to E.164 via Twilio Lookup.
+
+	Returns the E.164 number (e.g. "+96551096468") if valid, else None.
+	Note: each call is a billed Twilio Lookup request.
+	"""
+	if not raw_number:
+		return None
+	try:
+		twilio = frappe.get_doc("Twilio Setting")
+		client = TwilioClient(twilio.sid, twilio.token)
+		lookup = client.lookups.v2.phone_numbers(raw_number).fetch(country_code=country_code)
+		return lookup.phone_number if lookup.valid else None
+	except TwilioRestException:
+		return None
+
 @frappe.whitelist()
-def send_whatsapp(sender_id, template_name, content_variables):
+def send_whatsapp(sender_id: str, template_name: str, content_variables):
+	number = validate_whatsapp_number(sender_id)
+	if not number:
+		frappe.log_error(title="Invalid WhatsApp number", message=sender_id)
+		return
+
 	twilio = frappe.get_doc('Twilio Setting')
 	content_sid = frappe.get_value('Content Template', {'template_name':template_name}, ['content_sid'])
 
 	client =  TwilioClient(twilio.sid, twilio.token)
 
+	message = None
 	if content_sid:
 		message = client.messages.create(
 								from_='whatsapp:' + twilio.t_number,
 								messaging_service_sid=twilio.messaging_service_sid,
 								content_sid=content_sid,
 								content_variables=json.dumps(content_variables),
-								to='whatsapp:+'+sender_id
+								to='whatsapp:' + number
 							)
 
 	return message


### PR DESCRIPTION
send_whatsapp prepended '+' to a bare number, so a national Kuwait number (e.g. 51096468) was read by Twilio as country code +51 (Peru) and rejected with an HTTP 400. Numbers with an existing country code were also stripped of their leading '+'.

- add validate_whatsapp_number() using Twilio Lookup with a KW country hint to normalize national numbers to E.164 and confirm reachability
- import TwilioRestException at module level so the except clause no longer shadows the Twilio Setting doc variable
- guard send_whatsapp: bail and log on invalid numbers, send to the normalized E.164 value, and init message to avoid UnboundLocalError when no content_sid is found
- preserve a leading '+' when building cell_number in the employee notification hook so an existing country code survives as E.164