### PR TITLE
fix: drive vehicle naming series from vehicle category

### DIFF
--- a/one_fm/custom/custom_field/vehicle.py
+++ b/one_fm/custom/custom_field/vehicle.py
@@ -83,15 +83,15 @@ def get_vehicle_custom_fields():
                 "reqd": 1
             },
             {
-                "fieldname": "custom_naming_series",
-                "fieldtype": "Data",
+                "fieldname": "naming_series",
+                "fieldtype": "Select",
                 "label": "Naming Series",
                 "insert_after": "one_fm_vehicle_category",
-                "hidden": 1,
+                "options": "\nVHL-S-.####\nVHL-L-.####\nVHL-.####",
                 "no_copy": 1,
-                "print_hide": 1,
                 "default": "VHL-.####",
-                "read_only": 1
+                "read_only": 1,
+                "print_hide": 1
             },
             {
                 "fieldname": "one_fm_vehicle_type",

--- a/one_fm/custom/property_setter/vehicle.py
+++ b/one_fm/custom/property_setter/vehicle.py
@@ -3,6 +3,13 @@ def get_vehicle_properties():
         {
             "doc_type": "Vehicle",
             "doctype_or_field": "DocType",
+            "property": "autoname",
+            "property_type": "Data",
+            "value": "naming_series:"
+        },
+        {
+            "doc_type": "Vehicle",
+            "doctype_or_field": "DocType",
             "property": "image_field",
             "property_type": "Data",
             "value": "image"

--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -299,7 +299,7 @@ doc_events = {
 		"validate": "one_fm.utils.validate_warehouse"
 	},
 	"Vehicle": {
-		"autoname": "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.vehicle_autoname",
+		"before_insert": "one_fm.overrides.vehicle.set_naming_series",
 		"after_insert": "one_fm.fleet_management.doctype.vehicle_leasing_contract.vehicle_leasing_contract.after_insert_vehicle",
 		"validate": [
 			"one_fm.overrides.vehicle.validate_vehicle_branding",

--- a/one_fm/overrides/vehicle.py
+++ b/one_fm/overrides/vehicle.py
@@ -3,6 +3,18 @@ from frappe import _
 from frappe.utils import cint, flt, getdate
 
 
+def set_naming_series(doc, method):
+	"""Set the Vehicle naming series based on the vehicle category before insert."""
+	if doc.one_fm_vehicle_category == "Leased":
+		series = "VHL-L-.####"
+	elif doc.one_fm_vehicle_category == "Subcontractor":
+		series = "VHL-S-.####"
+	else:
+		series = "VHL-.####"
+
+	doc.naming_series = series
+
+
 def validate_vehicle_branding(doc, method):
 	"""Validate branding details on Vehicle save."""
 	validate_branding_expiration_dates(doc)

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -301,6 +301,8 @@ one_fm.patches.v15_0.cleanup_todo_type_field
 one_fm.patches.v15_0.update_vehicle_category_naming #2026-06-17
 one_fm.patches.v15_0.rename_fleet_workspace_to_transportation #2026-06-10 #2
 one_fm.patches.v15_0.rename_route_planner_page_to_transportation_schedule
+one_fm.patches.v15_0.update_vehicle_naming_series_select #6
+one_fm.patches.v15_0.remove_vehicle_custom_naming_series_field #2026-07-27
 
 [post_model_sync]
 one_fm.patches.v15_0.process_task_for_wiki_employee_task

--- a/one_fm/patches/v15_0/remove_vehicle_custom_naming_series_field.py
+++ b/one_fm/patches/v15_0/remove_vehicle_custom_naming_series_field.py
@@ -1,0 +1,22 @@
+import frappe
+
+
+def execute():
+	"""Remove the obsolete custom_naming_series Custom Field from Vehicle.
+
+	Vehicle naming now uses the standard `naming_series` field (autoname
+	"naming_series:"), so the earlier custom_naming_series field is no longer
+	needed. Delete the Custom Field and drop its column if it exists.
+	"""
+	if frappe.db.exists("Custom Field", {"dt": "Vehicle", "fieldname": "custom_naming_series"}):
+		frappe.db.delete("Custom Field", {
+			"dt": "Vehicle",
+			"fieldname": "custom_naming_series",
+		})
+
+		# Drop the column from the table if it was already synced
+		if frappe.db.has_column("Vehicle", "custom_naming_series"):
+			frappe.db.sql_ddl("ALTER TABLE `tabVehicle` DROP COLUMN `custom_naming_series`")
+
+		frappe.clear_cache(doctype="Vehicle")
+		frappe.db.commit()

--- a/one_fm/patches/v15_0/update_vehicle_naming_series_select.py
+++ b/one_fm/patches/v15_0/update_vehicle_naming_series_select.py
@@ -1,0 +1,19 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from one_fm.custom.custom_field.vehicle import get_vehicle_custom_fields
+from one_fm.custom.property_setter.vehicle import get_vehicle_properties
+from one_fm.setup.setup import add_property_setter
+
+
+def execute():
+	"""
+	Convert Vehicle custom_naming_series to a Select naming series field and
+	set the Vehicle autoname Property Setter to field:custom_naming_series.
+	"""
+	# 1. Apply updated custom field (custom_naming_series -> Select)
+	create_custom_fields(get_vehicle_custom_fields(), update=True)
+
+	# 2. Apply the autoname Property Setter (field:custom_naming_series)
+	add_property_setter(get_vehicle_properties())
+
+	frappe.clear_cache(doctype="Vehicle")

--- a/one_fm/public/js/doctype_js/vehicle.js
+++ b/one_fm/public/js/doctype_js/vehicle.js
@@ -5,19 +5,17 @@ frappe.ui.form.on('Vehicle', {
 		frm.set_df_property('license_plate', 'hidden', false);
 	},
 	onload(frm) {
-		if (frm.is_new() && !frm.doc.custom_naming_series) {
-			frm.set_value("custom_naming_series", "VHL-.####");
+		if (frm.is_new()) {
+			set_naming_series(frm);
 		}
 	},
+	validate(frm) {
+		// Keep the naming series aligned with the category regardless of how it changed.
+		set_naming_series(frm);
+	},
 	one_fm_vehicle_category(frm) {
-		const series_map = {
-			"Owned": "VHL-.####",
-			"Leased": "VHL-L-.####",
-			"Subcontractor": "VHL-S-.####"
-		};
-		const category = frm.doc.one_fm_vehicle_category;
-		frm.set_value("custom_naming_series", series_map[category] || "VHL-.####");
-		frm.set_df_property("vehicle_leasing_contract", "reqd", category === "Leased");
+		set_naming_series(frm);
+		frm.set_df_property("vehicle_leasing_contract", "reqd", frm.doc.one_fm_vehicle_category === "Leased");
 	},
 	vehicle_leasing_contract(frm){
 	  if(!frm.doc.vehicle_leasing_contract){
@@ -66,6 +64,20 @@ frappe.ui.form.on('Vehicle', {
 		calculate_custodian_mileage(frm);
 	}
 })
+
+var set_naming_series = function(frm) {
+	// Mirror of the server-side before_insert logic (one_fm.overrides.vehicle.set_naming_series):
+	// derive the naming series from the vehicle category.
+	let series;
+	if (frm.doc.one_fm_vehicle_category === "Leased") {
+		series = "VHL-L-.####";
+	} else if (frm.doc.one_fm_vehicle_category === "Subcontractor") {
+		series = "VHL-S-.####";
+	} else {
+		series = "VHL-.####";
+	}
+	frm.set_value("naming_series", series);
+};
 
 var log_custodian_handover = function(frm) {
 	let row = frm.add_child("custom_vehicle_custodian_history", {


### PR DESCRIPTION
Switch Vehicle autoname to the standard naming_series field, populated from one_fm_vehicle_category, and retire the old custom_naming_series field.

- convert Naming Series custom field to a Select named naming_series (VHL-.####, VHL-L-.####, VHL-S-.####)
- add DocType property setter autoname "naming_series:"
- replace the vehicle_autoname doc_event with a before_insert set_naming_series that maps category to series
- mirror the mapping client-side via a shared set_naming_series helper, applied on onload, category change, and validate
- add patch to apply the field/property-setter changes
- add patch to remove the obsolete custom_naming_series field and column

<img width="1295" height="440" alt="Screenshot 2026-07-27 at 8 26 34 PM" src="https://github.com/user-attachments/assets/d0985a58-d22c-4f1a-b001-ab7b3813b353" />
