### PR TITLE
WI-001711: row-level costs, selling price and profit margins

### DIFF
--- a/one_fm/one_fm/doctype/manpower_service_item/manpower_service_item.json
+++ b/one_fm/one_fm/doctype/manpower_service_item/manpower_service_item.json
@@ -52,7 +52,17 @@
   "civil_id_fee",
   "bank_guarantee_fee",
   "wcf_insurance_fee",
-  "pifss_rate"
+  "pifss_rate",
+  "annual_leave",
+  "reliever_breakdown_section",
+  "reliever_salary",
+  "reliever_residency",
+  "reliever_accommodation",
+  "reliever_transportation",
+  "reliever_uniform",
+  "reliever_wcf_insurance",
+  "reliever_annual_leave",
+  "reliever_indemnity"
  ],
  "fields": [
   {
@@ -201,7 +211,8 @@
   {
    "fieldname": "reliever_cost",
    "fieldtype": "Currency",
-   "label": "Reliever Cost"
+   "label": "Reliever Cost",
+   "read_only": 1
   },
   {
    "fieldname": "indemnity",
@@ -297,13 +308,73 @@
   {
    "fieldname": "wcf_insurance_fee",
    "fieldtype": "Currency",
-   "label": "WCF Insurance Fee"
+   "label": "WCF Insurance Fee",
+   "read_only": 1
   },
   {
    "fieldname": "pifss_rate",
    "fieldtype": "Currency",
    "label": "PIFSS Rate",
-   "depends_on": "eval:doc.nationality == \"Kuwaiti\""
+   "depends_on": "eval:doc.nationality == \"Kuwaiti\"",
+   "read_only": 1
+  },
+  {
+   "fieldname": "annual_leave",
+   "fieldtype": "Currency",
+   "label": "Annual Leave"
+  },
+  {
+   "fieldname": "reliever_breakdown_section",
+   "fieldtype": "Section Break",
+   "label": "Reliever Cost Breakdown"
+  },
+  {
+   "fieldname": "reliever_salary",
+   "fieldtype": "Currency",
+   "label": "Reliever Salary",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reliever_residency",
+   "fieldtype": "Currency",
+   "label": "Reliever Residency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reliever_accommodation",
+   "fieldtype": "Currency",
+   "label": "Reliever Accommodation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reliever_transportation",
+   "fieldtype": "Currency",
+   "label": "Reliever Transportation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reliever_uniform",
+   "fieldtype": "Currency",
+   "label": "Reliever Uniform",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reliever_wcf_insurance",
+   "fieldtype": "Currency",
+   "label": "Reliever WCF Insurance",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reliever_annual_leave",
+   "fieldtype": "Currency",
+   "label": "Reliever Annual Leave",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reliever_indemnity",
+   "fieldtype": "Currency",
+   "label": "Reliever Indemnity",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/one_fm/one_fm/doctype/pricing_proposal/pricing_proposal.json
+++ b/one_fm/one_fm/doctype/pricing_proposal/pricing_proposal.json
@@ -32,6 +32,7 @@
   "total_cost",
   "selling_price",
   "column_break_dmsv",
+  "total_gross_margin",
   "gross_profit_margin",
   "net_profit_margin",
   "net_profit_amount"
@@ -164,16 +165,24 @@
   {
    "fieldname": "total_cost",
    "fieldtype": "Currency",
-   "label": "Total Cost"
+   "label": "Total Cost",
+   "read_only": 1
   },
   {
    "fieldname": "selling_price",
    "fieldtype": "Currency",
-   "label": "Selling Price"
+   "label": "Selling Price",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_dmsv",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_gross_margin",
+   "fieldtype": "Currency",
+   "label": "Total Gross Margin",
+   "read_only": 1
   },
   {
    "fieldname": "gross_profit_margin",

--- a/one_fm/one_fm/doctype/pricing_proposal/pricing_proposal.py
+++ b/one_fm/one_fm/doctype/pricing_proposal/pricing_proposal.py
@@ -4,12 +4,175 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import formatdate, getdate
+from frappe.utils import flt, formatdate, getdate
+
+
+# WI-001711: the eight reliever components, each scaled from a primary counterpart by
+# the reliever ratio. Reliever Indemnity is derived from Reliever Annual Leave instead
+# (see calculate_reliever_costs), so it is not in this map.
+RELIEVER_COMPONENTS = {
+	"reliever_salary": "average_basic_salary",
+	"reliever_residency": "residency_stamp_fee",
+	"reliever_accommodation": "accommodation_allowance",
+	"reliever_transportation": "transportation_allowance",
+	"reliever_uniform": "uniform_cost",
+	"reliever_wcf_insurance": "wcf_insurance_fee",
+	"reliever_annual_leave": "annual_leave",
+}
+
+RELIEVER_FIELDS = list(RELIEVER_COMPONENTS) + ["reliever_indemnity"]
+
+
+def average_over_contract(amount, increment_percent, contract_duration_years):
+	"""
+	Amount grown by the increment plan, averaged over the contract (WI-001711).
+
+	    amount + (amount x increment% x duration/2)
+
+	The AC's worked example: 75 + (75 x 0.02 x 2.5) = 78.75.
+	"""
+	return flt(amount) + (
+		flt(amount) * (flt(increment_percent) / 100.0) * (flt(contract_duration_years) / 2.0)
+	)
+
+
+def get_reliever_ratio(reliever_factor_percentage, quantity):
+	"""
+	Reliever Factor Percentage / Quantity.
+
+	Zero when there is no quantity - a row with no headcount carries no reliever cost, and
+	dividing by it would raise.
+	"""
+	if not flt(quantity):
+		return 0.0
+
+	return flt(reliever_factor_percentage) / flt(quantity)
+
+
+def get_wcf_insurance_cost(primary_salary, wcf_insurance_rate):
+	"""Primary Salary x rate / 100. Applies to every row, whatever the nationality."""
+	return flt(primary_salary) * flt(wcf_insurance_rate) / 100.0
+
+
+def get_pifss_cost(primary_salary, pifss_rate, nationality):
+	"""
+	(Primary Salary + Primary Salary / 2) x rate%, and only for Kuwaiti rows.
+
+	Matches the visibility rule from WI-001710, where PIFSS Rate is shown only when
+	nationality is "Kuwaiti".
+	"""
+	if nationality != "Kuwaiti":
+		return 0.0
+
+	base = flt(primary_salary) + (flt(primary_salary) / 2.0)
+	return base * flt(pifss_rate) / 100.0
+
+
+def calculate_total_chain(total_operational_cost, overhead_cost, markup_percent):
+	"""
+	Cost, selling price and margins (WI-001711 AC5).
+
+	    Total Cost      = Total Operation Cost + Indirect Overhead
+	    Selling Price   = Total Cost x (1 + Markup%)
+	    Gross Margin    = Selling Price - Total Operation Cost
+	    Net Profit      = Selling Price - Total Cost
+
+	"Indirect Overhead" is the proposal's own Overhead Cost. Both inputs are taken as
+	given: the AC does not define how either is arrived at, so neither is recomputed.
+	"""
+	total_cost = flt(total_operational_cost) + flt(overhead_cost)
+	selling_price = total_cost * (1 + (flt(markup_percent) / 100.0))
+	gross_margin = selling_price - flt(total_operational_cost)
+	net_profit = selling_price - total_cost
+
+	return frappe._dict(
+		total_cost=total_cost,
+		selling_price=selling_price,
+		total_gross_margin=gross_margin,
+		gross_profit_margin=get_margin_percentage(gross_margin, selling_price),
+		net_profit_amount=net_profit,
+		net_profit_margin=get_margin_percentage(net_profit, selling_price),
+	)
+
+
+def get_margin_percentage(amount, selling_price):
+	"""Margin as a percentage of the selling price; zero when nothing is being sold."""
+	if not flt(selling_price):
+		return 0.0
+
+	return flt(amount) / flt(selling_price) * 100.0
 
 
 class PricingProposal(Document):
 	def validate(self):
 		self.set_budget_configuration()
+		self.calculate_service_item_costs()
+		self.calculate_totals()
+
+	def calculate_service_item_costs(self):
+		"""Row-level costs for every Manpower Service Item (WI-001711)."""
+		rates = self.get_budget_rates()
+
+		for row in self.manpower_service_items or []:
+			# Average salaries over the contract, grown by the increment plan.
+			row.average_basic_salary = average_over_contract(
+				row.basic_salary, row.increment_plan_percentage, self.contract_duration_years
+			)
+			row.average_other_allowance = average_over_contract(
+				row.other_allowance, row.increment_plan_percentage, self.contract_duration_years
+			)
+			row.average_net_salary = flt(row.average_basic_salary) + flt(row.average_other_allowance)
+
+			# "Primary Salary" in the AC is the average basic salary.
+			primary_salary = row.average_basic_salary
+
+			row.wcf_insurance_fee = get_wcf_insurance_cost(primary_salary, rates.wcf_insurance_fee)
+			row.pifss_rate = get_pifss_cost(primary_salary, rates.pifss_rate, row.nationality)
+
+			self.calculate_reliever_costs(row, rates.reliever_factor_percentage)
+
+	def calculate_reliever_costs(self, row, reliever_factor_percentage):
+		"""
+		Scale each reliever component off its primary counterpart, then total them.
+
+		Reliever Indemnity is Reliever Annual Leave / 2 rather than a scaled primary, so it
+		is computed after the rest.
+		"""
+		ratio = get_reliever_ratio(reliever_factor_percentage, row.quantity)
+
+		for reliever_field, primary_field in RELIEVER_COMPONENTS.items():
+			row.set(reliever_field, flt(row.get(primary_field)) * ratio)
+
+		row.reliever_indemnity = flt(row.reliever_annual_leave) / 2.0
+		row.reliever_cost = sum(flt(row.get(field)) for field in RELIEVER_FIELDS)
+
+	def calculate_totals(self):
+		"""
+		Cost, selling price and margins (WI-001711).
+
+		Total Operational Cost and Overhead Cost are inputs here - the AC does not define
+		how either is arrived at, so neither is overwritten. "Indirect Overhead" in the AC
+		is this proposal's Overhead Cost.
+		"""
+		self.update(
+			calculate_total_chain(
+				self.total_operational_cost, self.overhead_cost, self.markup_percent
+			)
+		)
+
+	def get_budget_rates(self):
+		"""Rates from the resolved Budget Configuration; zeros when none is resolved yet."""
+		if not self.budget_configuration:
+			return frappe._dict(
+				wcf_insurance_fee=0, pifss_rate=0, reliever_factor_percentage=0
+			)
+
+		return frappe.db.get_value(
+			"Budget Configuration",
+			self.budget_configuration,
+			["wcf_insurance_fee", "pifss_rate", "reliever_factor_percentage"],
+			as_dict=True,
+		) or frappe._dict(wcf_insurance_fee=0, pifss_rate=0, reliever_factor_percentage=0)
 
 	def set_budget_configuration(self):
 		"""

--- a/one_fm/one_fm/doctype/pricing_proposal/test_pricing_proposal.py
+++ b/one_fm/one_fm/doctype/pricing_proposal/test_pricing_proposal.py
@@ -5,7 +5,13 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from one_fm.one_fm.doctype.pricing_proposal.pricing_proposal import (
+	average_over_contract,
+	calculate_total_chain,
 	get_budget_configuration_for_date,
+	get_margin_percentage,
+	get_pifss_cost,
+	get_reliever_ratio,
+	get_wcf_insurance_cost,
 )
 
 
@@ -96,3 +102,91 @@ class TestPricingProposal(FrappeTestCase):
 		proposal.validate()
 
 		self.assertEqual(proposal.budget_configuration, original.name)
+
+
+class TestPricingFormulas(FrappeTestCase):
+	"""
+	WI-001711 formulas, exercised through the module-level helpers so each AC's worked
+	example is asserted directly, without Budget Configuration or Item fixtures.
+	"""
+
+	def test_average_basic_salary_matches_the_worked_example(self):
+		# AC: Basic 75, Increment 2%, Duration 5 -> 75 + (75 x 0.02 x 2.5) = 78.75
+		self.assertEqual(average_over_contract(75, 2, 5), 78.75)
+
+	def test_average_other_allowance_uses_the_same_growth(self):
+		# AC: [Other] + ([Other] x [Inc %] x ([Duration]/2))
+		self.assertEqual(average_over_contract(100, 2, 5), 105)
+
+	def test_no_increment_leaves_the_amount_untouched(self):
+		self.assertEqual(average_over_contract(75, 0, 5), 75)
+		self.assertEqual(average_over_contract(75, 2, 0), 75)
+
+	def test_wcf_insurance_is_a_rate_per_hundred(self):
+		# AC: WCF Insurance Cost = Primary Salary x 0.66 / 100
+		self.assertAlmostEqual(get_wcf_insurance_cost(78.75, 0.66), 78.75 * 0.66 / 100)
+
+	def test_pifss_only_applies_to_kuwaiti_rows(self):
+		# AC: only when Nationality = "Kuwaiti": (Primary + Primary/2) x 11.5%
+		expected = (78.75 + 78.75 / 2) * 11.5 / 100
+		self.assertAlmostEqual(get_pifss_cost(78.75, 11.5, "Kuwaiti"), expected)
+
+		for nationality in ("Non-Kuwaiti", "Non-State", "", None):
+			self.assertEqual(get_pifss_cost(78.75, 11.5, nationality), 0, msg=str(nationality))
+
+	def test_reliever_ratio_is_factor_over_quantity(self):
+		# AC: Reliever Ratio = Reliever Factor Percentage / Quantity
+		self.assertEqual(get_reliever_ratio(10, 4), 2.5)
+
+	def test_reliever_ratio_is_zero_without_quantity(self):
+		# A row with no headcount carries no reliever cost, and dividing by it would raise.
+		self.assertEqual(get_reliever_ratio(10, 0), 0)
+		self.assertEqual(get_reliever_ratio(10, None), 0)
+
+	def test_margin_percentage_guards_a_zero_selling_price(self):
+		self.assertEqual(get_margin_percentage(50, 200), 25)
+		self.assertEqual(get_margin_percentage(50, 0), 0)
+
+
+class TestPricingProposalTotals(FrappeTestCase):
+	"""
+	The AC5 chain. Driven through calculate_total_chain so it runs without the Pricing
+	Proposal doctype installed.
+	"""
+
+	def test_total_cost_adds_the_indirect_overhead(self):
+		# AC: Total Cost (COST+OH) = Total Operation Cost + Indirect Overhead
+		self.assertEqual(calculate_total_chain(1000, 200, 0).total_cost, 1200)
+
+	def test_selling_price_applies_the_markup(self):
+		# AC: Selling Price = Total Cost x (1 + Markup%)
+		self.assertEqual(calculate_total_chain(1000, 200, 25).selling_price, 1500)
+
+	def test_gross_margin_is_measured_against_operational_cost(self):
+		# AC: Total Gross Margin = Selling Price - Total Operation Cost
+		result = calculate_total_chain(1000, 200, 25)
+
+		self.assertEqual(result.total_gross_margin, 500)
+		self.assertAlmostEqual(result.gross_profit_margin, 500 / 1500 * 100)
+
+	def test_net_profit_is_measured_against_total_cost(self):
+		# AC: Net Profit Amount = Selling Price - Total Cost
+		result = calculate_total_chain(1000, 200, 25)
+
+		self.assertEqual(result.net_profit_amount, 300)
+		self.assertAlmostEqual(result.net_profit_margin, 300 / 1500 * 100)
+
+	def test_zero_markup_leaves_no_net_profit_but_recovers_overhead(self):
+		result = calculate_total_chain(1000, 200, 0)
+
+		self.assertEqual(result.selling_price, 1200)
+		self.assertEqual(result.net_profit_amount, 0)
+		self.assertEqual(result.net_profit_margin, 0)
+		self.assertEqual(result.total_gross_margin, 200)
+
+	def test_empty_proposal_does_not_raise(self):
+		result = calculate_total_chain(None, None, None)
+
+		self.assertEqual(result.total_cost, 0)
+		self.assertEqual(result.gross_profit_margin, 0)
+		self.assertEqual(result.net_profit_margin, 0)


### PR DESCRIPTION
Implements the pricing formulas. **Four terms the AC leaves open** were settled before building, and each is recorded in a comment where the code applies it:

| Open term | Settled as | Why |
|---|---|---|
| "Primary Salary" | **Average Basic Salary** | WCF and PIFSS are charges on basic pay, and the story computes Average Basic Salary immediately before using the term |
| "Indirect Overhead" | the proposal's **Overhead Cost** | WI-001713 already derives it from the resolved Budget Configuration |
| The 8 reliever components | **created** | only a single `reliever_cost` existed |
| Total Gross Margin amount | **created** | only the percentage existed |

## New fields

**Manpower Service Item** — `annual_leave` (input, the primary the AC multiplies) and a **Reliever Cost Breakdown** section holding the eight read-only components: Salary, Residency, Accommodation, Transportation, Uniform, WCF Insurance, Annual Leave, Indemnity.

`wcf_insurance_fee`, `pifss_rate` and `reliever_cost` become read-only now that the controller owns them, as do the derived totals on Pricing Proposal. **Pricing Proposal** gains `total_gross_margin`.

## Formulas

```
average_basic_salary    = basic + (basic × inc% × duration/2)      # 75, 2%, 5 → 78.75
average_other_allowance = same growth applied to other_allowance
average_net_salary      = the two averages added
wcf_insurance_fee       = average_basic_salary × config rate / 100   # every row
pifss_rate              = (primary + primary/2) × config rate%      # Kuwaiti only
reliever ratio          = config reliever factor % / quantity
each reliever component = its primary counterpart × ratio
reliever_indemnity      = reliever_annual_leave / 2
reliever_cost           = the eight components added
```

Then: Total Cost = Operational + Overhead → Selling Price = Total Cost × (1 + Markup%) → Gross Margin = Selling Price − Operational Cost → Net Profit = Selling Price − Total Cost, each margin as a percentage of selling price.

**Total Operational Cost and Overhead Cost are treated as inputs** — the AC doesn't define how either is arrived at, so neither is overwritten.

**Guards:** a zero quantity yields a zero reliever ratio rather than dividing by it; a zero selling price yields zero margins rather than dividing by it.

## Tests

14 new, driving the AC's own worked example and every branch, written against pure functions so they run without fixtures. Note the **7 pre-existing WI-001713 tests error on my machine** — `DocType Budget Configuration not found`, because the pricing doctypes aren't migrated into this site. They're unrelated to this change and should pass wherever the chain is migrated.

## Deploy

`bench migrate` (10 new fields), then `bench restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)