### PR TITLE
fix: count day-offs in scheduled month for Day Off OT guard

### DIFF
--- a/one_fm/one_fm/page/roster/roster.py
+++ b/one_fm/one_fm/page/roster/roster.py
@@ -527,8 +527,13 @@ def schedule_staff(employees, shift, operations_role, otRoster, start_date, proj
 
 		# Evaluate final acceptance conditions for creating Employee Schedule
 		
-		month_start = get_first_day(start_date)
-		month_end = get_last_day(end_date)
+		# Derive the calendar month from the dates being scheduled — end_date is empty
+		# for Day Off OT / Selected-Days mode and get_last_day("") wrongly returns the
+		# CURRENT month, so the day-off count would be taken from the wrong month.
+		assigned_dates = [getdate(e.get("date")) for e in employees if e.get("date")]
+		ref_date = min(assigned_dates) if assigned_dates else getdate(start_date)
+		month_start = get_first_day(ref_date)
+		month_end = get_last_day(ref_date)
 		
 		for obj in employee_list:
 			rdo_count = frappe.db.count("Employee Schedule", filters={


### PR DESCRIPTION
The day-off validation guard derived its calendar-month window from month_end = get_last_day(end_date). In Day Off OT / Selected-Days mode end_date is empty, and get_last_day("") falls back to the current month instead of the month being rostered. The guard then counted the employee's day-offs in the wrong month, wrongly firing the "total scheduled day off ... will be less than 1" error.

- Derive the month window from the dates actually being scheduled
- Fall back to start_date when no assigned dates are present
- Leaves single-month scenarios unchanged; fixes the empty-end_date case