### PR TITLE
fix(ccp): stop reference_type from requiring DocType read permission

### DIFF
--- a/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
+++ b/one_fm/one_fm/doctype/candidate_country_process_details/candidate_country_process_details.json
@@ -160,9 +160,8 @@
   },
   {
    "fieldname": "reference_type",
-   "fieldtype": "Link",
+   "fieldtype": "Select",
    "label": "Reference Type",
-   "options": "DocType",
    "read_only": 1
   },
   {
@@ -205,7 +204,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-07-20 01:00:00.000000",
+ "modified": "2026-08-03 09:00:00.000000",
  "modified_by": "Administrator",
  "module": "one_fm",
  "name": "Candidate Country Process Details",


### PR DESCRIPTION
## Problem

Opening a Candidate Country Process record (or any record whose Agency Process Details rows have a `reference_type` set — Visa Request, PCC Clearance, Overseas Medical Appointment WAFID, Visa Stamping, Arrival and Deployment, etc.) throws:

> User ... does not have doctype access via role permission for document **DocType**
> No permission for DocType

for every role except System Manager/Administrator — including HR Manager, HR User, Recruiter, GRD Manager, Onboarding Officer. The desk falls back to a blank "New Candidate Country Process" form instead of showing the actual record.

## Root cause

`Candidate Country Process Details.reference_type` was a `Link` field with `options: "DocType"` — i.e. it points into Frappe's core `DocType` table (the schema/meta table for every doctype in the system), not into a normal business record. `DocType`'s own permission list only grants `read` to `System Manager` and `Administrator`, by Frappe's own default. Any code path that resolves/validates that field's value (e.g. `frappe.client.get_value("DocType", ...)`) is denied for every other role.

Confirmed directly: `frappe.client.get_value("DocType", "module", filters="Visa Request")` throws `PermissionError: No permission for DocType` for a plain `HR Manager` user — the exact error text reported.

## Fix

Change `reference_type` from `Link(options: DocType)` to `Select` (no fixed options list):
- Still satisfies Frappe's own validation requiring a `Dynamic Link` field's target (`reference_name`, `options: "reference_type"`) to point at either a `Link(DocType)` or a `Select` field.
- No fixed option list, so no `"... is not a valid value"` errors regardless of which downstream doctype gets referenced.
- Underlying DB column type is unchanged (`Link`/`Select`/`Data` all map to the same `varchar(140)`), so no data migration is needed — existing values are untouched.
- Every consumer of this field (`get_workflow()`, the auto-create-next-step cascade in `_create_linked_record`, the "Open Record" `frappe.set_route` in the client script) only ever reads the plain string value — none of it depends on the field being a validated Link.

## Testing

Verified on a local dev site (`onefm.local`) against a real record with populated `reference_type` rows, using a disposable test user with only the `HR Manager` role (no System Manager):
- **Before fix:** `frappe.client.get_value("DocType", ...)` → `PermissionError: No permission for DocType` (reproduces the reported bug exactly).
- **After fix:** `frappe.reload_doc(...)` applies cleanly (no validation errors), field type confirmed `Select`, `getdoc()` on the record succeeds, and all existing `reference_type`/`reference_name` values are intact (Job Offer, Visa Request, Overseas Medical Appointment WAFID, PCC Clearance, Visa Stamping, Arrival and Deployment).
- Existing `test_candidate_country_process.py` is an empty stub — no automated regression suite exists for this doctype.

## Self-review against `review-erpnext-pr` checklist

- No protected files touched (`hooks.py`, `patches.txt`, `setup.py`, `modules.txt`, Workflow/Assignment Rule fixtures, mobile auth utils).
- No protected patterns (`ignore_permissions`, raw SQL, `frappe.get_all()` in whitelisted methods, direct `workflow_state` writes, `frappe.db.commit()` in the wrong place).
- **Known, deliberate trade-off:** switching from `Link` to `Select` removes Frappe's automatic "this value must be an existing DocType record" check on this specific field. This is low-risk because (a) the field is `read_only` — it's never directly user-edited on the Candidate Country Process form, and (b) the value is always copied from `Agency Process Details.reference_type` on the `Agency Country Process` template, which is still a validated `Link(DocType)` field (unchanged in this PR — only System Manager edits templates, and System Manager already has `DocType` read permission, so it was never affected by this bug). If a bad value ever did get in, downstream code (`frappe.get_meta`, `frappe.get_doc`) would fail with a normal "doctype does not exist" error at the point of use rather than silently corrupting data.
- Diff is scoped to exactly this one field + the `modified` timestamp bump — no unrelated changes.