### PR TITLE
WI-001776: surface a project's Contracts in the Project connections dashboard

### DIFF
--- a/one_fm/overrides/project_dashboard.py
+++ b/one_fm/overrides/project_dashboard.py
@@ -12,7 +12,11 @@ def get_data(**kwargs):
 				"items": ["Task", "Timesheet", "Issue", "Project Update"],
 			},
 			{"label": _("Material"), "items": ["Material Request", "BOM", "Stock Entry"]},
-			{"label": _("Sales"), "items": ["Sales Order", "Delivery Note", "Sales Invoice"]},
+			# WI-001776: Contracts sits beside Sales Order so a Project Manager can see,
+			# open and raise a project's contracts from the one place. Contracts carries a
+			# standard `project` link field, so the badge count, the pre-filtered list and
+			# the prefilled new-Contract form all come from the dashboard's own fieldname.
+			{"label": _("Sales"), "items": ["Sales Order", "Contracts", "Delivery Note", "Sales Invoice"]},
 			{"label": _("Purchase"), "items": ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]},
 			{"label": _("Operations"), "items": ["MOM", "Operations Site", "Operations Shift", "Operations Role", "Operations Post"]},
 		],

--- a/one_fm/tests/test_project_dashboard.py
+++ b/one_fm/tests/test_project_dashboard.py
@@ -1,0 +1,48 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.overrides.project_dashboard import get_data
+
+
+class TestProjectDashboardConnections(FrappeTestCase):
+    """
+    WI-001776: a Project Manager sees linked Contracts with a count under the Sales
+    group, and can open the filtered list or raise a new Contract from there.
+    """
+
+    def setUp(self):
+        self.data = get_data()
+        self.sales = next(
+            g for g in self.data["transactions"] if g["label"] == frappe._("Sales")
+        )
+
+    def test_contracts_is_listed_next_to_sales_order(self):
+        items = self.sales["items"]
+        self.assertIn("Contracts", items)
+        self.assertEqual(items.index("Contracts"), items.index("Sales Order") + 1)
+
+    def test_contracts_links_to_the_project_via_the_dashboard_fieldname(self):
+        # The badge count, the pre-filtered list and the prefilled new-Contract form
+        # all key off this field, so its absence would silently break all three.
+        fieldname = self.data["fieldname"]
+        self.assertEqual(fieldname, "project")
+        meta = frappe.get_meta("Contracts")
+        self.assertTrue(meta.has_field(fieldname))
+
+    def test_the_contracts_project_field_points_at_project(self):
+        df = frappe.get_meta("Contracts").get_field("project")
+        self.assertEqual(df.fieldtype, "Link")
+        self.assertEqual(df.options, "Project")
+
+    def test_contracts_needs_no_special_link_handling(self):
+        # Contracts is reached by its own `project` field, so it must not be declared
+        # as an internal link or a non-standard fieldname.
+        self.assertNotIn("Contracts", self.data.get("internal_links", {}))
+        self.assertNotIn("Contracts", self.data.get("non_standard_fieldnames", {}))
+
+    def test_every_listed_doctype_exists(self):
+        for group in self.data["transactions"]:
+            for doctype in group["items"]:
+                self.assertTrue(
+                    frappe.db.exists("DocType", doctype), msg=f"{doctype} does not exist"
+                )


### PR DESCRIPTION
Implements WI-001776 [Abbas] Project Doctype's Connection Section.

## Change

`Contracts` added to the **Sales** group of the Project connections dashboard, immediately after `Sales Order` as the AC specifies.

That single list entry satisfies all four acceptance criteria, because `Contracts` carries a standard `project` link field and `project` is already the dashboard's own `fieldname`:

| AC | Where it comes from |
|---|---|
| Contracts listed next to Sales Order under Sales | The list entry |
| Badge shows the accurate total count | Framework — `get_open_count` counts on the dashboard `fieldname` |
| Clicking through opens the Contract list filtered to the project | Framework |
| `+` opens a new Contract with the Project prefilled | Framework |

No `internal_links` or `non_standard_fieldnames` entry is needed, and there is deliberately no custom count logic to maintain.

## Verification

Rather than assume the framework wiring resolves, I checked it against real data on the dev site — for a project with 2 contracts:

```
project: French School (expects 2 contracts)
Contracts badge count: 2
matches direct query: True
all badge counts: {'Task': 0, ..., 'Sales Order': 0, 'Contracts': 2, ...}
```

## Testing

`bench run-tests --module one_fm.tests.test_project_dashboard` → **5 passed**.

Covers Contracts being present and positioned directly after Sales Order, the dashboard fieldname existing on Contracts as a Link to Project, Contracts needing no special link handling, and every doctype named anywhere in the dashboard actually existing (which would otherwise fail silently at runtime).

No migration needed — this is a hooked dashboard function, so a `bench restart` (or a clear-cache) is enough to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
