### PR TITLE
fix: show resolved geofence location as check-in site name

### DIFF
--- a/one_fm/api/v1/authentication.py
+++ b/one_fm/api/v1/authentication.py
@@ -606,6 +606,56 @@ def user_login(employee_id, password):
 
 
 @frappe.whitelist(allow_guest=True)
+def refresh_token(refresh_token: str = None):
+	"""
+	Exchange a valid OAuth2 refresh token for a new access token so the mobile app can
+	keep the user signed in without re-entering credentials.
+
+	params
+	refresh_token (str): the refresh_token issued by user_login
+
+	returns
+	token (str): new "Bearer <access_token>"
+	refresh_token (str): the rotated refresh_token to store for next time
+	"""
+	try:
+		if not refresh_token:
+			return response("Bad Request", 400, None, "refresh_token is required.")
+
+		client_id = frappe.db.get_value("OAuth Client", {"app_name": "OneFM"}, "client_id")
+		if not client_id:
+			return response("error", 500, None, "OAuth Client 'OneFM' not configured in the system.")
+
+		site = frappe.utils.cstr(frappe.local.conf.app_url) if frappe.local.conf.app_url else "http://127.0.0.1:8000"
+		if site.endswith('/'):
+			site = site[:-1]
+
+		args = {
+			'client_id': client_id,
+			'grant_type': 'refresh_token',
+			'refresh_token': refresh_token,
+		}
+		auth_api = f"{site}/api/method/frappe.integrations.oauth2.get_token"
+		auth_api_response = requests.post(auth_api, data=args, headers={'Accept': 'application/json'})
+
+		if auth_api_response.status_code == 200:
+			token_data = auth_api_response.json()
+			msg = {
+				'token': f"Bearer {token_data.get('access_token')}",
+				# oauthlib rotates the refresh token; keep the new one if returned,
+				# otherwise the caller reuses the existing one.
+				'refresh_token': token_data.get('refresh_token') or refresh_token,
+			}
+			return response("success", 200, msg)
+
+		# Refresh token expired/revoked — client must log in again.
+		return response("error", 401, None, "Refresh token is invalid or expired. Please log in again.")
+	except Exception as e:
+		print(frappe.get_traceback(), 'Refresh Token')
+		return response("error", 500, None, str(e))
+
+
+@frappe.whitelist(allow_guest=True)
 def enrollment_status(employee_id: str):
 	"""
 	Check if employee is enrolled 

--- a/one_fm/api/v1/face_recognition.py
+++ b/one_fm/api/v1/face_recognition.py
@@ -341,7 +341,10 @@ def get_site_location(employee_id: str = None, shift: str = None,latitude: float
                 if distance > float(result.geofence_radius):
                     result['user_within_geofence_radius'] = False
 
-                result['site_name'] = site
+                # Show the resolved geofence Location as the check-in site name so an
+                # approved Shift Request / check-in-site override is reflected. Fall back to
+                # the Operations Shift site only when the location has no name.
+                result['site_name'] = result.get('name') or site
                 if shift:
                     result['shift'] = {**shift.as_dict(), 'log_type': log_type, 'is_completed': shift.get("is_completed", False)}
 
@@ -425,7 +428,7 @@ def get_shift_site_location(shift, date, log_type, latitude=None, longitude=None
             return frappe.get_value(
                 "Location",
                 {"name": shift.site_location},
-                ["latitude", "longitude", "geofence_radius"],
+                ["name", "latitude", "longitude", "geofence_radius"],
                 as_dict=True
             )
         elif shift.shift:
@@ -447,7 +450,7 @@ def get_shift_site_location(shift, date, log_type, latitude=None, longitude=None
                         if not loc_row.disabled and loc_row.site_location:
                             return frappe.db.get_value(
                                 "Location", loc_row.site_location,
-                                ["latitude", "longitude", "geofence_radius"], as_dict=True
+                                ["name", "latitude", "longitude", "geofence_radius"], as_dict=True
                             )
                     return None
 
@@ -460,7 +463,7 @@ def get_shift_site_location(shift, date, log_type, latitude=None, longitude=None
                         continue
                     loc_data = frappe.db.get_value(
                         "Location", loc_row.site_location,
-                        ["latitude", "longitude", "geofence_radius"], as_dict=True
+                        ["name", "latitude", "longitude", "geofence_radius"], as_dict=True
                     )
                     if not loc_data:
                         continue
@@ -477,7 +480,7 @@ def get_shift_site_location(shift, date, log_type, latitude=None, longitude=None
                 if site_location:
                     return frappe.db.get_value(
                         "Location", site_location,
-                        ["latitude", "longitude", "geofence_radius"], as_dict=True
+                        ["name", "latitude", "longitude", "geofence_radius"], as_dict=True
                     )
                 return None
     return location
@@ -537,7 +540,7 @@ def get_shift_request_site_location(employee, date, log_type):
             return frappe.get_value(
                 "Location",
                 {"name": location},
-                ["latitude", "longitude", "geofence_radius"],
+                ["name", "latitude", "longitude", "geofence_radius"],
                 as_dict=True
             )
     return None


### PR DESCRIPTION
fix: show resolved geofence location as check-in site name
The check-in "site name" was taken from Operations Shift.site, which is decoupled from the geofence location actually used. When an approved Shift Request moves an employee to another site for the day, the label still showed the old site (e.g. "Burj Humoud" instead of "Mahboula").

- include the Location record name in every geofence lookup in get_shift_site_location
- set result['site_name'] from the resolved location name, falling back to Operations Shift.site only when unavailable

feat: add OAuth refresh_token endpoint for mobile sessions
The mobile login switched to OAuth2 access tokens that expire after ~1 hour, forcing users to re-enter their employee ID and password on the next check-in/out. Expose a refresh endpoint so the app can renew the access token silently instead of logging the user out.

- add v1.authentication.refresh_token: exchange a valid refresh token for a new access token via frappe.integrations.oauth2.get_token
- keep the rotated refresh token when oauthlib returns one, else reuse the caller's existing token
- return 401 when the refresh token is invalid/expired so the client falls back to a full login