### PR TITLE
fix(ccp): don't deny create permission on Candidate Country Process

### DIFF
--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -590,8 +590,22 @@ def has_permission(doc, ptype=None, user=None, **kwargs):
     never have an Arrival and Deployment record linked to it yet, so this check
     would always deny creation outright (e.g. the automatic CCP creation cascade
     from Job Offer's create_candidate_country_process()) regardless of role.
+
+    Internal ETA-recalculation cascades are also excluded: recalculate_ccp_live_eta()
+    (called from every downstream step doctype -- Visa Request, PCC Clearance,
+    Overseas Medical Appointment WAFID, Overseas Remedical, Visa Stamping, Arrival
+    and Deployment -- whenever any of them is saved) does its own `doc.save()` on
+    this CCP under whatever user triggered that save. That's not a direct edit by
+    the acting user, so it shouldn't be subject to the Onboarding-Officer-specific
+    restriction either -- otherwise ETA tracking silently stops updating for the
+    entire process (not just the Arrival stage) for any user who happens to also
+    hold the Onboarding Officer role, since the restriction only lifts once Arrival
+    (the very last of the 11 steps) reaches a late stage.
     """
     if ptype not in ("write", "delete", "submit", "cancel"):
+        return None
+
+    if getattr(frappe.local, "in_ccp_recalculation", False):
         return None
 
     user = user or frappe.session.user

--- a/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
+++ b/one_fm/one_fm/doctype/candidate_country_process/candidate_country_process.py
@@ -581,12 +581,17 @@ def has_permission(doc, ptype=None, user=None, **kwargs):
     record has actually reached "Pending Onboarding" or a later stage in that flow.
 
     Frappe's controller has_permission hooks can only DENY access, never grant
-    anything beyond the role permission table — so write/create/delete/submit/cancel
+    anything beyond the role permission table — so write/delete/submit/cancel
     is granted at the role-permission level (see the DocType's own permissions),
     and this hook denies it back for Onboarding Officer specifically until that
     condition is met. Returns None everywhere else so other roles are never affected.
+
+    "create" is deliberately excluded: a brand-new, not-yet-inserted document can
+    never have an Arrival and Deployment record linked to it yet, so this check
+    would always deny creation outright (e.g. the automatic CCP creation cascade
+    from Job Offer's create_candidate_country_process()) regardless of role.
     """
-    if ptype not in ("write", "create", "delete", "submit", "cancel"):
+    if ptype not in ("write", "delete", "submit", "cancel"):
         return None
 
     user = user or frappe.session.user


### PR DESCRIPTION
## Summary
Backports the CCP `has_permission()` fix from #6580 (already on `staging`) onto `version-15`, where it's still missing.

- `has_permission()` on Candidate Country Process was denying `create` for any user holding the Onboarding Officer role, since the linked Arrival and Deployment record can never exist yet on a brand-new document. This unconditionally blocked the automatic CCP creation cascade in Job Offer's `create_candidate_country_process()` (triggered when a Job Offer moves to "Submit to Onboarding Officer"), regardless of what other roles (System Manager, HR Manager, Recruiter, etc.) the acting user also had.
- Also carries the follow-up fix so the same hook doesn't silently deny `recalculate_ccp_live_eta()`'s internal `doc.save()` (called from every downstream step doctype) for users who hold Onboarding Officer — previously failing silently behind a bare except/log_error, so ETA recalculation just stopped working for those users without any visible error.

Cherry-picked only the two commits specific to this permission bug (`3509da81a`, `748e096b7`) — left out the unrelated parallel-date-computation and resignation-form-visibility commits also bundled in #6580, to keep this hotfix minimal.

## Test plan
- [ ] Confirm on version-15: a user holding only Onboarding Officer (no System Manager/HR Manager/Recruiter) can push a Job Offer to "Submit to Onboarding Officer" without the "Not permitted" / create-permission error
- [ ] Confirm Onboarding Officer is still blocked from directly editing a CCP before its Arrival record reaches a late stage (the restriction this hook exists for)
- [ ] Confirm ETA recalculation from a downstream step (e.g. Visa Request) still updates the linked CCP's planned/live dates for a user holding Onboarding Officer