### PR TITLE
feat(google): ONE FM owns its own Google service account

### DIFF
--- a/one_fm/one_fm/doctype/document_register/document_register.py
+++ b/one_fm/one_fm/doctype/document_register/document_register.py
@@ -14,6 +14,12 @@
 # document keeps its file, its content and every version snapshot, and only
 # loses its Drive sharing — which is the part staff actually experience as
 # "it's gone".
+#
+# Drive access here authenticates as ONE FM's own service account (ONEFM General
+# Setting > Google > Service Account JSON), not as a BPMN connector — see
+# `_drive_service`. The register is ONE FM's catalogue; the connectors are how
+# processes create the files it catalogues. Both accounts therefore need to be
+# members of the same Shared Drive.
 
 import re
 
@@ -107,6 +113,8 @@ class DocumentRegister(Document):
 
 		try:
 			from one_bpmn.one_bpmn.integrations import google_drive as gd
+
+			service = _drive_service()
 		except Exception:
 			if not self.title:
 				self.title = self.drive_file_id
@@ -115,8 +123,7 @@ class DocumentRegister(Document):
 		try:
 			if not self.title or not self.drive_file_link:
 				meta = (
-					gd._get_service()
-					.files()
+					service.files()
 					.get(fileId=self.drive_file_id, fields="name,webViewLink", supportsAllDrives=True)
 					.execute()
 				)
@@ -125,7 +132,7 @@ class DocumentRegister(Document):
 				if not self.drive_file_link:
 					self.drive_file_link = meta.get("webViewLink")
 			if not self.content:
-				self.content = gd.download_file_text(self.drive_file_id)
+				self.content = gd.download_file_text(self.drive_file_id, service=service)
 		except Exception as e:
 			frappe.log_error(
 				title="Document Register: Drive auto-fill failed",
@@ -151,7 +158,7 @@ class DocumentRegister(Document):
 		"""
 		text = str(error)
 		if "File not found" in text or "404" in text or "notFound" in text:
-			account = _service_account_email() or "the Processa service account"
+			account = _service_account_email() or "ONE FM's Google service account"
 			frappe.msgprint(
 				_(
 					"Could not read {0} from Google Drive, so the title and content were "
@@ -175,14 +182,31 @@ class DocumentRegister(Document):
 		)
 
 
-def _service_account_email():
-	"""Which Google identity Processa uses, for an actionable error message."""
-	try:
-		from one_bpmn.one_bpmn.integrations.google_common import load_service_account_info
+def _drive_service():
+	"""Drive client for the register, as ONE FM's own service account.
 
-		return (load_service_account_info("google_drive") or {}).get("client_email")
-	except Exception:
-		return None
+	The register is ONE FM's catalogue, so it authenticates as ONE FM rather than
+	borrowing a BPMN connector's key — the connectors create these files, this
+	account reads and shares them, and each can now be rotated alone.
+
+	The consequence to know about: both accounts must be members of the same
+	Shared Drive. Drive answers 404 for a file an account cannot see, so a
+	missing membership looks exactly like a deleted document (which is what
+	``_warn_autofill_failed`` exists to explain).
+
+	one_bpmn's Drive helpers are still reused — they take an optional
+	``service``, so only the identity differs, not the .docx/.pptx handling.
+	"""
+	from one_fm.one_fm.google_credentials import get_drive_service
+
+	return get_drive_service()
+
+
+def _service_account_email():
+	"""Which Google identity ONE FM uses, for an actionable error message."""
+	from one_fm.one_fm.google_credentials import service_account_email
+
+	return service_account_email()
 
 
 def code_prefix(document_type: str) -> str:
@@ -281,7 +305,7 @@ def deactivate(document: str, reason: str = None, via_request: str = None, revok
 		try:
 			from one_bpmn.one_bpmn.integrations.google_drive import revoke_permissions
 
-			outcome = revoke_permissions(doc.drive_file_id, scope="all")
+			outcome = revoke_permissions(doc.drive_file_id, scope="all", service=_drive_service())
 			revoked = len(outcome["removed"])
 			skipped = outcome["skipped"]
 		except Exception as e:
@@ -328,7 +352,9 @@ def reactivate(document: str, reason: str = None) -> dict:
 	try:
 		from one_bpmn.one_bpmn.integrations.google_drive import set_permissions
 
-		granted = len(set_permissions(doc.drive_file_id, DEFAULT_GRANTS))
+		granted = len(
+			set_permissions(doc.drive_file_id, DEFAULT_GRANTS, service=_drive_service())
+		)
 	except Exception as e:
 		share_error = str(e)
 		frappe.log_error(

--- a/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
+++ b/one_fm/one_fm/doctype/onefm_general_setting/onefm_general_setting.json
@@ -39,6 +39,9 @@
   "wiki_page_access",
   "employee_info_access",
   "google_tab",
+  "google_service_account_section",
+  "google_service_account_intro",
+  "google_service_account_json",
   "google_task_section",
   "google_task_synchronization_enabled",
   "sync_google_tasks_btn",
@@ -211,6 +214,23 @@
    "fieldname": "google_tab",
    "fieldtype": "Tab Break",
    "label": "Google"
+  },
+  {
+   "fieldname": "google_service_account_section",
+   "fieldtype": "Section Break",
+   "label": "Service Account"
+  },
+  {
+   "fieldname": "google_service_account_intro",
+   "fieldtype": "HTML",
+   "options": "<p>The Google identity <b>ONE FM itself</b> acts as — Google Tasks sync, Gmail out-of-office, and reading documents into the Document Register.</p><p>This is <b>not</b> the credential the BPMN connectors use. Each connector carries its own key (BPMN Connector → Authentication → Secret) and neither falls back to the other, so the two can be different Google accounts and either can be rotated alone.</p><p><b>Both accounts need access to the same Shared Drive.</b> The connectors create the document files; this account reads and shares them. Add both as <i>Content Manager</i> — Drive answers <code>404 File not found</code> rather than a permission error when an account cannot see a file, which reads as a missing document and sends people looking in the wrong place.</p><p>Google Tasks and Gmail additionally need <b>domain-wide delegation</b> enabled for this service account in Google Workspace admin, because they act as an employee rather than as the service account itself.</p>"
+  },
+  {
+   "description": "Paste the whole key file Google issued — every brace, the full private_key, nothing trimmed. Stored encrypted.",
+   "fieldname": "google_service_account_json",
+   "fieldtype": "Password",
+   "label": "Service Account JSON",
+   "length": 10000
   },
   {
    "fieldname": "google_task_section",

--- a/one_fm/one_fm/google_credentials.py
+++ b/one_fm/one_fm/google_credentials.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026, one-fm and contributors
+# For license information, please see license.txt
+"""
+The Google identity ONE FM itself acts as.
+
+ONE FM talks to Google in three places that are its own work, not a BPMN
+process's: Google Tasks sync, Gmail out-of-office, and reading document files
+into the Document Register. All three used to read the key straight off disk at
+``private/files/gcp.json``.
+
+WHY THAT MOVED ONTO A FIELD
+---------------------------
+A key on disk is invisible. It is not encrypted, it cannot be seen or rotated
+without shell access to the server, and it does not travel with a database
+restore — so a site can look configured and have no credential at all. That is
+not hypothetical: the file was absent on the site this was written against,
+which meant Gmail out-of-office had been failing into ``frappe.log_error`` with
+nothing on screen to say so.
+
+It now lives on ONEFM General Setting → Google → Service Account JSON, a
+Password field: encrypted in ``__Auth``, visible and rotatable in Desk, and
+carried with the database.
+
+THIS IS NOT THE CONNECTORS' CREDENTIAL
+--------------------------------------
+Each BPMN Connector carries its own key (BPMN Connector → Authentication →
+Secret) and this module never reads one, just as ``one_bpmn``'s loader never
+reads this field. Two owners, no chain. A fallback between them is what makes a
+shared credential invisible: with one in place, every consumer silently uses one
+account, so pointing one at a second Google project looks configured and
+changes nothing.
+
+Both accounts do need access to the same Shared Drive, because the connectors
+create the document files and this account reads and shares them. Drive answers
+``404 File not found`` rather than a permission error for a file an account
+cannot see, so a missing membership presents as a missing document.
+"""
+
+import json
+
+import frappe
+
+SETTINGS_DOCTYPE = "ONEFM General Setting"
+SETTINGS_FIELD = "google_service_account_json"
+
+# Kept as a fallback on purpose, so a site still carrying the file keeps working
+# without a deployment step. Every read of it is logged: the file cannot be seen
+# or rotated from Desk, so a site quietly running off it should be visible to
+# whoever looks at the logs rather than discovered later.
+LEGACY_KEY_PATH = ("private", "files", "gcp.json")
+
+DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+
+class GoogleCredentialError(Exception):
+	"""Missing or unusable configuration — not a transient API failure."""
+
+
+def load_service_account_info():
+	"""Return ONE FM's own service-account key as a dict.
+
+	Order: the settings field, then ``private/files/gcp.json``. A site with
+	neither gets an error naming the field to fill, because the alternative —
+	what this code used to do — was to log and hand back ``None``, which every
+	caller then turned into a silent no-op.
+	"""
+	raw = _field_key()
+	if raw:
+		return _parse(raw, f"{SETTINGS_DOCTYPE} > Google > Service Account JSON")
+
+	raw = _legacy_file_key()
+	if raw:
+		_warn_legacy_key()
+		return _parse(raw, frappe.get_site_path(*LEGACY_KEY_PATH))
+
+	raise GoogleCredentialError(
+		"No Google service account is configured for ONE FM. Paste the key file "
+		f"Google issued on {SETTINGS_DOCTYPE} > Google > Service Account JSON."
+	)
+
+
+def _field_key():
+	try:
+		return frappe.get_single(SETTINGS_DOCTYPE).get_password(
+			SETTINGS_FIELD, raise_exception=False
+		)
+	except Exception:
+		# A settings row that cannot be read must not be the thing that breaks a
+		# scheduled job; fall through to the file and let that report the problem.
+		return None
+
+
+def _legacy_file_key():
+	try:
+		with open(frappe.get_site_path(*LEGACY_KEY_PATH)) as f:
+			return f.read()
+	except (FileNotFoundError, OSError):
+		return None
+
+
+def _warn_legacy_key():
+	"""Say so, once per request, when the on-disk key is still in play."""
+	flag = "_onefm_legacy_gcp_key_warned"
+	if getattr(frappe.flags, flag, False):
+		return
+	setattr(frappe.flags, flag, True)
+	try:
+		frappe.logger("one_fm").warning(
+			"Google credential came from private/files/gcp.json — deprecated. That "
+			"file is unencrypted, invisible in Desk and lost on a database restore. "
+			f"Paste the key on {SETTINGS_DOCTYPE} > Google > Service Account JSON."
+		)
+	except Exception:
+		pass
+
+
+def _parse(raw, where):
+	if isinstance(raw, dict):
+		return raw
+	try:
+		return json.loads(raw)
+	except ValueError as e:
+		raise GoogleCredentialError(
+			f"The Google service account at {where} is not valid JSON — it must be "
+			f"the whole key file Google issued, not just the private key ({e})."
+		) from e
+
+
+def get_credentials(scopes, subject=None):
+	"""Credentials for ONE FM's own service account.
+
+	``subject`` turns on domain-wide delegation — the credential then acts *as*
+	that user rather than as the service account. Gmail and Tasks need it (a
+	service account has no mailbox and no task list of its own); Drive does not.
+	Delegation must be enabled for this key in Google Workspace admin, or Google
+	refuses the token with ``unauthorized_client``.
+	"""
+	from google.oauth2 import service_account
+
+	creds = service_account.Credentials.from_service_account_info(
+		load_service_account_info(), scopes=scopes
+	)
+	return creds.with_subject(subject) if subject else creds
+
+
+def get_service(api, version, scopes, subject=None):
+	"""Build a googleapiclient service as ONE FM's own identity."""
+	from googleapiclient.discovery import build
+
+	return build(api, version, credentials=get_credentials(scopes, subject), cache_discovery=False)
+
+
+def get_drive_service():
+	"""Drive client for ONE FM's own work — the Document Register.
+
+	Deliberately separate from ``one_bpmn``'s Drive client, which authenticates
+	as a connector. The *logic* in one_bpmn's integration is still reused (its
+	helpers take an optional ``service``); only the identity differs.
+	"""
+	return get_service("drive", "v3", DRIVE_SCOPES)
+
+
+def service_account_email():
+	"""Which Google identity ONE FM uses, for actionable error messages."""
+	try:
+		return (load_service_account_info() or {}).get("client_email")
+	except Exception:
+		return None

--- a/one_fm/overrides/todo.py
+++ b/one_fm/overrides/todo.py
@@ -4,9 +4,7 @@ from frappe.utils import get_fullname, get_url_to_form, getdate
 from bs4 import BeautifulSoup
 from datetime import datetime,timezone, timedelta
 from one_fm.processor import is_user_id_company_prefred_email_in_employee, sendemail
-from googleapiclient.discovery import build
 from frappe import _
-from google.oauth2 import service_account
 from frappe.desk.doctype.todo.todo import ToDo as FrappeToDo
 
 class ToDo(FrappeToDo):
@@ -119,13 +117,14 @@ def get_google_task_service(employee_email):
         )
         return None
 
-    credentials_path = frappe.get_site_path("private", "files", "gcp.json")
+    # Key from ONEFM General Setting > Google > Service Account JSON, falling
+    # back to private/files/gcp.json for sites still carrying the file.
+    from one_fm.one_fm.google_credentials import get_service
+
     try:
-        with open(credentials_path, "r") as file:
-            credentials_dict = json.load(file)
-        credentials = service_account.Credentials.from_service_account_info(credentials_dict, scopes=["https://www.googleapis.com/auth/tasks"])
-        delegated_credentials = credentials.with_subject(employee_email)
-        return build("tasks", "v1", credentials=delegated_credentials)
+        return get_service(
+            "tasks", "v1", ["https://www.googleapis.com/auth/tasks"], subject=employee_email
+        )
     except Exception as e:
         frappe.log_error(title="Error reading Google credentials", message=str(e))
         return None

--- a/one_fm/tests/test_document_versioning.py
+++ b/one_fm/tests/test_document_versioning.py
@@ -17,7 +17,7 @@ Two properties hold this together, and both are easy to break by accident:
 """
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 
@@ -55,6 +55,19 @@ class VersioningFixtures:
 		self.requester = frappe.db.get_value(
 			"Employee", {"status": "Active", "reports_to": ["is", "set"]}, "name"
 		)
+
+		# The register authenticates as ONE FM's own service account, so building
+		# the Drive client is a second collaborator alongside the Drive calls the
+		# tests already stub. Without this, a site with no key configured raises
+		# before revoke_permissions/set_permissions is ever reached — the
+		# revocation is skipped and reported in revoke_error, which is correct
+		# behaviour but not what these tests are about.
+		patcher = patch(
+			"one_fm.one_fm.doctype.document_register.document_register._drive_service",
+			return_value=MagicMock(name="drive_service"),
+		)
+		patcher.start()
+		self.addCleanup(patcher.stop)
 
 	def tearDown(self):
 		frappe.db.rollback()

--- a/one_fm/tests/test_google_service_account.py
+++ b/one_fm/tests/test_google_service_account.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026, ONE FM and contributors
+# For license information, please see license.txt
+"""
+ONE FM's own Google identity, and its separation from the connectors'.
+
+The property these guard is an *absence*: nothing in one_fm reads a BPMN
+connector's key, and nothing in one_bpmn reads this field. Two owners, no chain.
+
+That is worth pinning precisely because breaking it is invisible. Both fields
+currently tend to hold the same key, so a cross-read works — right up until
+someone rotates one of them and the other silently keeps using the old account.
+The failure then surfaces as Drive's ``404 File not found``, which reads as a
+deleted document rather than a credential problem.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from one_fm.one_fm import google_credentials as gc
+
+FAKE_KEY = {"type": "service_account", "client_email": "onefm@x.iam.gserviceaccount.com"}
+
+
+class TestOneFMCredentialLoader(unittest.TestCase):
+	def setUp(self):
+		frappe.flags._onefm_legacy_gcp_key_warned = False
+
+	def test_the_settings_field_is_the_first_choice(self):
+		with patch.object(gc, "_field_key", return_value=json.dumps(FAKE_KEY)):
+			self.assertEqual(
+				gc.load_service_account_info()["client_email"], FAKE_KEY["client_email"]
+			)
+
+	def test_the_field_wins_over_the_file(self):
+		"""If this inverts, a site that has filled the field keeps running off a
+		stale file and nothing looks wrong."""
+		with patch.object(gc, "_field_key", return_value=json.dumps(FAKE_KEY)), patch.object(
+			gc, "_legacy_file_key", return_value='{"client_email": "file@x"}'
+		):
+			self.assertEqual(
+				gc.load_service_account_info()["client_email"], FAKE_KEY["client_email"]
+			)
+
+	def test_the_file_still_works_and_says_so(self):
+		"""Kept deliberately, so a site carrying gcp.json needs no deployment
+		step — but never silently: the file cannot be seen or rotated from Desk."""
+		with patch.object(gc, "_field_key", return_value=None), patch.object(
+			gc, "_legacy_file_key", return_value='{"client_email": "file@x"}'
+		), patch.object(gc, "_warn_legacy_key") as warned:
+			info = gc.load_service_account_info()
+
+		self.assertEqual(info["client_email"], "file@x")
+		warned.assert_called_once()
+
+	def test_nothing_configured_names_the_field_to_fill(self):
+		"""The old code logged and returned None, so every caller became a silent
+		no-op. An error that names the form is the whole improvement."""
+		with patch.object(gc, "_field_key", return_value=None), patch.object(
+			gc, "_legacy_file_key", return_value=None
+		):
+			with self.assertRaises(gc.GoogleCredentialError) as ctx:
+				gc.load_service_account_info()
+
+		self.assertIn("ONEFM General Setting", str(ctx.exception))
+
+	def test_a_secret_that_is_not_a_whole_key_file_says_so(self):
+		with patch.object(gc, "_field_key", return_value="not-json"):
+			with self.assertRaises(gc.GoogleCredentialError) as ctx:
+				gc.load_service_account_info()
+
+		self.assertIn("whole key file", str(ctx.exception))
+
+	def test_delegation_is_applied_only_when_a_subject_is_given(self):
+		"""Gmail and Tasks act *as* an employee; Drive acts as the service
+		account. Passing a subject where Google has no delegation configured
+		fails the token exchange, so this must not be applied by default."""
+		creds = MagicMock()
+		with patch.object(gc, "load_service_account_info", return_value=FAKE_KEY), patch(
+			"google.oauth2.service_account.Credentials.from_service_account_info",
+			return_value=creds,
+		):
+			gc.get_credentials(gc.DRIVE_SCOPES)
+			creds.with_subject.assert_not_called()
+
+			gc.get_credentials(gc.DRIVE_SCOPES, subject="a@one-fm.com")
+			creds.with_subject.assert_called_once_with("a@one-fm.com")
+
+
+class TestTheFieldExists(unittest.TestCase):
+	def test_the_field_is_an_encrypted_password_on_the_google_tab(self):
+		field = frappe.get_meta("ONEFM General Setting").get_field("google_service_account_json")
+		self.assertIsNotNone(field, "the settings field was not created")
+		self.assertEqual(
+			field.fieldtype, "Password", "a Data field would store the key unencrypted"
+		)
+
+	def test_the_field_is_long_enough_for_a_real_key(self):
+		"""A service-account key is ~2.3kB, mostly the PEM private key. Frappe's
+		Password control caps input at ``df.length`` or 140 for a non-Single
+		doctype; ONEFM General Setting is a Single, which skips the cap
+		altogether, so this is belt-and-braces rather than load-bearing here —
+		but it documents the real requirement and survives the doctype ever
+		ceasing to be a Single.
+		"""
+		field = frappe.get_meta("ONEFM General Setting").get_field("google_service_account_json")
+		self.assertGreaterEqual(field.length, 10000)
+
+
+def _executable_code(module):
+	"""A module's code with docstrings and comments stripped.
+
+	Both loaders *name* the other app's credential in prose, to explain why they
+	must not read it. Grepping the raw source would therefore fail on the very
+	documentation that makes the rule clear, so the rule is checked against code.
+	"""
+	import ast
+	import inspect
+
+	tree = ast.parse(inspect.getsource(module))
+	for node in ast.walk(tree):
+		body = getattr(node, "body", None)
+		if isinstance(body, list) and body:
+			first = body[0]
+			if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+				if isinstance(first.value.value, str):
+					node.body = body[1:] or [ast.Pass()]
+	return ast.unparse(tree)  # unparse drops comments
+
+
+class TestTheTwoCredentialsDoNotCross(unittest.TestCase):
+	"""Neither app may read the other's key. See the module docstring."""
+
+	def test_onefm_never_reads_a_connector_secret(self):
+		code = _executable_code(gc)
+		for forbidden in ("BPMN Connector", "auth_secret", "google_common"):
+			self.assertNotIn(
+				forbidden, code, f"one_fm's loader reaches into one_bpmn via {forbidden}"
+			)
+
+	def test_one_bpmn_never_reads_the_onefm_field(self):
+		from one_bpmn.one_bpmn.integrations import google_common
+
+		code = _executable_code(google_common)
+		for forbidden in ("ONEFM General Setting", "google_service_account_json"):
+			self.assertNotIn(
+				forbidden, code, f"one_bpmn's loader reaches into one_fm via {forbidden}"
+			)
+
+	def test_the_document_register_authenticates_as_one_fm(self):
+		"""The register catalogues files the connectors create, but reads them as
+		ONE FM — that is the ownership decision this change made."""
+		from one_fm.one_fm.doctype.document_register import document_register as dr
+
+		sentinel = object()
+		with patch.object(gc, "get_drive_service", return_value=sentinel):
+			self.assertIs(dr._drive_service(), sentinel)
+
+	def test_no_onefm_key_reports_the_reason_instead_of_borrowing_one(self):
+		"""The behaviour change with teeth.
+
+		The register used to fall back to the connector's key, so a site with no
+		ONE FM credential still revoked sharing. It no longer does — and the
+		important part is that withdrawal says so in ``revoke_error`` rather than
+		reporting a clean success. A document marked Inactive whose sharing was
+		never revoked is still readable by everyone holding the link, so a silent
+		failure here is the dangerous one.
+		"""
+		from one_fm.one_fm.doctype.document_register import document_register as dr
+
+		with patch.object(gc, "_field_key", return_value=None), patch.object(
+			gc, "_legacy_file_key", return_value=None
+		):
+			with self.assertRaises(gc.GoogleCredentialError):
+				dr._drive_service()
+
+	def test_the_register_reuses_one_bpmn_drive_logic_with_its_own_identity(self):
+		"""The .docx/.pptx handling stays in one place; only the identity differs.
+		If the helpers stop accepting ``service``, the register would silently
+		fall back to the connector's account."""
+		import inspect
+
+		from one_bpmn.one_bpmn.integrations import google_drive as gd
+
+		for fn in (gd.download_file_text, gd.list_files, gd.set_permissions, gd.revoke_permissions):
+			with self.subTest(fn=fn.__name__):
+				self.assertIn(
+					"service",
+					inspect.signature(fn).parameters,
+					f"{fn.__name__} no longer accepts a caller-supplied service",
+				)

--- a/one_fm/utils.py
+++ b/one_fm/utils.py
@@ -57,9 +57,7 @@ from one_fm.one_fm.payroll_utils import get_user_list_by_role
 from one_fm.operations.doctype.operations_shift.operations_shift import get_shift_supervisor
 from one_fm.api import api
 from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
-from google.oauth2 import service_account
 
 
 def get_common_email_args(doc):
@@ -3753,21 +3751,29 @@ def is_holiday(employee, date=None, raise_exception=True,include_weekly_off = Fa
 
 
 def get_service(employee_email, api, version, scopes):
-    credentials_path = frappe.get_site_path('private', 'files', 'gcp.json')
-    credentials_dict = None
+    """Google client acting as ``employee_email`` (domain-wide delegation).
+
+    The key comes from ONEFM General Setting > Google > Service Account JSON,
+    falling back to private/files/gcp.json for sites still carrying the file —
+    see one_fm.one_fm.google_credentials, which logs when the file is used.
+
+    Returning None on a configuration problem is kept deliberately: every caller
+    here is a notification side-effect (out-of-office, task sync), and failing
+    an employee's leave submission because Google is misconfigured would be
+    worse than not setting their auto-reply. The reason is logged.
+    """
+    from one_fm.one_fm.google_credentials import GoogleCredentialError, get_service as _google_service
+
     try:
-        with open(credentials_path, 'r') as file:
-            credentials_dict = json.load(file)
-    except Exception as e:
-        frappe.log_error(title="Error reading Google credentials:", message=str(e))
+        return _google_service(api, version, scopes, subject=employee_email)
+    except GoogleCredentialError as e:
+        frappe.log_error(title="Google service account not configured", message=str(e))
         return
-
-    credentials = service_account.Credentials.from_service_account_info(credentials_dict, scopes=scopes)
-
-    delegated_credentials = credentials.with_subject(employee_email)
-
-    service = build(api, version, credentials=delegated_credentials)
-    return service
+    except Exception:
+        frappe.log_error(
+            title="Error building Google service", message=frappe.get_traceback()
+        )
+        return
 
 
 def set_out_of_office(employee_email, start_date, end_date, custom_reliever_name, custom_reliever, employee_name):


### PR DESCRIPTION
> **Depends on** ONE-F-M/one_bpmn `refactor/connector-owns-google-credential`, which
> adds the optional `service` argument the Document Register uses here. Merge that first.

## Why

ONE FM talks to Google in three places that are its own work rather than a BPMN
process's: Google Tasks sync, Gmail out-of-office, and reading document files into the
Document Register. All three read the key straight off disk at `private/files/gcp.json`.

A key on disk is invisible. It is unencrypted, it cannot be seen or rotated without
shell access, and it does not travel with a database restore — so a site can look
configured and have no credential at all. That is not hypothetical: **the file is
absent on `one_fm.15`**, so Gmail out-of-office has been failing into
`frappe.log_error` with nothing on screen to say so.

## What changed

**The key lives on a field.** `ONEFM General Setting → Google → Service Account JSON`,
a Password field on the `google_tab` that already existed: encrypted in `__Auth`,
rotatable in Desk, carried with the database. New `one_fm/one_fm/google_credentials.py`
is the single loader — field first, then `gcp.json` for sites still carrying it, and a
site with neither gets an error naming the form instead of the old
log-and-return-`None` that turned every caller into a silent no-op.

The `gcp.json` fallback is deliberate, to avoid a deployment step, and **every read of
it is logged** — a site quietly running off an invisible file should show up in the
logs rather than be discovered later.

**Two owners, no chain.** This field is not the connectors' credential. Each BPMN
Connector carries its own key and neither side reads the other's, enforced by a test
that inspects the *executable code* of both loaders (their prose names the other on
purpose, to explain the rule). A fallback between them is what makes a shared
credential invisible.

**The Document Register moves to it.** The register is ONE FM's catalogue, so it
authenticates as ONE FM rather than borrowing the `google_drive` connector's key,
across all four touchpoints (autofill, content read, `set_permissions`,
`revoke_permissions`). It still reuses one_bpmn's Drive logic via the new `service`
argument — only the identity differs, not the .docx/.pptx handling.

## Deploy prerequisite

**Both service accounts must be Content Manager on the same Shared Drive.** The
connectors create these files; this account reads and shares them. Drive answers `404
File not found` rather than a permission error for a file an account cannot see, so a
missing membership presents as a *deleted document* — which is what
`_warn_autofill_failed` already exists to explain.

Google Tasks and Gmail additionally need **domain-wide delegation** enabled for this
key in Workspace admin, because they act as an employee rather than as the service
account. Drive does not.

## Behaviour change worth reviewing

A site with no ONE FM key no longer silently falls back to the connector's, so
withdrawal reports the reason in `revoke_error` instead of a clean success. A document
marked Inactive whose sharing was never revoked is still readable by anyone holding the
link, so that had to be the loud failure.

`test_document_versioning` gains a `_drive_service` stub for the same reason: the
register now has a credential collaborator alongside the Drive calls those tests
already stubbed. Five tests failed without it, correctly — building the client is
evaluated before the Drive call, so with no key the revoke never ran at all.

## Verification

Against live Google: all three registered documents read as ONE FM, including a `.pptx`
parsed through one_bpmn's extractor under one_fm's credential, and a 9795-char
bilingual Arabic/English policy. Neither loader falls back to the other; the file
fallback still works and logs. 12/12 on the separation harness.

Suites: `test_google_service_account` 13/13, `test_document_versioning` 33/33,
`test_document_request_link` 24/24, `test_withdrawn_not_offered` 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
