### PR TITLE
WI-001732: Distinct colour for unassigned Outbound vs Return shipment cards

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -2872,7 +2872,7 @@ function injectRPVueTemplate() {
 
           <div v-show="!collapsedGroups[group.acc]" class="rp-group-cards">
             <div v-for="card in group.cards" :key="card.id"
-                 :class="['rp-card', selectedPoolCard && selectedPoolCard.id === card.id ? 'rp-card-selected' : '']"
+                 :class="['rp-card', card.direction === 'OUTBOUND' ? 'rp-card-out' : 'rp-card-ret', selectedPoolCard && selectedPoolCard.id === card.id ? 'rp-card-selected' : '']"
                  draggable="true"
                  @dragstart="onCardDragStart($event, card)"
                  @dragend="onCardDragEnd"
@@ -3719,6 +3719,9 @@ function injectRPStyles() {
         }
 
         /* Cards */
+        /* WI-001732: distinct colour for Unassigned Outbound vs Return cards */
+        .rp-card-out { border-left: 4px solid #1565c0; }
+        .rp-card-ret { border-left: 4px solid #c62828; }
         .rp-card {
             background: var(--md-sys-color-surface-bright); border: 1px solid var(--md-sys-color-outline-variant); border-radius: 12px;
             padding: 11px 12px; cursor: grab;


### PR DESCRIPTION
## WI-001732 — VH 4: Different colour code for Unassigned Outbound and Return Shipment Card

Unassigned shipment cards on the Transportation Schedule now carry a direction-distinct colour so users identify Outbound vs Return at a glance.

### Change (`transportation_schedule.js`)
- Added a direction class to the unassigned pool card: `rp-card-out` (Outbound) / `rp-card-ret` (Return).
- New CSS: blue left accent for Outbound (`#1565c0`), red for Return (`#c62828`) — reusing the same palette the corner direction badge already uses.
- No backend change — `card.direction` is already emitted for every card.

### AC coverage
- ✅ Unassigned Outbound and Return cards have unique, distinct colours.

Requires `bench build` + hard refresh for the JS/CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)