### PR TITLE
WI-001790: drop the Shift column from the Monthly Attendance Sheet

### DIFF
--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.py
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/operations_monthly_attendance_sheet.py
@@ -141,7 +141,10 @@ def get_columns(filters, dates):
 		{"label": _("Employment Type"), "fieldname": "employment_type", "fieldtype": "Data", "width": 110},
 		{"label": _("Roster Type"), "fieldname": "roster_type", "fieldtype": "Data", "width": 80},
 		{"label": _("Day Off OT"), "fieldname": "day_off_ot", "fieldtype": "Check", "width": 70},
-		{"label": _("Shift"), "fieldname": "shift", "fieldtype": "Data", "width": 90},
+		# No Shift column: WI-001790 lists the columns to display and shift is not one of
+		# them. Rows are still grouped by shift (see row_group), so a day worked across two
+		# shifts stays on its own row rather than being merged into one - the column is what
+		# was asked for, not the grouping.
 	]
 
 	columns.extend(get_columns_for_days(dates))
@@ -587,8 +590,10 @@ def get_attendance_status(
 	groups = set(employee_non_day_off_attendance.keys()) | set(employee_non_day_off_schedule.keys())
 
 	for group in groups:
-		shift, roster_type, day_off_ot = group
-		row = {"shift": shift, "roster_type": roster_type, "day_off_ot": day_off_ot}
+		# Shift still separates the rows (see row_group) but is not carried into the row:
+		# WI-001790 does not list it as a column, and an undeclared key is dead weight.
+		_shift, roster_type, day_off_ot = group
+		row = {"roster_type": roster_type, "day_off_ot": day_off_ot}
 
 		# Merge Attendance and Schedule statuses
 		attendance_dict = { **employee_non_day_off_attendance.get(group, {}), **employee_non_day_off_schedule.get(group, {}) }

--- a/one_fm/one_fm/report/operations_monthly_attendance_sheet/test_operations_monthly_attendance_sheet.py
+++ b/one_fm/one_fm/report/operations_monthly_attendance_sheet/test_operations_monthly_attendance_sheet.py
@@ -94,9 +94,26 @@ class TestColumns(FrappeTestCase):
 		fieldnames = [c["fieldname"] for c in get_columns(_filters(), [])]
 		for expected in (
 			"employee_id", "employee_name", "project", "employee_status",
-			"employment_type", "roster_type", "day_off_ot", "shift",
+			"employment_type", "roster_type", "day_off_ot",
 		):
 			self.assertIn(expected, fieldnames)
+
+	def test_no_column_the_ac_does_not_list_is_shown(self):
+		# WI-001790 enumerates the columns to display; Shift is not among them. The
+		# hidden employee column is excluded - it carries the docname for the in-page
+		# filters and renders nothing.
+		allowed = {
+			"employee", "employee_id", "employee_name", "project", "employee_status",
+			"employment_type", "roster_type", "day_off_ot",
+			"working_days", "off_days", "total_hours",
+		}
+		shown = {
+			c["fieldname"]
+			for c in get_columns(_filters(), [])
+			if not c.get("hidden")
+		}
+		self.assertEqual(shown - allowed, set())
+		self.assertNotIn("shift", shown)
 
 	def test_column_keys_are_unique(self):
 		fieldnames = [c["fieldname"] for c in get_columns(_filters(), get_date_range(_filters()))]
@@ -250,8 +267,12 @@ class TestShiftHours(FrappeTestCase):
 		)
 
 	def test_the_row_names_its_group(self):
+		# Shift is part of the group key but is not a column, so the row carries only the
+		# two attributes WI-001790 lists.
 		row = self._rows(BY_SHIFT_HOURS)[0]
-		self.assertEqual((row["shift"], row["roster_type"], row["day_off_ot"]), self.GROUP)
+		_shift, roster_type, day_off_ot = self.GROUP
+		self.assertEqual((row["roster_type"], row["day_off_ot"]), (roster_type, day_off_ot))
+		self.assertNotIn("shift", row)
 
 	def test_the_cells_carry_the_scheduled_duration(self):
 		row = self._rows(BY_SHIFT_HOURS)[0]


### PR DESCRIPTION
[WI-001790](https://one-fm.com/app/work-item/WI-001790) enumerates the columns to display — Employee ID, Employee Name, Project Name, Employee Status, Employment Type, Roster Type, Day Off OT and the daily attendance details. **Shift is not among them**, and neither WI-001790 nor WI-001791 asks for it. It was added on my side and is now removed.

## What changed

The column is gone from `get_columns`, and the group key no longer travels into the row — an undeclared `shift` key was dead weight once nothing rendered it. The existing `test_rows_only_use_declared_columns` caught that second half.

**Rows are still grouped by shift.** Only the column was asked for, not the grouping, and the grouping is what keeps a day worked across two shifts on separate rows rather than merged into one — which is the double-shift overlap WI-001791 exists to avoid.

One consequence worth knowing: with the column gone, an employee who worked two shifts on the same Roster Type / Day Off OT combination now shows two rows that look identical apart from their day cells. Say the word if you'd rather those rows merged, but that would change what WI-001791's shift-hours view reports.

## Verification

- `bench run-tests --module one_fm.one_fm.report.operations_monthly_attendance_sheet.test_operations_monthly_attendance_sheet` — **48 passed**
- New `test_no_column_the_ac_does_not_list_is_shown` pins the visible column set to the criteria, so a column cannot creep back in unnoticed
- `test_the_attribute_columns_the_ac_lists_are_present` and `test_the_row_names_its_group` updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)