### PR TITLE
WI-001802: add the Maintenance Scenario master and the Maintenance ticket type

### DIFF
--- a/one_fm/one_fm/doctype/maintenance_scenario/maintenance_scenario.json
+++ b/one_fm/one_fm/doctype/maintenance_scenario/maintenance_scenario.json
@@ -1,0 +1,126 @@
+{
+ "name": "Maintenance Scenario",
+ "creation": "2026-07-31 16:04:54.659707",
+ "modified": "2026-07-31 17:15:07.333923",
+ "modified_by": "h.imran@one-fm.com",
+ "owner": "h.imran@one-fm.com",
+ "editable_grid": 0,
+ "module": "One Fm",
+ "autoname": "naming_series:",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "allow_rename": 1,
+ "engine": "InnoDB",
+ "index_web_pages_for_search": 1,
+ "naming_rule": "Expression",
+ "grid_page_length": 50,
+ "row_format": "Dynamic",
+ "doctype": "DocType",
+ "field_order": [
+  "client",
+  "column_break_bdjv",
+  "scenario_name",
+  "column_break_gsop",
+  "priority",
+  "section_break_mvtv",
+  "naming_series"
+ ],
+ "fields": [
+  {
+   "fieldname": "client",
+   "label": "Client",
+   "fieldtype": "Link",
+   "options": "Customer",
+   "reqd": 1,
+   "in_list_view": 1,
+   "doctype": "DocField"
+  },
+  {
+   "fieldname": "column_break_bdjv",
+   "fieldtype": "Column Break",
+   "doctype": "DocField"
+  },
+  {
+   "fieldname": "scenario_name",
+   "label": "Scenario Name",
+   "fieldtype": "Select",
+   "options": "\nComplete Power Outage\nAC Unit is not Working",
+   "reqd": 1,
+   "in_list_view": 1,
+   "doctype": "DocField"
+  },
+  {
+   "fieldname": "column_break_gsop",
+   "fieldtype": "Column Break",
+   "doctype": "DocField"
+  },
+  {
+   "fieldname": "priority",
+   "label": "Priority",
+   "fieldtype": "Link",
+   "options": "Issue Priority",
+   "reqd": 1,
+   "in_list_view": 1,
+   "doctype": "DocField"
+  },
+  {
+   "fieldname": "section_break_mvtv",
+   "fieldtype": "Section Break",
+   "doctype": "DocField"
+  },
+  {
+   "fieldname": "naming_series",
+   "label": "Naming Series",
+   "fieldtype": "Select",
+   "options": "MSCN-.#####",
+   "hidden": 1,
+   "doctype": "DocField"
+  }
+ ],
+ "permissions": [
+  {
+   "role": "System Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "report": 1,
+   "export": 1,
+   "share": 1,
+   "print": 1,
+   "email": 1,
+   "doctype": "DocPerm"
+  },
+  {
+   "role": "Maintenance Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "report": 1,
+   "export": 1,
+   "share": 1,
+   "print": 1,
+   "email": 1,
+   "select": 1,
+   "doctype": "DocPerm"
+  },
+  {
+   "role": "Maintenance User",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "report": 1,
+   "export": 1,
+   "share": 1,
+   "print": 1,
+   "email": 1,
+   "select": 1,
+   "doctype": "DocPerm"
+  }
+ ],
+ "actions": [],
+ "links": [],
+ "states": []
+}

--- a/one_fm/one_fm/doctype/maintenance_scenario/maintenance_scenario.py
+++ b/one_fm/one_fm/doctype/maintenance_scenario/maintenance_scenario.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class MaintenanceScenario(Document):
+	def validate(self):
+		self.validate_unique_scenario_per_client()
+
+	def validate_unique_scenario_per_client(self):
+		"""One priority per scenario per client.
+
+		The scenario is what a client picks on the portal and the priority is what the
+		system derives from it, so a second record for the same pair would make that
+		derivation ambiguous.
+		"""
+		duplicate = frappe.db.exists(
+			"Maintenance Scenario",
+			{
+				"client": self.client,
+				"scenario_name": self.scenario_name,
+				"name": ("!=", self.name),
+			},
+		)
+
+		if duplicate:
+			frappe.throw(
+				_("{0} already has a scenario for {1}: {2}").format(
+					frappe.bold(self.client),
+					frappe.bold(self.scenario_name),
+					frappe.get_desk_link("Maintenance Scenario", duplicate),
+				)
+			)
+
+
+def get_scenario_priority(client: str, scenario_name: str) -> str | None:
+	"""The priority tier behind a scenario, for the client who reported it.
+
+	Returned rather than sent from the browser: the point of scenarios is that an
+	external client cannot choose the priority directly (WI-001802).
+	"""
+	if not (client and scenario_name):
+		return None
+
+	return frappe.db.get_value(
+		"Maintenance Scenario", {"client": client, "scenario_name": scenario_name}, "priority"
+	)

--- a/one_fm/one_fm/doctype/maintenance_scenario/test_maintenance_scenario.py
+++ b/one_fm/one_fm/doctype/maintenance_scenario/test_maintenance_scenario.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, ONE FM and contributors
+# See license.txt
+"""Tests for the Maintenance Scenario master (WI-001802).
+
+A scenario is what a client picks on the portal; the priority behind it is what the
+system derives. The pair is per client, so the same scenario can carry a different
+priority for a different customer.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from one_fm.one_fm.doctype.maintenance_scenario.maintenance_scenario import (
+	get_scenario_priority,
+)
+
+SCENARIO = "Complete Power Outage"
+
+
+def _a_client():
+	return frappe.db.get_value("Customer", {"disabled": 0}, "name")
+
+
+def _a_priority():
+	return frappe.db.get_value("Issue Priority", {}, "name")
+
+
+class TestMaintenanceScenario(FrappeTestCase):
+	def setUp(self):
+		self.client = _a_client()
+		self.priority = _a_priority()
+		if not (self.client and self.priority):
+			self.skipTest("needs a Customer and an Issue Priority on this instance")
+
+	def _scenario(self, **overrides):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Maintenance Scenario",
+				"client": self.client,
+				"scenario_name": SCENARIO,
+				"priority": self.priority,
+			}
+		)
+		doc.update(overrides)
+		return doc
+
+	def test_it_names_itself_from_the_series(self):
+		doc = self._scenario().insert()
+		self.assertTrue(doc.name.startswith("MSCN-"), msg=doc.name)
+
+	def test_the_priority_is_looked_up_by_client_and_scenario(self):
+		self._scenario().insert()
+		self.assertEqual(get_scenario_priority(self.client, SCENARIO), self.priority)
+
+	def test_an_unknown_pair_resolves_to_nothing(self):
+		# The caller decides what to do; it must not fall back to a guessed priority.
+		self.assertIsNone(get_scenario_priority(self.client, "_not a scenario_"))
+		self.assertIsNone(get_scenario_priority(None, SCENARIO))
+		self.assertIsNone(get_scenario_priority(self.client, None))
+
+	def test_the_same_scenario_cannot_be_defined_twice_for_one_client(self):
+		# A second record would make the priority behind a scenario ambiguous.
+		self._scenario().insert()
+		with self.assertRaises(frappe.ValidationError):
+			self._scenario().insert()
+
+	def test_client_scenario_and_priority_are_all_required(self):
+		for missing in ("client", "scenario_name", "priority"):
+			with self.assertRaises(frappe.exceptions.MandatoryError, msg=missing):
+				self._scenario(**{missing: None}).insert()
+
+
+class TestMaintenanceTicketType(FrappeTestCase):
+	"""WI-001805 keys every SLA rule off this ticket type existing."""
+
+	def test_the_maintenance_ticket_type_exists(self):
+		self.assertTrue(frappe.db.exists("HD Ticket Type", "Maintenance"))

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -543,3 +543,4 @@ one_fm.patches.v15_0.set_candidate_title_fields
 one_fm.patches.v15_0.update_attendance_check
 one_fm.patches.v15_0.update_employee_and_user_references
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
+one_fm.patches.v15_0.add_maintenance_ticket_type #2026-07-31

--- a/one_fm/patches/v15_0/add_maintenance_ticket_type.py
+++ b/one_fm/patches/v15_0/add_maintenance_ticket_type.py
@@ -1,0 +1,24 @@
+import frappe
+
+MAINTENANCE = "Maintenance"
+
+
+def execute():
+	"""Add the Maintenance ticket type (WI-001805).
+
+	Every rule in M5-M8 keys off Ticket Type == "Maintenance": which SLA fields the
+	form shows, whether the native helpdesk SLA is suppressed, and whether a Work
+	Order can be raised. None of it can be reached until the type exists.
+	"""
+	if frappe.db.exists("HD Ticket Type", MAINTENANCE):
+		return
+
+	frappe.get_doc(
+		{
+			"doctype": "HD Ticket Type",
+			"name": MAINTENANCE,
+			"description": "Reactive facility maintenance reported by a client or logged "
+			"by the Helpdesk team. Carries the maintenance SLA rather than the native "
+			"IT support SLA.",
+		}
+	).insert(ignore_permissions=True)


### PR DESCRIPTION
## Maintenance Scenario

The doctype from `WI-001802.json`: a **per-client** record of scenario name and the priority behind it.

| Field | Type | |
|---|---|---|
| `client` | Link → Customer | mandatory, in list view |
| `scenario_name` | Select — *Complete Power Outage*, *AC Unit is not Working* | mandatory, in list view |
| `priority` | Link → Issue Priority | mandatory, in list view |
| `naming_series` | `MSCN-.#####` | hidden |

Permissions as supplied: System Manager, Maintenance Manager, Maintenance User (both roles verified to exist). Every field, option, label, mandatory flag and permission row is unchanged from the export — verified attribute by attribute by the script that generated the file.

**Per client is the point**: the same scenario can carry a different priority for a different customer, so `get_scenario_priority(client, scenario_name)` takes both. It is a server-side lookup by design — M5's whole purpose is that an external client picking a scenario cannot send a priority. The controller also refuses a second record for the same client + scenario, which would otherwise make that lookup ambiguous.

### One deviation, in delivery not definition

The export carries `custom: 1`, which is how it was built in the UI. A doctype shipped in the app cannot be custom: `DocType.export_doc()` returns early for a custom doctype, so it is never written to or read from the app folder and `bench migrate` would not own its schema. It is therefore a file-based doctype in the **One Fm** module like the other 580 in this app — which is also what puts it under review here rather than living only in one site's database.

## Maintenance ticket type

Every rule in M5–M8 keys off `Ticket Type == "Maintenance"` — which SLA fields show, whether the native helpdesk SLA is suppressed, whether a Work Order can be raised. The type did not exist, so nothing downstream could be reached. Added by patch so existing sites get it.

## Worth deciding before the portal work

`priority` links to **Issue Priority**, whose only records on production are `Medium`, `Shits on Fire!`, `Hot Potato`, `To the Next Sprint` and `ICE ICE BABY`. **M5's example priority, `Critical`, does not exist** — the scenario master cannot map to sensible tiers until the real ones are created.

## Testing

`one_fm/one_fm/doctype/maintenance_scenario/test_maintenance_scenario.py` — naming from the series, the priority lookup by client + scenario, an unknown pair resolving to nothing rather than a guessed priority, the duplicate guard, all three mandatory fields, and the Maintenance ticket type existing.

```
bench migrate
bench run-tests --app one_fm --module one_fm.one_fm.doctype.maintenance_scenario.test_maintenance_scenario --skip-before-tests
```

The tests need the table, so they run after `bench migrate`. What I could verify without it: the DocType JSON passes `DocType.validate()` in memory, its naming rule resolves, both Link targets exist and all three roles exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)