### PR TITLE
fix(hr): grant Onboarding Officer real access to Arrival and Deployment

### DIFF
--- a/one_fm/patches.txt
+++ b/one_fm/patches.txt
@@ -549,3 +549,4 @@ one_fm.patches.v15_0.update_employee_and_user_references
 one_fm.patches.v15_0.send_work_item_notify_assignee_demo_email
 one_fm.patches.v15_0.mark_present_auto_attendance_missed_checkin_jul13
 one_fm.patches.v15_0.add_employee_schedule_suspension_workflow #2026-07-24
+one_fm.patches.v15_0.add_onboarding_officer_arrival_deployment_permission #2026-08-04

--- a/one_fm/patches/v15_0/add_onboarding_officer_arrival_deployment_permission.py
+++ b/one_fm/patches/v15_0/add_onboarding_officer_arrival_deployment_permission.py
@@ -1,0 +1,54 @@
+import frappe
+
+
+def execute():
+	"""Grant Onboarding Officer real access to Arrival and Deployment.
+
+	The workflow already assigns Onboarding Officer as the owner of the
+	Pending Support Departments / Joined / Did Not Arrive states, and as the
+	allowed role on the "Submit to Support Departments" transition -- but the
+	role was never actually granted read/write on the DocType itself (not in
+	the DocType JSON's own permissions, not in Custom DocPerm). Every real
+	Onboarding Officer in production currently also holds another role
+	(HR Manager/HR User/Recruiter/etc.) that already grants access, which is
+	why this has gone unnoticed -- but anyone assigned Onboarding Officer
+	alone, exactly as the workflow is designed to support, would be blocked
+	from the entire back half of this process.
+
+	Custom DocPerm is currently completely empty for this doctype -- every
+	other role (System Manager, HR Manager, HR User, Recruitment Manager,
+	Recruiter, Senior Recruiter, Interviewer, Transportation Manager) is
+	relying purely on the DocType JSON fallback. Adding a Custom DocPerm row
+	for Onboarding Officer alone would immediately break all of them (same
+	precedence rule as everywhere else this has come up today), so this
+	mirrors every existing role in alongside the new grant.
+
+	No submit/cancel granted anywhere: every state in this workflow stays at
+	docstatus 0, it's driven entirely by workflow_state.
+	"""
+	existing_role_perms = {
+		"System Manager": {"read": 1, "write": 1},
+		"HR Manager": {"read": 1, "write": 1},
+		"HR User": {"read": 1, "write": 1},
+		"Recruitment Manager": {"read": 1, "write": 1},
+		"Recruiter": {"read": 1, "write": 1},
+		"Senior Recruiter": {"read": 1, "write": 1},
+		"Interviewer": {"read": 1, "write": 1},
+		"Transportation Manager": {"read": 1, "write": 1},
+		"Onboarding Officer": {"read": 1, "write": 1},
+	}
+
+	for role, perms in existing_role_perms.items():
+		if frappe.db.exists("Custom DocPerm", {"parent": "Arrival and Deployment", "role": role}):
+			continue
+		frappe.get_doc({
+			"doctype": "Custom DocPerm",
+			"parent": "Arrival and Deployment",
+			"parenttype": "DocType",
+			"parentfield": "permissions",
+			"role": role,
+			"permlevel": 0,
+			**perms,
+		}).insert()
+
+	frappe.clear_cache(doctype="Arrival and Deployment")


### PR DESCRIPTION
## Summary
- The Arrival and Deployment workflow already assigns Onboarding Officer as owner of the `Pending Support Departments` / `Joined` / `Did Not Arrive` states, and as the allowed role on the "Submit to Support Departments" transition -- but the role was never actually granted read/write on the DocType itself, in either the DocType JSON or Custom DocPerm.
- Confirmed directly against a real production backup: Onboarding Officer had **zero** permission rows on this doctype, isolated from any other role's grant.
- Every real Onboarding Officer in production currently also holds another role (HR Manager/HR User/Recruiter/etc.) that independently grants access, which is why this has gone unnoticed in practice -- but anyone assigned Onboarding Officer alone, exactly as the workflow is designed to support, would be completely blocked from the back half of this process.

## Why the patch touches 9 roles, not just 1
Custom DocPerm was completely empty for this doctype -- every other role (System Manager, HR Manager, HR User, Recruitment Manager, Recruiter, Senior Recruiter, Interviewer, Transportation Manager) is currently relying purely on the DocType JSON fallback. Adding a Custom DocPerm row for Onboarding Officer alone would immediately break all 8 of them (same precedence rule seen elsewhere in this app: once any Custom DocPerm row exists for a doctype, every other role loses the JSON fallback). This patch mirrors all 8 existing roles in alongside the new grant.

No submit/cancel granted anywhere -- every state in this workflow stays at docstatus 0, driven entirely by `workflow_state`.

## Test plan
- [x] Ran the patch directly against a real production database backup
- [x] Confirmed all 9 roles (8 existing + Onboarding Officer) have `read`/`write` afterward, verified via `frappe.get_meta("Arrival and Deployment").permissions`
- [x] Confirmed Custom DocPerm row count went from 0 -> 9, no existing role dropped
- [ ] Confirm on live `one-fm.com` after deploy that an Onboarding-Officer-only user can perform "Submit to Support Departments"