### PR TITLE
fix(ccp): don't deny create permission on Candidate Country Process

### DIFF
--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -590,8 +590,22 @@ def has_permission(doc, ptype=None, user=None, **kwargs):
     never have an Arrival and Deployment record linked to it yet, so this check
     would always deny creation outright (e.g. the automatic CCP creation cascade
     from Job Offer's create_candidate_country_process()) regardless of role.
+
+    Internal ETA-recalculation cascades are also excluded: recalculate_ccp_live_eta()
+    (called from every downstream step doctype -- Visa Request, PCC Clearance,
+    Overseas Medical Appointment WAFID, Overseas Remedical, Visa Stamping, Arrival
+    and Deployment -- whenever any of them is saved) does its own `doc.save()` on
+    this CCP under whatever user triggered that save. That's not a direct edit by
+    the acting user, so it shouldn't be subject to the Onboarding-Officer-specific
+    restriction either -- otherwise ETA tracking silently stops updating for the
+    entire process (not just the Arrival stage) for any user who happens to also
+    hold the Onboarding Officer role, since the restriction only lifts once Arrival
+    (the very last of the 11 steps) reaches a late stage.
     """
     if ptype not in ("write", "delete", "submit", "cancel"):
+        return None
+
+    if getattr(frappe.local, "in_ccp_recalculation", False):
         return None
 
     user = user or frappe.session.user

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -105,7 +105,10 @@ class CandidateCountryProcess(Document):
                 visiting.remove(row.process_name)
                 return None
 
-            before_tasks = self._expand_through_skipped(self._parse_task_list(row.get("before_task")), row_map)
+            before_tasks = self._expand_through_skipped(
+                self._expand_parallel_siblings(self._parse_task_list(row.get("before_task")), row_map),
+                row_map
+            )
             if not before_tasks:
                 planned = frappe.utils.add_days(start, row.duration_in_days)
                 memo[row.process_name] = planned
@@ -166,7 +169,10 @@ class CandidateCountryProcess(Document):
                 visiting.remove(row.process_name)
                 return actual
 
-            before_tasks = self._expand_through_skipped(self._parse_task_list(row.get("before_task")), row_map)
+            before_tasks = self._expand_through_skipped(
+                self._expand_parallel_siblings(self._parse_task_list(row.get("before_task")), row_map),
+                row_map
+            )
             if not before_tasks:
                 live = frappe.utils.add_days(start, row.duration_in_days)
                 memo[row.process_name] = live
@@ -206,6 +212,29 @@ class CandidateCountryProcess(Document):
         if not task_str:
             return []
         return [t.strip() for t in task_str.split(",") if t.strip()]
+
+    def _expand_parallel_siblings(self, task_names, row_map):
+        """
+        If a named before_task is itself marked "Parallel", automatically pull
+        in every other row that shares its exact before_task and is also
+        marked "Parallel" -- referencing just one member of a parallel group
+        in a downstream before_task is enough to wait on the whole group,
+        instead of requiring every sibling to be enumerated by hand.
+        Sequential dependencies are untouched: this only expands a name when
+        that row's own sequence_type is "Parallel".
+        """
+        expanded = set(task_names)
+        for name in list(expanded):
+            dep_row = row_map.get(name)
+            if not dep_row or dep_row.get("sequence_type") != "Parallel":
+                continue
+            shared_before = dep_row.get("before_task")
+            for other_name, other_row in row_map.items():
+                if other_name in expanded:
+                    continue
+                if other_row.get("sequence_type") == "Parallel" and other_row.get("before_task") == shared_before:
+                    expanded.add(other_name)
+        return list(expanded)
 
     def _expand_through_skipped(self, task_names, row_map, _seen=None):
         """

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -581,12 +581,17 @@ def has_permission(doc, ptype=None, user=None, **kwargs):
     record has actually reached "Pending Onboarding" or a later stage in that flow.
 
     Frappe's controller has_permission hooks can only DENY access, never grant
-    anything beyond the role permission table — so write/create/delete/submit/cancel
+    anything beyond the role permission table — so write/delete/submit/cancel
     is granted at the role-permission level (see the DocType's own permissions),
     and this hook denies it back for Onboarding Officer specifically until that
     condition is met. Returns None everywhere else so other roles are never affected.
+
+    "create" is deliberately excluded: a brand-new, not-yet-inserted document can
+    never have an Arrival and Deployment record linked to it yet, so this check
+    would always deny creation outright (e.g. the automatic CCP creation cascade
+    from Job Offer's create_candidate_country_process()) regardless of role.
     """
-    if ptype not in ("write", "create", "delete", "submit", "cancel"):
+    if ptype not in ("write", "delete", "submit", "cancel"):
         return None
 
     user = user or frappe.session.user

--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
@@ -234,7 +234,8 @@
    "fieldtype": "Small Text",
    "label": "Supervisor Remarks",
    "max_height": "4rem",
-   "mandatory_depends_on": "eval:!doc.__islocal && !['Draft', 'Pending Supervisor', 'Pending Relieving Date Correction'].includes(doc.workflow_state)"
+   "mandatory_depends_on": "eval:!doc.__islocal && !['Draft', 'Pending Supervisor', 'Pending Relieving Date Correction'].includes(doc.workflow_state)",
+   "read_only_depends_on": "eval:!doc.__islocal && doc.workflow_state !== 'Pending Supervisor'"
   },
   {
    "fieldname": "replacement_required",
@@ -314,8 +315,9 @@
    "fieldtype": "Small Text",
    "label": "Operations Manager Remarks",
    "max_height": "4rem",
-   "depends_on": "eval:doc.shift_working",
-   "mandatory_depends_on": "eval:doc.shift_working && !doc.__islocal && doc.workflow_state === 'Approved'"
+   "depends_on": "eval:doc.shift_working && ['Pending Operations Manager', 'Approved', 'Withdrawn'].includes(doc.workflow_state)",
+   "mandatory_depends_on": "eval:doc.shift_working && !doc.__islocal && doc.workflow_state === 'Approved'",
+   "read_only_depends_on": "eval:!doc.__islocal && doc.workflow_state !== 'Pending Operations Manager'"
   },
   {
    "fieldname": "column_break_jkbg",


### PR DESCRIPTION
## Summary
- **CCP create permission:** `has_permission()` for Candidate Country Process denied write/create/delete/submit/cancel to Onboarding Officers until the linked Arrival and Deployment record reaches a late stage. For `create`, a brand-new/not-yet-inserted doc can never have that linked record yet, so the check always fell through to deny -- blocking the automatic CCP creation cascade from Job Offer's `create_candidate_country_process()` for any user who also holds the Onboarding Officer role, regardless of what other roles (System Manager, HR Manager, etc.) they also carry. Drops `"create"` from the restricted ptype tuple; write/delete/submit/cancel restrictions are unchanged.
- **CCP ETA-recalculation permission:** the same restriction was also silently blocking `recalculate_ccp_live_eta()`, which every downstream step doctype (Visa Request, PCC Clearance, Overseas Medical Appointment WAFID, Overseas Remedical, Visa Stamping, Arrival and Deployment) calls on its own save to refresh the CCP's planned/live ETA. That `doc.save()` runs under whatever user triggered the downstream save, not a direct edit of the CCP -- and it was wrapped in a bare except/log_error, so an Onboarding-Officer user would see the downstream doctype save successfully while the CCP's ETA silently failed to update, with no visible error. Now recognized via the existing `frappe.local.in_ccp_recalculation` reentrancy-guard flag and exempted from the restriction, without weakening the direct-edit restriction itself.
- **Sequence Type now actually drives parallel date computation:** `sequence_type` was only ever copied from the template into CCP rows but never read by `_compute_planned_dates`/`_compute_live_plan_dates` -- marking two rows "Parallel" had zero effect on computed dates; only manually listing every parallel sibling by name in a downstream `before_task` worked. Adds `_expand_parallel_siblings()`: naming just one member of a Parallel group in `before_task` now automatically pulls in its Parallel siblings too, so the whole group's dates are considered without needing to enumerate them all by hand.
- **Resignation remarks visibility:** `operations_manager_remarks` was gated only on `shift_working`, with no workflow_state check, so it showed as soon as the record existed -- well before the Operations Manager stage was ever reached. Now gated to `Pending Operations Manager`/`Approved`/`Withdrawn`. `supervisor_remarks` is now read-only once `workflow_state` moves past `Pending Supervisor`, so the Operations Manager can see it but not edit it. `operations_manager_remarks` is read-only once past `Pending Operations Manager`, symmetric with `supervisor_remarks`.

## Test plan
- [x] Advanced a real Job Offer (`HR-OFF-2026-00059`, then again with a fresh applicant on `HR-OFF-2026-00075`) through the actual "Offer Accepted" workflow transition as a real user (not Administrator) holding both Onboarding Officer and other roles -- Candidate Country Process created successfully with all 11 steps.
- [x] Walked a fresh CCP through its full 11-step lifecycle to `Joined` end-to-end as the same real user, including the actual Visa Request (6-transition) and Arrival and Deployment (3-transition) workflows -- zero permission errors.
- [x] Confirmed direct edits to an existing CCP are still correctly denied for Onboarding Officers before Arrival reaches a late stage (no regression).
- [x] Created/updated downstream doctypes (Visa Request, Overseas Medical Appointment WAFID, PCC Clearance, Visa Stamping, Arrival and Deployment) tied to that CCP as the same user -- `recalculate_ccp_live_eta()` runs clean with zero new Error Log entries (previously silently failed every time).
- [x] Synthetic test: two Parallel rows sharing a `before_task`, with the downstream row naming only one of them -- planned_date correctly anchors off the later of the two.
- [x] Confirmed idempotent and no regression against the existing real, fully-sequential Kanchan template (two consecutive recalculations produce identical output).
- [ ] At `Pending Supervisor`: confirm `supervisor_remarks` is visible and editable, `operations_manager_remarks` is hidden.
- [ ] At `Pending Operations Manager`: confirm `supervisor_remarks` is visible but read-only, and `operations_manager_remarks` is visible and editable.
- [ ] At `Approved`/`Withdrawn`: confirm both remarks fields are visible and read-only.