### PR TITLE
WI-001797: strip spaces from the Bank Account IBAN and fix its length at 30

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -69,6 +69,7 @@ page_js = {
 # include js in doctype views
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 doctype_js = {
+	"Bank Account": "public/js/doctype_js/bank_account.js",
 	"Location" : "public/js/doctype_js/location.js",
 	"Shift Type" : "public/js/doctype_js/shift_type.js",
 	"Leave Type" : "public/js/doctype_js/leave_type.js",
@@ -327,7 +328,10 @@ doc_events = {
 		"after_insert": "one_fm.api.doc_methods.bank_account.after_insert",
 		"on_update": "one_fm.utils.bank_account_on_update",
 		"on_trash": "one_fm.utils.bank_account_on_trash",
-		"validate": "one_fm.utils.validate_iban_is_filled",
+		"validate": [
+			"one_fm.utils.validate_iban_is_filled",
+			"one_fm.overrides.bank_account.validate_iban",
+		],
 	},
 	"Employee Checkin": {
 		"on_update": "one_fm.utils.create_additional_salary_for_overtime_request_for_head_office"

--- a/one_fm/overrides/bank_account.py
+++ b/one_fm/overrides/bank_account.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe import _
+
+# A Kuwaiti IBAN is exactly 30 characters (e.g. KW48NBOK0000000000204576567).
+IBAN_LENGTH = 30
+
+
+def normalise_iban(iban: str) -> str:
+	"""Strip every space out of an IBAN.
+
+	Banks print an IBAN in groups of four, so a pasted or typed value routinely
+	arrives with grouping spaces. Pure/stdlib so it is cheap to test.
+	"""
+	return "".join((iban or "").split())
+
+
+def validate_iban(doc, method=None):
+	"""Normalise the IBAN and hold a changed one to its fixed length (WI-001797).
+
+	Spaces are always removed: the payroll export reads this field raw, so a
+	value carrying the bank's grouping spaces is unusable downstream.
+
+	The length rule is enforced only when the IBAN actually changes. Applied to
+	every save it would freeze any legacy account whose stored IBAN is not 30
+	characters - blocking edits and workflow transitions that have nothing to do
+	with the IBAN - so an untouched legacy value is left alone and becomes
+	compliant the next time someone edits it.
+	"""
+	if not doc.iban:
+		return
+
+	cleaned = normalise_iban(doc.iban)
+	doc.iban = cleaned
+
+	before = doc.get_doc_before_save()
+	# Compare normalised to normalised, so merely stripping the spaces out of a
+	# legacy value does not read as a change and trip the length check.
+	if before and normalise_iban(before.iban) == cleaned:
+		return
+
+	if len(cleaned) != IBAN_LENGTH:
+		frappe.throw(_("IBAN must be exactly {0} characters long.").format(IBAN_LENGTH))

--- a/one_fm/public/js/doctype_js/bank_account.js
+++ b/one_fm/public/js/doctype_js/bank_account.js
@@ -1,0 +1,12 @@
+frappe.ui.form.on("Bank Account", {
+	iban(frm) {
+		// WI-001797: banks print an IBAN in groups of four, so a pasted value arrives
+		// with grouping spaces. Strip them as the field is edited rather than waiting
+		// for the save, so what the user sees is what gets stored. The server strips
+		// them too, for imports and API writes that never touch this form.
+		const cleaned = (frm.doc.iban || "").replace(/\s+/g, "");
+		if (cleaned !== frm.doc.iban) {
+			frm.set_value("iban", cleaned);
+		}
+	},
+});

--- a/one_fm/tests/test_bank_account_iban.py
+++ b/one_fm/tests/test_bank_account_iban.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Tests for the Bank Account IBAN rules (WI-001797).
+
+Spaces are always stripped; the 30-character rule bites only when the IBAN
+changes, so a legacy account with a non-conforming IBAN can still be saved for
+unrelated edits instead of being frozen.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.overrides.bank_account import IBAN_LENGTH, normalise_iban, validate_iban
+
+VALID_IBAN = "KW48NBOK0000000000204576567500"
+SHORT_IBAN = "KW48NBOK123"
+
+
+class TestNormaliseIban(FrappeTestCase):
+	def test_the_fixture_is_the_length_the_rule_expects(self):
+		self.assertEqual(len(VALID_IBAN), IBAN_LENGTH)
+
+	def test_grouping_spaces_are_removed(self):
+		self.assertEqual(
+			normalise_iban("KW48 NBOK 0000 0000 0020 4576 5675 00"),
+			"KW48NBOK0000000000204576567500",
+		)
+
+	def test_all_whitespace_is_removed(self):
+		self.assertEqual(normalise_iban("KW48\tNBOK\n0000"), "KW48NBOK0000")
+
+	def test_blank_input_is_safe(self):
+		self.assertEqual(normalise_iban(""), "")
+		self.assertEqual(normalise_iban(None), "")
+
+	def test_a_clean_iban_is_untouched(self):
+		self.assertEqual(normalise_iban(VALID_IBAN), VALID_IBAN)
+
+
+class TestValidateIban(FrappeTestCase):
+	"""Exercises the hook against a document stub, so no Bank Account is created."""
+
+	def _doc(self, iban, before_iban=None):
+		doc = frappe._dict(iban=iban)
+		before = frappe._dict(iban=before_iban) if before_iban is not None else None
+		doc.get_doc_before_save = lambda: before
+		return doc
+
+	def test_a_valid_new_iban_passes_and_is_stored_clean(self):
+		doc = self._doc(VALID_IBAN)
+		validate_iban(doc)
+		self.assertEqual(doc.iban, VALID_IBAN)
+
+	def test_spaces_are_stripped_on_a_new_record(self):
+		spaced = " ".join([VALID_IBAN[i : i + 4] for i in range(0, len(VALID_IBAN), 4)])
+		doc = self._doc(spaced)
+		validate_iban(doc)
+		self.assertEqual(doc.iban, VALID_IBAN)
+		self.assertEqual(len(doc.iban), IBAN_LENGTH)
+
+	def test_a_short_new_iban_is_rejected(self):
+		doc = self._doc(SHORT_IBAN)
+		with self.assertRaises(frappe.ValidationError):
+			validate_iban(doc)
+
+	def test_a_long_new_iban_is_rejected(self):
+		doc = self._doc(VALID_IBAN + "99")
+		with self.assertRaises(frappe.ValidationError):
+			validate_iban(doc)
+
+	def test_the_error_message_is_the_one_the_ac_specifies(self):
+		doc = self._doc(SHORT_IBAN)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			validate_iban(doc)
+		self.assertIn("IBAN must be exactly 30 characters long.", str(cm.exception))
+
+	def test_an_empty_iban_is_left_to_the_existing_workflow_rule(self):
+		# validate_iban_is_filled already guards the Active Account transition.
+		doc = self._doc("")
+		validate_iban(doc)
+		self.assertFalse(doc.iban)
+
+	def test_an_untouched_legacy_iban_does_not_block_an_unrelated_save(self):
+		# The whole point of validating on change: a short stored IBAN must not
+		# freeze the record.
+		doc = self._doc(SHORT_IBAN, before_iban=SHORT_IBAN)
+		validate_iban(doc)
+		self.assertEqual(doc.iban, SHORT_IBAN)
+
+	def test_stripping_a_legacy_value_is_not_treated_as_a_change(self):
+		# Normalised-to-normalised comparison: removing the stored spaces must not
+		# by itself trip the length check.
+		doc = self._doc("KW48 NBOK 123", before_iban="KW48 NBOK 123")
+		validate_iban(doc)
+		self.assertEqual(doc.iban, "KW48NBOK123")
+
+	def test_editing_a_legacy_iban_to_another_bad_value_is_rejected(self):
+		doc = self._doc("KW48NBOK999", before_iban=SHORT_IBAN)
+		with self.assertRaises(frappe.ValidationError):
+			validate_iban(doc)
+
+	def test_editing_a_legacy_iban_to_a_valid_one_is_accepted(self):
+		doc = self._doc(VALID_IBAN, before_iban=SHORT_IBAN)
+		validate_iban(doc)
+		self.assertEqual(doc.iban, VALID_IBAN)
+
+
+class TestIbanHookIsWired(FrappeTestCase):
+	"""The logic above is only reached if the hook is registered, and a validate
+	hook that was left a bare string would silently drop the existing IBAN rule."""
+
+	def test_both_bank_account_validate_hooks_are_registered(self):
+		hooks = frappe.get_hooks("doc_events").get("Bank Account", {})
+		validate = hooks.get("validate") or []
+		if isinstance(validate, str):
+			validate = [validate]
+		self.assertIn("one_fm.overrides.bank_account.validate_iban", validate)
+		self.assertIn("one_fm.utils.validate_iban_is_filled", validate)
+
+	def test_the_form_script_is_registered(self):
+		self.assertEqual(
+			frappe.get_hooks("doctype_js").get("Bank Account"),
+			["public/js/doctype_js/bank_account.js"],
+		)


### PR DESCRIPTION
Implements WI-001797 [Mariam] Bank Account Doctype Update.

## What ERPNext already does, and the two gaps

Worth stating up front, because it changes what this PR needs to be. ERPNext's `Bank Account.validate_iban` checks the **mod-97 checksum** — and:

- it removes whitespace **only to compute the checksum** (`iban = "".join(self.iban.split(" ")).upper()`) and **never writes the cleaned value back**. So an IBAN pasted from a bank statement passes validation and is **stored with its grouping spaces**. The payroll export reads this field raw.
- it **never checks length**. A checksum-valid IBAN of the wrong length is accepted.

Both ACs are therefore real gaps, not duplication.

## Changes

- **`overrides/bank_account.py`** — `validate_iban` strips all whitespace and writes it back, then enforces the 30-character rule.
- **`public/js/doctype_js/bank_account.js`** — strips spaces as the field is edited, so what the user sees is what gets stored. The server strips too, for imports and API writes that never touch the form.
- **`hooks.py`** — the Bank Account `validate` hook becomes a list so the existing `validate_iban_is_filled` rule is preserved alongside the new one.

## The legacy-record decision

The length rule fires **only when the IBAN changes**. Enforcing it on every save would freeze any account whose stored IBAN is not 30 characters — blocking unrelated field edits and workflow transitions with an IBAN error.

The comparison is normalised on *both* sides, so stripping the spaces out of a legacy value does not itself read as a change and trip the check:

```python
before = doc.get_doc_before_save()
if before and normalise_iban(before.iban) == cleaned:
    return
```

For context, this turns out to be belt-and-braces on the current data: **all 2750 Bank Accounts on the dev site already hold 30-character, space-free IBANs** (0 wrong length, 0 containing a space). The guard matters for future edits rather than a backlog.

## Testing

`bench run-tests --module one_fm.tests.test_bank_account_iban` → **17 passed**.

Covers normalisation (grouping spaces, tabs/newlines, blank, already-clean), new-record accept/reject for short and long values, the exact AC error string, an empty IBAN being left to the existing workflow rule, and the four legacy paths — untouched short IBAN saves fine, stripping a legacy value is not a change, editing to another bad value is rejected, editing to a valid one is accepted. Plus two tests asserting both validate hooks and the form script are actually registered, since a hook left as a bare string would silently drop the existing rule.

Verified end to end against real documents on the dev site:

```
real IBAN 'KW75NBOK0000000000002047816836' (30)
  saved as 'KW75 NBOK 0000 0000 0000 2047 8168 36'
  -> stored 'KW75NBOK0000000000002047816836'
  spaces removed: True   value preserved: True

DE89370400440532013000 (22 chars, valid checksum, accepted by ERPNext)
  -> rejected: "IBAN must be exactly 30 characters long."
```

That last case is the one that shows the length rule earns its place: a canonical valid German IBAN passes ERPNext's checksum and is stopped only by this change.

No migration needed; a `bench restart` and `bench build` pick up the hook and the form script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
