### PR TITLE
feat(project): Sprint Prefix field + show PM/Users section for SCRUM

### DIFF
--- a/one_fm/custom/custom_field/project.py
+++ b/one_fm/custom/custom_field/project.py
@@ -144,6 +144,14 @@ def get_project_custom_fields():
                 "translatable": 1
             },
             {
+                "fieldname": "custom_sprint_prefix",
+                "label": "Sprint Prefix",
+                "fieldtype": "Data",
+                "insert_after": "type",
+                "depends_on": "eval: doc.type==\"SCRUM\"",
+                "mandatory_depends_on": "eval: doc.type==\"SCRUM\"",
+            },
+            {
                 "fieldname": "total_expense_claim",
                 "label": "Total Expense Claim (via Expense Claims)",
                 "fieldtype": "Currency",

--- a/one_fm/custom/property_setter/project.py
+++ b/one_fm/custom/property_setter/project.py
@@ -22,7 +22,10 @@ def get_project_properties():
             "field_name":"users_section",
             "property":"depends_on",
             "property_type":"Data",
-            "value":"eval:['External','Internal'].includes(doc.project_type)"
+            # Show the "Project Manager and Users" section for External, Internal,
+            # and SCRUM projects (SCRUM already requires `users` via
+            # mandatory_depends_on, so it must be visible for them too).
+            "value":"eval:['External','Internal','SCRUM Project'].includes(doc.project_type)"
         },
         {
             "doctype_or_field":"DocField",

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -495,3 +495,5 @@ one_fm.patches.v15_0.warm_zenquote_cache #2026-07-13
 one_fm.patches.v15_0.backfill_subcontractor_name_in_onboard_subcontract_employee #2026-07-12
 one_fm.patches.v15_0.delete_pending_approval_attendance_checks_airport_t4_jul12 #2026-07-13
 one_fm.patches.v15_0.send_amp_verification_test_email #2026-07-14
+one_fm.patches.v15_0.add_project_sprint_prefix_field #2026-07-23
+one_fm.patches.v15_0.show_project_users_section_for_scrum #2026-07-23

--- a/one_fm/patches/v15_0/add_project_sprint_prefix_field.py
+++ b/one_fm/patches/v15_0/add_project_sprint_prefix_field.py
@@ -1,0 +1,18 @@
+"""Add the "Sprint Prefix" (custom_sprint_prefix) custom field to Project.
+
+A Data field shown/required only for SCRUM projects (depends_on /
+mandatory_depends_on eval:doc.type=="SCRUM"), inserted after the "type" field.
+
+The definition lives in one_fm.custom.custom_field.project (the source of
+truth); this patch re-applies the full Project custom-field set with
+update=True, so it is idempotent and also reconciles any drift in the other
+Project fields.
+"""
+
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+from one_fm.custom.custom_field.project import get_project_custom_fields
+
+
+def execute():
+    create_custom_fields(get_project_custom_fields(), update=True)

--- a/one_fm/patches/v15_0/show_project_users_section_for_scrum.py
+++ b/one_fm/patches/v15_0/show_project_users_section_for_scrum.py
@@ -1,0 +1,17 @@
+"""Show the "Project Manager and Users" section on SCRUM projects.
+
+The `users_section` (a standard Project field) was only shown for External and
+Internal projects, but `users` is mandatory for SCRUM projects too — so the
+required field was hidden. This re-applies the Project property setters (the
+source of truth in one_fm.custom.property_setter.project), whose `users_section`
+depends_on now also includes 'SCRUM Project'.
+
+make_property_setter upserts, so this is idempotent.
+"""
+
+from one_fm.custom.property_setter.project import get_project_properties
+from one_fm.setup.setup import add_property_setter
+
+
+def execute():
+    add_property_setter(get_project_properties())


### PR DESCRIPTION
## Summary
Support the FrappeAgile Project > Sprint hierarchy on the **standard** Project
DocType. Because Project is a standard (ERPNext) doctype, changes are made via a
**custom field** + **property setters**, applied by **patches** (one_fm's
`custom/` + `patches/` convention).

## Changes
- **Add `custom_sprint_prefix` ("Sprint Prefix")** to Project — a Data field
  shown/required only for SCRUM projects (`depends_on` /
  `mandatory_depends_on` = `eval:doc.type=="SCRUM"`), inserted after `type`.
  This is the source the Sprint's `sprint_prefix` fetches from.
  - Definition: `one_fm/custom/custom_field/project.py`
  - Patch: `add_project_sprint_prefix_field`
- **Show the "Project Manager and Users" section (`users_section`) for SCRUM
  projects** — its `depends_on` now includes `'SCRUM Project'` alongside
  External/Internal. Fixes a latent bug where `users` was *mandatory* on SCRUM
  projects while its section was *hidden*.
  - Definition: `one_fm/custom/property_setter/project.py`
  - Patch: `show_project_users_section_for_scrum`

Both patches re-apply the full Project field/property set with `update=True` /
upsert, so they are idempotent.

## Testing
Ran both patches on a live site: `Project-custom_sprint_prefix` created with the
correct depends_on rules; `users_section.depends_on` resolves to
`eval:['External','Internal','SCRUM Project'].includes(doc.project_type)`.
