### PR TITLE
WI-001654: open the roster from the Roster Day Off Checker, already filtered

### DIFF
--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.js
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.js
@@ -4,8 +4,42 @@
 frappe.ui.form.on('Roster Day Off Checker', {
     refresh: function(frm) {
         add_make_cdo_button(frm);
+        add_take_action_button(frm);
     }
 });
+
+// WI-001654: open the roster already filtered to this employee's allocation, so a
+// supervisor can correct the day off schedule without rebuilding the filters by hand.
+function add_take_action_button(frm) {
+    if (!frm.is_new()) {
+        frm.add_custom_button(__('Take Action'), function() {
+            open_filtered_roster(frm);
+        }).addClass('btn-primary');
+    }
+}
+
+function open_filtered_roster(frm) {
+    frappe.call({
+        method: 'one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker.get_take_action_data',
+        args: { checker: frm.doc.name },
+        freeze: true,
+        freeze_message: __('Opening roster...'),
+        callback: function(r) {
+            if (!r.message || !r.message.path) {
+                frappe.msgprint(__('Unable to determine the roster filters for this record.'));
+                return;
+            }
+
+            // Same handling as the Roster Client Day Off Checker: build the URL from the
+            // returned params, dropping any the server could not resolve.
+            let url = new URL(r.message.path, window.location.origin);
+            Object.entries(r.message.params || {}).forEach(function([key, value]) {
+                if (value) url.searchParams.set(key, value);
+            });
+            window.open(url.toString(), '_blank');
+        }
+    });
+}
 
 function add_make_cdo_button(frm) {
     if (!frm.doc.__islocal && 

--- a/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_day_off_checker/roster_day_off_checker.py
@@ -788,3 +788,48 @@ def update_attendance_to_cdo(employee, attendance_date):
             'error': True,
             'message': f'Failed to update attendance: {str(e)}'
         }
+
+@frappe.whitelist()
+def get_take_action_data(checker: str) -> dict:
+	"""
+	Redirect path and roster filters for the Take Action button (WI-001654).
+
+	Returns the same {path, params} shape as the Roster Client Day Off Checker's
+	equivalent, so the client handling is identical.
+
+	The checker stores the employee's allocations as plain text (project_allocation,
+	site_allocation, shift_allocation) and carries no operations role, so anything
+	missing is resolved from the Employee record - which is also where the role lives.
+	"""
+	doc = frappe.get_doc("Roster Day Off Checker", checker)
+	doc.check_permission("read")
+
+	employee = (
+		frappe.db.get_value(
+			"Employee",
+			doc.employee,
+			["project", "site", "shift", "custom_operations_role_allocation", "employee_id", "employee_name"],
+			as_dict=True,
+		)
+		or frappe._dict()
+	)
+
+	# The roster reads these off the query string in setup_preset_filters(); year and
+	# month drive which month the calendar opens on.
+	date = getdate(doc.date) if doc.date else getdate(nowdate())
+
+	return {
+		"path": "/app/roster",
+		"params": {
+			"main_view": "roster",
+			"sub_view": "roster",
+			"employee_id": doc.employee_id or employee.employee_id,
+			"employee_name": doc.employee_name or employee.employee_name,
+			"project": doc.project_allocation or employee.project,
+			"site": doc.site_allocation or employee.site,
+			"shift": doc.shift_allocation or employee.shift,
+			"operations_role": employee.custom_operations_role_allocation,
+			"year": str(date.year),
+			"month": str(date.month),
+		},
+	}

--- a/one_fm/operations/doctype/roster_day_off_checker/test_roster_day_off_checker.py
+++ b/one_fm/operations/doctype/roster_day_off_checker/test_roster_day_off_checker.py
@@ -1,13 +1,30 @@
 # Copyright (c) 2022, ONE FM and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import getdate
 
 from one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker import (
 	calculate_expected_days_off,
+	get_take_action_data,
 	is_exit_before_month_midpoint,
 )
+
+MODULE = "one_fm.operations.doctype.roster_day_off_checker.roster_day_off_checker"
+
+
+class StubChecker(frappe._dict):
+	"""Stand-in for the checker document.
+
+	A module-level class rather than a _dict carrying a lambda: Frappe pickles values it
+	caches, and a locally defined lambda cannot be pickled.
+	"""
+
+	def check_permission(self, *args, **kwargs):
+		return None
 
 
 class TestRosterDayOffChecker(FrappeTestCase):
@@ -104,3 +121,107 @@ class TestCalculateExpectedDaysOff(FrappeTestCase):
 		# 20 applicable / 30 days * 4 = 2.666...
 		self.assertAlmostEqual(calculate_expected_days_off(20, 30, 4), 20 / 30 * 4)
 		self.assertEqual(round(calculate_expected_days_off(20, 30, 4)), 3)
+
+
+
+class TestTakeActionData(FrappeTestCase):
+	"""
+	WI-001654: Take Action opens the roster pre-filtered by employee, project, site, shift
+	and role. The checker document and Employee lookup are stubbed so the filter
+	resolution is tested without Employee/Operations fixtures.
+	"""
+
+	def _checker(self, **overrides):
+		doc = StubChecker(
+			{
+				"name": "OPR-RDOC-TEST",
+				"employee": "EMP-TEST-0001",
+				"employee_id": "EMPID-1",
+				"employee_name": "Test Worker",
+				"project_allocation": "Project A",
+				"site_allocation": "Site A",
+				"shift_allocation": "Shift A",
+				"date": "2026-07-11",
+			}
+		)
+		doc.update(overrides)
+		return doc
+
+	def _employee(self, **overrides):
+		employee = frappe._dict(
+			{
+				"project": "Employee Project",
+				"site": "Employee Site",
+				"shift": "Employee Shift",
+				"custom_operations_role_allocation": "Role A",
+				"employee_id": "EMPID-FALLBACK",
+				"employee_name": "Fallback Name",
+			}
+		)
+		employee.update(overrides)
+		return employee
+
+	def _run(self, checker=None, employee="default"):
+		employee_value = self._employee() if employee == "default" else employee
+		with patch(f"{MODULE}.frappe.get_doc", return_value=checker or self._checker()):
+			with patch(f"{MODULE}.frappe.db.get_value", return_value=employee_value):
+				return get_take_action_data("OPR-RDOC-TEST")
+
+	def test_every_filter_the_ac_asks_for_is_returned(self):
+		params = self._run()["params"]
+
+		# AC: Employee Name & ID, Project, Site, Shift, Role
+		self.assertEqual(params["employee_id"], "EMPID-1")
+		self.assertEqual(params["employee_name"], "Test Worker")
+		self.assertEqual(params["project"], "Project A")
+		self.assertEqual(params["site"], "Site A")
+		self.assertEqual(params["shift"], "Shift A")
+		self.assertEqual(params["operations_role"], "Role A")
+
+	def test_redirects_to_the_roster(self):
+		result = self._run()
+
+		self.assertEqual(result["path"], "/app/roster")
+		# These two open the right view; the rest are read as page filters.
+		self.assertEqual(result["params"]["main_view"], "roster")
+		self.assertEqual(result["params"]["sub_view"], "roster")
+
+	def test_calendar_opens_on_the_checker_month(self):
+		params = self._run()["params"]
+
+		self.assertEqual(params["year"], "2026")
+		self.assertEqual(params["month"], "7")
+
+	def test_allocations_fall_back_to_the_employee_record(self):
+		# The checker stores allocations as free text and they can be blank. The Employee
+		# record is the fallback, and is the only source for the operations role.
+		checker = self._checker(project_allocation="", site_allocation=None, shift_allocation="")
+		params = self._run(checker=checker)["params"]
+
+		self.assertEqual(params["project"], "Employee Project")
+		self.assertEqual(params["site"], "Employee Site")
+		self.assertEqual(params["shift"], "Employee Shift")
+		self.assertEqual(params["operations_role"], "Role A")
+
+	def test_employee_identity_falls_back_too(self):
+		checker = self._checker(employee_id="", employee_name="")
+		params = self._run(checker=checker)["params"]
+
+		self.assertEqual(params["employee_id"], "EMPID-FALLBACK")
+		self.assertEqual(params["employee_name"], "Fallback Name")
+
+	def test_missing_employee_record_does_not_raise(self):
+		# get_value returns None when the Employee is gone. The button should still open
+		# the roster with whatever the checker itself holds rather than erroring.
+		params = self._run(employee=None)["params"]
+
+		self.assertEqual(params["project"], "Project A")
+		self.assertIsNone(params["operations_role"])
+
+	def test_no_date_falls_back_to_today(self):
+		checker = self._checker(date=None)
+		params = self._run(checker=checker)["params"]
+
+		today = getdate(frappe.utils.nowdate())
+		self.assertEqual(params["year"], str(today.year))
+		self.assertEqual(params["month"], str(today.month))


### PR DESCRIPTION
## What

A supervisor looking at a day-off shortfall had to leave the record, open the roster, and rebuild the filters by hand before they could correct anything. **Take Action** now opens the roster in a new tab, filtered to that employee.

Filters returned, matching the acceptance criteria exactly:

| AC asks for | Param | Source |
|---|---|---|
| Employee Name & ID | `employee_id`, `employee_name` | checker, falling back to Employee |
| Project | `project` | `project_allocation` → `Employee.project` |
| Site (Operations Site) | `site` | `site_allocation` → `Employee.site` |
| Shift (Operations Shift) | `shift` | `shift_allocation` → `Employee.shift` |
| Role (Operations Role) | `operations_role` | `Employee.custom_operations_role_allocation` |

Plus `main_view`/`sub_view` to land on the roster view and `year`/`month` so the calendar opens on the month the checker is reporting.

## How

The same button the **Roster Client Day Off Checker** got in WI-001690, resolved the same way, so the two behave identically: a whitelisted `get_take_action_data` returns `{path, params}` and the client builds the URL, dropping any param the server could not resolve rather than sending it empty. The roster reads them in `get_preset_filters()` — `main_view`, `sub_view`, `employee_id`, `employee_name` are handled specially and the rest become page filters.

The allocations on the checker are free text and can be blank, so each falls back to the Employee record, which is also the only place the operations role lives. A missing Employee record does not raise; the button still opens with whatever the checker holds.

## Note

The resolver is a copy of the Client checker's rather than a shared helper — two callers, and sharing would mean editing a feature already in staging. Worth extracting if a third checker ever needs it.

## Testing

```
bench run-tests --app one_fm --module one_fm.operations.doctype.roster_day_off_checker.test_roster_day_off_checker --skip-before-tests
Ran 26 tests in 0.085s — OK
```

7 new cases: every AC filter is returned, it redirects to the roster view, the calendar opens on the checker month, blank allocations fall back to the Employee, employee identity falls back too, a missing Employee record does not raise, and no date falls back to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)