### PR TITLE
fix(staging): unregister 30 patches with no files + ne_fm typo (unblocks bench migrate)

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -294,7 +294,6 @@ one_fm.patches.v15_0.add_sales_invoice_contract_fields #3
 one_fm.patches.v15_0.add_sales_taxes_charges_add_or_deduct_field
 one_fm.patches.v15_0.add_workflow_penalty_and_investigation
 one_fm.patches.v15_0.update_penalty_and_investigation_workflow
-one_fm.patches.v15_0.update_day_off_category_erf_2025_00030
 one_fm.patches.v15_0.add_rambo_reliever_custom_field #2026-05-14
 one_fm.patches.v15_0.update_vehicle_naming_series
 one_fm.patches.v15_0.remove_vehicle_autoname_property_setter
@@ -302,12 +301,6 @@ one_fm.patches.v15_0.cleanup_todo_type_field
 one_fm.patches.v15_0.update_vehicle_category_naming #2026-06-17
 one_fm.patches.v15_0.rename_fleet_workspace_to_transportation #2026-06-10 #2
 one_fm.patches.v15_0.rename_route_planner_page_to_transportation_schedule
-one_fm.patches.v15_0.update_purchase_receipt_prc_2026_000101_posting_date
-one_fm.patches.v15_0.update_job_offer_day_off_category_for_job_applicants
-one_fm.patches.v15_0.add_phone_option_to_job_applicant_contact_number
-one_fm.patches.v15_0.remove_employee_marital_status_property_setter
-one_fm.patches.v15_0.update_vehicle_property_setter
-one_fm.patches.v15_0.add_hd_ticket_category_field
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task
@@ -463,38 +456,14 @@ one_fm.patches.v15_0.add_leave_application_resumption_contact_fields #1
 one_fm.patches.v15_0.add_absence_investigation_hr_officer_to_hr_settings
 one_fm.patches.v15_0.add_vehicle_custodian_history_fields
 one_fm.patches.v15_0.update_leave_application_workflow_dss #2026-07-17-2
-ne_fm.patches.v15_0.update_sales_invoice_property_setter
 one_fm.patches.v15_0.add_subcontractor_exit_workflow
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_project_manager
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_operations_manager
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_gsd_supervisor
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_offboarding_officer
 one_fm.patches.v15_0.add_assignment_rule_subcontractor_exit_finance_manager
-one_fm.patches.v15_0.add_nationality_read_permission
-one_fm.patches.v15_0.update_workflows_for_ops_admin_edit
-one_fm.patches.v15_0.backfill_ojt_employee_schedules #2026-06-18
-one_fm.patches.v15_0.delete_medical_appointment_todos #2026-06-15
-one_fm.patches.v15_0.sync_erf_workflow_state_with_closed_status #2026-06-15
-one_fm.patches.v15_0.close_job_openings_for_closed_erf #2026-06-15
-one_fm.patches.v15_0.update_interview_console_permissions
-one_fm.patches.v15_0.standardize_marital_status_options
-one_fm.patches.v15_0.standardize_employee_marital_status_options
-one_fm.patches.v15_0.fix_nirmala_day_off_client_event_conflict #2026-06-18
-one_fm.patches.v15_0.update_pmr_workflow_in_process_role
-one_fm.patches.v15_0.fix_shift_worker_annual_leave_total_days #2026-06-24
-one_fm.patches.v15_0.fix_leave_extension_request_leave_application_status #2026-06-30
-one_fm.patches.v15_0.update_pmr_and_resignation_workflow_permissions #2026-06-30
-one_fm.patches.v15_0.fix_day_off_client_event_conflict_bulk #2026-07-03
 # --- Operations-011 (24th-30th) release patches ---
 one_fm.patches.v15_0.update_bank_account_workflow
-one_fm.patches.v15_0.resync_resignation_workflow_draft_state #2026-07-07
-one_fm.patches.v15_0.mark_draft_pmr_as_completed #2026-07-07
-one_fm.patches.v15_0.backfill_checkin_geolocation_from_device_id #2026-07-12
-one_fm.patches.v15_0.normalize_user_mobile_country_code #2026-07-13
-one_fm.patches.v15_0.warm_zenquote_cache #2026-07-13
-one_fm.patches.v15_0.backfill_subcontractor_name_in_onboard_subcontract_employee #2026-07-12
-one_fm.patches.v15_0.delete_pending_approval_attendance_checks_airport_t4_jul12 #2026-07-13
-one_fm.patches.v15_0.send_amp_verification_test_email #2026-07-14
 one_fm.patches.v15_0.add_project_sprint_prefix_field #2026-07-23
 one_fm.patches.v15_0.show_project_users_section_for_scrum #2026-07-23
 one_fm.patches.v15_0.add_bonus_request_line_manager_workflow #2026-07-23


### PR DESCRIPTION
## Problem

`bench migrate` cannot complete on `staging`. `patches.txt` registers **30 patches whose `.py` files are not on this branch**, plus one entry naming a package that does not exist.

## Cause — one commit

**`a0b905fb8` — "fix: conflict resolutions for PR #6469 (9 files only)", 19 Jul.**

It resolved a merge by taking version-15's `patches.txt` wholesale — **+47 patch lines** — while resolving only 9 files, none of which were the patch files. The registrations arrived without the code.

The files were never deleted from staging; they were never here. The commits that created them (`007bd778e`, `23155f094`) are **not ancestors of staging at all** — they reached version-15 via hotfix branches. Only the text crossed over.

That same commit also introduced:

```
+ne_fm.patches.v15_0.update_sales_invoice_property_setter
```

`ne_fm` — missing the `o`. The correctly-spelled entry was already registered on staging before `a0b905fb8` and is untouched here.

## Why remove rather than import the files

These are one-off **production** data fixes keyed to production records — `MAP-2026-00114`, `PRC-2026-000101`, "Airport Terminal 4 on 2026-07-12". Of the 30:

- **5 delete rows** (`delete_medical_appointment_todos`, `delete_pending_approval_attendance_checks_airport_t4_jul12`, …)
- **11 write records** (backfills, workflow-state rewrites)
- **1 sends a real email** — `send_amp_verification_test_email`: *"One-time trigger: send a real AMP-for-Email test message"*

Importing the files would run all of that against staging on the next migrate. None of it belongs there.

And there is no state to reconcile: because the files were never on staging, Frappe could never have executed these patches here, so there is nothing in the Patch Log to undo. Unregistering is a no-op even in the unlikely case some did run.

`version-15` and `test-production` keep their own registrations **and** their files. They are unaffected.

## This restores staging's own prior state

None of the 31 removed lines were on staging before `a0b905fb8`:

| | active entries |
|---|---|
| staging before `a0b905fb8` | 455 |
| staging now | 490 |
| **this branch** | **459** |

The +4 over 455 is legitimate work merged since.

## Verification

- Every remaining entry resolves to a real `.py` file — full-file audit, zero exceptions
- Hyphenated entries `update_employee_HR-EMP-03572` and `update_on_boarding_EMP-ONB-2025-00315` preserved (an earlier pass of my script mis-parsed these at the hyphen and would have wrongly deleted them — caught and fixed; verified against `git ls-tree` rather than the case-insensitive macOS filesystem)
- No `ne_fm` reference remains
- Only `patches.txt` is touched

## Why this keeps recurring

Feature branches are cut from `staging`, so every one of them inherits this broken `patches.txt` and carries it back on merge. That is exactly what happened in #6562, where the WI-001555 commit dragged this same file — `ne_fm` typo included — into a cherry-pick onto `test-production`. I overrode it there; this fixes the source.

**Not addressed here:** `staging` is 439 commits behind `version-15`. That gap is the reason a hand-pasted `patches.txt` was attempted in the first place, and it deserves its own sync.
