### PR TITLE
WI-001688: Roster Double Shift OT Checker

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -709,6 +709,7 @@ scheduler_events = {
 		],
 		"15 12 * * *": [ #"At 12:15 pm - preponed from 01:30 pm (WI-001704); run after attendance is marked"
 			'one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker.generate_checker',
+			'one_fm.operations.doctype.roster_double_shift_ot_checker.roster_double_shift_ot_checker.check_roster_double_shift_ot',
 		],
 		"30 4 * * *": [
 			'one_fm.utils.check_grp_operator_submission_four_half',

--- a/one_fm/operations/doctype/roster_double_shift_ot_checker/roster_double_shift_ot_checker.json
+++ b/one_fm/operations/doctype/roster_double_shift_ot_checker/roster_double_shift_ot_checker.json
@@ -1,0 +1,322 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "format:OPR-RDSOTC-{employee}-{monthweek}",
+ "creation": "2026-07-21 16:34:09.444279",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "employee",
+  "employee_name",
+  "date",
+  "column_break_3",
+  "status",
+  "column_break_xlfy",
+  "monthweek",
+  "repeat_count",
+  "section_break_qccb",
+  "shift_supervisor",
+  "shift_supervisor_name",
+  "shift_supervisor_user",
+  "column_break_yuke",
+  "site_supervisor",
+  "site_supervisor_name",
+  "site_supervisor_user",
+  "column_break_hope",
+  "project_manager",
+  "project_manager_name",
+  "project_manager_user",
+  "shift_details_section",
+  "operations_shift",
+  "operations_site",
+  "project",
+  "column_break_ljlg",
+  "double_shift_ot_dates",
+  "double_shift_ot_explanation",
+  "detail_section_section",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "label": "Employee",
+   "options": "Employee",
+   "reqd": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "employee_name",
+   "fieldtype": "Data",
+   "label": "Employee Name",
+   "fetch_from": "employee.employee_name",
+   "read_only": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date",
+   "reqd": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Pending\nCompleted\nOverdue\nCancelled",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "column_break_xlfy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "monthweek",
+   "fieldtype": "Data",
+   "label": "Reporting Week",
+   "read_only": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "repeat_count",
+   "fieldtype": "Int",
+   "label": "Repeat Count",
+   "default": "1",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_qccb",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "shift_supervisor",
+   "fieldtype": "Link",
+   "label": "Shift Supervisor",
+   "options": "Employee",
+   "read_only": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "shift_supervisor_name",
+   "fieldtype": "Data",
+   "label": "Shift Supervisor Name",
+   "fetch_from": "shift_supervisor.employee_name",
+   "read_only": 1,
+   "in_list_view": 1,
+   "fetch_if_empty": 1
+  },
+  {
+   "fieldname": "shift_supervisor_user",
+   "fieldtype": "Link",
+   "label": "Shift Supervisor User",
+   "options": "User",
+   "hidden": 1,
+   "fetch_from": "shift_supervisor.user_id",
+   "read_only": 1,
+   "fetch_if_empty": 1
+  },
+  {
+   "fieldname": "column_break_yuke",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "site_supervisor",
+   "fieldtype": "Link",
+   "label": "Site Supervisor",
+   "options": "Employee",
+   "read_only": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "site_supervisor_name",
+   "fieldtype": "Data",
+   "label": "Site Supervisor Name",
+   "fetch_from": "site_supervisor.employee_name",
+   "read_only": 1,
+   "in_list_view": 1,
+   "fetch_if_empty": 1
+  },
+  {
+   "fieldname": "site_supervisor_user",
+   "fieldtype": "Link",
+   "label": "Site Supervisor User",
+   "options": "User",
+   "hidden": 1,
+   "fetch_from": "site_supervisor.user_id",
+   "read_only": 1,
+   "fetch_if_empty": 1
+  },
+  {
+   "fieldname": "column_break_hope",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "project_manager",
+   "fieldtype": "Link",
+   "label": "Project Manager",
+   "options": "Employee",
+   "read_only": 1,
+   "ignore_user_permissions": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "project_manager_name",
+   "fieldtype": "Data",
+   "label": "Project Manager Name",
+   "fetch_from": "project_manager.employee_name",
+   "read_only": 1,
+   "in_list_view": 1,
+   "fetch_if_empty": 1
+  },
+  {
+   "fieldname": "project_manager_user",
+   "fieldtype": "Link",
+   "label": "Project Manager User",
+   "options": "User",
+   "hidden": 1,
+   "fetch_from": "project_manager.user_id",
+   "read_only": 1,
+   "fetch_if_empty": 1
+  },
+  {
+   "fieldname": "shift_details_section",
+   "fieldtype": "Section Break",
+   "label": "Shift Details"
+  },
+  {
+   "fieldname": "operations_shift",
+   "fieldtype": "Link",
+   "label": "Operations Shift",
+   "options": "Operations Shift",
+   "read_only": 1
+  },
+  {
+   "fieldname": "operations_site",
+   "fieldtype": "Data",
+   "label": "Operations Site",
+   "fetch_from": "operations_shift.site",
+   "read_only": 1
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Data",
+   "label": "Project",
+   "fetch_from": "operations_shift.project",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_ljlg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "double_shift_ot_dates",
+   "fieldtype": "Small Text",
+   "label": "Double Shift OT Dates",
+   "read_only": 1
+  },
+  {
+   "fieldname": "double_shift_ot_explanation",
+   "fieldtype": "Data",
+   "label": "Double Shift OT Explanation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "detail_section_section",
+   "fieldtype": "Section Break",
+   "label": "Detail Section"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "options": "Roster Double Shift OT Checker",
+   "read_only": 1,
+   "print_hide": 1,
+   "no_copy": 1,
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 0,
+ "links": [],
+ "modified": "2026-07-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Operations",
+ "name": "Roster Double Shift OT Checker",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "role": "System Manager",
+   "read": 1,
+   "write": 1,
+   "report": 1,
+   "export": 1,
+   "print": 1,
+   "email": 1,
+   "share": 1,
+   "create": 1,
+   "delete": 1
+  },
+  {
+   "role": "Site Supervisor",
+   "read": 1,
+   "write": 1,
+   "report": 1,
+   "export": 1,
+   "print": 1,
+   "email": 1,
+   "share": 1,
+   "create": 0,
+   "delete": 0
+  },
+  {
+   "role": "Shift Supervisor",
+   "read": 1,
+   "write": 1,
+   "report": 1,
+   "export": 1,
+   "print": 1,
+   "email": 1,
+   "share": 1,
+   "create": 0,
+   "delete": 1
+  },
+  {
+   "role": "Projects User",
+   "read": 1,
+   "write": 1,
+   "report": 1,
+   "export": 1,
+   "print": 1,
+   "email": 1,
+   "share": 1,
+   "create": 0,
+   "delete": 1
+  },
+  {
+   "role": "Projects Manager",
+   "read": 1,
+   "write": 1,
+   "report": 1,
+   "export": 1,
+   "print": 1,
+   "email": 1,
+   "share": 1,
+   "create": 0,
+   "delete": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/one_fm/operations/doctype/roster_double_shift_ot_checker/roster_double_shift_ot_checker.py
+++ b/one_fm/operations/doctype/roster_double_shift_ot_checker/roster_double_shift_ot_checker.py
@@ -1,8 +1,159 @@
 # Copyright (c) 2026, ONE FM and contributors
 # For license information, please see license.txt
 
+from collections import defaultdict
+
+import frappe
 from frappe.model.document import Document
+from frappe.utils import add_days, get_first_day_of_week, get_last_day_of_week, getdate, nowdate
+
+from one_fm.operations.doctype.operations_shift.operations_shift import get_shift_supervisor
 
 
 class RosterDoubleShiftOTChecker(Document):
 	pass
+
+
+def get_check_periods(from_date=None):
+	"""
+	Return the current and next calendar week as (start_date, end_date) tuples.
+
+	Calendar weeks (rather than rolling 7-day windows from today) keep the period label
+	stable for the whole week, which is what lets repeat_count grow each day the same
+	discrepancy is still unresolved.
+	"""
+	date = getdate(from_date or nowdate())
+	current_week_start = get_first_day_of_week(date)
+	next_week_start = add_days(current_week_start, 7)
+
+	return [
+		(current_week_start, get_last_day_of_week(date)),
+		(next_week_start, get_last_day_of_week(next_week_start)),
+	]
+
+
+def format_monthweek(start_date, end_date):
+	"""Period label matching the Roster Day Off Checker convention, e.g. "Jul 20 - Jul 26"."""
+	return f"{getdate(start_date):%b %d} - {getdate(end_date):%b %d}"
+
+
+def build_double_shift_ot_dates(schedules):
+	"""One line per offending schedule: the date and the shift it was rostered on."""
+	return "\n".join(f"{getdate(schedule.date)} ({schedule.shift})" for schedule in schedules)
+
+
+def build_double_shift_ot_explanation(schedules):
+	"""Kept short: double_shift_ot_explanation is a Data field (140 characters)."""
+	shifts = {schedule.shift for schedule in schedules}
+	return (
+		f"{len(schedules)} Over-Time schedule(s) on {len(shifts)} shift(s) that do not allow "
+		"Double Shift OT. Remove them or enable it on the shift."
+	)
+
+
+def get_disallowed_ot_schedules(start_date, end_date):
+	"""
+	Over-Time Employee Schedules rostered on shifts that do not allow Double Shift OT,
+	grouped by employee.
+
+	The roster blocks these at creation time (see extreme_schedule), so anything found
+	here predates the restriction or bypassed the UI - either way a supervisor has to
+	resolve it.
+	"""
+	EmployeeSchedule = frappe.qb.DocType("Employee Schedule")
+	OperationsShift = frappe.qb.DocType("Operations Shift")
+
+	rows = (
+		frappe.qb.from_(EmployeeSchedule)
+		.join(OperationsShift)
+		.on(EmployeeSchedule.shift == OperationsShift.name)
+		.select(
+			EmployeeSchedule.employee,
+			EmployeeSchedule.date,
+			EmployeeSchedule.shift,
+			OperationsShift.site,
+			OperationsShift.project,
+		)
+		.where(
+			(EmployeeSchedule.roster_type == "Over-Time")
+			& (EmployeeSchedule.date[start_date:end_date])
+			& (OperationsShift.double_shift_ot_allowed == 0)
+		)
+		.orderby(EmployeeSchedule.employee)
+		.orderby(EmployeeSchedule.date)
+	).run(as_dict=True)
+
+	schedules_by_employee = defaultdict(list)
+	for row in rows:
+		schedules_by_employee[row.employee].append(row)
+
+	return schedules_by_employee
+
+
+def create_double_shift_ot_checker(employee, monthweek, schedules, today):
+	# The record is keyed on employee + week (see autoname), so the linked shift is the
+	# first offending one of the week; every date/shift pair is listed in the dates field.
+	# ponytail: one record per employee-week, split per shift if supervisors of different
+	# shifts need to action them separately.
+	shift = schedules[0].shift
+
+	yesterday_repeat_count = frappe.db.get_value(
+		"Roster Double Shift OT Checker",
+		{
+			"employee": employee,
+			"monthweek": monthweek,
+			"date": add_days(today, -1),
+			"creation": ["between", [add_days(nowdate(), -1), nowdate()]],
+		},
+		["repeat_count"],
+	)
+
+	# Replace any existing record for this employee/week so the details reflect the latest
+	# roster state instead of stacking one record per run.
+	frappe.delete_doc_if_exists(
+		"Roster Double Shift OT Checker", f"OPR-RDSOTC-{employee}-{monthweek}"
+	)
+
+	checker = frappe.new_doc("Roster Double Shift OT Checker")
+	checker.employee = employee
+	checker.date = today
+	checker.monthweek = monthweek
+	checker.status = "Pending"
+	checker.repeat_count = (yesterday_repeat_count or 0) + 1
+	checker.operations_shift = shift
+	checker.shift_supervisor = get_shift_supervisor(shift)
+	checker.site_supervisor = frappe.db.get_value(
+		"Operations Site", schedules[0].site, "site_supervisor"
+	)
+	checker.project_manager = frappe.db.get_value("Project", schedules[0].project, "project_manager")
+	checker.double_shift_ot_dates = build_double_shift_ot_dates(schedules)
+	checker.double_shift_ot_explanation = build_double_shift_ot_explanation(schedules)
+	checker.insert(ignore_permissions=True)
+
+
+def check_roster_double_shift_ot():
+	"""
+	Flag employees rostered on a second (Over-Time) shift whose Operations Shift does not
+	have "Double Shift OT Allowed" enabled, for the current and next calendar week.
+	"""
+	try:
+		today = getdate()
+
+		for start_date, end_date in get_check_periods(today):
+			monthweek = format_monthweek(start_date, end_date)
+
+			for employee, schedules in get_disallowed_ot_schedules(start_date, end_date).items():
+				create_double_shift_ot_checker(employee, monthweek, schedules, today)
+
+		frappe.db.commit()
+
+	except Exception:
+		frappe.log_error(
+			title="Error creating double shift OT checkers", message=frappe.get_traceback()
+		)
+
+
+@frappe.whitelist()
+def generate_checker():
+	frappe.only_for(["Operations Manager", "System Manager"])
+	frappe.enqueue(check_roster_double_shift_ot, queue="long", timeout=4000)

--- a/one_fm/operations/doctype/roster_double_shift_ot_checker/roster_double_shift_ot_checker.py
+++ b/one_fm/operations/doctype/roster_double_shift_ot_checker/roster_double_shift_ot_checker.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class RosterDoubleShiftOTChecker(Document):
+	pass

--- a/one_fm/operations/doctype/roster_double_shift_ot_checker/test_roster_double_shift_ot_checker.py
+++ b/one_fm/operations/doctype/roster_double_shift_ot_checker/test_roster_double_shift_ot_checker.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, date_diff, getdate
+
+from one_fm.operations.doctype.roster_double_shift_ot_checker.roster_double_shift_ot_checker import (
+	build_double_shift_ot_dates,
+	build_double_shift_ot_explanation,
+	format_monthweek,
+	get_check_periods,
+)
+
+
+class TestRosterDoubleShiftOTChecker(FrappeTestCase):
+	def test_two_consecutive_full_weeks(self):
+		(week1_start, week1_end), (week2_start, week2_end) = get_check_periods("2026-07-25")
+
+		self.assertEqual(date_diff(week1_end, week1_start), 6)
+		self.assertEqual(date_diff(week2_end, week2_start), 6)
+		self.assertEqual(week2_start, add_days(week1_end, 1))
+
+	def test_current_week_contains_the_given_date(self):
+		date = getdate("2026-07-25")
+		(week1_start, week1_end), _ = get_check_periods(date)
+
+		self.assertLessEqual(week1_start, date)
+		self.assertLessEqual(date, week1_end)
+
+	def test_periods_are_stable_across_the_week(self):
+		# repeat_count relies on the label being identical on consecutive runs within a week
+		date = getdate("2026-07-25")
+		week_start = get_check_periods(date)[0][0]
+
+		self.assertEqual(get_check_periods(week_start), get_check_periods(date))
+
+	def test_monthweek_label_format(self):
+		self.assertEqual(format_monthweek("2026-07-20", "2026-07-26"), "Jul 20 - Jul 26")
+
+	def test_dates_list_one_line_per_schedule(self):
+		schedules = [
+			frappe._dict(date="2026-07-20", shift="SHIFT-A"),
+			frappe._dict(date="2026-07-22", shift="SHIFT-B"),
+		]
+		self.assertEqual(
+			build_double_shift_ot_dates(schedules), "2026-07-20 (SHIFT-A)\n2026-07-22 (SHIFT-B)"
+		)
+
+	def test_explanation_counts_schedules_and_distinct_shifts(self):
+		schedules = [
+			frappe._dict(date="2026-07-20", shift="SHIFT-A"),
+			frappe._dict(date="2026-07-21", shift="SHIFT-A"),
+			frappe._dict(date="2026-07-22", shift="SHIFT-B"),
+		]
+		explanation = build_double_shift_ot_explanation(schedules)
+
+		self.assertIn("3 Over-Time schedule(s)", explanation)
+		self.assertIn("2 shift(s)", explanation)
+
+	def test_explanation_fits_the_data_field(self):
+		# double_shift_ot_explanation is a Data field (varchar 140)
+		schedules = [frappe._dict(date="2026-07-20", shift="SHIFT-A")]
+		self.assertLessEqual(len(build_double_shift_ot_explanation(schedules)), 140)


### PR DESCRIPTION
## What

New **Roster Double Shift OT Checker** doctype plus the scheduler that populates it.

It flags employees rostered on a second (Over-Time) shift whose Operations Shift does **not** have `Double Shift OT Allowed` enabled, for the current and next calendar week, and routes the record to the shift supervisor / site supervisor / project manager.

## Doctype

`Roster Double Shift OT Checker` (Operations module), named `OPR-RDSOTC-{employee}-{monthweek}`, with the supervisor block, shift details, `Double Shift OT Dates`, `Double Shift OT Explanation`, `status` and `repeat_count` — same shape as the existing Roster Day Off Checker so supervisors get a familiar record.

## Generator

- `get_disallowed_ot_schedules`: Query Builder join of Employee Schedule (`roster_type = "Over-Time"`) to Operations Shift (`double_shift_ot_allowed = 0`), grouped per employee. The roster already blocks this at creation time (`extreme_schedule`), so anything found here is legacy data or an API/import bypass.
- Calendar weeks (not rolling 7-day windows from today) so the period label is stable for the whole week — that is what lets `repeat_count` grow each day the discrepancy stays unresolved.
- Per employee/week: any existing record is replaced (details always reflect the latest roster state), `repeat_count` carried over from yesterday's run + 1, `status = Pending`, supervisors resolved from the offending shift/site/project, and every offending date/shift listed in `Double Shift OT Dates`.
- Explanation text kept inside the 140-char Data field (covered by a test).
- Registered on the existing 12:15 pm cron next to the Day Off Checker generator.

## Notes

- The record is keyed on employee + week, so the `Operations Shift` link shows the first offending shift of that week; all date/shift pairs are still listed in `Double Shift OT Dates`. Marked with a `ponytail:` comment — split into one record per shift if supervisors of different shifts need to action them separately.
- Assignment rules for this doctype are stacked in #6547.

## Tests

`bench run-tests --module one_fm.operations.doctype.roster_double_shift_ot_checker.test_roster_double_shift_ot_checker` — 7 passing (period windows, label stability, dates/explanation builders, Data-field length).

## Deploy

`bench migrate` (new doctype), then `bench restart` (controller + hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)