### PR TITLE
feat: enforce Add as POC mandatory fields on submit only

### DIFF
--- a/one_fm/one_fm/doctype/poc_check_general_attendees/poc_check_general_attendees.json
+++ b/one_fm/one_fm/doctype/poc_check_general_attendees/poc_check_general_attendees.json
@@ -33,7 +33,6 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Email Address",
-   "mandatory_depends_on": "eval: doc.action == \"Add as POC\"",
    "options": "Email",
    "read_only_depends_on": "eval: doc.action != \"Add as POC\""
   },
@@ -42,7 +41,6 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Phone",
-   "mandatory_depends_on": "eval: doc.action == \"Add as POC\"",
    "options": "Phone",
    "read_only_depends_on": "eval: doc.action != \"Add as POC\""
   },
@@ -51,7 +49,6 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Destination Doctype",
-   "mandatory_depends_on": "eval: doc.action == \"Add as POC\"",
    "options": "\nOperations Site\nProject\nBoth",
    "read_only_depends_on": "eval: doc.action != \"Add as POC\""
   },
@@ -60,7 +57,6 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Gender",
-   "mandatory_depends_on": "eval: doc.action == \"Add as POC\"",
    "options": "\nMale\nFemale",
    "read_only_depends_on": "eval: doc.action != \"Add as POC\""
   },
@@ -69,7 +65,6 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Designation",
-   "mandatory_depends_on": "eval: doc.action == \"Add as POC\"",
    "read_only_depends_on": "eval: doc.action != \"Add as POC\""
   },
   {
@@ -89,15 +84,17 @@
    "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-28 14:25:44.324497",
+ "modified": "2026-07-29 15:38:08.181873",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "POC Check General Attendees",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/one_fm/operations/doctype/poc_check/poc_check.py
+++ b/one_fm/operations/doctype/poc_check/poc_check.py
@@ -106,9 +106,29 @@ class POCCheck(Document):
 				self.insert_poc(attendee_contact.name, destinations)
 
 	def validate_general_attendees_rows(self):
+		# Fields that are only mandatory when the attendee is being added as a POC.
+		# Enforced here (called from on_submit) so drafts stay saveable, mirroring
+		# the client-side `mandatory_depends_on` on these fields.
+		add_as_poc_required_fields = {
+			"first_name": "First Name",
+			"last_name": "Last Name",
+			"designation": "Designation",
+			"email_address": "Email Address",
+			"phone": "Phone",
+			"destination_doctype": "Destination Doctype",
+			"gender": "Gender",
+		}
 		for each in self.general_attendees:
 			if each.action not in ["Do Nothing", "Add as POC"]:
 				frappe.throw(f"Please set an action for row {each.idx} in General Attendees Table")
+
+			if each.action == "Add as POC":
+				missing = [label for fieldname, label in add_as_poc_required_fields.items() if not each.get(fieldname)]
+				if missing:
+					frappe.throw(
+						f"Row {each.idx} in General Attendees: <b>{', '.join(missing)}</b> "
+						f"{'is' if len(missing) == 1 else 'are'} required when Action is 'Add as POC'."
+					)
 
 	def insert_poc(self, attendee_name, destinations):
 		for one in destinations:


### PR DESCRIPTION
Previously POC attendee fields were mandatory in the UI whenever the action was 'Add as POC', which blocked saving partially-filled rows as a draft and caused entered details to be lost on redirect.

Move the requirement to submit time so drafts stay saveable:

- remove mandatory_depends_on from designation, email_address, phone, destination_doctype, and gender on POC Check General Attendees
- validate these fields plus first_name and last_name server-side in validate_general_attendees_rows (called from on_submit), throwing a clear message listing any missing fields per row