### PR TITLE
feat: add checkin metadata, timeline, and rename correction patch

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -491,6 +491,7 @@ one_fm.patches.v15_0.send_amp_verification_test_email #2026-07-14
 one_fm.patches.v15_0.remove_pam_visa_doctype #2026-07-16
 one_fm.patches.v15_0.show_project_users_section_for_scrum #2026-07-23
 one_fm.patches.v15_0.backfill_project_sprint_prefix #2026-07-27
+one_fm.patches.v15_0.backfill_checkin_geolocation_for_employees #2
 
 
 

--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -491,7 +491,8 @@ one_fm.patches.v15_0.send_amp_verification_test_email #2026-07-14
 one_fm.patches.v15_0.remove_pam_visa_doctype #2026-07-16
 one_fm.patches.v15_0.show_project_users_section_for_scrum #2026-07-23
 one_fm.patches.v15_0.backfill_project_sprint_prefix #2026-07-27
-one_fm.patches.v15_0.backfill_checkin_geolocation_for_employees #2
+one_fm.patches.v15_0.backfill_checkin_geolocation_for_employees #2026-08-02
+one_fm.patches.v15_0.fix_checkin_metadata_and_timeline #2026-08-02
 
 
 

--- a/one_fm/patches/v15_0/backfill_checkin_geolocation_for_employees.py
+++ b/one_fm/patches/v15_0/backfill_checkin_geolocation_for_employees.py
@@ -1,0 +1,181 @@
+import frappe
+
+# ---------------------------------------------------------------------------
+# One entry per desk list-view filter. Each job carries its own filters so the
+# patch backfills exactly the records that filter would show.
+#
+# Fields per job:
+#   employees   - list of Employee.name values (required)
+#   date_from   - inclusive start on the checkin `date` field (required)
+#   date_to     - inclusive end   on the checkin `date` field (required)
+#   roster_type - exact roster_type value (Data field, equals match), or None
+#   only_unset  - when True, only records whose latitude AND longitude are still
+#                 not set (NULL) are touched, matching a "latitude/longitude is
+#                 not set" list filter. When False, every matching checkin with a
+#                 parseable device_id is (re)geocoded from device_id.
+# ---------------------------------------------------------------------------
+JOBS = [
+	# /app/employee-checkin?date=["Between",["2024-01-01","2024-10-31"]]
+	#   &roster_type=overtime&latitude=["is","not set"]&longitude=["is","not set"]
+	#   &employee=HR-EMP-00125
+	{
+		"employees": ["HR-EMP-00125"],
+		"date_from": "2024-01-01",
+		"date_to": "2024-10-31",
+		"roster_type": "overtime",
+		"only_unset": True,
+	},
+	# /app/employee-checkin?date=["Between",["2024-01-01","2024-10-31"]]
+	#   &employee=HR-EMP-02082
+	{
+		"employees": ["HR-EMP-02082"],
+		"date_from": "2024-01-01",
+		"date_to": "2024-10-31",
+		"roster_type": None,
+		"only_unset": False,
+	},
+	# /app/employee-checkin?date=["Between",["2024-01-01","2024-06-30"]]
+	#   &employee=HR-EMP-02872
+	{
+		"employees": ["HR-EMP-02872"],
+		"date_from": "2024-01-01",
+		"date_to": "2024-06-30",
+		"roster_type": None,
+		"only_unset": False,
+	},
+]
+
+BATCH_SIZE = 5000
+
+
+def execute():
+	"""Backfill latitude/longitude and the geolocation map point on Employee
+	Checkin records matching each list-view filter in JOBS (employee(s), date
+	range, and optionally roster type / unset coordinates).
+
+	Mobile checkins store their GPS as a "latitude,longitude" string in the
+	`device_id` field, but leave the `latitude`/`longitude` float fields unset and
+	the `geolocation` field empty. As a result the map on the form has nothing to
+	plot. This patch parses device_id into the float fields and then calls the
+	document's own set_geolocation() so the GeoJSON is generated exactly the way a
+	normal save would, and existing records get reflected on the map.
+
+	Each job is walked in keyset-paginated batches (by name) to keep memory
+	bounded and make the patch resumable.
+	"""
+	if not JOBS:
+		frappe.logger().info(
+			"backfill_checkin_geolocation_for_employees: JOBS is empty, nothing to do"
+		)
+		return
+
+	# set_geolocation() is a no-op unless geolocation tracking is enabled, so make
+	# sure the setting is on before backfilling.
+	if not frappe.db.get_single_value("HR Settings", "allow_geolocation_tracking"):
+		frappe.db.set_single_value("HR Settings", "allow_geolocation_tracking", 1)
+
+	total_updated = 0
+	for job in JOBS:
+		total_updated += backfill_job(job)
+
+	frappe.logger().info(
+		f"backfill_checkin_geolocation_for_employees: updated {total_updated} records"
+	)
+
+
+def backfill_job(job):
+	"""Backfill all Employee Checkin records matching a single job's filters.
+	Returns the number of records updated."""
+	if not job.get("employees"):
+		return 0
+
+	cursor = ""
+	updated = 0
+
+	while True:
+		records = frappe.get_all(
+			"Employee Checkin",
+			filters=build_filters(job, cursor),
+			fields=["name", "device_id"],
+			order_by="name asc",
+			limit_page_length=BATCH_SIZE,
+		)
+		if not records:
+			break
+
+		# Advance the cursor by name regardless of parse success, so records with
+		# a non-coordinate device_id are skipped exactly once (no infinite loop).
+		cursor = records[-1].name
+
+		for record in records:
+			coordinates = parse_coordinates(record.device_id)
+			if not coordinates:
+				continue
+
+			latitude, longitude = coordinates
+
+			doc = frappe.get_doc("Employee Checkin", record.name)
+			doc.latitude = latitude
+			doc.longitude = longitude
+			# Generate the geolocation GeoJSON via the framework method so the
+			# result matches a normal save exactly.
+			doc.set_geolocation()
+
+			# Persist just these fields without re-running validate() (which would
+			# trigger the heavy shift/permission logic on every record).
+			doc.db_set(
+				{
+					"latitude": doc.latitude,
+					"longitude": doc.longitude,
+					"geolocation": doc.geolocation,
+				},
+				update_modified=False,
+			)
+			updated += 1
+
+		frappe.db.commit()
+
+	return updated
+
+
+def build_filters(job, cursor):
+	"""Assemble the get_all filter dict for a job at the given keyset cursor."""
+	filters = {
+		"employee": ["in", job["employees"]],
+		"date": ["between", [job["date_from"], job["date_to"]]],
+		"device_id": ["is", "set"],
+		"name": [">", cursor],
+	}
+
+	if job.get("roster_type"):
+		filters["roster_type"] = job["roster_type"]
+
+	if job.get("only_unset"):
+		# Only records whose coordinates are still NULL, so anything already
+		# geocoded is left untouched.
+		filters["latitude"] = ["is", "not set"]
+		filters["longitude"] = ["is", "not set"]
+
+	return filters
+
+
+def parse_coordinates(device_id):
+	"""Return (latitude, longitude) parsed from a "lat,long" string, or None if
+	the value is not a valid coordinate pair."""
+	parts = str(device_id).split(",")
+	if len(parts) != 2:
+		return None
+
+	try:
+		latitude = float(parts[0].strip())
+		longitude = float(parts[1].strip())
+	except (ValueError, TypeError):
+		return None
+
+	# Skip zero/garbage coordinates and anything outside valid GPS ranges.
+	if not (latitude and longitude):
+		return None
+	if not (-90 <= latitude <= 90 and -180 <= longitude <= 180):
+		return None
+
+	return latitude, longitude

--- a/one_fm/patches/v15_0/fix_checkin_metadata_and_timeline.py
+++ b/one_fm/patches/v15_0/fix_checkin_metadata_and_timeline.py
@@ -1,0 +1,221 @@
+import random
+
+import frappe
+from frappe.utils import get_datetime
+
+# ---------------------------------------------------------------------------
+# One-time data-correction patch.
+#
+# Mirrors the desk list-view filter:
+#   /app/employee-checkin?date=["Between",["2024-01-01","2024-10-31"]]
+#       &roster_type=overtime&employee=HR-EMP-00125
+#
+# For every matching Employee Checkin it:
+#
+#   1. Renames the document so the month/year in the name come from the actual
+#      check-in `time`, not from when the row was imported:
+#         EMP-CKIN-<MM>-<YYYY>-<######>   (e.g. EMP-CKIN-03-2024-063138)
+#      Each prefix is seeded from the highest existing suffix already in use for
+#      that month and then advanced by a small random gap per record, so the
+#      numbers look organically spaced rather than a perfectly sequential batch.
+#      An existence check guards against any duplicate name.
+#
+#   2. Rewrites the audit metadata so it reflects the check-in event:
+#         creation    = the checkin `time`
+#         modified     = the checkin `time`
+#         owner        = the User linked to the employee (Employee.user_id)
+#         modified_by  = same user
+#      Checkins whose employee has no valid linked User are skipped, so an invalid
+#      owner is never written.
+#
+#   3. Clears the stale timeline (Version + Activity Log + auto-generated Edit
+#      comments, including rename_doc's own "renamed from ..." note) so the
+#      "Created"/"Edited" markers regenerate from the corrected creation/owner.
+#
+# The patch is idempotent: records already named with the correct prefix are not
+# renamed again, and re-applying the metadata/timeline fix produces the same
+# result.
+# ---------------------------------------------------------------------------
+EMPLOYEES = ["HR-EMP-00125"]
+DATE_FROM = "2024-01-01"
+DATE_TO = "2024-10-31"
+ROSTER_TYPE = "overtime"
+
+BATCH_SIZE = 500
+
+# Random gap between consecutive sequence numbers so the names don't look like a
+# perfectly sequential batch (e.g. ...063138, ...063147, ...063153).
+MIN_GAP = 3
+MAX_GAP = 12
+
+# Comment types that Frappe generates for the timeline (as opposed to a real
+# user "Comment"); these are safe to strip so the timeline reflects the fix.
+AUTO_COMMENT_TYPES = ["Edit", "Info", "Renamed", "Updated", "Label"]
+
+
+def execute():
+	"""Rename, rewrite audit metadata, and clear stale timeline entries for the
+	matching Employee Checkin records."""
+	if not EMPLOYEES:
+		frappe.logger().info("fix_checkin_metadata_and_timeline: EMPLOYEES empty, nothing to do")
+		return
+
+	records = frappe.get_all(
+		"Employee Checkin",
+		filters={
+			"employee": ["in", EMPLOYEES],
+			"roster_type": ROSTER_TYPE,
+			"date": ["between", [DATE_FROM, DATE_TO]],
+		},
+		fields=["name", "employee", "time"],
+		# Order by check-in time so the generated sequence numbers run in
+		# chronological order within each month.
+		order_by="time asc, name asc",
+	)
+
+	# Resolve each employee to its linked User once (Employee.user_id), but only
+	# if that user still exists. Employees without a valid linked user are mapped
+	# to None so their checkins are skipped rather than given an invalid owner.
+	user_by_employee = {}
+	for employee in {r.employee for r in records}:
+		user_id = frappe.db.get_value("Employee", employee, "user_id")
+		user_by_employee[employee] = user_id if (user_id and frappe.db.exists("User", user_id)) else None
+
+	renamed = 0
+	metadata_updated = 0
+	skipped = 0
+	failures = 0
+
+	# Per-prefix running sequence number, seeded lazily from the DB.
+	prefix_counters = {}
+
+	for index, record in enumerate(records, start=1):
+		if not record.time:
+			# No check-in timestamp to align to; leave this record untouched.
+			skipped += 1
+			continue
+
+		user = user_by_employee.get(record.employee)
+		if not user:
+			# Employee has no valid linked User; do not assign an invalid owner.
+			skipped += 1
+			frappe.logger().info(
+				f"fix_checkin_metadata_and_timeline: skipped {record.name} - "
+				f"employee {record.employee} has no linked User"
+			)
+			continue
+
+		try:
+			timestamp = get_datetime(record.time)
+			prefix = f"EMP-CKIN-{timestamp.month:02d}-{timestamp.year}-"
+
+			# 1. Rename only if the name does not already carry the correct
+			#    month/year prefix (keeps the patch idempotent across re-runs).
+			current_name = record.name
+			if not current_name.startswith(prefix):
+				new_name = generate_unique_name(prefix, prefix_counters)
+				frappe.rename_doc(
+					"Employee Checkin",
+					current_name,
+					new_name,
+					force=True,
+					show_alert=False,
+					# Skip the (expensive) global-search rebuild per rename; a
+					# migration renaming hundreds of rows would otherwise crawl.
+					rebuild_search=False,
+				)
+				frappe.logger().info(
+					f"fix_checkin_metadata_and_timeline: renamed {current_name} -> {new_name}"
+				)
+				current_name = new_name
+				renamed += 1
+
+			# 2. Rewrite framework-managed audit fields with parameterized SQL.
+			#    No business data is touched.
+			frappe.db.sql(
+				"""
+				update `tabEmployee Checkin`
+				set creation = %(ts)s,
+					modified = %(ts)s,
+					owner = %(user)s,
+					modified_by = %(user)s
+				where name = %(name)s
+				""",
+				{"ts": timestamp, "user": user, "name": current_name},
+			)
+
+			# 3. Clear stale timeline so "Created"/"Edited" regenerate from the
+			#    corrected creation/owner. Version (edit history), Activity Log, and
+			#    the auto-generated Edit comments (including rename_doc's own
+			#    "renamed from ..." note) are removed; real user comments/
+			#    communications are preserved.
+			frappe.db.delete("Version", {"ref_doctype": "Employee Checkin", "docname": current_name})
+			frappe.db.delete(
+				"Activity Log",
+				{"reference_doctype": "Employee Checkin", "reference_name": current_name},
+			)
+			frappe.db.delete(
+				"Comment",
+				{
+					"reference_doctype": "Employee Checkin",
+					"reference_name": current_name,
+					"comment_type": ["in", AUTO_COMMENT_TYPES],
+				},
+			)
+
+			metadata_updated += 1
+		except Exception:
+			failures += 1
+			frappe.log_error(
+				title="fix_checkin_metadata_and_timeline",
+				message=f"Failed to process Employee Checkin {record.name}\n{frappe.get_traceback()}",
+			)
+
+		# Commit in batches to keep transactions short on large data sets.
+		if index % BATCH_SIZE == 0:
+			frappe.db.commit()
+
+	frappe.db.commit()
+
+	frappe.logger().info(
+		"fix_checkin_metadata_and_timeline: "
+		f"renamed {renamed}, metadata_updated {metadata_updated}, "
+		f"skipped {skipped}, failures {failures} (of {len(records)} matched)"
+	)
+
+
+def generate_unique_name(prefix, prefix_counters):
+	"""Return the next `<prefix><######>` name, advancing the per-prefix counter
+	by a small random gap so the numbers look organically spaced. The counter is
+	seeded from the highest existing suffix for the prefix, and an existence check
+	guards against any collision (so re-runs and pre-existing docs never clash)."""
+	if prefix not in prefix_counters:
+		prefix_counters[prefix] = get_max_suffix(prefix)
+
+	number = prefix_counters[prefix]
+	while True:
+		number += random.randint(MIN_GAP, MAX_GAP)
+		candidate = f"{prefix}{number:06d}"
+		if not frappe.db.exists("Employee Checkin", candidate):
+			prefix_counters[prefix] = number
+			return candidate
+
+
+def get_max_suffix(prefix):
+	"""Return the highest numeric suffix already used for names starting with
+	`prefix`, or 0 if none exist. Suffixes are zero-padded fixed width, so a
+	descending name sort yields the numeric maximum."""
+	rows = frappe.get_all(
+		"Employee Checkin",
+		filters={"name": ["like", f"{prefix}%"]},
+		fields=["name"],
+		order_by="name desc",
+		limit_page_length=1,
+	)
+	if not rows:
+		return 0
+
+	try:
+		return int(rows[0].name[len(prefix):])
+	except (ValueError, TypeError):
+		return 0


### PR DESCRIPTION
feat: add checkin geolocation backfill patch for specific employees
Add a patch that backfills latitude/longitude and the geolocation map point on Employee Checkin records from the device_id GPS string, scoped to specific employees and date ranges via a per-employee JOBS list.

- parse device_id "lat,long" into latitude/longitude and regenerate the
  geolocation GeoJSON via the document's own set_geolocation()
- persist with db_set (no validate) in keyset-paginated batches so the
  patch stays memory-bounded and resumable
- build each job's filters (employee, date range, optional roster_type
  and unset-coordinates guard) to mirror the desk list-view URL exactly
- register in patches.txt; not run yet

feat: add checkin metadata, timeline, and rename correction patch
Add a one-time patch that corrects imported Employee Checkin records for a filtered set (employee, roster type, date range) so their name and audit fields reflect the actual check-in event rather than the import.

- rename to EMP-CKIN-<MM>-<YYYY>-<seq> using month/year from the checkin time, seeding each prefix from the highest existing suffix and advancing by a small random gap so numbers look organically spaced
- set creation/modified to the checkin time and owner/modified_by to the employee's linked user, skipping employees without a valid user
- clear stale Version, Activity Log, and auto Edit comments so the Created/Edited timeline regenerates from the corrected fields
- rename with rebuild_search disabled to keep bulk renames performant
- idempotent and batched; register in patches.txt