### PR TITLE
WI-001764: link Accommodation Leave Movement from the Hospitality workspace

### DIFF
--- a/one_fm/one_fm/workspace/hospitality/hospitality.json
+++ b/one_fm/one_fm/workspace/hospitality/hospitality.json
@@ -14,7 +14,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Accommodation",
-   "link_count": 7,
+   "link_count": 8,
    "onboard": 0,
    "type": "Card Break"
   },
@@ -64,6 +64,16 @@
    "label": "Checkin/Checkout",
    "link_count": 0,
    "link_to": "Accommodation Checkin Checkout",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Leave Movement",
+   "link_count": 0,
+   "link_to": "Accommodation Leave Movement",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -255,7 +265,7 @@
    "type": "Link"
   }
  ],
- "modified": "2022-10-31 21:19:33.769979",
+ "modified": "2026-07-30 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "One Fm",
  "name": "Hospitality",

--- a/one_fm/tests/test_hospitality_workspace.py
+++ b/one_fm/tests/test_hospitality_workspace.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Tests for the Hospitality workspace (WI-001764).
+
+Accommodation Leave Movement is reachable from the Hospitality workspace so an
+Accommodation Manager does not have to search for it. Visibility is governed by
+the doctype's own permissions, not the workspace, which carries no roles.
+"""
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+WORKSPACE = ("one_fm", "one_fm", "workspace", "hospitality", "hospitality.json")
+ALM = "Accommodation Leave Movement"
+
+
+class TestHospitalityWorkspace(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.doc = json.loads(frappe.read_file(frappe.get_app_path(*WORKSPACE)))
+		cls.links = cls.doc["links"]
+
+	def _card_break(self, label):
+		return next(
+			link for link in self.links
+			if link.get("type") == "Card Break" and link.get("label") == label
+		)
+
+	def test_leave_movement_is_linked(self):
+		targets = [link.get("link_to") for link in self.links]
+		self.assertIn(ALM, targets)
+
+	def test_it_sits_beside_checkin_checkout(self):
+		targets = [link.get("link_to") for link in self.links]
+		self.assertEqual(
+			targets.index(ALM), targets.index("Accommodation Checkin Checkout") + 1
+		)
+
+	def test_the_card_break_counts_the_new_link(self):
+		# A stale link_count silently truncates the card, hiding the last entries.
+		card = self._card_break("Accommodation")
+		first = self.links.index(card)
+		# Links belonging to this card run until the next Card Break.
+		count = 0
+		for link in self.links[first + 1 :]:
+			if link.get("type") == "Card Break":
+				break
+			count += 1
+		self.assertEqual(card["link_count"], count)
+
+	def test_the_linked_doctype_exists(self):
+		self.assertTrue(frappe.db.exists("DocType", ALM))
+
+	def test_the_workspace_is_under_gsd_and_public(self):
+		self.assertEqual(self.doc["parent_page"], "GSD")
+		self.assertEqual(self.doc["public"], 1)
+
+	def test_visibility_comes_from_the_doctype_permissions(self):
+		# The workspace declares no roles, so who sees the link is decided by the
+		# doctype's own permissions - Accommodation User is the operational role.
+		self.assertEqual(self.doc["roles"], [])
+		roles = {p.role for p in frappe.get_meta(ALM).permissions if p.read}
+		self.assertIn("Accommodation User", roles)
+
+	def test_the_card_layout_still_renders_the_accommodation_card(self):
+		# `content` references cards by name; adding a link must not disturb it.
+		blocks = json.loads(self.doc["content"])
+		names = [b["data"].get("card_name") for b in blocks if b["type"] == "card"]
+		self.assertIn("Accommodation", names)


### PR DESCRIPTION
Implements WI-001764 [Yaser] Workspace Update for Hospitality.

## Change

`Accommodation Leave Movement` added to the **Accommodation** card of the Hospitality workspace (under GSD), positioned directly after Checkin/Checkout since both record a resident moving in or out.

The card's `link_count` is bumped from 7 to 8 along with it — Frappe truncates a card to that count, so leaving it stale would have silently hidden the new entry. The workspace `content` blocks reference cards by name, so the layout needed no change.

The `modified` timestamp is bumped, otherwise `bench migrate` will not re-import a standard workspace fixture.

## On the visibility requirement

The AC says the link should be visible to Mr Yaser Alluqman, Mr Irfan Anware and Mr Krishna Thapa. That is a **permissions** matter rather than a workspace one — this workspace declares `roles: []`, so who sees the link is decided by the doctype's own permissions, and `Accommodation Leave Movement` grants read to `Accommodation User` and `System Manager`.

I checked the three people against production:

| Person | Account | `Accommodation User` |
|---|---|---|
| Yaser Alluqman | `y.alluqman@one-fm.com` | ✅ has it |
| Irfan Moosa Anware | `i.anware@one-fm.com` | ✅ has it |
| Krishna Thapa | — | ❌ **not held** |

So **Yaser and Irfan get the link as soon as this merges**, with no further action.

Krishna Thapa does not currently hold `Accommodation User`, and there are two enabled accounts under that name (`2402059np185@one-fm.com` and `2407006np176@one-fm.com`), both employee-numbered rather than manager-style addresses. Granting a role is a production data change on a specific user, not something this PR should encode, so I have deliberately left it out — **please confirm which account is the right one and have the role granted**, or say the word and I will prepare it.

## Testing

`bench run-tests --module one_fm.tests.test_hospitality_workspace` → **7 passed**.

Covers the link being present, sitting immediately after Checkin/Checkout, the card's `link_count` matching the number of links that actually belong to the card (computed by walking to the next Card Break, so it stays honest if links are added later), the linked doctype existing, the workspace remaining public under GSD, `Accommodation User` holding read on the doctype, and the `content` layout still rendering the Accommodation card.

Requires `bench migrate` to re-import the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
