### PR TITLE
WI-001690: Take Action button on the Client Day Off Checker

### DIFF
--- a/one_fm/operations/doctype/roster_client_day_off_checker/roster_client_day_off_checker.js
+++ b/one_fm/operations/doctype/roster_client_day_off_checker/roster_client_day_off_checker.js
@@ -3,6 +3,14 @@
 
 frappe.ui.form.on("Roster Client Day Off Checker", {
 	refresh(frm) {
+		// WI-001690: open the roster already filtered to this employee's allocation, so a
+		// supervisor can correct the Client Day Off without rebuilding the filters by hand.
+		if (!frm.is_new()) {
+			frm.add_custom_button(__("Take Action"), () => open_filtered_roster(frm)).addClass(
+				"btn-primary"
+			);
+		}
+
 		// Set all fields as read-only except status for supervisors
 		if (!frappe.user.has_role("System Manager")) {
 			frm.set_df_property("employee", "read_only", 1);
@@ -14,3 +22,27 @@ frappe.ui.form.on("Roster Client Day Off Checker", {
 		}
 	},
 });
+
+function open_filtered_roster(frm) {
+	frappe.call({
+		method:
+			"one_fm.operations.doctype.roster_client_day_off_checker.roster_client_day_off_checker.get_take_action_data",
+		args: { checker: frm.doc.name },
+		freeze: true,
+		freeze_message: __("Opening roster..."),
+		callback: function (r) {
+			if (!r.message || !r.message.path) {
+				frappe.msgprint(__("Unable to determine the roster filters for this record."));
+				return;
+			}
+
+			// Same handling as the Contract Compliance Checker: build the URL from the
+			// returned params, dropping any the server could not resolve.
+			let url = new URL(r.message.path, window.location.origin);
+			Object.entries(r.message.params || {}).forEach(function ([key, value]) {
+				if (value) url.searchParams.set(key, value);
+			});
+			window.open(url.toString(), "_blank");
+		},
+	});
+}

--- a/one_fm/operations/doctype/roster_client_day_off_checker/roster_client_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_client_day_off_checker/roster_client_day_off_checker.py
@@ -311,3 +311,49 @@ def generate_client_day_off_checker():
 		)
 	frappe.enqueue(check_roster_client_day_off, queue="long", timeout=4000)
 
+
+
+@frappe.whitelist()
+def get_take_action_data(checker: str) -> dict:
+	"""
+	Redirect path and roster filters for the Take Action button (WI-001690).
+
+	Returns the same {path, params} shape as the Contract Compliance Checker's
+	equivalent, so the client handling is identical.
+
+	The checker stores the employee's allocations as plain text (project_allocation,
+	site_allocation, shift_allocation) and carries no operations role, so anything
+	missing is resolved from the Employee record - which is also where the role lives.
+	"""
+	doc = frappe.get_doc("Roster Client Day Off Checker", checker)
+	doc.check_permission("read")
+
+	employee = (
+		frappe.db.get_value(
+			"Employee",
+			doc.employee,
+			["project", "site", "shift", "custom_operations_role_allocation", "employee_id", "employee_name"],
+			as_dict=True,
+		)
+		or frappe._dict()
+	)
+
+	# The roster reads these off the query string in setup_staff_filters(); year and
+	# month drive which month the calendar opens on.
+	date = getdate(doc.date) if doc.date else getdate(nowdate())
+
+	return {
+		"path": "/app/roster",
+		"params": {
+			"main_view": "roster",
+			"sub_view": "roster",
+			"employee_id": doc.employee_id or employee.employee_id,
+			"employee_name": doc.employee_name or employee.employee_name,
+			"project": doc.project_allocation or employee.project,
+			"site": doc.site_allocation or employee.site,
+			"shift": doc.shift_allocation or employee.shift,
+			"operations_role": employee.custom_operations_role_allocation,
+			"year": str(date.year),
+			"month": str(date.month),
+		},
+	}

--- a/one_fm/operations/doctype/roster_client_day_off_checker/test_roster_client_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_client_day_off_checker/test_roster_client_day_off_checker.py
@@ -1,9 +1,131 @@
 # Copyright (c) 2026, ONE FM and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from one_fm.operations.doctype.roster_client_day_off_checker.roster_client_day_off_checker import (
+	get_take_action_data,
+)
+
+MODULE = "one_fm.operations.doctype.roster_client_day_off_checker.roster_client_day_off_checker"
+
+
+class StubChecker(frappe._dict):
+	"""Stand-in for the checker document.
+
+	A module-level class rather than a _dict carrying a lambda: Frappe pickles values it
+	caches, and a locally defined lambda cannot be pickled.
+	"""
+
+	def check_permission(self, *args, **kwargs):
+		return None
 
 
 class TestRosterClientDayOffChecker(FrappeTestCase):
 	pass
+
+
+class TestTakeActionData(FrappeTestCase):
+	"""
+	WI-001690: Take Action opens the roster pre-filtered by employee, project, site, shift
+	and role. The checker document and Employee lookup are stubbed so the filter
+	resolution is tested without Employee/Operations fixtures.
+	"""
+
+	def _checker(self, **overrides):
+		doc = StubChecker(
+			{
+				"name": "OPR-RCDOC-TEST",
+				"employee": "EMP-TEST-0001",
+				"employee_id": "EMPID-1",
+				"employee_name": "Test Worker",
+				"project_allocation": "Project A",
+				"site_allocation": "Site A",
+				"shift_allocation": "Shift A",
+				"date": "2026-07-11",
+			}
+		)
+		doc.update(overrides)
+		return doc
+
+	def _employee(self, **overrides):
+		employee = frappe._dict(
+			{
+				"project": "Employee Project",
+				"site": "Employee Site",
+				"shift": "Employee Shift",
+				"custom_operations_role_allocation": "Role A",
+				"employee_id": "EMPID-FALLBACK",
+				"employee_name": "Fallback Name",
+			}
+		)
+		employee.update(overrides)
+		return employee
+
+	def _run(self, checker=None, employee="default"):
+		employee_value = self._employee() if employee == "default" else employee
+		with patch(f"{MODULE}.frappe.get_doc", return_value=checker or self._checker()):
+			with patch(f"{MODULE}.frappe.db.get_value", return_value=employee_value):
+				return get_take_action_data("OPR-RCDOC-TEST")
+
+	def test_every_filter_the_ac_asks_for_is_returned(self):
+		params = self._run()["params"]
+
+		# AC: Employee Name & ID, Project, Site, Shift, Role
+		self.assertEqual(params["employee_id"], "EMPID-1")
+		self.assertEqual(params["employee_name"], "Test Worker")
+		self.assertEqual(params["project"], "Project A")
+		self.assertEqual(params["site"], "Site A")
+		self.assertEqual(params["shift"], "Shift A")
+		self.assertEqual(params["operations_role"], "Role A")
+
+	def test_redirects_to_the_roster(self):
+		result = self._run()
+
+		self.assertEqual(result["path"], "/app/roster")
+		# These two open the right view; the rest are read by setup_staff_filters().
+		self.assertEqual(result["params"]["main_view"], "roster")
+		self.assertEqual(result["params"]["sub_view"], "roster")
+
+	def test_calendar_opens_on_the_checker_month(self):
+		params = self._run()["params"]
+
+		self.assertEqual(params["year"], "2026")
+		self.assertEqual(params["month"], "7")
+
+	def test_allocations_fall_back_to_the_employee_record(self):
+		# The checker stores allocations as free text and they can be blank. The Employee
+		# record is the fallback, and is the only source for the operations role.
+		checker = self._checker(project_allocation="", site_allocation=None, shift_allocation="")
+		params = self._run(checker=checker)["params"]
+
+		self.assertEqual(params["project"], "Employee Project")
+		self.assertEqual(params["site"], "Employee Site")
+		self.assertEqual(params["shift"], "Employee Shift")
+		self.assertEqual(params["operations_role"], "Role A")
+
+	def test_employee_identity_falls_back_too(self):
+		checker = self._checker(employee_id="", employee_name="")
+		params = self._run(checker=checker)["params"]
+
+		self.assertEqual(params["employee_id"], "EMPID-FALLBACK")
+		self.assertEqual(params["employee_name"], "Fallback Name")
+
+	def test_missing_employee_record_does_not_raise(self):
+		# get_value returns None when the Employee is gone. The button should still open
+		# the roster with whatever the checker itself holds rather than erroring.
+		params = self._run(employee=None)["params"]
+
+		self.assertEqual(params["project"], "Project A")
+		self.assertIsNone(params["operations_role"])
+
+	def test_no_date_falls_back_to_today(self):
+		checker = self._checker(date=None)
+		params = self._run(checker=checker)["params"]
+
+		today = frappe.utils.getdate(frappe.utils.nowdate())
+		self.assertEqual(params["year"], str(today.year))
+		self.assertEqual(params["month"], str(today.month))


### PR DESCRIPTION
## What

A **Take Action** button on the Client Day Off Checker that opens the roster already filtered to the employee's allocation, so a supervisor can correct a wrong Client Day Off without rebuilding the filters by hand.

Follows the **Contract Compliance Checker's** Take Action pattern you pointed me at: a whitelisted `get_take_action_data()` returns `{path, params}` and the client builds the URL from it, dropping any param the server couldn't resolve. Same shape, so the two behave identically and there's one convention rather than two.

## Filters returned, per the AC

| AC field | Param | Consumed by |
|---|---|---|
| Employee Name & ID | `employee_id`, `employee_name` | the roster's employee search boxes |
| Project | `project` | `setup_staff_filters()` |
| Site | `site` | `setup_staff_filters()` |
| Shift | `shift` | `setup_staff_filters()` |
| Role | `operations_role` | `setup_staff_filters()` |
| — | `year`, `month` | opens the calendar on the checker's month |

## Where the values come from

The checker stores allocations as **free text** (`project_allocation`, `site_allocation`, `shift_allocation`) and **carries no operations role at all**, so anything blank falls back to the Employee record — which is also the only source for the role (`custom_operations_role_allocation`). A missing Employee record doesn't raise; the button still opens the roster with whatever the checker holds.

## Verified against a real record

Every AC filter resolved, none blank:

```
employee_id      2102015BD185
employee_name    MANIK MIA HASHEM
project          TAQA Well Solutions
site             TAWA Kabad Yard
shift            Janitorial-TAWA Kabad Yard-Day-1
operations_role  Janitor-Janitorial-TAWA Kabad Yard-Day-1
year / month     2026 / 7
```

7 tests, covering each AC filter, the roster view params, the month, both fallback paths and a missing Employee.

## Deploy

`bench build`, then `bench restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)