### PR TITLE
fix(recruitment): restore guest permission bypass for auto-created Job Offer

### DIFF
--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -1502,6 +1502,13 @@ def issue_job_offer_for_applicant(job_applicant):
         job_offer = frappe.get_doc('Job Offer', existing_offer)
         if job_offer.docstatus == 0 and job_offer.workflow_state == "Open":
             from frappe.model.workflow import apply_workflow
+            # Guest-triggered (e.g. the magic-link candidate self-service form
+            # marking a Bulk Recruitment applicant Selected) has no Job Offer
+            # workflow-transition permission of its own. Same elevation already
+            # used in JobOfferOverride.submit_job_offer_to_candidate() for this
+            # exact scenario.
+            if frappe.session.user == "Guest":
+                frappe.set_user("Administrator")
             apply_workflow(job_offer, "Submit for Candidate Response")
         return
 
@@ -1526,7 +1533,10 @@ def _insert_job_offer_from_applicant(job_app):
     if job_app.one_fm_erf:
         erf = frappe.get_doc('ERF', job_app.one_fm_erf)
         set_erf_details(job_offer, erf, job_app)
-    job_offer.save()
+    # Guest-triggered (magic-link candidate self-service) has no Job Offer
+    # create permission of its own -- Recruiter/HR User (the desk-side
+    # triggers) already do, so this bypass only ever matters for Guest.
+    job_offer.save(ignore_permissions=(frappe.session.user == "Guest"))
 
 def set_erf_details(job_offer, erf, job_app):
     job_offer.erf = erf.name

--- a/one_fm/www/job_applicant_magic_link/index.py
+++ b/one_fm/www/job_applicant_magic_link/index.py
@@ -459,7 +459,8 @@ def submit_job_applicant(job_applicant):
         select_applicant_on_magic_link_submit(job_applicant)
         return {'msg':'Your application has been successfully submitted, we will be intouch soonest.'}
     except Exception as e:
-        return {'error':e}
+        frappe.log_error(message=frappe.get_traceback(), title='Magic Link: submit_job_applicant')
+        return {'error': str(e)}
 
 def select_applicant_on_magic_link_submit(job_applicant_id):
     job_applicant = frappe.get_doc('Job Applicant', job_applicant_id)


### PR DESCRIPTION
## Summary
- Marking a Bulk Recruitment applicant Selected via the guest-facing magic link form saves the Job Applicant fine, but the `on_update_job_applicant -> issue_job_offer_for_applicant` cascade it fires creates/submits the Job Offer as that same Guest session, which has no Job Offer permissions -- surfaces to the candidate as a bare `PermissionError()`, and the Job Offer is never created.
- Root cause: PR #6532's last commit removed `ignore_permissions` from `_insert_job_offer_from_applicant()` on the reasoning that Recruiter/HR User (the desk-side triggers) already have Job Offer create permission -- true for that case, but the magic-link guest path wasn't part of that verification and regressed silently.
- Restores the bypass for Guest specifically (not unconditionally, so #6532's tightening for desk-side users still holds), matching the same `if frappe.session.user == "Guest": frappe.set_user("Administrator")` pattern already used in `JobOfferOverride.submit_job_offer_to_candidate()` for this identical scenario.
- Also stops `submit_job_applicant()` from returning the raw exception object on failure (surfaced to the candidate as a bare `PermissionError()` with no message) -- returns `str(e)` and logs the traceback instead.

## Test plan
- [x] Confirmed via git blame/log that PR #6532's "Remove ignore_permissions from _insert_job_offer_from_applicant()" commit introduced this regression
- [x] Verified the module imports cleanly and the edited code path executes as expected via `bench console`
- [ ] Manually verify end-to-end via a real magic link: Bulk Recruitment applicant, Selected via candidate self-service form, Job Offer now created/submitted without error