### PR TITLE
WI-001693: separate rejection reason lists for PAM and MOI

### DIFF
--- a/one_fm/visa_management/doctype/visa_request/visa_request.js
+++ b/one_fm/visa_management/doctype/visa_request/visa_request.js
@@ -90,26 +90,34 @@ function set_rejection_remarks(frm) {
 	}
 }
 
-// Predefined rejection reasons for PAM & MOI states (WI-001693)
-const PAM_MOI_REJECTION_REASONS = [
-	'Passport Validity is Less than 18 Months',
-	"Worker's age is below the legal minimum",
-	"The worker's gender does not match the profession",
-	"The occupation requires amendment to specify the worker's specialization",
-	'An active file exists for this worker',
-	'Worker is in Black List'
-];
+// Predefined rejection reasons per workflow state (WI-001693). PAM and MOI reject for
+// different reasons, so each state offers its own list rather than a shared one.
+const REJECTION_REASONS_BY_STATE = {
+	'Pending By PAM': [
+		'Passport Validity is Less than 18 Months',
+		"Worker's age is below the legal minimum",
+		"The worker's gender does not match the profession",
+		"The occupation requires amendment to specify the worker's specialization",
+		'An active file exists for this worker',
+		'Worker is in Black List'
+	],
+	'Pending By MOI': [
+		'Block Due to Pending Transactions in MOI',
+		'Active Driving License , Rejected by Transportation Department'
+	]
+};
 
 function get_rejection_remarks(frm, resolve, reject) {
 	frappe.dom.unfreeze();
-	// PAM & MOI require a predefined reason (Select); other states keep free text
-	const use_select = ['Pending By PAM', 'Pending By MOI'].includes(frm.doc.workflow_state);
-	const reason_field = use_select
+	// PAM & MOI require a predefined reason (Select), each from its own list; the other
+	// states keep free text.
+	const state_reasons = REJECTION_REASONS_BY_STATE[frm.doc.workflow_state];
+	const reason_field = state_reasons
 		? {
 			label: 'Reason for Rejection',
 			fieldname: 'reason',
 			fieldtype: 'Select',
-			options: PAM_MOI_REJECTION_REASONS.join('\n'),
+			options: state_reasons.join('\n'),
 			reqd: 1
 		}
 		: {


### PR DESCRIPTION
Follow-up to the merged WI-001693, for a change outside the original criteria.

## What

The rejection popup offered **one shared list** of six reasons to both `Pending By PAM` and `Pending By MOI`. MOI rejects for different reasons, so the list is now keyed by workflow state.

**`Pending By MOI`** — new list:
1. Block Due to Pending Transactions in MOI
2. Active Driving License , Rejected by Transportation Department

**`Pending By PAM`** — unchanged, the six reasons from the story notes.

Every other state (`Pending Initial Review`, `Pending GRD Manager Approval`) keeps its free-text box, and the selected reason still lands in that state's own remark field — `pam_rejection_remark` / `moi_rejection_remark` — so the audit trail is untouched.

Option text is stored verbatim as supplied, including the spacing in `Active Driving License , Rejected by Transportation Department`.

## Note

The mandatory-reason rule is enforced client-side (`reqd: 1` on the prompt), as in the original story — the remark fields are plain `Small Text` with no server-side list validation, so an API caller could still reject without a predefined reason. Out of scope here, but worth knowing if it matters for audit.

## Deploy

`bench build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)