### PR TITLE
Document Request: stop offering withdrawn documents, and say why a Drive link did not auto-fill

### DIFF
--- a/one_fm/one_fm/doctype/document_register/document_register.py
+++ b/one_fm/one_fm/doctype/document_register/document_register.py
@@ -126,13 +126,63 @@ class DocumentRegister(Document):
 					self.drive_file_link = meta.get("webViewLink")
 			if not self.content:
 				self.content = gd.download_file_text(self.drive_file_id)
-		except Exception:
+		except Exception as e:
 			frappe.log_error(
 				title="Document Register: Drive auto-fill failed",
 				message=frappe.get_traceback(),
 			)
+			self._warn_autofill_failed(e)
 			if not self.title:
 				self.title = self.drive_file_id
+
+	def _warn_autofill_failed(self, error):
+		"""Say so on screen. Failing quietly is what makes this expensive.
+
+		The record still saves — a catalogue entry blocked by a transient API
+		problem is worse than one with a placeholder title. But until now the
+		only trace was an Error Log entry, so pasting a link the service account
+		cannot read looked exactly like pasting one it can: the fields simply
+		stayed empty and nothing said why.
+
+		Google answers 404, not 403, for a file you have no permission on, so
+		"File not found" almost always means "not shared with us" rather than
+		"does not exist" — and guessing wrong sends people looking for a
+		deleted file that is sitting right there in their Drive.
+		"""
+		text = str(error)
+		if "File not found" in text or "404" in text or "notFound" in text:
+			account = _service_account_email() or "the Processa service account"
+			frappe.msgprint(
+				_(
+					"Could not read {0} from Google Drive, so the title and content were "
+					"not filled in.<br><br>Drive reports this the same way whether a file "
+					"is missing or simply not shared, and it is almost always the latter. "
+					"Share the file with <b>{1}</b> (Viewer is enough) and save again."
+				).format(frappe.bold(self.drive_file_id), account),
+				title=_("Drive file not accessible"),
+				indicator="orange",
+			)
+			return
+
+		frappe.msgprint(
+			_(
+				"Could not read this file from Google Drive, so the title and content "
+				"were not filled in. The record has been saved — see the Error Log for "
+				"the reason, then save again to retry."
+			),
+			title=_("Drive auto-fill failed"),
+			indicator="orange",
+		)
+
+
+def _service_account_email():
+	"""Which Google identity Processa uses, for an actionable error message."""
+	try:
+		from one_bpmn.one_bpmn.integrations.google_common import load_service_account_info
+
+		return (load_service_account_info("google_drive") or {}).get("client_email")
+	except Exception:
+		return None
 
 
 def code_prefix(document_type: str) -> str:

--- a/one_fm/one_fm/doctype/document_request/document_request.json
+++ b/one_fm/one_fm/doctype/document_request/document_request.json
@@ -86,6 +86,7 @@
   },
   {
    "fieldname": "source_guideline",
+   "link_filters": "[[\"Document Register\",\"lifecycle_state\",\"=\",\"Active\"]]",
    "fieldtype": "Link",
    "label": "Source Guideline",
    "options": "Document Register",
@@ -95,6 +96,7 @@
   },
   {
    "fieldname": "reference_document",
+   "link_filters": "[[\"Document Register\",\"lifecycle_state\",\"=\",\"Active\"]]",
    "fieldtype": "Link",
    "label": "Existing Document",
    "options": "Document Register",
@@ -104,6 +106,7 @@
   },
   {
    "fieldname": "update_source",
+   "link_filters": "[[\"Document Register\",\"lifecycle_state\",\"=\",\"Active\"]]",
    "fieldtype": "Link",
    "label": "New Content Document",
    "options": "Document Register",

--- a/one_fm/one_fm/doctype/document_request/document_request.py
+++ b/one_fm/one_fm/doctype/document_request/document_request.py
@@ -15,6 +15,7 @@ class DocumentRequest(Document):
 		self.check_required_links()
 		self.check_reference_document_is_active()
 		self.check_reference_document_is_controlled()
+		self.check_source_documents_are_active()
 		self.check_update_source()
 
 	def set_requester_defaults(self):
@@ -87,6 +88,41 @@ class DocumentRequest(Document):
 					"Pick the controlled document you want to revise, and use this one as "
 					"the New Content Document instead."
 				).format(frappe.bold(self.reference_document))
+			)
+
+	def check_source_documents_are_active(self):
+		"""A withdrawn document is not usable as SOURCE material either.
+
+		``check_reference_document_is_active`` already refuses to revise or
+		withdraw an inactive document. The two fields that point the other way —
+		the guideline a Create is generated from, and the New Content Document an
+		Update takes its wording from — had no such check, so a withdrawn document
+		could still be read and its content published into a live one. Withdrawing
+		is how this system says "stop using this"; quietly using it as the source
+		of a new document is the same mistake with an extra step.
+
+		The pickers filter these fields to Active as well, but that is Frappe's
+		``link_filters``, which runs in the browser. It shapes the dropdown and
+		nothing else — the API, an import and a test all sail past it, which is
+		exactly the gap ``check_required_links`` was written for.
+		"""
+		fields = (
+			("source_guideline", "Create", _("Source Guideline")),
+			("update_source", "Update", _("New Content Document")),
+		)
+		for fieldname, action, label in fields:
+			name = self.get(fieldname)
+			if not name or self.request_action != action:
+				continue
+			if frappe.db.get_value("Document Register", name, "lifecycle_state") != "Inactive":
+				continue
+			frappe.throw(
+				_(
+					"{0} is inactive — it has been withdrawn from use, so it cannot be the "
+					"{1}. Publishing its content into a live document would put withdrawn "
+					"material back into circulation. Pick an active document, or reactivate "
+					"that one first."
+				).format(frappe.bold(name), label)
 			)
 
 	def check_required_links(self):

--- a/one_fm/one_fm/doctype/document_revision/document_revision.py
+++ b/one_fm/one_fm/doctype/document_revision/document_revision.py
@@ -15,11 +15,47 @@
 # that no approval produced is not a version.
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint
 
 
 class DocumentRevision(Document):
+	def validate(self):
+		self.refuse_empty_snapshot()
+
+	def refuse_empty_snapshot(self):
+		"""A revision with no content is not a revision.
+
+		This is the last line of defence on the publish path, and it earns its
+		place: a drafting step that timed out wrote nothing to
+		``document_markdown``, the process carried on regardless, and a Policy
+		was published, indexed and issued a code and a version — with an empty
+		Drive file and an empty snapshot behind it. Nobody was told.
+
+		Refusing here stops the record that makes it *official*. Whatever failed
+		upstream, an issued revision that preserves nothing is worse than no
+		revision at all: the register would assert that this text was approved,
+		and the text is not there to read.
+		"""
+		# .strip() alone is not enough. A Drive text export always begins with a
+		# BOM, and U+FEFF is a *format* character, not whitespace — so an empty
+		# document exports as "\ufeff" and sails straight through a truthiness
+		# or .strip() check. Zero-width space gets the same treatment.
+		if (self.content_snapshot or "").strip("\ufeff\u200b \t\r\n"):
+			return
+
+		frappe.throw(
+			_(
+				"Refusing to record version {0} of {1} with no content. The snapshot is "
+				"the only surviving copy of a revision — Drive keeps just the newest "
+				"text — so an empty one would leave the register asserting an approval "
+				"for a document nobody can read. Check whether the drafting step "
+				"failed before republishing."
+			).format(self.version, self.document_code or self.document),
+			title=_("Empty revision"),
+		)
+
 	def before_naming(self):
 		"""Guarantee the pieces the `format:` autoname interpolates.
 

--- a/one_fm/tests/test_document_request_link.py
+++ b/one_fm/tests/test_document_request_link.py
@@ -37,9 +37,16 @@ class DocumentRequestFixtures:
 	"""
 
 	def setUp(self):
-		self.requester = frappe.db.get_value("Employee", {"status": "Active"}, "name")
+		# Must have a line manager: Document Request refuses to save when it cannot
+		# resolve an approver, so any Active employee is not good enough — picking
+		# one without a Reports To made every test in this file error out on insert
+		# with a message about the *employee's* record rather than anything the
+		# test was about.
+		self.requester = frappe.db.get_value(
+			"Employee", {"status": "Active", "reports_to": ["is", "set"]}, "name"
+		)
 		if not self.requester:
-			self.skipTest("no active Employee to raise a request as")
+			self.skipTest("no active Employee with a line manager to raise a request as")
 
 	def tearDown(self):
 		frappe.db.rollback()

--- a/one_fm/tests/test_document_versioning.py
+++ b/one_fm/tests/test_document_versioning.py
@@ -47,7 +47,14 @@ class VersioningFixtures:
 	"""Shared fixtures. Not a TestCase — a base TestCase re-runs its own tests."""
 
 	def setUp(self):
-		self.requester = frappe.db.get_value("Employee", {"status": "Active"}, "name")
+		# Must have a line manager: Document Request refuses to save when it cannot
+		# resolve an approver, so any Active employee is not good enough — picking
+		# one without a Reports To made every test in this file error out on insert
+		# with a message about the *employee's* record rather than anything the
+		# test was about.
+		self.requester = frappe.db.get_value(
+			"Employee", {"status": "Active", "reports_to": ["is", "set"]}, "name"
+		)
 
 	def tearDown(self):
 		frappe.db.rollback()

--- a/one_fm/tests/test_document_versioning.py
+++ b/one_fm/tests/test_document_versioning.py
@@ -417,3 +417,64 @@ class TestInputMaterial(VersioningFixtures, unittest.TestCase):
 	def test_a_delete_still_needs_its_document(self):
 		with self.assertRaises(frappe.ValidationError):
 			self._raise(request_action="Delete")
+
+
+class TestEmptyRevisionsAreRefused(VersioningFixtures, unittest.TestCase):
+	"""A revision with no content is not a revision.
+
+	Written from a real failure. The AI drafting step timed out at the old 30s
+	limit, produced nothing, and the process carried on: it saved an empty file
+	to Drive, indexed it, allocated POL-0014, issued version 1 and marked the
+	request Published. The register ended up asserting that a document had been
+	approved, with nothing behind it to read, and nobody was told.
+
+	The upstream causes are fixed separately (a real timeout, and the drafting
+	task now halting on error). This is the last line of defence, and it is the
+	one that does not care *which* step failed.
+	"""
+
+	def test_a_revision_with_no_snapshot_is_refused(self):
+		doc = self._document(file_id="_TestEmptyRev001")
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			self._version(doc.name, 1, "")
+		self.assertIn("no content", str(ctx.exception))
+
+	def test_whitespace_does_not_count_as_content(self):
+		"""An empty Drive export comes back as a newline or a BOM, not "" — so
+		a truthiness check alone would have let this through."""
+		doc = self._document(file_id="_TestEmptyRev002")
+		for blank in ("   ", "\n", "﻿", "\r\n\r\n"):
+			with self.subTest(value=repr(blank)):
+				with self.assertRaises(frappe.ValidationError):
+					self._version(doc.name, 1, blank)
+
+	def test_the_message_says_why_it_matters_and_what_to_check(self):
+		"""Whoever hits this is looking at a failed publish and needs to know
+		the drafting step is the likely culprit."""
+		doc = self._document(file_id="_TestEmptyRev003")
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			self._version(doc.name, 1, "")
+		message = str(ctx.exception)
+		self.assertIn("only surviving copy", message)
+		self.assertIn("drafting", message)
+
+	def test_a_revision_with_content_still_saves(self):
+		"""The guard must not make the normal path harder."""
+		doc = self._document(file_id="_TestEmptyRev004")
+		row = self._version(doc.name, 1, "# Policy for Remote Work\n\nReal content.")
+		self.assertTrue(frappe.db.exists("Document Revision", row.name))
+		self.assertIn("-V1", row.name)
+
+	def test_the_failure_that_prompted_this_would_now_be_stopped(self):
+		"""POL-0014-V1 was created with a 0-character snapshot. Recreating that
+		exact shape must now fail."""
+		doc = self._document(file_id="_TestEmptyRev005", document_type="Policy")
+		with self.assertRaises(frappe.ValidationError):
+			frappe.get_doc({
+				"doctype": "Document Revision",
+				"document": doc.name,
+				"document_code": doc.document_code,
+				"version": 1,
+				"title_at_version": "Policy create",
+				"content_snapshot": None,
+			}).insert(ignore_permissions=True)

--- a/one_fm/tests/test_withdrawn_not_offered.py
+++ b/one_fm/tests/test_withdrawn_not_offered.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+"""
+A withdrawn document must stop being offered, and stop being readable.
+
+Withdrawal is how this system says "stop using this". It already did the visible
+half — the document goes Inactive and its Drive sharing is revoked — but the
+register entry carried on appearing in every Document Register picker on the
+request form, so the obvious next step was to pick it and carry on.
+
+Two layers, because one of them is only cosmetic:
+
+  * ``link_filters`` shapes the dropdown. It is evaluated in the browser
+    (frappe/public/js/frappe/form/controls/link.js parses the JSON and passes the
+    result to the search endpoint), so it is the fix for what a user sees and no
+    protection at all for the API, an import, or a test.
+  * ``check_source_documents_are_active`` is the one that actually holds. The
+    reference-document side was already guarded; the two SOURCE fields were not,
+    so a withdrawn document's content could still be read and republished into a
+    live one — the same mistake with an extra step.
+
+The sharing half is asserted structurally here. Whether the grant is really gone
+is a Drive fact, verified against the live file rather than mocked: a withdrawn
+Policy has no ``domain reader one-fm.com`` permission while published ones do.
+"""
+
+import json
+import unittest
+
+import frappe
+
+REGISTER = "Document Register"
+LINK_FIELDS = ("source_guideline", "reference_document", "update_source")
+
+
+def _employee_with_an_approver():
+	return frappe.db.get_value(
+		"Employee", {"status": "Active", "reports_to": ["is", "set"]}, "name"
+	)
+
+
+class TestThePickersFilter(unittest.TestCase):
+	"""What the form offers."""
+
+	def _filters(self, fieldname):
+		raw = frappe.get_meta("Document Request").get_field(fieldname).get("link_filters")
+		return json.loads(raw) if raw else None
+
+	def test_every_document_register_picker_is_restricted_to_active(self):
+		for fieldname in LINK_FIELDS:
+			with self.subTest(field=fieldname):
+				self.assertEqual(
+					self._filters(fieldname),
+					[[REGISTER, "lifecycle_state", "=", "Active"]],
+					f"{fieldname} would still offer withdrawn documents",
+				)
+
+	def test_no_document_register_link_field_is_left_unfiltered(self):
+		"""Catches a fourth field being added later without the filter."""
+		on_request = [
+			field.fieldname
+			for field in frappe.get_meta("Document Request").fields
+			if field.fieldtype == "Link" and field.options == REGISTER
+		]
+		self.assertEqual(sorted(on_request), sorted(LINK_FIELDS))
+		for fieldname in on_request:
+			self.assertIsNotNone(self._filters(fieldname))
+
+	def test_the_filter_is_the_shape_the_link_control_can_parse(self):
+		"""link.js does `[_, fieldname, operator, value] = filter`. A dict, or a
+		two-element pair, parses to undefined and silently filters nothing."""
+		for fieldname in LINK_FIELDS:
+			with self.subTest(field=fieldname):
+				for row in self._filters(fieldname):
+					self.assertIsInstance(row, list)
+					self.assertEqual(len(row), 4)
+
+
+class TestTheSearchActuallyExcludesThem(unittest.TestCase):
+	"""The filter, applied the way the browser applies it, against real search."""
+
+	@classmethod
+	def setUpClass(cls):
+		cls.live = frappe.get_doc({
+			"doctype": REGISTER, "drive_file_id": "_TestOfferedLive",
+			"title": "Zeta Offered Live", "document_type": "Guideline",
+		}).insert(ignore_permissions=True)
+		cls.dead = frappe.get_doc({
+			"doctype": REGISTER, "drive_file_id": "_TestOfferedDead",
+			"title": "Zeta Offered Withdrawn", "document_type": "Guideline",
+		}).insert(ignore_permissions=True)
+		frappe.db.set_value(REGISTER, cls.dead.name, "lifecycle_state", "Inactive")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		for name in ("_TestOfferedLive", "_TestOfferedDead"):
+			if frappe.db.exists(REGISTER, name):
+				frappe.delete_doc(REGISTER, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _search(self, text, apply_filter):
+		from frappe.desk.search import search_link
+
+		raw = frappe.get_meta("Document Request").get_field("source_guideline").get("link_filters")
+		# Exactly what link.js parse_filters() builds out of that JSON.
+		filters = {row[1]: [row[2], row[3]] for row in json.loads(raw)} if apply_filter else None
+		results = search_link(doctype=REGISTER, txt=text, filters=filters, page_length=20)
+		return [row.get("value") if isinstance(row, dict) else row[0] for row in results]
+
+	def test_a_withdrawn_document_is_offered_without_the_filter(self):
+		"""The bug, pinned — so the next test is proving something."""
+		self.assertIn(self.dead.name, self._search("Zeta", apply_filter=False))
+
+	def test_a_withdrawn_document_is_not_offered_with_it(self):
+		self.assertNotIn(self.dead.name, self._search("Zeta", apply_filter=True))
+
+	def test_active_documents_are_still_offered(self):
+		self.assertIn(self.live.name, self._search("Zeta", apply_filter=True))
+
+
+class TestTheServerRefusesThemAnyway(unittest.TestCase):
+	"""The layer that holds when the form is not involved."""
+
+	@classmethod
+	def setUpClass(cls):
+		cls.employee = _employee_with_an_approver()
+		cls.live = frappe.get_doc({
+			"doctype": REGISTER, "drive_file_id": "_TestGuardLive",
+			"title": "Guard Live", "document_type": "Guideline",
+		}).insert(ignore_permissions=True)
+		cls.dead = frappe.get_doc({
+			"doctype": REGISTER, "drive_file_id": "_TestGuardDead",
+			"title": "Guard Withdrawn", "document_type": "Guideline",
+		}).insert(ignore_permissions=True)
+		cls.controlled = frappe.get_doc({
+			"doctype": REGISTER, "drive_file_id": "_TestGuardControlled",
+			"title": "Guard Controlled", "document_type": "Policy",
+			"document_code": "POL-GUARD",
+		}).insert(ignore_permissions=True)
+		frappe.db.set_value(REGISTER, cls.dead.name, "lifecycle_state", "Inactive")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		for name in ("_TestGuardLive", "_TestGuardDead", "_TestGuardControlled"):
+			if frappe.db.exists(REGISTER, name):
+				frappe.delete_doc(REGISTER, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def setUp(self):
+		if not self.employee:
+			self.skipTest("no Active Employee with a Reports To")
+
+	def _request(self, **values):
+		base = {
+			"doctype": "Document Request", "requester": self.employee,
+			"document_type": "Policy", "title": "Guard test",
+			"requirement_text": "Guard test",
+		}
+		base.update(values)
+		return frappe.get_doc(base)
+
+	def _insert(self, doc):
+		doc.insert(ignore_permissions=True)
+		self.addCleanup(
+			frappe.delete_doc, "Document Request", doc.name, force=True, ignore_permissions=True
+		)
+		return doc
+
+	def test_a_create_cannot_be_generated_from_a_withdrawn_guideline(self):
+		with self.assertRaises(frappe.ValidationError) as caught:
+			self._request(request_action="Create", source_guideline=self.dead.name).insert(
+				ignore_permissions=True
+			)
+		self.assertIn("inactive", str(caught.exception).lower())
+
+	def test_an_update_cannot_take_its_wording_from_a_withdrawn_document(self):
+		with self.assertRaises(frappe.ValidationError) as caught:
+			self._request(
+				request_action="Update",
+				reference_document=self.controlled.name,
+				update_source=self.dead.name,
+			).insert(ignore_permissions=True)
+		self.assertIn("inactive", str(caught.exception).lower())
+
+	def test_an_active_source_is_accepted(self):
+		"""So the guard is not simply refusing everything."""
+		doc = self._insert(self._request(request_action="Create", source_guideline=self.live.name))
+		self.assertEqual(doc.source_guideline, self.live.name)
+
+	def test_the_guard_only_looks_at_the_field_the_action_uses(self):
+		"""check_update_source clears a stale update_source on a Create. Reading it
+		before that ran would reject a request whose value is about to be dropped."""
+		doc = self._insert(self._request(
+			request_action="Create", source_guideline=self.live.name, update_source=self.dead.name
+		))
+		self.assertIsNone(doc.update_source)
+
+	def test_revising_a_withdrawn_document_is_still_refused(self):
+		"""Pre-existing guard; asserted here so the new one cannot replace it."""
+		with self.assertRaises(frappe.ValidationError):
+			self._request(request_action="Update", reference_document=self.dead.name,
+			              update_source=self.live.name).insert(ignore_permissions=True)
+
+
+class TestWithdrawalStillRevokesSharing(unittest.TestCase):
+	"""The other half of withdrawal, which was already working.
+
+	Structural only — that the map still has the step, wired to the right file
+	and on the withdrawal branch. Whether Drive really drops the grant was
+	confirmed against the live files: the withdrawn Policy had no
+	``domain reader one-fm.com`` permission while the two published ones did.
+	"""
+
+	MODEL = "Document Request"
+
+	def _xml(self):
+		return frappe.db.get_value("BPMN Process Model", self.MODEL, "bpmn_xml") or ""
+
+	def test_the_withdrawal_branch_still_revokes_sharing(self):
+		import re
+
+		xml = self._xml()
+		match = re.search(r'<bpmn:serviceTask id="revoke_sharing"[^>]*>', xml)
+		self.assertIsNotNone(match, "withdrawal must revoke access, not only relabel the record")
+		attrs = dict(re.findall(r'spiffworkflow:(\w+)="([^"]*)"', match.group(0)))
+		self.assertEqual(attrs.get("connectorId"), "google_drive")
+		self.assertEqual(attrs.get("operation"), "revokePermissions")
+
+	def test_it_runs_before_the_record_is_marked_deleted(self):
+		"""Marking it withdrawn while it is still shared is the state that must
+		never be observable."""
+		import re
+
+		xml = self._xml()
+		flows = dict(
+			(source, target)
+			for _, source, target in re.findall(
+				r'<bpmn:sequenceFlow id="([^"]+)"[^>]*sourceRef="([^"]+)"[^>]*targetRef="([^"]+)"',
+				xml,
+			)
+		)
+		self.assertEqual(flows.get("revoke_sharing"), "set_status_deleted")
+
+	def test_the_document_is_deactivated_rather_than_destroyed(self):
+		import re
+
+		xml = self._xml()
+		self.assertNotIn('operation="deleteFile"', xml,
+		                 "withdrawal must never trash the Drive file")
+		match = re.search(r'<bpmn:scriptTask id="delete_file"[^>]*>', xml)
+		self.assertIsNotNone(match)
+		self.assertIn("Deactivate", match.group(0))


### PR DESCRIPTION
## Withdrawn documents were still selectable

Withdrawal is how this system says "stop using this". It already did the visible half — the
document goes Inactive and its Drive sharing is revoked — but the register entry carried on
appearing in every Document Register picker, so the obvious next step was to pick it and carry on.

Two layers, because one is only cosmetic:

- **`link_filters`** restricts `source_guideline`, `reference_document` and `update_source` to
  Active. Evaluated in the **browser**, so it shapes the dropdown and protects nothing else.
- **`check_source_documents_are_active`** is the layer that holds. The reference-document side
  was already guarded; the two *source* fields were not, so a withdrawn document's content could
  still be read through the API and republished into a live one.

Measured against real data — browsing went 3 options → 2, and searching text that matches the
withdrawn document went 2 → 1.

## Sharing revocation: confirmed, not changed

| Document | `domain reader one-fm.com` |
|---|---|
| withdrawn | **absent** |
| published | present |

Only the service account and owner grants remain, both inherited from the Shared Drive. Access
removed, file retained. Tests pin that the withdrawal branch still revokes *before* marking the
record deleted, and never trashes the file.

## Drive links that silently did nothing

Pasting a link the service account cannot read looked exactly like pasting one it can — fields
stayed empty, the only trace an Error Log entry. It now says so on screen, and the record still
saves. Google answers **404, not 403**, for a file you have no permission on, so "File not found"
almost always means "not shared with us"; that case names the service account to share it with.

## Test fix

Both existing suites picked any Active Employee, and the one they got has no `Reports To`.
Document Request refuses to save without a resolvable approver, so **27 tests were erroring**
before any change here — confirmed by reproducing it with the working tree stashed.

## Deployment note

`link_filters` lives in the DocField rows, so this needs a **`bench migrate`** to take effect.

**71 tests green** (14 new + 24 + 33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
