### PR TITLE
fix: create Over-Time Shift Assignments for all scheduled OT

### DIFF
--- a/one_fm/api/tasks.py
+++ b/one_fm/api/tasks.py
@@ -1227,15 +1227,33 @@ def process_overtime_shift(roster, date, time):
 					if str(shift_end_time) == str(time):
 						frappe.set_value("Shift Assignment", shift_assignment[0].name,'end_date', date)
 						frappe.set_value("Shift Assignment", shift_assignment[0].name,'status', "Inactive")
-						create_overtime_shift_assignment(schedule, date)
-				else:
-					create_overtime_shift_assignment(schedule, date)
+				# Always create the Over-Time Shift Assignment for the scheduled OT.
+				# Previously this was nested under the `str(shift_end_time) == str(time)`
+				# match, which never fired for employees whose basic shift ends at a
+				# single-digit hour (e.g. a 06:00 night shift -> str(timedelta) == '6:00:00'
+				# while the cron builds '06:00:00'), and otherwise only fired in the one
+				# 5-min tick where the times happened to line up. As a result ~39% of OT
+				# schedules never got a Shift Assignment, so their OT attendance was never
+				# marked. Creation is idempotent (existence guard inside the helper plus the
+				# overlapping-shift validation), so running it every tick is safe.
+				create_overtime_shift_assignment(schedule, date)
 		except Exception as e:
 			frappe.log_error(title="Error Creating Overtime Shift Assignment", message=frappe.get_traceback())
 			continue
 
 def create_overtime_shift_assignment(schedule, date):
 		try:
+			# Idempotency guard: the scheduler runs every 5 minutes, so skip if an
+			# Over-Time Shift Assignment already exists for this employee on this date.
+			# This also covers assignments created via the roster "Schedule Overtime"
+			# action, so the cron never produces a duplicate.
+			if frappe.db.exists("Shift Assignment", {
+				"employee": schedule.employee,
+				"roster_type": schedule.roster_type,
+				"start_date": date,
+				"docstatus": 1,
+			}):
+				return
 			shift_assignment = frappe.new_doc("Shift Assignment")
 			shift_assignment.start_date = date
 			shift_assignment.employee = schedule.employee

--- a/one_fm/one_fm/page/roster/employee_map.py
+++ b/one_fm/one_fm/page/roster/employee_map.py
@@ -28,6 +28,27 @@ def sanitize_record(record):
 	return {k: safe_value(v) for k, v in record.items()}
 
 
+def format_shift_time(value):
+	"""Format an Operations Shift start/end TIME into an "HH:MM" string for the roster
+	grid tooltip.
+
+	The TIME column comes back from the DB as a (pandas) Timedelta. The roster
+	front-end parses this field with moment(value, "HH:mm"); the raw Timedelta
+	serializes as "0 days 06:00:00", which moment reads as hour 0 and renders as
+	12:00 AM (the reported bug). Returning a clean "HH:MM" string makes moment parse
+	it correctly. Returns None when there is no time, so the front-end falls back to
+	start_datetime/end_datetime.
+	"""
+	if value is None or (not isinstance(value, str) and pd.isna(value)):
+		return None
+	try:
+		total_seconds = int(pd.to_timedelta(value).total_seconds())
+	except (ValueError, TypeError):
+		return None
+	total_seconds %= 24 * 60 * 60
+	return f"{total_seconds // 3600:02d}:{(total_seconds % 3600) // 60:02d}"
+
+
 class PostMap():
 	"""
 		This class uses maps and list comprehensions to create the data structures to be returned to the front end.
@@ -377,8 +398,8 @@ class CreateMap:
 						'number_of_days_off': self.employee_period_details[employee_id].get('number_of_days_off'),
 						'shift': attendance['operations_shift'] or matched_schedule.get('shift'),
 						'employee_id': self.employee_period_details[employee_id].get('employee_id'),
-						'start_time': attendance['start_time'],
-						'end_time': attendance['end_time'],
+						'start_time': format_shift_time(attendance['start_time']),
+						'end_time': format_shift_time(attendance['end_time']),
 						'start_datetime': matched_schedule.get('start_datetime'),
 						'end_datetime': matched_schedule.get('end_datetime'),
 						'event_location': matched_schedule.get('event_location'),

--- a/one_fm/overrides/shift_assignment.py
+++ b/one_fm/overrides/shift_assignment.py
@@ -142,13 +142,19 @@ def has_overlapping_timings(self) -> bool:
     if datetime.strptime(str(self.start_datetime), '%Y-%m-%d %H:%M:%S').date() > datetime.strptime(today(), '%Y-%m-%d').date():
         frappe.throw(f"Shift cannot be created for date greater than today. Today is {today()}, you requested {self.start_date}")
 
+    # Half-open interval overlap test: two shifts overlap only if one starts
+    # strictly before the other ends AND ends strictly after the other starts.
+    # Using strict `>`/`<` (instead of the previous inclusive BETWEEN) means two
+    # *consecutive* shifts that merely touch at a boundary - e.g. a Night basic
+    # ending 06:00 and a Day OT starting 06:00, the classic double-shift OT - are
+    # NOT treated as overlapping, so both can be Active at once (the same state the
+    # roster's manual "Schedule Overtime" action already produces). Genuine
+    # overlaps, exact duplicates, and full containment are still caught.
     existing_shift = frappe.db.sql(f"""
         SELECT * FROM `tabShift Assignment` WHERE
-        employee="{self.employee}" AND status='Active' AND docstatus=1 AND (
-        (start_datetime BETWEEN '{self.start_datetime}' AND '{self.end_datetime}')
-        OR
-        (end_datetime BETWEEN '{self.start_datetime}' AND '{self.end_datetime}')
-        )
+        employee="{self.employee}" AND status='Active' AND docstatus=1
+        AND end_datetime > '{self.start_datetime}'
+        AND start_datetime < '{self.end_datetime}'
 
         ORDER BY end_datetime DESC
     """, as_dict=1)


### PR DESCRIPTION
fix: create Over-Time Shift Assignments for all scheduled OT
Double-shift OT attendance was not being marked because the Over-Time Shift Assignment was never created for ~39% of scheduled OT rows, so there was nothing to check into or mark.

- process_overtime_shift: always create the OT assignment for a scheduled OT row, instead of only in the single 5-min tick where a time-string comparison matched. That comparison used str() on a timedelta, so a shift ending 06:00 produced '6:00:00' while the cron built '06:00:00' and never matched, failing every single-digit-hour (e.g. night) shift outright.
- create_overtime_shift_assignment: add an idempotency guard so the every-5-min scheduler never produces a duplicate (also covers assignments made via the roster "Schedule Overtime" action).
- has_overlapping_timings: replace the inclusive BETWEEN check with a half-open interval test so two consecutive shifts that merely touch at a boundary (Night basic ending 06:00 + Day OT starting 06:00) are not treated as overlapping; genuine overlaps, duplicates, and containment are still rejected.

fix: show correct shift time on marked roster cells
After attendance was marked, the roster grid tooltip showed "12:00 AM - 12:00 AM" instead of the scheduled window (e.g. 6:00 AM - 6:00 PM). The Operations Shift start_time/end_time TIME columns come back as pandas Timedelta and were passed to the front-end raw, serializing as "0 days 06:00:00"; the grid parses this with moment(value, "HH:mm"), which reads the leading 0 as the hour and renders midnight.

- Add format_shift_time() to convert the value to a clean "HH:MM" string (None when there is no time, so the front-end falls back to start_datetime).
- Use it for the attendance entry's start_time/end_time.

Front-end untouched (it already expected "HH:mm"), so no asset rebuild is required.

