### PR TITLE
WI-001704: Prepone Roster Day Off Checker generation to 12:15 PM

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -707,7 +707,7 @@ scheduler_events = {
 			'one_fm.operations.doctype.post_scheduler_checker.post_scheduler_checker.schedule_roster_checker',
             'one_fm.operations.doctype.default_shift_checker.default_shift_checker.create_default_shift_checker'
 		],
-		"30 13 * * *": [ #“At 01:30 pm - Need to run after attendance is marked”
+		"15 12 * * *": [ #"At 12:15 pm - preponed from 01:30 pm (WI-001704); run after attendance is marked"
 			'one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker.generate_checker',
 		],
 		"30 4 * * *": [


### PR DESCRIPTION
## WI-001704 — Preponing the timing of Roster Day Off Checker Generation

**Change:** the scheduled `roster_day_off_checker.generate_checker` job now runs at **12:15 PM** (`15 12 * * *`) instead of 1:30 PM (`30 13 * * *`).

- `generate_checker` was the only job in the 1:30 PM cron block, so retargeting the cron key fully removes the old 1:30 PM trigger (no duplicate run).
- File: `one_fm/hooks.py`.

### Deploy
Run `bench migrate` after merge so the **Scheduled Job Type** record syncs to the new cron — the stale 1:30 PM DB row otherwise persists (this is the real 'runs twice' risk, resolved by migrate, not the hooks edit alone).

### AC coverage
- ✅ AC1: timer triggers at 12:15 PM daily
- ✅ AC2: 1:30 PM schedule removed (single job, key retargeted)
- ✅ AC3: no other checker/process affected (only this job's cron key changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)