### PR TITLE
fix: enable ToDo class override to delete Google Task on trash

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -566,7 +566,7 @@ override_doctype_class = {
     "Interview": "one_fm.overrides.interview.InterviewOverride",
     "Purchase Order": "one_fm.overrides.purchase_order.PurchaseOrderOverride",
     "HD Ticket": "one_fm.overrides.hd_ticket.HDTicketOverride",
-    # "ToDo": "one_fm.overrides.todo.ToDo",
+    "ToDo": "one_fm.overrides.todo.ToDo",
     "Task": "one_fm.overrides.task.TaskOverride",
     "Loan Application": "one_fm.overrides.loan_application.LoanApplicationOverride",
     "Loan": "one_fm.overrides.loan.LoanOverride",


### PR DESCRIPTION
Register the custom ToDo controller in override_doctype_class so its on_trash handler runs. Previously the override was commented out, so deleting or force-deleting a ToDo (including via delete_linked_todos when a reference doc is removed) left its Google Task alive. Orphaned Google Tasks were then re-imported by the 5-minute sync as duplicate, reference-less ToDos.

- Uncomment "ToDo": "one_fm.overrides.todo.ToDo" so on_trash fires and removes the linked Google Task on deletion
