### PR TITLE
WI-001778: label canvas vehicle lanes "<plate>, <model>"

### DIFF
--- a/one_fm/one_fm/page/transportation_schedule/test_vehicle_lane_label.py
+++ b/one_fm/one_fm/page/transportation_schedule/test_vehicle_lane_label.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Tests for the Route Plan canvas vehicle label (WI-001778).
+
+A dispatcher identifies a lane by plate and model, so the lane header and the
+right-hand details panel both read "<plate>, <model>". The string is composed in
+the page's `vehicleString` method; what is guarded here is that the model reaches
+the canvas at all, and that every place naming a vehicle to the dispatcher goes
+through the one helper - a stray `vehicle.label` would show the VHL code beside
+lanes labelled with a plate.
+"""
+
+import re
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+PAGE_JS = ("one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.js")
+PAGE_PY = ("one_fm", "one_fm", "page", "transportation_schedule", "transportation_schedule.py")
+
+
+class TestVehicleLaneLabel(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.js = frappe.read_file(frappe.get_app_path(*PAGE_JS))
+		cls.py = frappe.read_file(frappe.get_app_path(*PAGE_PY))
+
+	def test_model_is_a_real_vehicle_field(self):
+		self.assertTrue(frappe.get_meta("Vehicle").has_field("model"))
+
+	def test_the_canvas_payload_carries_the_model(self):
+		self.assertIn('"model":         v.model or ""', self.py)
+
+	def test_the_canvas_query_selects_the_model(self):
+		# The canvas builds its own vehicle list, separate from the manifest's.
+		query = re.search(
+			r'transport_vehicles = frappe\.get_all\("Vehicle".*?\)', self.py, re.S
+		)
+		self.assertIsNotNone(query, msg="canvas Vehicle query not found")
+		self.assertIn('"model"', query.group(0))
+
+	def test_the_helper_composes_plate_and_model(self):
+		helper = re.search(r"vehicleString\(v\) \{.*?\n\s*\},", self.js, re.S)
+		self.assertIsNotNone(helper, msg="vehicleString helper not found")
+		body = helper.group(0)
+		self.assertIn("[v.license_plate, v.model]", body)
+		self.assertIn(".filter(Boolean)", body)
+		self.assertIn(".join(', ')", body)
+
+	def test_a_lane_is_never_left_unlabelled(self):
+		# With neither plate nor model the vehicle code stands in, otherwise a lane
+		# would render blank and be undroppable in practice.
+		helper = re.search(r"vehicleString\(v\) \{.*?\n\s*\},", self.js, re.S)
+		self.assertIn("v.label || v.id", helper.group(0))
+
+	def test_the_lane_header_shows_the_composed_string(self):
+		self.assertIn("{{ vehicleString(vehicle) }}", self.js)
+
+	def test_the_details_panel_shows_the_composed_string(self):
+		# The panel renders vehicleLabelForItem, which must delegate to the helper.
+		self.assertIn("{{ vehicleLabelForItem(selectedItem) }}", self.js)
+		resolver = re.search(
+			r"vehicleLabelForItem\(item\) \{.*?\n\s*\},", self.js, re.S
+		)
+		self.assertIsNotNone(resolver, msg="vehicleLabelForItem not found")
+		self.assertIn("this.vehicleString(v)", resolver.group(0))
+
+	def test_no_dispatcher_message_names_a_vehicle_by_its_raw_label(self):
+		self.assertNotIn("vehicle.label", self.js)
+
+	def test_the_duplicate_plate_line_and_its_styles_are_gone(self):
+		# The separate plate line was folded into the header string; leaving its CSS
+		# behind would be dead weight.
+		self.assertNotIn("rp-gv-lp", self.js)

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.js
@@ -766,7 +766,7 @@ function mountRoutePlannerApp(wrapper, data) {
                 // vehicle is already held by another shipment's multi-day lock. ──
                 const lock = this.vehicleLockToday(vehicle.id, card.id);
                 if (lock) {
-                    frappe.throw(`Vehicle Locked: ${vehicle.label} is reserved for a multi-day run until ${lock.lockTo}. It cannot take another overlapping shipment.`);
+                    frappe.throw(`Vehicle Locked: ${this.vehicleString(vehicle)} is reserved for a multi-day run until ${lock.lockTo}. It cannot take another overlapping shipment.`);
                     return;
                 }
 
@@ -800,7 +800,7 @@ function mountRoutePlannerApp(wrapper, data) {
                 if (handover) {
                     frappe.show_alert({
                         message: __('{0} is under a handover to {1} ({2}–{3}) during this window. The run was still placed.', [
-                            vehicle.label,
+                            this.vehicleString(vehicle),
                             handover.driver_name,
                             this.fmtTime(handover.start),
                             this.fmtTime(handover.end)
@@ -844,7 +844,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         const newDirBadge = card.direction === 'RETURN' ? '← RET' : '→ OUT';
                         const newCamp = card.accommodation ? `<strong>${card.accommodation}</strong> — ` : '';
                         frappe.confirm(
-                            `<strong>${vehicle.label}</strong> already has an active trip:<br><br>` +
+                            `<strong>${this.vehicleString(vehicle)}</strong> already has an active trip:<br><br>` +
                             existingStops.map((s, i) => `&nbsp;&nbsp;${i + 1}. ${s}`).join('<br>') +
                             `<br><br>Add ${newCamp}<strong>${card.site_location}</strong> <span style="font-size:11px;color:#888">(${newDirBadge})</span> as the next stop on this trip?`,
                             () => this._chainToTrip(card, tripMap[tripKeys[0]], vehicle.id),
@@ -878,7 +878,7 @@ function mountRoutePlannerApp(wrapper, data) {
                                 {
                                     fieldtype: 'HTML',
                                     options: `<p style="margin:0 0 12px;color:#555;font-size:13px">
-                                        <strong>${vehicle.label}</strong> has <strong>${tripKeys.length} active trips</strong>.
+                                        <strong>${this.vehicleString(vehicle)}</strong> has <strong>${tripKeys.length} active trips</strong>.
                                         Choose which trip to add <strong>${card.accommodation ? card.accommodation + ' — ' : ''}${card.site_location}</strong> to:</p>`
                                 },
                                 {
@@ -1921,7 +1921,7 @@ function mountRoutePlannerApp(wrapper, data) {
                         const tName = t.items.find(i => i.tripName)?.tripName;
                         const prefix = tName ? tName : (t.isSolo ? 'Single stop' : 'Trip');
                         tripOptions.push({
-                            label: `[${vehicle.label}] ${prefix} ending at ${lastCard.site_location}`,
+                            label: `[${this.vehicleString(vehicle)}] ${prefix} ending at ${lastCard.site_location}`,
                             value: tid,
                             lastItem, lastCard, vehicle,
                             tripName: tName || null
@@ -2030,15 +2030,27 @@ function mountRoutePlannerApp(wrapper, data) {
                         self.canSave = self.assignedCards.size > 0;
                         self.persistAssignments();
 
-                        frappe.show_alert({ message: `Merged into ${selectedOpt.vehicle.label} trip`, indicator: 'green' });
+                        frappe.show_alert({ message: `Merged into ${self.vehicleString(selectedOpt.vehicle)} trip`, indicator: 'green' });
                     }
                 });
                 d.show();
             },
 
+            /**
+             * WI-001778: a dispatcher identifies a vehicle by its plate and model, so
+             * both are shown as "<plate>, <model>". A vehicle whose master record has
+             * no model shows the plate alone - the parts are filtered before joining,
+             * so there is no orphaned comma. With neither, the vehicle code stands in
+             * so a lane is never left unlabelled.
+             */
+            vehicleString(v) {
+                if (!v) return '';
+                return [v.license_plate, v.model].filter(Boolean).join(', ') || v.label || v.id;
+            },
+
             vehicleLabelForItem(item) {
                 const v = this.planData.vehicles.find(v => v.id === item.vehicleId);
-                return v ? v.label : item.vehicleId;
+                return v ? this.vehicleString(v) : item.vehicleId;
             },
 
             /**
@@ -3063,11 +3075,10 @@ function injectRPVueTemplate() {
             <!-- Vehicle label column -->
             <div class="rp-lane-label">
               <div class="rp-gv-plate">
-                {{ vehicle.label }}
+                {{ vehicleString(vehicle) }}
                 <span v-if="lockedLaneIds.has(vehicle.id)" class="rp-lock-badge" title="Reserved for a multi-day run — blocked for other shipments">&#x1F512;</span>
                 <span v-else-if="upcomingLockByVehicle[vehicle.id]" class="rp-lock-upcoming" :title="'Reserved for an upcoming multi-day run from ' + upcomingLockByVehicle[vehicle.id]">&#x1F512; from {{ upcomingLockByVehicle[vehicle.id] }}</span>
               </div>
-              <div v-if="vehicle.license_plate" class="rp-gv-lp">{{ vehicle.license_plate }}</div>
               <div class="rp-gv-meta">{{ vehicle.driver }} &middot; {{ vehicle.seats }} seats</div>
               <div class="rp-gv-acc">{{ vehicle.accommodation }}</div>
             </div>
@@ -3948,7 +3959,6 @@ function injectRPStyles() {
         .rp-lock-badge { font-size: 12px; margin-left: 4px; vertical-align: middle; }
         .rp-lock-upcoming { font-size: 10px; margin-left: 4px; padding: 1px 5px; border-radius: 8px; background: rgba(124,58,237,0.12); color: #7c3aed; white-space: nowrap; vertical-align: middle; }
         .rp-lane-locked .rp-lane-label { background: rgba(120,120,120,0.08); }
-        .rp-gv-lp    { font-size: 11px; font-weight: 500; color: var(--md-sys-color-outline); margin-top: 1px; }
         .rp-gv-meta  { font-size: 12px; color: var(--md-sys-color-on-surface-variant); margin-top: 1px; }
         .rp-gv-acc   { font-size: 11px; color: var(--md-sys-color-outline); margin-top: 1px; }
 
@@ -4158,7 +4168,6 @@ function injectRPStyles() {
             .rp-lane-label { width: 100px; min-width: 100px; padding: 4px 8px; }
             .rp-label-stub { min-height: 36px; }
             .rp-gv-plate { font-size: 11px; }
-            .rp-gv-lp    { font-size: 9px; }
             .rp-gv-meta  { font-size: 9px; }
             .rp-gv-acc   { display: none; } /* Hide accommodation on label */
 
@@ -4197,7 +4206,6 @@ function injectRPStyles() {
             /* Lane labels: even narrower */
             .rp-lane-label { width: 75px; min-width: 75px; padding: 3px 6px; }
             .rp-gv-plate { font-size: 10px; }
-            .rp-gv-lp    { display: none; }
             .rp-gv-meta  { display: none; }
 
             /* Zoom buttons */
@@ -4320,7 +4328,6 @@ function injectRPStyles() {
         #rp-shell.rp-dark .rp-lane-alt { background: rgba(255,255,255,0.02); }
         #rp-shell.rp-dark .rp-lane-label { border-color: var(--md-sys-color-outline-variant); }
         #rp-shell.rp-dark .rp-gv-plate { color: var(--md-sys-color-on-surface); }
-        #rp-shell.rp-dark .rp-gv-lp    { color: var(--md-sys-color-outline); }
         #rp-shell.rp-dark .rp-gv-meta { color: var(--md-sys-color-outline); }
         #rp-shell.rp-dark .rp-gv-acc { color: var(--md-sys-color-outline); }
 

--- a/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
+++ b/one_fm/one_fm/page/transportation_schedule/transportation_schedule.py
@@ -43,7 +43,7 @@ def get_route_planner_data():
         # ── 1. Vehicles (batch queries) ──
         transport_vehicles = frappe.get_all("Vehicle",
             filters={"transport_stop_vehicle": 1},
-            fields=["name", "license_plate", "location", "seats", "one_fm_vehicle_type", "make", "employee", "one_fm_vehicle_category"],
+            fields=["name", "license_plate", "location", "seats", "one_fm_vehicle_type", "make", "model", "employee", "one_fm_vehicle_category"],
             order_by="name asc"
         )
 
@@ -84,6 +84,9 @@ def get_route_planner_data():
                 "id":            v.name,
                 "label":         v.name,
                 "license_plate": v.license_plate or "",
+                # WI-001778: the lane header and the details panel identify a vehicle
+                # as "<plate>, <model>", so the model rides along with the plate.
+                "model":         v.model or "",
                 "driver":        driver_name,
                 "seats":         v.seats or 0,
                 "type":          v.one_fm_vehicle_type or "—",


### PR DESCRIPTION
Implements WI-001778 [Yaser] Transportation Schedule Frontend Canvas.

## Change

The Vehicle **model** now reaches the Route Plan canvas and is shown inline after the plate in both places the AC names:

- **vehicle lane header** (left sidebar) — `50-1234, Nissan Urvan`
- **right-hand details panel** — via `vehicleLabelForItem`, which the panel already renders

One helper composes it:

```js
vehicleString(v) {
    if (!v) return '';
    return [v.license_plate, v.model].filter(Boolean).join(', ') || v.label || v.id;
}
```

The AC asks for the header to read *strictly* `[plate], [model]`, so the composed string replaces the `VHL-` code on the header line and the separate plate line below it is folded in — along with its four now-dead CSS rules.

## Consistency fix that came with it

Six places named a vehicle to the dispatcher via the raw `vehicle.label` (the docname): the multi-day-lock rejection, the handover warning, the "already has an active trip" confirm, the multi-trip dialog, the trip-option labels and the trip-merge alert. Once the lane header shows a plate, those messages showing `VHL-L-0011` would be talking about a lane the dispatcher can no longer identify by that name. All six now go through the same helper.

## Vehicle identity is untouched

Worth being explicit, since this file keys a lot off the vehicle:

- The payload still sends `label: v.name`; only the *rendering* changed.
- `generateTripName` derives its number from the vehicle **id** (`/VHL-(\d+)/`), not the label, so trip naming is unaffected.
- `vehicleMeta` lookups and lane drop targets key off `vehicle.id` throughout.

The `|| v.label || v.id` fallback exists so a vehicle missing both plate and model still renders an identifiable, droppable lane rather than a blank one.

## Testing

`bench run-tests --module one_fm.one_fm.page.transportation_schedule.test_vehicle_lane_label` → **9 passed**.
`bench run-tests --module one_fm.one_fm.page.transportation_schedule.test_transportation_schedule` → **6 passed** (existing canvas tests, unaffected).

New tests guard that `model` is a real Vehicle field, that the canvas query selects it and the payload publishes it, that the helper composes and filters the parts, that a lane is never left unlabelled, that the header and details panel both use the composed string, that no dispatcher message still uses a raw label, and that the duplicate plate line and its styles are gone.

The helper's branches were exercised directly through node against the real source — all six cases pass, including the fallback chain:

```
ok  {plate:"50-1234", model:"Nissan Urvan"} -> "50-1234, Nissan Urvan"
ok  {plate:"50-1234", model:""}             -> "50-1234"
ok  {plate:"",        model:"Coaster"}      -> "Coaster"
ok  {plate:"", model:"", label:"VHL-0007"}  -> "VHL-0007"
ok  {plate:"", model:"", label:"", id:...}  -> "VHL-0009"
ok  null                                    -> ""
```

Sibling of #6586 (WI-001766), which does the same for the Transportation Manifest page. The two touch different functions in `transportation_schedule.py` (the canvas builder here, the manifest builder there) and are independent.

No migration needed; `bench build`/`bench clear-cache` picks up the page asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
