### PR TITLE
WI-001806: resolve a Trip Request destination from its Event Staff source

### DIFF
--- a/one_fm/one_fm/doctype/trip_request/test_trip_request.py
+++ b/one_fm/one_fm/doctype/trip_request/test_trip_request.py
@@ -4,8 +4,45 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from one_fm.one_fm.doctype.trip_request.trip_request import resolve_destination_location
+from one_fm.one_fm.doctype.trip_request.trip_request import (
+	SOURCE_DESTINATION_FIELD_MAP,
+	resolve_destination_location,
+)
 from one_fm.tests.utils import make_employee
+
+
+def _get_or_create_location(location_name):
+	"""A Location to point an event at, inserted raw.
+
+	The Location controller enforces latitude/longitude and maintains a nested set;
+	a plain link target needs neither.
+	"""
+	if frappe.db.exists("Location", location_name):
+		return location_name
+
+	location = frappe.new_doc("Location")
+	location.location_name = location_name
+	location.name = location_name
+	location.db_insert()
+	return location_name
+
+
+def _make_event_staff(location):
+	"""Insert a minimal Event Staff row, bypassing its controller.
+
+	The controller validates client-event staffing requirements, employee days off
+	and overlapping assignments, and writes roster side effects on submit - none of
+	which the destination resolver touches, and all of which would need a full
+	Client Event fixture.
+	"""
+	name = f"_TEST-ES-{location or 'NO-LOCATION'}"
+	frappe.db.delete("Event Staff", {"name": name})
+
+	event_staff = frappe.new_doc("Event Staff")
+	event_staff.name = name
+	event_staff.event_location = location
+	event_staff.db_insert()
+	return name
 
 
 class TestTripRequest(FrappeTestCase):
@@ -83,3 +120,61 @@ class TestTripRequest(FrappeTestCase):
 		doc.insert(ignore_permissions=True)
 
 		self.assertEqual(doc.destination_location, "Manually Entered Destination")
+
+
+class TestEventStaffDestination(FrappeTestCase):
+	"""WI-001806: selecting an Event Staff source resolves the destination from the
+	event's Location, so the dispatcher does not re-key data the system already has."""
+
+	def setUp(self):
+		self.location = _get_or_create_location("_Test Trip Event Location")
+
+	def test_event_staff_is_mapped_to_its_event_location(self):
+		self.assertEqual(SOURCE_DESTINATION_FIELD_MAP["Event Staff"], "event_location")
+
+	def test_the_mapped_field_exists_on_event_staff(self):
+		# resolve_destination_location guards on this, so a rename would silently
+		# stop resolving rather than error.
+		self.assertTrue(frappe.get_meta("Event Staff").has_field("event_location"))
+
+	def test_the_mapped_field_links_to_location(self):
+		# Transportation Shipment copies the resolved value into its `stop_location`
+		# Link field, so anything but a Location docname would fail link validation
+		# downstream.
+		df = frappe.get_meta("Event Staff").get_field("event_location")
+		self.assertEqual(df.fieldtype, "Link")
+		self.assertEqual(df.options, "Location")
+
+	def test_a_location_docname_is_its_location_name(self):
+		# Location autonames from location_name, which is why storing the docname
+		# satisfies the AC's "pull the Location address".
+		self.assertEqual(
+			frappe.db.get_value("Location", self.location, "location_name"), self.location
+		)
+
+	def test_resolver_returns_the_event_location(self):
+		event_staff = _make_event_staff(self.location)
+		self.assertEqual(
+			resolve_destination_location("Event Staff", event_staff), self.location
+		)
+
+	def test_resolver_returns_none_when_the_event_has_no_location(self):
+		event_staff = _make_event_staff(None)
+		self.assertIsNone(resolve_destination_location("Event Staff", event_staff))
+
+	def test_the_destination_is_filled_on_save(self):
+		doc = frappe.get_doc({
+			"doctype": "Trip Request",
+			"from_date": "2026-08-01",
+			"to_date": "2026-08-02",
+			"departure_time": "08:00:00",
+			"return_time": "11:00:00",
+			"transportation_method": "Company Fleet",
+			"source_doctype": "Event Staff",
+			"source_reference": _make_event_staff(self.location),
+			"transport_request_passenger": [
+				{"employee_id": make_employee("test_trip_es1@example.com").name}
+			],
+		})
+		doc.insert(ignore_permissions=True)
+		self.assertEqual(doc.destination_location, self.location)

--- a/one_fm/one_fm/doctype/trip_request/trip_request.py
+++ b/one_fm/one_fm/doctype/trip_request/trip_request.py
@@ -10,6 +10,12 @@ from frappe.model.document import Document
 # listed here (e.g. "Client Interview Shortlist") carry no location, so the
 # Destination Location is left empty for the dispatcher to fill in manually.
 SOURCE_DESTINATION_FIELD_MAP = {
+	# WI-001806: Event Staff carries the event's Location, so a dispatcher raising a
+	# Trip Request against it does not re-enter the destination. `event_location` is a
+	# Link to Location and Location autonames from `location_name`, so the value is
+	# both the location's name and a valid link - which matters because Transportation
+	# Shipment copies this field straight into its `stop_location` Link field.
+	"Event Staff": "event_location",
 	"Fingerprint Appointment": "service_location",
 	"Medical Appointment": "service_location",
 }


### PR DESCRIPTION
Implements WI-001806 [Yaser] Trip Request Destination Location Fetching from Event Staff.

## Change

One entry in `SOURCE_DESTINATION_FIELD_MAP`:

```python
"Event Staff": "event_location",
```

The resolver, its permission check, the server-side fallback in `validate` and the client-side fetch on `source_reference` were all built for the appointment sources in earlier work, so selecting Event Staff now populates Destination Location with no further wiring.

## Why the Location name, not a free-text address

The AC says "pull the Location address", which read as ambiguous until I traced where the field goes. It isn't ambiguous:

`Transportation Shipment` copies this field **straight into its `stop_location` field**, which is a `Link` to `Location`:

```python
if not self.stop_location:
    self.stop_location = trq.destination_location
```

So anything that is not a Location docname would fail link validation the moment a shipment is generated from the Trip Request. And because `Location` autonames from `location_name` (`naming_rule: By fieldname`), the docname **is** the location's name — so storing it satisfies the AC's wording and keeps the downstream link valid. `Event Staff.event_location` is already a `Link` to `Location`, so the value passes through correctly.

I've noted this reasoning in the code, since the map looks like free text at a glance and a future entry pointing at a Data field would break shipment generation rather than the Trip Request itself. That is worth bearing in mind for **WI-001807**, whose AC says `service_location` "has been set as Link field which needs to be updated" — the two appointment doctypes currently map to a `Data` field, so that item is what makes the existing entries sound.

## Testing

`bench run-tests --module one_fm.one_fm.doctype.trip_request.test_trip_request` → **14 passed** (7 pre-existing, 7 new).

New tests cover the map entry, the mapped field existing on Event Staff and being a Link to Location, a Location docname equalling its `location_name`, the resolver returning the event's location, the resolver returning nothing when the event has no location, and the destination actually being filled on save.

Event Staff fixtures are inserted raw via `db_insert()`, matching the pattern (and rationale) already used for Contracts in the Proof of Work tests: its controller validates client-event staffing requirements, employee days off and overlapping assignments and writes roster side effects on submit, none of which the destination resolver touches, and all of which would need a full Client Event fixture.

No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
