### PR TITLE
feat: client interview in roster

### DIFF
--- a/one_fm/one_fm/doctype/client_interview_shortlist/client_interview_shortlist.py
+++ b/one_fm/one_fm/doctype/client_interview_shortlist/client_interview_shortlist.py
@@ -22,10 +22,6 @@ class ClientInterviewShortlist(Document):
 			self.prospective_client = None
 			self.customer_name = None
 
-	def before_workflow_action(self):
-		if self.workflow_action == "Submit":
-			self.validate_qoa_check_for_attended_employees()
-
 	def validate_qoa_check_for_attended_employees(self):
 		"""Ensure all attended employees have QOA Check and Upload Picture filled."""
 		for row in self.client_interview_employee:
@@ -143,6 +139,8 @@ class ClientInterviewShortlist(Document):
 		employee_schedule.insert(ignore_permissions=True)
 
 	def on_update_after_submit(self):
+		if self.has_value_changed("workflow_state") and self.workflow_state == "Completed":
+			self.validate_qoa_check_for_attended_employees()
 		self.mark_attendance_for_interviewed_employees()
 
 	def mark_attendance_for_interviewed_employees(self):

--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -207,11 +207,11 @@ class CreateMap:
 	def schedule_query(self):
 		# SQL to fetch all schedule records for selected employees and date range
 		return f"""
-			SELECT es.employee, es.employee_name, es.date, es.operations_role, es.post_abbrv, 
-				es.shift, es.start_datetime, es.end_datetime, es.roster_type, es.employee_availability, 
+			SELECT es.employee, es.employee_name, es.date, es.operations_role, es.post_abbrv,
+				es.shift, es.start_datetime, es.end_datetime, es.roster_type, es.employee_availability,
 				es.day_off_ot, es.project, es.site, emp.project as actual_project,
 				emp.site as actual_site, emp.shift as actual_shift, es.event_location, es.client_event,
-				es.on_the_job_training
+				es.on_the_job_training, es.reference_doctype, es.reference_docname
 			FROM `tabEmployee Schedule` es 
 			JOIN `tabEmployee` emp
 			ON es.employee = emp.name
@@ -382,6 +382,9 @@ class CreateMap:
 						'end_datetime': matched_schedule.get('end_datetime'),
 						'event_location': matched_schedule.get('event_location'),
 						'client_event': matched_schedule.get('client_event'),
+						'project': matched_schedule.get('project'),
+						'reference_doctype': matched_schedule.get('reference_doctype'),
+						'reference_docname': matched_schedule.get('reference_docname'),
 						'post_abbrv': matched_schedule.get('post_abbrv'),
 						'day_off_ot': attendance['day_off_ot'],
 						'actual_shift': attendance.get('actual_shift')

--- a/one_fm/one_fm/page/roster/roster.js
+++ b/one_fm/one_fm/page/roster/roster.js
@@ -1390,7 +1390,11 @@ function render_roster(res, page) {
 			if (employees_data[employee_key][date_key] && employees_data[employee_key][date_key].length > 0) {
 				for (let k = 0; k < employees_data[employee_key][date_key].length; k++) {
 					let record = employees_data[employee_key][date_key][k];
-					let { employee, date, operations_role, post_abbrv, employee_availability, shift, start_datetime, end_datetime, start_time, end_time, roster_type, attendance, day_off_ot, leave_type, leave_application, event_location, actual_site, client_event, on_the_job_training, project, site } = record;
+					let { employee, date, operations_role, post_abbrv, employee_availability, shift, start_datetime, end_datetime, start_time, end_time, roster_type, attendance, day_off_ot, leave_type, leave_application, event_location, actual_site, client_event, on_the_job_training, project, site, reference_doctype, reference_docname } = record;
+					// Tooltip details for Client Interview (same for scheduled/attended cases)
+					let client_interview_tooltip = `Client Interview`;
+					if (project) client_interview_tooltip += `<br>Project: ${project}`;
+					if (reference_docname) client_interview_tooltip += `<br>Ref: ${reference_docname}`;
 					// NR Logic: Determine if we are on a foreign grid, and if today's schedule is outside this grid.
 					if (employee_has_relieving_days && page.filters) {
 						let is_foreign_grid = false;
@@ -1491,7 +1495,7 @@ function render_roster(res, page) {
 							data_selectid = `${employee}|${date}|${operations_role}|${shift}|${employee_availability}`;
 						}
 					}
-					else if (attendance && in_list(["Day Off", "On Leave", "Absent", "On Hold", "Client Day Off", "Fingerprint Appointment", "Medical Appointment", "Client Event"], attendance)) {
+					else if (attendance && in_list(["Day Off", "On Leave", "Absent", "On Hold", "Client Day Off", "Fingerprint Appointment", "Medical Appointment", "Client Event", "Client Interview"], attendance)) {
 						data_selectid = `${employee}|${date}|${employee_availability}`;
 						if (attendance == "Fingerprint Appointment") {
 							is_fingerprint_appointment = true;
@@ -1537,6 +1541,9 @@ function render_roster(res, page) {
 						} else if (attendance && attendance == "Medical Appointment") {
 							tooltiptext += `Medical Appointment`;
 							abbrv += `${abbr_map[attendance]}<br>`;
+						} else if (attendance && attendance == "Client Interview") {
+							tooltiptext += client_interview_tooltip;
+							abbrv += `${abbr_map[attendance]}<br>`;
 						} else if (attendance && attendance == "Client Event") {
 							tooltiptext += `Client Event<br>Event Location: ${event_location}<br>Start: ${shift_start}<br>End: ${shift_end}<br>`;
 							abbrv += `${abbr_map[attendance]}<br>`;
@@ -1555,6 +1562,8 @@ function render_roster(res, page) {
 							abbrv += `${abbr_map[employee_availability]}<br>`;
 							if (employee_availability == "Client Event") {
 								tooltiptext += `Client Event<br>Event Location: ${event_location}<br>Start: ${shift_start}<br>End: ${shift_end}<br>`;
+							} else if (employee_availability == "Client Interview") {
+								tooltiptext += client_interview_tooltip;
 							}
 						} else {
 							if (!shift && client_event) {

--- a/one_fm/www/css/site.css
+++ b/one_fm/www/css/site.css
@@ -1073,6 +1073,16 @@ body[data-route="roster"] .presentdifferent {
   background: #50C878;
 }
 
+/* Route-scoped so the box colour also wins on the tooltip (customtooltiptext),
+   which the black default rule (.customtooltip .customtooltiptext) would otherwise beat. */
+body[data-route="roster"] .cyanboxcolor {
+  background-color: #00BCD4;
+}
+
+body[data-route="roster"] .tealboxcolor {
+  background-color: #00897B;
+}
+
 body[data-route="roster"] .presentdayoffot {
   background: #70ad47;
 }


### PR DESCRIPTION
feat: render Client Interview on roster with details and matching colour
Client Interview entries showed a blank box on the roster grid. Once an
Attendance row exists the backend gives the cell precedence over the
schedule with a "Client Interview" status the frontend did not handle, so
no data_selectid was set and the empty-box fallback rendered. The
schedule-only (present/future) case coloured the box but left the tooltip
empty, and the cyan class lost a specificity fight with the default black
tooltip rule.

- add "Client Interview" to the roster.js attendance status list and a
  matching tooltip/abbr branch so the cyan "CI" box renders
- build a shared Client Interview tooltip (status, project, reference)
  used by both the attended and scheduled branches
- fetch reference_doctype/reference_docname in CreateMap.schedule_query
  and propagate project/reference into the attendance entry
- add route-scoped cyanboxcolor/tealboxcolor rules so the box colour also
  wins on the tooltip background

fix: run QOA validation from a real controller hook
before_workflow_action is not a Frappe controller hook, so the QOA check
for attended employees never ran. Move it into on_update_after_submit,
guarded on the workflow_state transition to Completed, since attended
flags are only set after the document is submitted.

- remove the dead before_workflow_action method
- call validate_qoa_check_for_attended_employees on the transition to
  Completed before marking attendance