### PR TITLE
WI-001785: invite a client Contact to the portal with a usable outcome

### DIFF
--- a/one_fm/hooks.py
+++ b/one_fm/hooks.py
@@ -843,6 +843,7 @@ fixtures = [
 # ------------------------------
 #
 override_whitelisted_methods = {
+    "frappe.contacts.doctype.contact.contact.invite_user": "one_fm.overrides.contact.invite_user",
     "frappe.model.workflow.get_transitions":"one_fm.overrides.workflow.get_transitions",
 	"frappe.model.workflow.apply_workflow":"one_fm.overrides.workflow.apply_workflow",
 	"frappe.core.doctype.user.user.update_password": "one_fm.api.doc_methods.user.update_password",

--- a/one_fm/overrides/contact.py
+++ b/one_fm/overrides/contact.py
@@ -1,0 +1,63 @@
+import frappe
+from frappe import _
+
+# The site's only website-only role for clients (desk_access = 0). A portal user
+# needs it to reach their own organisation's records.
+CUSTOMER_PORTAL_ROLE = "Customer"
+
+
+def get_linked_customer(contact) -> str | None:
+	"""The Customer this Contact belongs to, if any."""
+	for link in contact.get("links") or []:
+		if link.link_doctype == "Customer":
+			return link.link_name
+	return None
+
+
+@frappe.whitelist()
+def invite_user(contact: str):
+	"""Invite a Contact to the portal (WI-001785).
+
+	Overrides ``frappe.contacts.doctype.contact.contact.invite_user`` to add what
+	the framework's version leaves out: the client portal role, a duplicate check
+	that names the address, and messages an internal user can act on rather than
+	"Please set Email Address" or a raw duplicate-entry traceback.
+
+	The portal role is granted only when the Contact is actually linked to a
+	Customer. This method also serves supplier and employee contacts, which must
+	not pick up a client role as a side effect.
+	"""
+	contact = frappe.get_doc("Contact", contact)
+	contact.check_permission()
+
+	if not contact.email_id:
+		frappe.throw(
+			_("Cannot invite user: Primary email address is missing on this contact.")
+		)
+
+	# Checked up front so the caller gets the address back, rather than the
+	# DuplicateEntryError the insert would otherwise raise.
+	if frappe.db.exists("User", contact.email_id):
+		frappe.throw(
+			_("User with email {0} already exists in the system.").format(contact.email_id)
+		)
+
+	user = frappe.get_doc(
+		{
+			"doctype": "User",
+			"first_name": contact.first_name,
+			"last_name": contact.last_name,
+			"email": contact.email_id,
+			"user_type": "Website User",
+			# Carries the secure password-setup link.
+			"send_welcome_email": 1,
+		}
+	).insert()
+
+	if get_linked_customer(contact) and frappe.db.exists("Role", CUSTOMER_PORTAL_ROLE):
+		user.add_roles(CUSTOMER_PORTAL_ROLE)
+
+	frappe.msgprint(_("Invitation email sent successfully"), indicator="green", alert=True)
+
+	# Frappe's Contact form writes this back into the `user` field.
+	return user.name

--- a/one_fm/tests/test_contact_invite_user.py
+++ b/one_fm/tests/test_contact_invite_user.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Tests for inviting a Contact to the portal (WI-001785)."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.overrides.contact import (
+	CUSTOMER_PORTAL_ROLE,
+	get_linked_customer,
+	invite_user,
+)
+
+CUSTOMER_EMAIL = "_test_portal_client@example.com"
+
+
+def _get_or_create_customer():
+	name = "_Test Invite Customer"
+	if frappe.db.exists("Customer", name):
+		return name
+	return frappe.get_doc({"doctype": "Customer", "customer_name": name}).insert(
+		ignore_permissions=True
+	).name
+
+
+def _make_contact(email=None, customer=None):
+	# Contact autonames from the person's name, so runs collide. Child rows outlive a
+	# parent delete, and a leftover primary email makes the next insert fail with
+	# "Only one Email ID can be set as primary".
+	for name in frappe.get_all("Contact", filters={"first_name": "_TestInvite"}, pluck="name"):
+		frappe.db.delete("Contact Email", {"parent": name})
+		frappe.db.delete("Contact Phone", {"parent": name})
+		frappe.db.delete("Dynamic Link", {"parent": name})
+		frappe.db.delete("Contact", {"name": name})
+
+	contact = frappe.get_doc(
+		{
+			"doctype": "Contact",
+			"first_name": "_TestInvite",
+			"last_name": "Client",
+		}
+	)
+	if email:
+		contact.append("email_ids", {"email_id": email, "is_primary": 1})
+	if customer:
+		contact.append("links", {"link_doctype": "Customer", "link_name": customer})
+	contact.insert(ignore_permissions=True)
+	return contact
+
+
+class TestLinkedCustomer(FrappeTestCase):
+	def test_a_customer_link_is_found(self):
+		customer = _get_or_create_customer()
+		contact = _make_contact(email=CUSTOMER_EMAIL, customer=customer)
+		self.assertEqual(get_linked_customer(contact), customer)
+
+	def test_a_contact_with_no_links_has_no_customer(self):
+		contact = _make_contact(email=CUSTOMER_EMAIL)
+		self.assertIsNone(get_linked_customer(contact))
+
+	def test_a_non_customer_link_is_ignored(self):
+		# The same button serves supplier and employee contacts, which must not be
+		# mistaken for clients.
+		contact = _make_contact(email=CUSTOMER_EMAIL)
+		contact.append("links", {"link_doctype": "Supplier", "link_name": "_Test Supplier"})
+		self.assertIsNone(get_linked_customer(contact))
+
+
+class TestInviteUserGuards(FrappeTestCase):
+	"""The two blocking scenarios, neither of which may create a User."""
+
+	def test_a_contact_without_an_email_is_refused(self):
+		contact = _make_contact()
+		with self.assertRaises(frappe.ValidationError) as cm:
+			invite_user(contact.name)
+		self.assertIn(
+			"Cannot invite user: Primary email address is missing on this contact.",
+			str(cm.exception),
+		)
+
+	def test_an_existing_user_is_refused_and_names_the_address(self):
+		existing = frappe.db.get_value("User", {"enabled": 1}, "name")
+		contact = _make_contact(email=existing)
+		before = frappe.db.count("User")
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			invite_user(contact.name)
+
+		self.assertIn(f"User with email {existing} already exists in the system.", str(cm.exception))
+		self.assertEqual(frappe.db.count("User"), before)
+
+
+class TestInviteUserCreatesPortalAccount(FrappeTestCase):
+	def setUp(self):
+		frappe.db.delete("User", {"email": CUSTOMER_EMAIL})
+		self.customer = _get_or_create_customer()
+		# Frappe sends the welcome mail from User.after_insert. Muting is not enough:
+		# the queue entry is *built* before the mute check, and building it resolves a
+		# sender from the site's default Email Account, which is unconfigured here.
+		# Sending is Frappe's concern; the invitation is what is under test.
+		patcher = patch("frappe.sendmail")
+		self.sendmail = patcher.start()
+		self.addCleanup(patcher.stop)
+
+	def test_a_website_user_is_created_with_the_portal_role(self):
+		contact = _make_contact(email=CUSTOMER_EMAIL, customer=self.customer)
+
+		user_name = invite_user(contact.name)
+
+		self.assertEqual(user_name, CUSTOMER_EMAIL)
+		user = frappe.get_doc("User", user_name)
+		self.assertEqual(user.user_type, "Website User")
+		self.assertIn(CUSTOMER_PORTAL_ROLE, [r.role for r in user.roles])
+
+	def test_the_welcome_email_is_requested_and_sent(self):
+		contact = _make_contact(email=CUSTOMER_EMAIL, customer=self.customer)
+		invite_user(contact.name)
+		# send_welcome_email is what carries the secure password-setup link, so both
+		# the flag and the resulting send matter.
+		self.assertTrue(frappe.db.get_value("User", CUSTOMER_EMAIL, "send_welcome_email"))
+		self.assertTrue(self.sendmail.called)
+
+	def test_a_contact_with_no_customer_gets_no_portal_role(self):
+		contact = _make_contact(email=CUSTOMER_EMAIL)
+
+		user_name = invite_user(contact.name)
+
+		user = frappe.get_doc("User", user_name)
+		self.assertNotIn(CUSTOMER_PORTAL_ROLE, [r.role for r in user.roles])
+
+
+class TestOverrideIsWired(FrappeTestCase):
+	def test_the_framework_method_is_overridden(self):
+		self.assertEqual(
+			frappe.get_hooks("override_whitelisted_methods").get(
+				"frappe.contacts.doctype.contact.contact.invite_user"
+			),
+			["one_fm.overrides.contact.invite_user"],
+		)
+
+	def test_the_portal_role_exists_and_is_website_only(self):
+		self.assertTrue(frappe.db.exists("Role", CUSTOMER_PORTAL_ROLE))
+		self.assertEqual(
+			frappe.db.get_value("Role", CUSTOMER_PORTAL_ROLE, "desk_access"), 0
+		)


### PR DESCRIPTION
Implements WI-001785 M1 [Ali] Sign Up Invitation to Customer for raising Maintenance Ticket in Contact Doctype.

## Approach

Frappe **already ships** the "Invite as User" button on Contact and the whitelisted method behind it, which creates a Website User with `send_welcome_email = 1` (that covers the AC's secure password-setup link). So this overrides that method via `override_whitelisted_methods` rather than adding a parallel button — the existing button keeps working and picks up the new behaviour, and no client-side change is needed.

| AC | Framework already | Added here |
|---|---|---|
| Creates a Website User | ✅ | — |
| Welcome email with password setup link | ✅ `send_welcome_email` | — |
| Assigns the Customer portal role | ❌ | ✅ |
| "Invitation email sent successfully" | ❌ | ✅ |
| "Cannot invite user: Primary email address is missing on this contact." | ❌ says "Please set Email Address" | ✅ |
| "User with email X already exists in the system." | ❌ raw `DuplicateEntryError` | ✅ |

## The portal role

There is exactly one website-only role for clients on this site — **`Customer`** (`desk_access = 0`) — so "the Customer portal role" is unambiguous. Confirmed against production, where the full set of website-only roles is `Agency, Course Instructor, Course Moderator, Customer, Guest, Job Applicant, Supplier`.

It is granted **only when the Contact is actually linked to a Customer**. This method also serves supplier and employee contacts, and giving those a client role as a side effect would be a quiet permissions bug. I deliberately did *not* make a Customer link mandatory, which would have broken supplier-portal invitations that work today — the AC's "Contact linked to a Customer" is the scenario's context, not a new restriction on the button.

## Duplicate check

Checked before the insert rather than catching the failure, so the message can name the address the AC asks for. Note the check is on existence rather than on `enabled`: a disabled user still holds the email as its primary key, so the insert would fail regardless, and reporting "already exists" is the accurate thing to say.

## Testing

`bench run-tests --module one_fm.tests.test_contact_invite_user` → **10 passed**.

Covers the Customer link being found, absent, and not confused with a Supplier link; both refusal paths asserting the exact AC strings and that **no User is created**; the happy path creating a Website User with the portal role and returning the name Frappe's form writes back; the welcome mail actually being sent; a contact with no Customer link *not* receiving the portal role; and the override plus the role's website-only status being wired as expected.

Two notes from writing the tests:

- The happy-path tests mock `frappe.sendmail`. Muting is not sufficient — the queue entry is *built* before the mute check, and building it resolves a sender from the default Email Account, which is unconfigured on the dev site. **This is local only**: production's default outgoing account (`notifications@one-fm.com`) is properly configured, so real invitations are unaffected.
- The Contact fixture clears `Contact Email`, `Contact Phone` and `Dynamic Link` rows before recreating, because child rows outlive a parent delete and a leftover primary email makes the next insert fail with "Only one Email ID can be set as primary".

Requires `bench restart` to load the override hook. No migration.

Note this is M1 of the maintenance chain; **WI-001799 (M2)** builds the first-time password/portal-landing experience on top of it, and still needs a decision on which portal the customer lands in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
