### PR TITLE
WI-001766: identify the manifest bus as "<plate>, <model>"

### DIFF
--- a/one_fm/one_fm/page/transportation_manifest_page/test_transportation_manifest_page.py
+++ b/one_fm/one_fm/page/transportation_manifest_page/test_transportation_manifest_page.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Tests for the Transportation Manifest page payload (WI-001766).
+
+The manifest identifies the assigned bus as "<plate>, <model>" so a driver or
+field supervisor does not have to look up the vehicle master on site. The string
+itself is composed in the page's `vehicleString` helper; what is guarded here is
+that the model actually reaches the frontend, since a dropped field would leave
+the helper silently rendering the plate alone.
+"""
+
+import re
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+PAGE_JS = ("one_fm", "one_fm", "page", "transportation_manifest_page", "transportation_manifest_page.js")
+BACKEND_PY = (
+	"one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.py",
+)
+
+
+def _read(parts):
+	return frappe.read_file(frappe.get_app_path(*parts))
+
+
+class TestManifestVehicleString(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.js = _read(PAGE_JS)
+		cls.py = _read(BACKEND_PY)
+
+	def test_model_is_a_real_vehicle_field(self):
+		# The whole feature rests on this fieldname; ERPNext renaming it would
+		# otherwise surface as a blank model rather than an error.
+		self.assertTrue(frappe.get_meta("Vehicle").has_field("model"))
+
+	def test_the_backend_fetches_the_model(self):
+		# Vehicle metadata for the manifest is batch-fetched once; the model has to
+		# be in that field list or vehicleMeta never carries it. The list spans
+		# several lines, hence the inline DOTALL.
+		self.assertRegex(
+			self.py, r'(?s)fields=\[\s*"name",\s*"license_plate".*?"model".*?\]',
+		)
+
+	def test_the_model_is_published_in_vehicle_meta(self):
+		self.assertIn('"model": v_doc.get("model", "")', self.py)
+
+	def test_the_page_composes_plate_and_model(self):
+		self.assertIn("function vehicleString(meta)", self.js)
+		self.assertIn("[meta.license_plate, meta.model]", self.js)
+
+	def test_blank_parts_are_filtered_so_no_orphaned_comma(self):
+		helper = re.search(r"function vehicleString\(meta\) \{.*?\n\t\}", self.js, re.S)
+		self.assertIsNotNone(helper, msg="vehicleString helper not found")
+		self.assertIn(".filter(Boolean)", helper.group(0))
+		self.assertIn('.join(", ")', helper.group(0))
+
+	def test_both_render_points_show_the_composed_string(self):
+		# The AC asks for it in the header strip and in the vehicle detail block.
+		self.assertIn('<span class="mfst-tab-plate">${escHtml(vstr)}</span>', self.js)
+		self.assertIn('<div class="mfst-vehicle-plate">${escHtml(vstr)}</div>', self.js)
+
+	def test_the_plate_is_no_longer_rendered_on_its_own(self):
+		self.assertNotIn("escHtml(meta.license_plate)", self.js)

--- a/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
+++ b/one_fm/one_fm/page/transportation_manifest_page/transportation_manifest_page.js
@@ -203,6 +203,13 @@ function renderManifest($container, data) {
 		return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;");
 	}
 
+	// WI-001766: a driver or supervisor identifies the bus on site by its plate and
+	// model, so both are shown as "<plate>, <model>". A vehicle whose master record
+	// carries no model shows the plate alone - no trailing comma.
+	function vehicleString(meta) {
+		return [meta.license_plate, meta.model].filter(Boolean).join(", ");
+	}
+
 	function showToast(msg) {
 		const toast = document.createElement("div");
 		toast.textContent = msg;
@@ -487,11 +494,12 @@ function renderManifest($container, data) {
 
 	parsed.forEach((pr, idx) => {
 		const meta = (ROUTE_DATA.vehicleMeta ?? {})[pr.label] ?? {};
+		const vstr = vehicleString(meta);
 		const tab = document.createElement("button");
 		tab.className = "mfst-tab";
 		tab.innerHTML = `
 			<span class="mfst-tab-name">${pr.label}</span>
-			${meta.license_plate ? `<span class="mfst-tab-plate">${escHtml(meta.license_plate)}</span>` : ""}
+			${vstr ? `<span class="mfst-tab-plate">${escHtml(vstr)}</span>` : ""}
 			<span class="mfst-tab-time">${fmtTime(pr.route.vehicleStartTime)} → ${fmtTime(pr.route.vehicleEndTime)}</span>
 		`;
 		tab.addEventListener("click", () => {
@@ -562,6 +570,7 @@ function renderManifest($container, data) {
 	function renderRoute(pr) {
 		activeView = pr;
 		const meta = (ROUTE_DATA.vehicleMeta ?? {})[pr.label] ?? {};
+		const vstr = vehicleString(meta);
 		const accommodation = meta.accommodation || meta.location || "Depot";
 		const allTrips = buildTrips(pr);
 
@@ -585,7 +594,7 @@ function renderManifest($container, data) {
 							<span class="material-symbols-outlined" style="font-size:28px;vertical-align:middle;margin-right:8px;color:var(--mfst-accent)">directions_bus</span>
 							${pr.label}
 						</div>
-						${meta.license_plate ? `<div class="mfst-vehicle-plate">${escHtml(meta.license_plate)}</div>` : ""}
+						${vstr ? `<div class="mfst-vehicle-plate">${escHtml(vstr)}</div>` : ""}
 					</div>
 					<div class="mfst-vehicle-card-right">
 						<div class="mfst-vehicle-time-badge">

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -1216,7 +1216,7 @@ def get_manifest_data_for_plan(plan_name: str):
 		for v in frappe.get_all("Vehicle",
 			filters={"name": ["in", vehicle_ids]},
 			fields=["name", "license_plate", "location", "seats",
-					"one_fm_vehicle_type", "make", "employee"]
+					"one_fm_vehicle_type", "make", "model", "employee"]
 		):
 			vehicle_map[v.name] = v
 
@@ -1511,6 +1511,9 @@ def get_manifest_data_for_plan(plan_name: str):
 			"location": v_doc.get("location", ""),
 			"license_plate": v_doc.get("license_plate", ""),
 			"make": v_doc.get("make", ""),
+			# WI-001766: the manifest identifies the bus as "<plate>, <model>", so the
+			# model travels with the plate rather than being looked up on site.
+			"model": v_doc.get("model", ""),
 			"type": v_doc.get("one_fm_vehicle_type", ""),
 			# Attendance-check lock state for this vehicle's manifest (MA2-11):
 			# active_stop_sequence drives which pickup camp is currently unlocked.


### PR DESCRIPTION
Implements WI-001766 [Yaser] Transportation Manifest Frontend.

## Change

The Vehicle **model** now travels with the vehicle metadata to the Transportation Manifest page and renders inline after the licence plate, separated by a comma, in both places the AC names:

- the **tab strip** (`mfst-tab-plate`) — the header section
- the **vehicle detail card** (`mfst-vehicle-plate`) — the detail block

```
50-1234, Nissan Urvan     <- plate + model
KWT-12345                 <- model blank: plate alone, no trailing comma
```

Composition is one helper beside the page's other utilities:

```js
function vehicleString(meta) {
    return [meta.license_plate, meta.model].filter(Boolean).join(", ");
}
```

Filtering before joining is what satisfies the second AC — an absent model cannot leave an orphaned comma, and the surrounding element is dropped entirely when both parts are empty.

## Two notes on scope

**The `VHL-` code stays as the heading.** `v_label` is the Vehicle docname and is used as the key into `vehicleMeta` and as `vehicleLabel` on every route, so it is an identifier rather than a display string. The user story asks for the model "displayed inline right after the License Plate No", i.e. beside the plate, not instead of the code — so the code is left alone and only the plate line changes.

**`make` was already being fetched, `model` was not.** The backend fetched `make` (Toyota) but never `model` (Coaster), so the model was simply unavailable to the page. That is the one-field backend change here.

For context on the AC's example, actual data on the dev site keeps these separate — `make='Toyota'`, `model='Coaster'`, `one_fm_vehicle_type='Bus'`, `seats=N` — so "Toyota Coaster 30-Seater" is not a single stored value. I implemented the field the AC names (`model`); if you want the richer string, that is a data or composition change worth its own decision.

## Testing

`bench run-tests --module one_fm.one_fm.page.transportation_manifest_page.test_transportation_manifest_page` → **7 passed**.

Guards that `model` is a real Vehicle field, that the backend fetches it and publishes it into `vehicleMeta`, that the page composes plate and model, that the parts are filtered before joining, that both render points use the composed string, and that the plate is no longer rendered on its own.

The helper's own branches were exercised directly through node against the real source — all five cases pass, including blank model, missing model key, blank plate and both empty:

```
ok  {"license_plate":"50-1234","model":"Nissan Urvan"} -> "50-1234, Nissan Urvan"
ok  {"license_plate":"KWT-12345","model":""}           -> "KWT-12345"
ok  {"license_plate":"KWT-12345"}                      -> "KWT-12345"
ok  {"license_plate":"","model":"Coaster"}             -> "Coaster"
ok  {}                                                 -> ""
```

There is no JS test harness in this app, hence the assertions on the page source plus the direct node check rather than a new framework.

No migration needed; a `bench build`/`bench clear-cache` picks up the page asset. All 28 transport vehicles on the dev site have a model populated, so the blank-model path is defensive rather than routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
