### PR TITLE
fix(hr): gate Supervisor/Operations Manager Remarks visibility to their own stage

### DIFF
--- a/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
+++ b/one_fm/one_fm/doctype/employee_resignation/employee_resignation.json
@@ -234,7 +234,8 @@
    "fieldtype": "Small Text",
    "label": "Supervisor Remarks",
    "max_height": "4rem",
-   "mandatory_depends_on": "eval:!doc.__islocal && !['Draft', 'Pending Supervisor', 'Pending Relieving Date Correction'].includes(doc.workflow_state)"
+   "mandatory_depends_on": "eval:!doc.__islocal && !['Draft', 'Pending Supervisor', 'Pending Relieving Date Correction'].includes(doc.workflow_state)",
+   "read_only_depends_on": "eval:!doc.__islocal && doc.workflow_state !== 'Pending Supervisor'"
   },
   {
    "fieldname": "replacement_required",
@@ -314,8 +315,9 @@
    "fieldtype": "Small Text",
    "label": "Operations Manager Remarks",
    "max_height": "4rem",
-   "depends_on": "eval:doc.shift_working",
-   "mandatory_depends_on": "eval:doc.shift_working && !doc.__islocal && doc.workflow_state === 'Approved'"
+   "depends_on": "eval:doc.shift_working && ['Pending Operations Manager', 'Approved', 'Withdrawn'].includes(doc.workflow_state)",
+   "mandatory_depends_on": "eval:doc.shift_working && !doc.__islocal && doc.workflow_state === 'Approved'",
+   "read_only_depends_on": "eval:!doc.__islocal && doc.workflow_state !== 'Pending Operations Manager'"
   },
   {
    "fieldname": "column_break_jkbg",


### PR DESCRIPTION
## Summary
- `operations_manager_remarks` was gated only on `shift_working`, with no workflow_state check, so it showed as soon as the record existed -- well before the Operations Manager stage was ever reached. Now gated to `Pending Operations Manager`/`Approved`/`Withdrawn`.
- `supervisor_remarks` is now read-only once `workflow_state` moves past `Pending Supervisor`, so the Operations Manager can see the supervisor's remarks but not edit them.
- `operations_manager_remarks` is read-only once past `Pending Operations Manager`, for the same reason -- symmetric with `supervisor_remarks`.

## Test plan
- [ ] At `Pending Supervisor`: confirm `supervisor_remarks` is visible and editable, `operations_manager_remarks` is hidden.
- [ ] At `Pending Operations Manager`: confirm `supervisor_remarks` is visible but read-only, and `operations_manager_remarks` is visible and editable.
- [ ] At `Approved`/`Withdrawn`: confirm both remarks fields are visible and read-only.