### PR TITLE
feat(agency): add Total Duration Without Remedical to Agency Country Process

### DIFF
--- a/one_fm/one_fm/doctype/agency_country_process/agency_country_process.js
+++ b/one_fm/one_fm/doctype/agency_country_process/agency_country_process.js
@@ -151,12 +151,19 @@ frappe.ui.form.on("Agency Process Details", {
 	}
 });
 
+var REMEDICAL_PROCESS_NAMES = ["Remedical appointment", "Remedical results"];
+
 var find_total_duration = function(frm){
     var total_duration = 0;
+    var total_duration_without_remedical = 0;
     $.each(frm.doc.agency_process_details || [], function (i, d) {
         if(d.duration_in_days){
             total_duration += flt(d.duration_in_days);
+            if(!REMEDICAL_PROCESS_NAMES.includes(d.process_name)){
+                total_duration_without_remedical += flt(d.duration_in_days);
+            }
         }
     });
     frm.set_value("total_duration", total_duration);
+    frm.set_value("total_duration_without_remedical", total_duration_without_remedical);
 };

--- a/one_fm/one_fm/doctype/agency_country_process/agency_country_process.json
+++ b/one_fm/one_fm/doctype/agency_country_process/agency_country_process.json
@@ -18,7 +18,9 @@
   "section_break_3",
   "agency_country_process_template",
   "agency_process_details",
-  "total_duration"
+  "total_duration",
+  "column_break_20",
+  "total_duration_without_remedical"
  ],
  "fields": [
   {
@@ -63,6 +65,16 @@
    "fieldname": "total_duration",
    "fieldtype": "Float",
    "label": "Total Duration",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_20",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_duration_without_remedical",
+   "fieldtype": "Float",
+   "label": "Total Duration Without Remedical",
    "read_only": 1
   },
   {


### PR DESCRIPTION
## Summary
- Remedical steps ("Remedical appointment", "Remedical results") only run when the initial medical result fails, so the existing "Total Duration" field overstates the typical/expected timeline for candidates who pass on the first medical.
- Adds a new read-only "Total Duration Without Remedical" field next to "Total Duration" (same section, second column) on **Agency Country Process**, computed the same way (client-side, on child table `duration_in_days` change / on validate) but excluding rows whose `process_name` is "Remedical appointment" or "Remedical results".

## Test plan
- [x] Reloaded the doctype via `bench console` (`frappe.reload_doc(..., force=True)`) and confirmed the new `total_duration_without_remedical` field (Float, read-only) is present in the live meta.
- [x] Manually traced the JS logic against the existing sample data (11 rows totaling 31 days, with the two Remedical rows at 2 days each) — confirms it would compute 27.
- [ ] Visual confirmation of the two-column layout and live recalculation on row edits — not verified in-browser this session (no browser tool available here); please confirm the layout renders as expected before merging.
- [x] Self-reviewed against the org's `review-erpnext-pr` checklist — no protected files, no permission bypasses, purely additive client-side field mirroring the existing `total_duration` pattern.